### PR TITLE
chore: upgrade @types/node to v24.11.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -63,7 +63,7 @@
         "@types/express": "^5.0.3",
         "@types/jest": "^30.0.0",
         "@types/multer": "^2.0.0",
-        "@types/node": "^24.7.0",
+        "@types/node": "^24.11.0",
         "@types/supertest": "^6.0.3",
         "@typescript-eslint/eslint-plugin": "^8.46.0",
         "@typescript-eslint/parser": "^8.46.0",
@@ -3377,9 +3377,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.10.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.14.tgz",
-      "integrity": "sha512-OowOUbD1lBCOFIPOZ8xnMIhgqA4sCutMiYOmPHL1PTLt5+y1XA+g2+yC9OOyz8p+deMZqPZLxfMjYIfrKsPeFg==",
+      "version": "24.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.11.0.tgz",
+      "integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -80,7 +80,7 @@
     "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",
     "@types/multer": "^2.0.0",
-    "@types/node": "^24.7.0",
+    "@types/node": "^24.11.0",
     "@types/supertest": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^8.46.0",
     "@typescript-eslint/parser": "^8.46.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -48,7 +48,7 @@
         "@testing-library/user-event": "^14.5.1",
         "@types/file-saver": "^2.0.7",
         "@types/lodash": "^4.14.202",
-        "@types/node": "^20.10.4",
+        "@types/node": "^24.11.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.4",
@@ -2525,13 +2525,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
-      "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+      "version": "24.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.11.0.tgz",
+      "integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/pako": {
@@ -5983,9 +5983,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,7 +56,7 @@
     "@testing-library/user-event": "^14.5.1",
     "@types/file-saver": "^2.0.7",
     "@types/lodash": "^4.14.202",
-    "@types/node": "^20.10.4",
+    "@types/node": "^24.11.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.4",

--- a/frontend/src/hooks/useIdleTimer.ts
+++ b/frontend/src/hooks/useIdleTimer.ts
@@ -85,9 +85,9 @@ export function useIdleTimer(options: UseIdleTimerOptions = {}): UseIdleTimerRet
   const [remainingTime, setRemainingTime] = useState(0)
   const [isPaused, setIsPaused] = useState(false)
 
-  const idleTimerRef = useRef<NodeJS.Timeout | null>(null)
-  const timeoutTimerRef = useRef<NodeJS.Timeout | null>(null)
-  const countdownIntervalRef = useRef<NodeJS.Timeout | null>(null)
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const timeoutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const countdownIntervalRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastActivityRef = useRef<number>(Date.now())
   const isIdleRef = useRef<boolean>(false)
 

--- a/frontend/src/pages/sales/CustomersPage.tsx
+++ b/frontend/src/pages/sales/CustomersPage.tsx
@@ -213,7 +213,7 @@ const CustomersPage: React.FC = () => {
   // Debounced phone validation
   const debouncedPhoneCheck = useMemo(
     () => {
-      let timeoutId: NodeJS.Timeout
+      let timeoutId: ReturnType<typeof setTimeout>
       return (phone: string) => {
         clearTimeout(timeoutId)
         timeoutId = setTimeout(() => checkPhoneDuplicate(phone), 500)


### PR DESCRIPTION
## Summary
- Upgrade `@types/node` from `^20.10.4` to `^24.11.0` in frontend
- Upgrade `@types/node` from `^24.7.0` to `^24.11.0` in backend
- Replace deprecated `NodeJS.Timeout` with `ReturnType<typeof setTimeout>` in `CustomersPage` and `useIdleTimer`

## Test Plan
- [x] All 503 backend tests pass
- [x] Frontend TypeScript type-check passes (`tsc --noEmit`)