### PR TITLE
chore(deps): upgrade class-validator to ^0.15.1

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -28,7 +28,7 @@
         "bcrypt": "^6.0.0",
         "bull": "^4.11.4",
         "class-transformer": "^0.5.1",
-        "class-validator": "^0.14.0",
+        "class-validator": "^0.15.1",
         "compression": "^1.7.4",
         "exceljs": "^4.4.0",
         "helmet": "^8.1.0",
@@ -2378,26 +2378,6 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
-    "node_modules/@nestjs/mapped-types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
-      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@nestjs/common": "^10.0.0 || ^11.0.0",
-        "class-transformer": "^0.4.0 || ^0.5.0",
-        "class-validator": "^0.13.0 || ^0.14.0",
-        "reflect-metadata": "^0.1.12 || ^0.2.0"
-      },
-      "peerDependenciesMeta": {
-        "class-transformer": {
-          "optional": true
-        },
-        "class-validator": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@nestjs/microservices": {
       "version": "11.1.14",
       "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-11.1.14.tgz",
@@ -2680,6 +2660,26 @@
         "@fastify/static": {
           "optional": true
         },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger/node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
         "class-transformer": {
           "optional": true
         },
@@ -5075,9 +5075,9 @@
       "license": "MIT"
     },
     "node_modules/class-validator": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
-      "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
+      "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
       "dependencies": {
         "@types/validator": "^13.15.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -45,7 +45,7 @@
     "bcrypt": "^6.0.0",
     "bull": "^4.11.4",
     "class-transformer": "^0.5.1",
-    "class-validator": "^0.14.0",
+    "class-validator": "^0.15.1",
     "compression": "^1.7.4",
     "exceljs": "^4.4.0",
     "helmet": "^8.1.0",


### PR DESCRIPTION
## Summary

- Bumps `class-validator` from `^0.14.0` to `^0.15.1` in `backend/package.json`
- No application code changes required — the one breaking change in 0.15.0 (`@IsIBAN` requiring `IsIBANOptions`) is not used in this codebase

## Test plan

- [x] `npm install` completed successfully, `class-validator@0.15.1` installed
- [x] Full backend test suite: 28 suites, 503 tests — all pass

## Known warning

`@nestjs/mapped-types@2.1.0` (latest) declares peer dep `"^0.13.0 || ^0.14.0"` and has not yet been updated to include 0.15.x. This produces an `npm warn ERESOLVE overriding peer dependency` at install time. The peer dep is marked optional upstream, the breaking change has zero exposure here, and all tests pass. Will auto-resolve when NestJS updates their peer range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)