### PR TITLE
feat(settings): document numbers overhaul with PREFIX-YY-NNN flow and owner equity support

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,7 +19,9 @@ FROM node:24-alpine3.23 AS production
 # Install security updates and runtime dependencies
 RUN apk update && apk upgrade && \
     apk add --no-cache curl 'postgresql18-client>=18.2-r0' dumb-init && \
-    rm -rf /var/cache/apk/*
+    rm -rf /var/cache/apk/* && \
+    rm -rf /usr/local/lib/node_modules/npm && \
+    rm -f /usr/local/bin/npm /usr/local/bin/npx
 
 # Create non-root user
 RUN addgroup -g 1001 -S nodejs && \

--- a/backend/src/config/database-config.factory.ts
+++ b/backend/src/config/database-config.factory.ts
@@ -13,7 +13,7 @@ import { Category } from '../database/entities/category.entity';
 import { ChartOfAccount } from '../database/entities/chart-of-account.entity';
 import { CompanySettings } from '../database/entities/company-settings.entity';
 import { Customer } from '../database/entities/customer.entity';
-import { DocumentNumberSettings } from '../database/entities/document-number-settings.entity';
+import { DocumentNumberSetting } from '../database/entities/document-number-settings.entity';
 import { Expense } from '../database/entities/expense.entity';
 import { FiscalPeriod } from '../database/entities/fiscal-period.entity';
 import { GoodsReceivedNote } from '../database/entities/goods-received-note.entity';
@@ -84,7 +84,7 @@ export function createDatabaseConfig(configService: ConfigService, allowDefaults
     entities: [
       AccountMapping, AuditLog, BackupLog, BackupSchedule, BackupRetentionSettings,
       BankReconciliation, Category, ChartOfAccount, CompanySettings, Customer,
-      DocumentNumberSettings, Expense, FiscalPeriod, GoodsReceivedNote, GoodsReceivedNoteItem,
+      DocumentNumberSetting, Expense, FiscalPeriod, GoodsReceivedNote, GoodsReceivedNoteItem,
       Invoice, InvoiceItem, JournalEntry, JournalEntryLine, OwnerEquityTransaction,
       Payment, PaymentMethodEntity, PriceCostingSettings, PriceList, PriceListItem,
       PrintSettings, Product, PurchaseCostHistory, PurchaseOrder, PurchaseOrderItem,

--- a/backend/src/database/entities/document-number-settings.entity.ts
+++ b/backend/src/database/entities/document-number-settings.entity.ts
@@ -1,15 +1,21 @@
-import { Entity, Column } from 'typeorm';
+import { Entity, Column, Index } from 'typeorm';
 import { BaseEntity } from './base.entity';
 
-export interface DocumentNumberConfig {
-  documentName: string;
-  prefix: string;
-  numberFormat: string;
-  nextNumber: number;
-}
-
 @Entity('document_number_settings')
-export class DocumentNumberSettings extends BaseEntity {
-  @Column({ type: 'jsonb', default: [] })
-  configurations: DocumentNumberConfig[];
+@Index(['documentName'], { unique: true })
+export class DocumentNumberSetting extends BaseEntity {
+  @Column({ type: 'varchar', length: 50, unique: true })
+  documentName: string;
+
+  @Column({ type: 'varchar', length: 10 })
+  prefix: string;
+
+  @Column({ type: 'smallint', default: 3 })
+  paddingDigits: number;
+
+  @Column({ type: 'int', default: 1 })
+  nextNumber: number;
+
+  @Column({ type: 'smallint' })
+  lastResetYear: number;
 }

--- a/backend/src/database/entities/expense.entity.ts
+++ b/backend/src/database/entities/expense.entity.ts
@@ -4,7 +4,6 @@ import {
   Index,
   ManyToOne,
   JoinColumn,
-  BeforeInsert,
 } from 'typeorm';
 import {
   IsString,
@@ -84,12 +83,4 @@ export class Expense extends BaseEntity {
   @ManyToOne(() => JournalEntry, { onDelete: 'SET NULL', nullable: true })
   @JoinColumn({ name: 'journalEntryId' })
   journalEntry?: JournalEntry;
-
-  @BeforeInsert()
-  generateReferenceNumber() {
-    if (!this.referenceNumber) {
-      const timestamp = Date.now().toString(36).toUpperCase();
-      this.referenceNumber = `EXP-${timestamp}`;
-    }
-  }
 }

--- a/backend/src/database/entities/owner-equity-transaction.entity.ts
+++ b/backend/src/database/entities/owner-equity-transaction.entity.ts
@@ -4,7 +4,6 @@ import {
   Index,
   ManyToOne,
   JoinColumn,
-  BeforeInsert,
 } from 'typeorm';
 import {
   IsString,
@@ -82,12 +81,4 @@ export class OwnerEquityTransaction extends BaseEntity {
   @ManyToOne(() => JournalEntry, { onDelete: 'SET NULL', nullable: true })
   @JoinColumn({ name: 'journalEntryId' })
   journalEntry?: JournalEntry;
-
-  @BeforeInsert()
-  generateReferenceNumber() {
-    if (!this.referenceNumber) {
-      const timestamp = Date.now().toString(36).toUpperCase();
-      this.referenceNumber = `EQ-${timestamp}`;
-    }
-  }
 }

--- a/backend/src/database/entities/settlement.entity.ts
+++ b/backend/src/database/entities/settlement.entity.ts
@@ -4,7 +4,6 @@ import {
   Index,
   ManyToOne,
   JoinColumn,
-  BeforeInsert,
 } from 'typeorm';
 import {
   IsString,
@@ -96,12 +95,4 @@ export class Settlement extends BaseEntity {
   })
   @JoinColumn({ name: 'paymentMethodId' })
   paymentMethod: PaymentMethodEntity;
-
-  @BeforeInsert()
-  generateSettlementNumber() {
-    if (!this.settlementNumber) {
-      const timestamp = Date.now().toString(36).toUpperCase();
-      this.settlementNumber = `STL-${timestamp}`;
-    }
-  }
 }

--- a/backend/src/database/migrations/1772100000000-NormalizeDocumentNumberSettings.ts
+++ b/backend/src/database/migrations/1772100000000-NormalizeDocumentNumberSettings.ts
@@ -1,0 +1,65 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class NormalizeDocumentNumberSettings1772100000000 implements MigrationInterface {
+  name = 'NormalizeDocumentNumberSettings1772100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "document_number_settings"`);
+
+    await queryRunner.query(`
+      CREATE TABLE "document_number_settings" (
+        "id"            uuid                   NOT NULL DEFAULT gen_random_uuid(),
+        "documentName"  character varying(50)  NOT NULL,
+        "prefix"        character varying(10)  NOT NULL,
+        "paddingDigits" smallint               NOT NULL DEFAULT 3,
+        "nextNumber"    integer                NOT NULL DEFAULT 1,
+        "lastResetYear" smallint               NOT NULL,
+        "isActive"      boolean                NOT NULL DEFAULT true,
+        "createdAt"     TIMESTAMP              NOT NULL DEFAULT now(),
+        "updatedAt"     TIMESTAMP              NOT NULL DEFAULT now(),
+        "deletedAt"     TIMESTAMP,
+        CONSTRAINT "PK_document_number_settings" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_document_number_settings_name" UNIQUE ("documentName")
+      )
+    `);
+
+    const currentYear = new Date().getFullYear() % 100;
+    const defaults = [
+      { name: 'Sales Orders',     prefix: 'SO'  },
+      { name: 'Invoices',         prefix: 'INV' },
+      { name: 'Payments',         prefix: 'PAY' },
+      { name: 'Purchase Orders',  prefix: 'PO'  },
+      { name: 'Goods Received',   prefix: 'GRN' },
+      { name: 'Vendor Payments',  prefix: 'VP'  },
+      { name: 'Stock Adjustment', prefix: 'SA'  },
+      { name: 'Journal Entries',  prefix: 'JE'  },
+      { name: 'Expenses',         prefix: 'EXP' },
+      { name: 'Settlements',      prefix: 'STL' },
+    ];
+
+    for (const row of defaults) {
+      await queryRunner.query(
+        `INSERT INTO "document_number_settings"
+          ("documentName", "prefix", "paddingDigits", "nextNumber", "lastResetYear")
+         VALUES ($1, $2, 3, 1, $3)`,
+        [row.name, row.prefix, currentYear],
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "document_number_settings"`);
+
+    await queryRunner.query(`
+      CREATE TABLE "document_number_settings" (
+        "id"             uuid      NOT NULL DEFAULT gen_random_uuid(),
+        "configurations" jsonb     NOT NULL DEFAULT '[]',
+        "isActive"       boolean   NOT NULL DEFAULT true,
+        "createdAt"      TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt"      TIMESTAMP NOT NULL DEFAULT now(),
+        "deletedAt"      TIMESTAMP,
+        CONSTRAINT "PK_document_number_settings_old" PRIMARY KEY ("id")
+      )
+    `);
+  }
+}

--- a/backend/src/database/migrations/1772100000000-NormalizeDocumentNumberSettings.ts
+++ b/backend/src/database/migrations/1772100000000-NormalizeDocumentNumberSettings.ts
@@ -35,6 +35,7 @@ export class NormalizeDocumentNumberSettings1772100000000 implements MigrationIn
       { name: 'Journal Entries',  prefix: 'JE'  },
       { name: 'Expenses',         prefix: 'EXP' },
       { name: 'Settlements',      prefix: 'STL' },
+      { name: 'Owner Equity',     prefix: 'EQ'  },
     ];
 
     for (const row of defaults) {

--- a/backend/src/database/migrations/1772200000000-AddOwnerEquityDocumentNumberSetting.ts
+++ b/backend/src/database/migrations/1772200000000-AddOwnerEquityDocumentNumberSetting.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOwnerEquityDocumentNumberSetting1772200000000 implements MigrationInterface {
+  name = 'AddOwnerEquityDocumentNumberSetting1772200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const currentYear = new Date().getFullYear() % 100;
+    await queryRunner.query(
+      `INSERT INTO "document_number_settings"
+        ("documentName", "prefix", "paddingDigits", "nextNumber", "lastResetYear")
+       VALUES ($1, $2, 3, 1, $3)
+       ON CONFLICT ("documentName") DO NOTHING`,
+      ['Owner Equity', 'EQ', currentYear],
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "document_number_settings" WHERE "documentName" = 'Owner Equity'`,
+    );
+  }
+}

--- a/backend/src/modules/accounting/accounting.module.ts
+++ b/backend/src/modules/accounting/accounting.module.ts
@@ -37,6 +37,7 @@ import { ReconciliationController } from './controllers/reconciliation.controlle
 import { SettlementController } from './controllers/settlement.controller';
 import { OwnerEquityController } from './controllers/owner-equity.controller';
 import { ExpenseController } from './controllers/expense.controller';
+import { SettingsModule } from '../settings/settings.module';
 
 @Module({
   imports: [
@@ -54,6 +55,7 @@ import { ExpenseController } from './controllers/expense.controller';
       OwnerEquityTransaction,
       Expense,
     ]),
+    SettingsModule,
   ],
   controllers: [
     ChartOfAccountsController,

--- a/backend/src/modules/accounting/services/expense.service.spec.ts
+++ b/backend/src/modules/accounting/services/expense.service.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../database/entities/chart-of-account.entity';
 import { PaymentMethodEntity } from '../../../database/entities/payment-method.entity';
 import { AccountingService } from './accounting.service';
+import { SettingsService } from '../../settings/settings.service';
 
 describe('ExpenseService', () => {
   let service: ExpenseService;
@@ -17,6 +18,7 @@ describe('ExpenseService', () => {
   let paymentMethodRepository: jest.Mocked<Repository<PaymentMethodEntity>>;
   let chartOfAccountRepository: jest.Mocked<Repository<ChartOfAccount>>;
   let accountingService: jest.Mocked<AccountingService>;
+  let settingsService: jest.Mocked<SettingsService>;
 
   const mockQueryBuilder = {
     leftJoinAndSelect: jest.fn().mockReturnThis(),
@@ -60,6 +62,12 @@ describe('ExpenseService', () => {
             postExpenseEntry: jest.fn(),
           },
         },
+        {
+          provide: SettingsService,
+          useValue: {
+            generateDocumentNumber: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -68,6 +76,8 @@ describe('ExpenseService', () => {
     paymentMethodRepository = module.get(getRepositoryToken(PaymentMethodEntity));
     chartOfAccountRepository = module.get(getRepositoryToken(ChartOfAccount));
     accountingService = module.get(AccountingService);
+    settingsService = module.get(SettingsService);
+    settingsService.generateDocumentNumber.mockResolvedValue('EXP-26-001');
 
     jest.clearAllMocks();
   });

--- a/backend/src/modules/accounting/services/expense.service.ts
+++ b/backend/src/modules/accounting/services/expense.service.ts
@@ -13,6 +13,7 @@ import {
   AccountType,
 } from '../../../database/entities/chart-of-account.entity';
 import { AccountingService } from './accounting.service';
+import { SettingsService } from '../../settings/settings.service';
 import {
   CreateExpenseDto,
   UpdateExpenseDto,
@@ -34,6 +35,7 @@ export class ExpenseService {
     @InjectRepository(ChartOfAccount)
     private readonly chartOfAccountRepository: Repository<ChartOfAccount>,
     private readonly accountingService: AccountingService,
+    private readonly settingsService: SettingsService,
   ) {}
 
   async findAll(query: QueryExpenseDto): Promise<ExpenseListResponseDto> {
@@ -139,7 +141,10 @@ export class ExpenseService {
       );
     }
 
+    const referenceNumber = await this.settingsService.generateDocumentNumber('Expenses');
+
     const expense = this.expenseRepository.create({
+      referenceNumber,
       expenseDate: new Date(dto.expenseDate),
       expenseAccountId: dto.expenseAccountId,
       amount: dto.amount,

--- a/backend/src/modules/accounting/services/journal-entry.service.spec.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.spec.ts
@@ -9,6 +9,7 @@ import {
 import { JournalEntryService } from './journal-entry.service';
 import { ChartOfAccountsService } from './chart-of-accounts.service';
 import { FiscalPeriodService } from './fiscal-period.service';
+import { SettingsService } from '../../settings/settings.service';
 import {
   JournalEntry,
   JournalEntryStatus,
@@ -36,6 +37,7 @@ describe('JournalEntryService', () => {
   let chartOfAccountRepository: jest.Mocked<Repository<ChartOfAccount>>;
   let chartOfAccountsService: jest.Mocked<ChartOfAccountsService>;
   let fiscalPeriodService: jest.Mocked<FiscalPeriodService>;
+  let settingsService: jest.Mocked<SettingsService>;
 
   // Test data
   const mockFiscalPeriod: Partial<FiscalPeriod> = {
@@ -158,6 +160,12 @@ describe('JournalEntryService', () => {
             findOne: jest.fn(),
           },
         },
+        {
+          provide: SettingsService,
+          useValue: {
+            generateDocumentNumber: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -168,6 +176,8 @@ describe('JournalEntryService', () => {
     chartOfAccountRepository = module.get(getRepositoryToken(ChartOfAccount));
     chartOfAccountsService = module.get(ChartOfAccountsService);
     fiscalPeriodService = module.get(FiscalPeriodService);
+    settingsService = module.get(SettingsService);
+    settingsService.generateDocumentNumber.mockResolvedValue('JE-26-001');
   });
 
   it('should be defined', () => {
@@ -255,7 +265,8 @@ describe('JournalEntryService', () => {
 
       const result = await service.create(createDto);
 
-      expect(result.referenceNumber).toMatch(/^JE-\d{4}-\d{3}$/);
+      expect(settingsService.generateDocumentNumber).toHaveBeenCalledWith('Journal Entries');
+      expect(result.referenceNumber).toBeDefined();
     });
 
     it('should throw BadRequestException if fiscal period is closed', async () => {

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -24,6 +24,7 @@ import {
 } from '../dto/journal-entry.dto';
 import { ChartOfAccountsService } from './chart-of-accounts.service';
 import { FiscalPeriodService } from './fiscal-period.service';
+import { SettingsService } from '../../settings/settings.service';
 
 @Injectable()
 export class JournalEntryService {
@@ -40,6 +41,7 @@ export class JournalEntryService {
     private readonly chartOfAccountRepository: Repository<ChartOfAccount>,
     private readonly chartOfAccountsService: ChartOfAccountsService,
     private readonly fiscalPeriodService: FiscalPeriodService,
+    private readonly settingsService: SettingsService,
   ) {}
 
   /**
@@ -61,7 +63,9 @@ export class JournalEntryService {
     this.validateEntryLines(createDto.lines);
 
     // Generate reference number if not provided
-    const referenceNumber = createDto.referenceNumber || await this.generateReferenceNumber(createDto.entryDate);
+    const referenceNumber =
+      createDto.referenceNumber ||
+      await this.settingsService.generateDocumentNumber('Journal Entries');
 
     // Check if reference number already exists
     const existingEntry = await this.journalEntryRepository.findOne({
@@ -435,7 +439,7 @@ export class JournalEntryService {
     }
 
     // Generate reference number for reversal entry
-    const reversalReferenceNumber = await this.generateReferenceNumber(new Date(), 'REV');
+    const reversalReferenceNumber = await this.settingsService.generateDocumentNumber('Journal Entries');
 
     // Create reversal entry
     const reversalEntry = this.journalEntryRepository.create({
@@ -506,7 +510,7 @@ export class JournalEntryService {
       );
     }
 
-    const reversalReferenceNumber = await this.generateReferenceNumber(new Date(), 'REV');
+    const reversalReferenceNumber = await this.settingsService.generateDocumentNumber('Journal Entries');
 
     const reversalEntry = this.journalEntryRepository.create({
       entryDate: new Date(),
@@ -674,31 +678,6 @@ export class JournalEntryService {
         );
       }
     }
-  }
-
-  /**
-   * Generate reference number in format "JE-YYYY-NNN" or "REV-YYYY-NNN"
-   */
-  private async generateReferenceNumber(date: Date, prefix: string = 'JE'): Promise<string> {
-    const year = date.getFullYear();
-    const yearPrefix = `${prefix}-${year}`;
-
-    // Find the highest sequence number for this year
-    const lastEntry = await this.journalEntryRepository
-      .createQueryBuilder('entry')
-      .where('entry.referenceNumber LIKE :pattern', { pattern: `${yearPrefix}-%` })
-      .orderBy('entry.referenceNumber', 'DESC')
-      .getOne();
-
-    let sequence = 1;
-    if (lastEntry) {
-      const match = lastEntry.referenceNumber.match(/-(\d+)$/);
-      if (match) {
-        sequence = parseInt(match[1], 10) + 1;
-      }
-    }
-
-    return `${yearPrefix}-${String(sequence).padStart(3, '0')}`;
   }
 
   /**

--- a/backend/src/modules/accounting/services/owner-equity.service.spec.ts
+++ b/backend/src/modules/accounting/services/owner-equity.service.spec.ts
@@ -10,12 +10,14 @@ import {
 } from '../../../database/entities/owner-equity-transaction.entity';
 import { PaymentMethodEntity } from '../../../database/entities/payment-method.entity';
 import { AccountingService } from './accounting.service';
+import { SettingsService } from '../../settings/settings.service';
 
 describe('OwnerEquityService', () => {
   let service: OwnerEquityService;
   let ownerEquityRepository: jest.Mocked<Repository<OwnerEquityTransaction>>;
   let paymentMethodRepository: jest.Mocked<Repository<PaymentMethodEntity>>;
   let accountingService: jest.Mocked<AccountingService>;
+  let settingsService: jest.Mocked<SettingsService>;
 
   const mockQueryBuilder = {
     withDeleted: jest.fn().mockReturnThis(),
@@ -54,6 +56,12 @@ describe('OwnerEquityService', () => {
             postOwnerEquityEntry: jest.fn(),
           },
         },
+        {
+          provide: SettingsService,
+          useValue: {
+            generateDocumentNumber: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -61,6 +69,9 @@ describe('OwnerEquityService', () => {
     ownerEquityRepository = module.get(getRepositoryToken(OwnerEquityTransaction));
     paymentMethodRepository = module.get(getRepositoryToken(PaymentMethodEntity));
     accountingService = module.get(AccountingService);
+    settingsService = module.get(SettingsService);
+
+    settingsService.generateDocumentNumber.mockResolvedValue('EQ-26-001');
 
     jest.clearAllMocks();
   });
@@ -147,6 +158,7 @@ describe('OwnerEquityService', () => {
 
     ownerEquityRepository.create.mockReturnValue({
       id: 'tx-1',
+      referenceNumber: 'EQ-26-001',
       transactionDate: new Date('2026-02-01'),
       type: OwnerEquityTransactionType.CAPITAL_INJECTION,
       amount: 100,
@@ -175,6 +187,7 @@ describe('OwnerEquityService', () => {
       paymentMethodId: 'pm-1',
     });
 
+    expect(settingsService.generateDocumentNumber).toHaveBeenCalledWith('Owner Equity');
     expect(result.status).toBe(OwnerEquityTransactionStatus.DRAFT);
   });
 

--- a/backend/src/modules/accounting/services/owner-equity.service.ts
+++ b/backend/src/modules/accounting/services/owner-equity.service.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../database/entities/owner-equity-transaction.entity';
 import { PaymentMethodEntity } from '../../../database/entities/payment-method.entity';
 import { AccountingService } from './accounting.service';
+import { SettingsService } from '../../settings/settings.service';
 import {
   CreateOwnerEquityDto,
   UpdateOwnerEquityDto,
@@ -32,6 +33,7 @@ export class OwnerEquityService {
     @InjectRepository(PaymentMethodEntity)
     private readonly paymentMethodRepository: Repository<PaymentMethodEntity>,
     private readonly accountingService: AccountingService,
+    private readonly settingsService: SettingsService,
   ) {}
 
   async findAll(query: QueryOwnerEquityDto): Promise<OwnerEquityListResponseDto> {
@@ -121,7 +123,10 @@ export class OwnerEquityService {
       throw new NotFoundException(`Payment method ${dto.paymentMethodId} not found`);
     }
 
+    const referenceNumber = await this.settingsService.generateDocumentNumber('Owner Equity');
+
     const transaction = this.ownerEquityRepository.create({
+      referenceNumber,
       transactionDate: new Date(dto.transactionDate),
       type: dto.type,
       amount: dto.amount,

--- a/backend/src/modules/accounting/services/settlement.service.spec.ts
+++ b/backend/src/modules/accounting/services/settlement.service.spec.ts
@@ -6,6 +6,7 @@ import { Settlement, SettlementStatus } from '../../../database/entities/settlem
 import { PaymentMethodEntity } from '../../../database/entities/payment-method.entity';
 import { Payment, SettlementStatusEnum } from '../../../database/entities/payment.entity';
 import { AccountingService } from './accounting.service';
+import { SettingsService } from '../../settings/settings.service';
 
 describe('SettlementService', () => {
   let service: SettlementService;
@@ -13,6 +14,7 @@ describe('SettlementService', () => {
   let paymentMethodRepository: jest.Mocked<Repository<PaymentMethodEntity>>;
   let paymentRepository: jest.Mocked<Repository<Payment>>;
   let accountingService: jest.Mocked<AccountingService>;
+  let settingsService: jest.Mocked<SettingsService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -48,6 +50,12 @@ describe('SettlementService', () => {
             postSettlementEntry: jest.fn(),
           },
         },
+        {
+          provide: SettingsService,
+          useValue: {
+            generateDocumentNumber: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -56,6 +64,8 @@ describe('SettlementService', () => {
     paymentMethodRepository = module.get(getRepositoryToken(PaymentMethodEntity));
     paymentRepository = module.get(getRepositoryToken(Payment));
     accountingService = module.get(AccountingService);
+    settingsService = module.get(SettingsService);
+    settingsService.generateDocumentNumber.mockResolvedValue('STL-26-001');
   });
 
   it('should be defined', () => {

--- a/backend/src/modules/accounting/services/settlement.service.ts
+++ b/backend/src/modules/accounting/services/settlement.service.ts
@@ -17,6 +17,7 @@ import {
   PendingPaymentsSummaryDto,
 } from '../dto/settlement.dto';
 import { AccountingService } from './accounting.service';
+import { SettingsService } from '../../settings/settings.service';
 
 @Injectable()
 export class SettlementService {
@@ -30,6 +31,7 @@ export class SettlementService {
     @InjectRepository(Payment)
     private readonly paymentRepository: Repository<Payment>,
     private readonly accountingService: AccountingService,
+    private readonly settingsService: SettingsService,
   ) {}
 
   async findAll(query: QuerySettlementsDto): Promise<SettlementListResponseDto> {
@@ -132,8 +134,10 @@ export class SettlementService {
     }
 
     const totalAmount = payments.reduce((sum, p) => sum + Number(p.amount), 0);
+    const settlementNumber = await this.settingsService.generateDocumentNumber('Settlements');
 
     const settlement = this.settlementRepository.create({
+      settlementNumber,
       paymentMethodId: dto.paymentMethodId,
       settlementDate: new Date(dto.settlementDate),
       totalAmount,

--- a/backend/src/modules/backup/backup.module.ts
+++ b/backend/src/modules/backup/backup.module.ts
@@ -10,7 +10,7 @@ import { BackupSchedule } from '@database/entities/backup-schedule.entity';
 import { BackupRetentionSettings } from '@database/entities/backup-settings.entity';
 import { CompanySettings } from '@database/entities/company-settings.entity';
 import { PriceCostingSettings } from '@database/entities/price-costing-settings.entity';
-import { DocumentNumberSettings } from '@database/entities/document-number-settings.entity';
+import { DocumentNumberSetting } from '@database/entities/document-number-settings.entity';
 import { PrintSettings } from '@database/entities/print-settings.entity';
 
 @Module({
@@ -21,7 +21,7 @@ import { PrintSettings } from '@database/entities/print-settings.entity';
       BackupRetentionSettings,
       CompanySettings,
       PriceCostingSettings,
-      DocumentNumberSettings,
+      DocumentNumberSetting,
       PrintSettings,
     ]),
     BullModule.registerQueue({

--- a/backend/src/modules/backup/backup.service.spec.ts
+++ b/backend/src/modules/backup/backup.service.spec.ts
@@ -6,7 +6,7 @@ import { BackupLog } from '@database/entities/backup-log.entity';
 import { BackupRetentionSettings } from '@database/entities/backup-settings.entity';
 import { CompanySettings } from '@database/entities/company-settings.entity';
 import { PriceCostingSettings } from '@database/entities/price-costing-settings.entity';
-import { DocumentNumberSettings } from '@database/entities/document-number-settings.entity';
+import { DocumentNumberSetting } from '@database/entities/document-number-settings.entity';
 import { PrintSettings } from '@database/entities/print-settings.entity';
 
 const mockRepository = () => ({
@@ -48,7 +48,7 @@ describe('BackupService - settings backup', () => {
   let service: BackupService;
   let companySettingsRepo: ReturnType<typeof mockRepository>;
   let priceCostingSettingsRepo: ReturnType<typeof mockRepository>;
-  let documentNumberSettingsRepo: ReturnType<typeof mockRepository>;
+  let documentNumberSettingRepo: ReturnType<typeof mockRepository>;
   let printSettingsRepo: ReturnType<typeof mockRepository>;
 
   beforeEach(async () => {
@@ -60,7 +60,7 @@ describe('BackupService - settings backup', () => {
         { provide: getRepositoryToken(BackupRetentionSettings), useFactory: mockRepository },
         { provide: getRepositoryToken(CompanySettings), useFactory: mockRepository },
         { provide: getRepositoryToken(PriceCostingSettings), useFactory: mockRepository },
-        { provide: getRepositoryToken(DocumentNumberSettings), useFactory: mockRepository },
+        { provide: getRepositoryToken(DocumentNumberSetting), useFactory: mockRepository },
         { provide: getRepositoryToken(PrintSettings), useFactory: mockRepository },
       ],
     }).compile();
@@ -68,7 +68,7 @@ describe('BackupService - settings backup', () => {
     service = module.get<BackupService>(BackupService);
     companySettingsRepo = module.get(getRepositoryToken(CompanySettings));
     priceCostingSettingsRepo = module.get(getRepositoryToken(PriceCostingSettings));
-    documentNumberSettingsRepo = module.get(getRepositoryToken(DocumentNumberSettings));
+    documentNumberSettingRepo = module.get(getRepositoryToken(DocumentNumberSetting));
     printSettingsRepo = module.get(getRepositoryToken(PrintSettings));
   });
 
@@ -155,10 +155,15 @@ describe('BackupService - settings backup', () => {
         isActive: true,
       });
 
-      documentNumberSettingsRepo.findOne.mockResolvedValue({
-        configurations: [{ documentName: 'Sales Orders', prefix: 'SO', numberFormat: '000001', nextNumber: 42 }],
-        isActive: true,
-      });
+      documentNumberSettingRepo.find.mockResolvedValue([
+        {
+          documentName: 'Sales Orders',
+          prefix: 'SO',
+          paddingDigits: 3,
+          nextNumber: 42,
+          lastResetYear: 26,
+        },
+      ]);
 
       printSettingsRepo.findOne.mockResolvedValue({
         companyName: 'Acme Corp', address: '1 Main St', city: 'KL',
@@ -192,7 +197,7 @@ describe('BackupService - settings backup', () => {
       },
       documentNumberSettings: {
         configurations: [
-          { documentName: 'Sales Orders', prefix: 'SO', numberFormat: '000001', nextNumber: 100 },
+          { documentName: 'Sales Orders', prefix: 'SO', paddingDigits: 3, nextNumber: 100, lastResetYear: 26 },
         ],
       },
       printSettings: {
@@ -216,8 +221,11 @@ describe('BackupService - settings backup', () => {
 
       priceCostingSettingsRepo.findOne.mockResolvedValue({ id: 'uuid-2', isActive: true });
       priceCostingSettingsRepo.save.mockResolvedValue({});
-      documentNumberSettingsRepo.findOne.mockResolvedValue({ id: 'uuid-3', isActive: true });
-      documentNumberSettingsRepo.save.mockResolvedValue({});
+      documentNumberSettingRepo.findOne.mockResolvedValue({
+        id: 'uuid-3',
+        documentName: 'Sales Orders',
+      });
+      documentNumberSettingRepo.save.mockResolvedValue({});
       printSettingsRepo.findOne.mockResolvedValue({ id: 'uuid-4' });
       printSettingsRepo.save.mockResolvedValue({});
 
@@ -235,8 +243,11 @@ describe('BackupService - settings backup', () => {
 
       priceCostingSettingsRepo.findOne.mockResolvedValue({ id: 'uuid-2', isActive: true });
       priceCostingSettingsRepo.save.mockResolvedValue({});
-      documentNumberSettingsRepo.findOne.mockResolvedValue({ id: 'uuid-3', isActive: true });
-      documentNumberSettingsRepo.save.mockResolvedValue({});
+      documentNumberSettingRepo.findOne.mockResolvedValue({
+        id: 'uuid-3',
+        documentName: 'Sales Orders',
+      });
+      documentNumberSettingRepo.save.mockResolvedValue({});
       printSettingsRepo.findOne.mockResolvedValue({ id: 'uuid-4' });
       printSettingsRepo.save.mockResolvedValue({});
 
@@ -259,8 +270,11 @@ describe('BackupService - settings backup', () => {
       companySettingsRepo.save.mockResolvedValue({});
       priceCostingSettingsRepo.findOne.mockResolvedValue({ id: 'uuid-2', isActive: true });
       priceCostingSettingsRepo.save.mockResolvedValue({});
-      documentNumberSettingsRepo.findOne.mockResolvedValue({ id: 'uuid-3', isActive: true });
-      documentNumberSettingsRepo.save.mockResolvedValue({});
+      documentNumberSettingRepo.findOne.mockResolvedValue({
+        id: 'uuid-3',
+        documentName: 'Sales Orders',
+      });
+      documentNumberSettingRepo.save.mockResolvedValue({});
       printSettingsRepo.findOne.mockResolvedValue({ id: 'uuid-4' });
       printSettingsRepo.save.mockResolvedValue({});
 

--- a/backend/src/modules/backup/backup.service.ts
+++ b/backend/src/modules/backup/backup.service.ts
@@ -14,7 +14,7 @@ import { BackupLog } from '@database/entities/backup-log.entity';
 import { BackupRetentionSettings } from '@database/entities/backup-settings.entity';
 import { CompanySettings } from '@database/entities/company-settings.entity';
 import { PriceCostingSettings } from '@database/entities/price-costing-settings.entity';
-import { DocumentNumberSettings } from '@database/entities/document-number-settings.entity';
+import { DocumentNumberSetting } from '@database/entities/document-number-settings.entity';
 import { PrintSettings } from '@database/entities/print-settings.entity';
 import { CreateBackupDto, BackupDatabase } from './dto/create-backup.dto';
 import { BackupMetadata } from './interfaces/backup-metadata.interface';
@@ -38,8 +38,8 @@ export class BackupService implements OnModuleDestroy {
     private readonly companySettingsRepository: Repository<CompanySettings>,
     @InjectRepository(PriceCostingSettings)
     private readonly priceCostingSettingsRepository: Repository<PriceCostingSettings>,
-    @InjectRepository(DocumentNumberSettings)
-    private readonly documentNumberSettingsRepository: Repository<DocumentNumberSettings>,
+    @InjectRepository(DocumentNumberSetting)
+    private readonly documentNumberSettingRepository: Repository<DocumentNumberSetting>,
     @InjectRepository(PrintSettings)
     private readonly printSettingsRepository: Repository<PrintSettings>,
     private readonly configService: ConfigService,
@@ -527,16 +527,16 @@ export class BackupService implements OnModuleDestroy {
   }
 
   private async getDocumentNumberSettings(): Promise<any> {
-    const settings = await this.documentNumberSettingsRepository.findOne({
-      where: { isActive: true },
+    const configurations = await this.documentNumberSettingRepository.find({
+      order: { documentName: 'ASC' },
     });
 
-    if (!settings) {
+    if (!configurations.length) {
       return {};
     }
 
     return {
-      configurations: settings.configurations,
+      configurations,
     };
   }
 
@@ -950,17 +950,29 @@ export class BackupService implements OnModuleDestroy {
     if (!data || Object.keys(data).length === 0) return;
 
     try {
-      const existing = await this.documentNumberSettingsRepository.findOne({ where: { isActive: true } });
+      const configurations = Array.isArray(data.configurations) ? data.configurations : [];
+      const currentYY = new Date().getFullYear() % 100;
 
-      if (existing) {
-        existing.configurations = data.configurations;
-        await this.documentNumberSettingsRepository.save(existing);
-      } else {
-        const created = this.documentNumberSettingsRepository.create({
-          configurations: data.configurations,
-          isActive: true,
+      for (const config of configurations) {
+        const existing = await this.documentNumberSettingRepository.findOne({
+          where: { documentName: config.documentName },
         });
-        await this.documentNumberSettingsRepository.save(created);
+
+        const payload = {
+          documentName: config.documentName,
+          prefix: config.prefix,
+          paddingDigits: config.paddingDigits || 3,
+          nextNumber: config.nextNumber || 1,
+          lastResetYear: config.lastResetYear ?? currentYY,
+        };
+
+        if (existing) {
+          Object.assign(existing, payload);
+          await this.documentNumberSettingRepository.save(existing);
+        } else {
+          const created = this.documentNumberSettingRepository.create(payload);
+          await this.documentNumberSettingRepository.save(created);
+        }
       }
 
       this.logger.log('Document number settings restored');

--- a/backend/src/modules/purchasing/services/vendor-payment.service.spec.ts
+++ b/backend/src/modules/purchasing/services/vendor-payment.service.spec.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../database/entities';
 import { AuditLogService } from '../../audit-logs/services';
 import { AccountingService } from '../../accounting/services/accounting.service';
+import { SettingsService } from '../../settings/settings.service';
 import { CreateVendorPaymentDto } from '../dto';
 
 describe('VendorPaymentService', () => {
@@ -22,6 +23,7 @@ describe('VendorPaymentService', () => {
   let paymentMethodRepository: jest.Mocked<Repository<PaymentMethodEntity>>;
   let accountingService: jest.Mocked<AccountingService>;
   let auditLogService: jest.Mocked<AuditLogService>;
+  let settingsService: jest.Mocked<SettingsService>;
 
   const mockSupplier: Partial<Supplier> = {
     id: 'supplier-123',
@@ -102,6 +104,12 @@ describe('VendorPaymentService', () => {
             postVendorPaymentEntry: jest.fn(),
           },
         },
+        {
+          provide: SettingsService,
+          useValue: {
+            generateDocumentNumber: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -112,6 +120,8 @@ describe('VendorPaymentService', () => {
     paymentMethodRepository = module.get(getRepositoryToken(PaymentMethodEntity));
     accountingService = module.get(AccountingService);
     auditLogService = module.get(AuditLogService);
+    settingsService = module.get(SettingsService);
+    settingsService.generateDocumentNumber.mockResolvedValue('VP-26-001');
 
     // Suppress logger output during tests
     jest.spyOn(Logger.prototype, 'log').mockImplementation();

--- a/backend/src/modules/purchasing/services/vendor-payment.service.ts
+++ b/backend/src/modules/purchasing/services/vendor-payment.service.ts
@@ -15,6 +15,7 @@ import {
 } from '../dto';
 import { AuditLogService } from '../../audit-logs/services';
 import { AccountingService } from '@modules/accounting/services/accounting.service';
+import { SettingsService } from '@modules/settings/settings.service';
 
 @Injectable()
 export class VendorPaymentService {
@@ -31,6 +32,7 @@ export class VendorPaymentService {
     private paymentMethodRepository: Repository<PaymentMethodEntity>,
     private readonly auditLogService: AuditLogService,
     private readonly accountingService: AccountingService,
+    private readonly settingsService: SettingsService,
   ) {}
 
   /**
@@ -40,7 +42,7 @@ export class VendorPaymentService {
     createDto: CreateVendorPaymentDto,
     user: string = 'system',
   ): Promise<VendorPayment> {
-    const paymentNumber = await this.generatePaymentNumber();
+    const paymentNumber = await this.settingsService.generateDocumentNumber('Vendor Payments');
     let paymentMethodId = createDto.paymentMethodId;
 
     if (!paymentMethodId) {
@@ -466,7 +468,7 @@ export class VendorPaymentService {
     });
 
     // Create vendor payment
-    const paymentNumber = await this.generatePaymentNumber();
+    const paymentNumber = await this.settingsService.generateDocumentNumber('Vendor Payments');
     const defaultPaymentMethod = await this.paymentMethodRepository.findOne({
       where: { code: 'BANK', isActive: true },
     });
@@ -568,29 +570,4 @@ export class VendorPaymentService {
     return { message: 'Vendor payment permanently deleted successfully' };
   }
 
-  /**
-   * Generate unique payment number
-   */
-  private async generatePaymentNumber(): Promise<string> {
-    const prefix = 'VP';
-
-    // Find the last payment number
-    const lastPayment = await this.vendorPaymentRepository
-      .createQueryBuilder('vendorPayment')
-      .where('vendorPayment.paymentNumber LIKE :pattern', {
-        pattern: `${prefix}-%`,
-      })
-      .orderBy('vendorPayment.paymentNumber', 'DESC')
-      .getOne();
-
-    let sequence = 1;
-    if (lastPayment) {
-      const lastSequence = parseInt(
-        lastPayment.paymentNumber.split('-')[1],
-      );
-      sequence = lastSequence + 1;
-    }
-
-    return `${prefix}-${sequence.toString().padStart(6, '0')}`;
-  }
 }

--- a/backend/src/modules/settings/dto/document-number-settings.dto.ts
+++ b/backend/src/modules/settings/dto/document-number-settings.dto.ts
@@ -1,32 +1,50 @@
-import { IsString, IsInt, IsArray, ValidateNested, Min } from 'class-validator';
+import { IsString, IsInt, IsArray, ValidateNested, Min, Max } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type, Expose } from 'class-transformer';
 
 export class DocumentNumberConfigDto {
-  @ApiProperty({ example: 'Sales Orders', description: 'Document name' })
+  @ApiProperty({ example: 'Sales Orders' })
   @IsString()
   @Expose()
   documentName: string;
 
-  @ApiProperty({ example: 'SO', description: 'Document prefix' })
+  @ApiProperty({ example: 'SO' })
   @IsString()
   @Expose()
   prefix: string;
 
-  @ApiProperty({ example: '000001', description: 'Number format pattern' })
-  @IsString()
+  @ApiProperty({ example: 3, description: 'Minimum digits for sequence padding' })
+  @IsInt()
+  @Min(1)
+  @Max(10)
   @Expose()
-  numberFormat: string;
+  paddingDigits: number;
 
-  @ApiProperty({ example: 1, description: 'Next document number' })
+  @ApiProperty({ example: 1 })
   @IsInt()
   @Min(1)
   @Expose()
   nextNumber: number;
+
+  @ApiProperty({ example: 26, description: 'Last 2-digit year when sequence was reset' })
+  @IsInt()
+  @Expose()
+  lastResetYear: number;
+}
+
+export class UpdateDocumentNumberSettingDto {
+  @ApiProperty({ example: 'SO', description: 'New prefix for this document type' })
+  @IsString()
+  prefix: string;
+
+  @ApiProperty({ example: 1 })
+  @IsInt()
+  @Min(1)
+  nextNumber: number;
 }
 
 export class UpdateDocumentNumberSettingsDto {
-  @ApiProperty({ type: [DocumentNumberConfigDto], description: 'Document number configurations' })
+  @ApiProperty({ type: [DocumentNumberConfigDto] })
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => DocumentNumberConfigDto)
@@ -34,34 +52,19 @@ export class UpdateDocumentNumberSettingsDto {
 }
 
 export class DocumentNumberSettingsResponseDto {
-  @ApiProperty()
-  @Expose()
-  id: string;
-
   @ApiProperty({ type: [DocumentNumberConfigDto] })
   @Expose()
   configurations: DocumentNumberConfigDto[];
-
-  @ApiProperty()
-  @Expose()
-  createdAt: Date;
-
-  @ApiProperty()
-  @Expose()
-  updatedAt: Date;
 }
 
 export class GenerateDocumentNumberDto {
-  @ApiProperty({
-    example: 'Sales Orders',
-    description: 'Document name to generate number for',
-  })
+  @ApiProperty({ example: 'Sales Orders' })
   @IsString()
   documentName: string;
 }
 
 export class GenerateDocumentNumberResponseDto {
-  @ApiProperty({ example: 'SO-000001' })
+  @ApiProperty({ example: 'SO-26-001' })
   documentNumber: string;
 
   @ApiProperty({ example: 'Sales Orders' })

--- a/backend/src/modules/settings/settings.module.ts
+++ b/backend/src/modules/settings/settings.module.ts
@@ -6,7 +6,7 @@ import { SettingsService } from './settings.service';
 import { SettingsController } from './settings.controller';
 import { CompanySettings } from '../../database/entities/company-settings.entity';
 import { PriceCostingSettings } from '../../database/entities/price-costing-settings.entity';
-import { DocumentNumberSettings } from '../../database/entities/document-number-settings.entity';
+import { DocumentNumberSetting } from '../../database/entities/document-number-settings.entity';
 import { SalesOrder } from '../../database/entities/sales-order.entity';
 import { Invoice } from '../../database/entities/invoice.entity';
 import { Payment } from '../../database/entities/payment.entity';
@@ -18,6 +18,8 @@ import { PaymentMethodEntity } from '../../database/entities/payment-method.enti
 import { AccountMapping } from '../../database/entities/account-mapping.entity';
 import { ChartOfAccount } from '../../database/entities/chart-of-account.entity';
 import { Settlement } from '../../database/entities/settlement.entity';
+import { JournalEntry } from '../../database/entities/journal-entry.entity';
+import { Expense } from '../../database/entities/expense.entity';
 import { PaymentMethodController } from './controllers/payment-method.controller';
 import { PaymentMethodService } from './services/payment-method.service';
 
@@ -31,7 +33,7 @@ import { PaymentMethodService } from './services/payment-method.service';
     TypeOrmModule.forFeature([
       CompanySettings,
       PriceCostingSettings,
-      DocumentNumberSettings,
+      DocumentNumberSetting,
       SalesOrder,
       Invoice,
       Payment,
@@ -43,6 +45,8 @@ import { PaymentMethodService } from './services/payment-method.service';
       Settlement,
       AccountMapping,
       ChartOfAccount,
+      JournalEntry,
+      Expense,
     ]),
 
     // Multer for file upload

--- a/backend/src/modules/settings/settings.module.ts
+++ b/backend/src/modules/settings/settings.module.ts
@@ -20,6 +20,7 @@ import { ChartOfAccount } from '../../database/entities/chart-of-account.entity'
 import { Settlement } from '../../database/entities/settlement.entity';
 import { JournalEntry } from '../../database/entities/journal-entry.entity';
 import { Expense } from '../../database/entities/expense.entity';
+import { OwnerEquityTransaction } from '../../database/entities/owner-equity-transaction.entity';
 import { PaymentMethodController } from './controllers/payment-method.controller';
 import { PaymentMethodService } from './services/payment-method.service';
 
@@ -47,6 +48,7 @@ import { PaymentMethodService } from './services/payment-method.service';
       ChartOfAccount,
       JournalEntry,
       Expense,
+      OwnerEquityTransaction,
     ]),
 
     // Multer for file upload

--- a/backend/src/modules/settings/settings.service.ts
+++ b/backend/src/modules/settings/settings.service.ts
@@ -19,6 +19,7 @@ import { StockAdjustment } from '../../database/entities/stock-adjustment.entity
 import { JournalEntry } from '../../database/entities/journal-entry.entity';
 import { Expense } from '../../database/entities/expense.entity';
 import { Settlement } from '../../database/entities/settlement.entity';
+import { OwnerEquityTransaction } from '../../database/entities/owner-equity-transaction.entity';
 import {
   UpdateCompanySettingsDto,
   CompanySettingsResponseDto,
@@ -67,6 +68,8 @@ export class SettingsService {
     private expenseRepository: Repository<Expense>,
     @InjectRepository(Settlement)
     private settlementRepository: Repository<Settlement>,
+    @InjectRepository(OwnerEquityTransaction)
+    private ownerEquityRepository: Repository<OwnerEquityTransaction>,
   ) {}
 
   /**
@@ -484,6 +487,7 @@ export class SettingsService {
       { documentName: 'Journal Entries', prefix: 'JE' },
       { documentName: 'Expenses', prefix: 'EXP' },
       { documentName: 'Settlements', prefix: 'STL' },
+      { documentName: 'Owner Equity', prefix: 'EQ' },
     ];
 
     for (const d of defaults) {
@@ -633,6 +637,17 @@ export class SettingsService {
                 .limit(1)
                 .getOne();
               if (r?.settlementNumber) maxNumber = parseInt(r.settlementNumber.split('-')[2], 10) || 0;
+              break;
+            }
+            case 'Owner Equity': {
+              const r = await this.ownerEquityRepository
+                .createQueryBuilder('eq')
+                .select('eq.referenceNumber')
+                .where('eq.referenceNumber LIKE :p', { p: pattern(row.prefix) })
+                .orderBy('eq.referenceNumber', 'DESC')
+                .limit(1)
+                .getOne();
+              if (r?.referenceNumber) maxNumber = parseInt(r.referenceNumber.split('-')[2], 10) || 0;
               break;
             }
             default:

--- a/backend/src/modules/settings/settings.service.ts
+++ b/backend/src/modules/settings/settings.service.ts
@@ -8,7 +8,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CompanySettings } from '../../database/entities/company-settings.entity';
 import { PriceCostingSettings } from '../../database/entities/price-costing-settings.entity';
-import { DocumentNumberSettings } from '../../database/entities/document-number-settings.entity';
+import { DocumentNumberSetting } from '../../database/entities/document-number-settings.entity';
 import { SalesOrder } from '../../database/entities/sales-order.entity';
 import { Invoice } from '../../database/entities/invoice.entity';
 import { Payment } from '../../database/entities/payment.entity';
@@ -16,6 +16,9 @@ import { PurchaseOrder } from '../../database/entities/purchase-order.entity';
 import { GoodsReceivedNote } from '../../database/entities/goods-received-note.entity';
 import { VendorPayment } from '../../database/entities/vendor-payment.entity';
 import { StockAdjustment } from '../../database/entities/stock-adjustment.entity';
+import { JournalEntry } from '../../database/entities/journal-entry.entity';
+import { Expense } from '../../database/entities/expense.entity';
+import { Settlement } from '../../database/entities/settlement.entity';
 import {
   UpdateCompanySettingsDto,
   CompanySettingsResponseDto,
@@ -42,8 +45,8 @@ export class SettingsService {
     private companySettingsRepository: Repository<CompanySettings>,
     @InjectRepository(PriceCostingSettings)
     private priceCostingSettingsRepository: Repository<PriceCostingSettings>,
-    @InjectRepository(DocumentNumberSettings)
-    private documentNumberSettingsRepository: Repository<DocumentNumberSettings>,
+    @InjectRepository(DocumentNumberSetting)
+    private documentNumberSettingRepository: Repository<DocumentNumberSetting>,
     @InjectRepository(SalesOrder)
     private salesOrderRepository: Repository<SalesOrder>,
     @InjectRepository(Invoice)
@@ -58,6 +61,12 @@ export class SettingsService {
     private vendorPaymentRepository: Repository<VendorPayment>,
     @InjectRepository(StockAdjustment)
     private stockAdjustmentRepository: Repository<StockAdjustment>,
+    @InjectRepository(JournalEntry)
+    private journalEntryRepository: Repository<JournalEntry>,
+    @InjectRepository(Expense)
+    private expenseRepository: Repository<Expense>,
+    @InjectRepository(Settlement)
+    private settlementRepository: Repository<Settlement>,
   ) {}
 
   /**
@@ -369,41 +378,20 @@ export class SettingsService {
    */
   async getDocumentNumberSettings(): Promise<DocumentNumberSettingsResponseDto> {
     try {
-      let settings = await this.documentNumberSettingsRepository.findOne({
-        where: { isActive: true },
+      let rows = await this.documentNumberSettingRepository.find({
+        order: { documentName: 'ASC' },
       });
 
-      let isNewSettings = false;
-      // Create default settings if none exist
-      if (!settings) {
-        settings = await this.createDefaultDocumentNumberSettings();
-        isNewSettings = true;
+      if (!rows.length) {
+        await this.createDefaultDocumentNumberSettings();
+        rows = await this.documentNumberSettingRepository.find({
+          order: { documentName: 'ASC' },
+        });
       }
 
-      // If this is newly created settings, sync with database
-      if (isNewSettings) {
-        this.logger.log('Syncing new document number settings with existing database records');
-        try {
-          await this.syncDocumentNumbersWithDatabase();
-          // Reload settings after sync
-          settings = await this.documentNumberSettingsRepository.findOne({
-            where: { isActive: true },
-          });
-        } catch (syncError) {
-          this.logger.error(
-            `Failed to sync document numbers: ${syncError.message}`,
-            syncError.stack,
-          );
-          // Continue even if sync fails, settings are still usable
-        }
-      }
-
-      return this.mapToDocumentNumberResponseDto(settings);
+      return { configurations: rows };
     } catch (error) {
-      this.logger.error(
-        `Failed to get document number settings: ${error.message}`,
-        error.stack,
-      );
+      this.logger.error(`Failed to get document number settings: ${error.message}`, error.stack);
       throw new InternalServerErrorException('Failed to retrieve document number settings');
     }
   }
@@ -416,33 +404,16 @@ export class SettingsService {
     updatedBy = 'system',
   ): Promise<DocumentNumberSettingsResponseDto> {
     try {
-      let settings = await this.documentNumberSettingsRepository.findOne({
-        where: { isActive: true },
-      });
-
-      if (!settings) {
-        // Create new settings if none exist
-        settings = this.documentNumberSettingsRepository.create({
-          configurations: updateDto.configurations,
-          isActive: true,
-        });
-      } else {
-        // Update existing settings
-        settings.configurations = updateDto.configurations;
+      for (const cfg of updateDto.configurations) {
+        await this.documentNumberSettingRepository.update(
+          { documentName: cfg.documentName },
+          { prefix: cfg.prefix, nextNumber: cfg.nextNumber },
+        );
       }
-
-      const savedSettings = await this.documentNumberSettingsRepository.save(settings);
-
-      this.logger.log(
-        `Document number settings updated by ${updatedBy}`,
-      );
-
-      return this.mapToDocumentNumberResponseDto(savedSettings);
+      this.logger.log(`Document number settings updated by ${updatedBy}`);
+      return this.getDocumentNumberSettings();
     } catch (error) {
-      this.logger.error(
-        `Failed to update document number settings: ${error.message}`,
-        error.stack,
-      );
+      this.logger.error(`Failed to update document number settings: ${error.message}`, error.stack);
       throw new InternalServerErrorException('Failed to update document number settings');
     }
   }
@@ -451,47 +422,29 @@ export class SettingsService {
    * Generate next document number for a specific document type
    */
   async generateDocumentNumber(documentName: string): Promise<string> {
-    try {
-      const settings = await this.documentNumberSettingsRepository.findOne({
-        where: { isActive: true },
-      });
+    const row = await this.documentNumberSettingRepository.findOne({
+      where: { documentName },
+    });
 
-      if (!settings || !settings.configurations) {
-        throw new NotFoundException('Document number settings not found');
-      }
-
-      // Find the configuration for this document type
-      const config = settings.configurations.find(
-        (c: any) => c.documentName === documentName,
-      );
-
-      if (!config) {
-        throw new NotFoundException(`Configuration for ${documentName} not found`);
-      }
-
-      // Generate the document number
-      const paddedNumber = String(config.nextNumber).padStart(config.numberFormat.length, '0');
-      const documentNumber = `${config.prefix}-${paddedNumber}`;
-
-      // Increment the next number
-      const updatedConfigs = settings.configurations.map((c: any) => {
-        if (c.documentName === documentName) {
-          return { ...c, nextNumber: c.nextNumber + 1 };
-        }
-        return c;
-      });
-
-      settings.configurations = updatedConfigs;
-      await this.documentNumberSettingsRepository.save(settings);
-
-      return documentNumber;
-    } catch (error) {
-      this.logger.error(
-        `Failed to generate document number: ${error.message}`,
-        error.stack,
-      );
-      throw error;
+    if (!row) {
+      throw new NotFoundException(`Document number config for '${documentName}' not found`);
     }
+
+    const currentYY = new Date().getFullYear() % 100;
+
+    if (row.lastResetYear !== currentYY) {
+      row.nextNumber = 1;
+      row.lastResetYear = currentYY;
+    }
+
+    const yy = String(currentYY).padStart(2, '0');
+    const seq = String(row.nextNumber).padStart(row.paddingDigits, '0');
+    const documentNumber = `${row.prefix}-${yy}-${seq}`;
+
+    row.nextNumber += 1;
+    await this.documentNumberSettingRepository.save(row);
+
+    return documentNumber;
   }
 
   /**
@@ -499,29 +452,18 @@ export class SettingsService {
    */
   async previewDocumentNumber(documentName: string): Promise<string> {
     try {
-      const settings = await this.documentNumberSettingsRepository.findOne({
-        where: { isActive: true },
+      const row = await this.documentNumberSettingRepository.findOne({
+        where: { documentName },
       });
 
-      if (!settings || !settings.configurations) {
-        return 'N/A';
-      }
+      if (!row) return 'N/A';
 
-      const config = settings.configurations.find(
-        (c: any) => c.documentName === documentName,
-      );
-
-      if (!config) {
-        return 'N/A';
-      }
-
-      const paddedNumber = String(config.nextNumber).padStart(config.numberFormat.length, '0');
-      return `${config.prefix}-${paddedNumber}`;
-    } catch (error) {
-      this.logger.error(
-        `Failed to preview document number: ${error.message}`,
-        error.stack,
-      );
+      const currentYY = new Date().getFullYear() % 100;
+      const nextNum = row.lastResetYear !== currentYY ? 1 : row.nextNumber;
+      const yy = String(currentYY).padStart(2, '0');
+      const seq = String(nextNum).padStart(row.paddingDigits, '0');
+      return `${row.prefix}-${yy}-${seq}`;
+    } catch {
       return 'N/A';
     }
   }
@@ -529,33 +471,37 @@ export class SettingsService {
   /**
    * Create default document number settings
    */
-  private async createDefaultDocumentNumberSettings(): Promise<DocumentNumberSettings> {
-    const defaultSettings = this.documentNumberSettingsRepository.create({
-      configurations: [
-        { documentName: 'Sales Orders', prefix: 'SO', numberFormat: '000001', nextNumber: 1 },
-        { documentName: 'Invoices', prefix: 'INV', numberFormat: '000001', nextNumber: 1 },
-        { documentName: 'Payments', prefix: 'PAY', numberFormat: '000001', nextNumber: 1 },
-        { documentName: 'Purchase Orders', prefix: 'PO', numberFormat: '000001', nextNumber: 1 },
-        { documentName: 'Goods Received', prefix: 'GRN', numberFormat: '000001', nextNumber: 1 },
-        { documentName: 'Vendor Payments', prefix: 'VP', numberFormat: '000001', nextNumber: 1 },
-        { documentName: 'Stock Adjustment', prefix: 'SA', numberFormat: '000001', nextNumber: 1 },
-      ],
-      isActive: true,
-    });
+  private async createDefaultDocumentNumberSettings(): Promise<void> {
+    const currentYY = new Date().getFullYear() % 100;
+    const defaults = [
+      { documentName: 'Sales Orders', prefix: 'SO' },
+      { documentName: 'Invoices', prefix: 'INV' },
+      { documentName: 'Payments', prefix: 'PAY' },
+      { documentName: 'Purchase Orders', prefix: 'PO' },
+      { documentName: 'Goods Received', prefix: 'GRN' },
+      { documentName: 'Vendor Payments', prefix: 'VP' },
+      { documentName: 'Stock Adjustment', prefix: 'SA' },
+      { documentName: 'Journal Entries', prefix: 'JE' },
+      { documentName: 'Expenses', prefix: 'EXP' },
+      { documentName: 'Settlements', prefix: 'STL' },
+    ];
 
-    const savedSettings = await this.documentNumberSettingsRepository.save(defaultSettings);
+    for (const d of defaults) {
+      const exists = await this.documentNumberSettingRepository.findOne({
+        where: { documentName: d.documentName },
+      });
+      if (!exists) {
+        await this.documentNumberSettingRepository.save(
+          this.documentNumberSettingRepository.create({
+            ...d,
+            paddingDigits: 3,
+            nextNumber: 1,
+            lastResetYear: currentYY,
+          }),
+        );
+      }
+    }
     this.logger.log('Default document number settings created');
-
-    return savedSettings;
-  }
-
-  /**
-   * Map entity to document number response DTO
-   */
-  private mapToDocumentNumberResponseDto(settings: DocumentNumberSettings): DocumentNumberSettingsResponseDto {
-    return plainToInstance(DocumentNumberSettingsResponseDto, settings, {
-      excludeExtraneousValues: true,
-    });
   }
 
   /**
@@ -564,170 +510,149 @@ export class SettingsService {
    */
   async syncDocumentNumbersWithDatabase(): Promise<void> {
     try {
-      let settings = await this.documentNumberSettingsRepository.findOne({
-        where: { isActive: true },
-      });
-
-      if (!settings) {
-        this.logger.warn('Document number settings not found, creating defaults');
-        settings = await this.createDefaultDocumentNumberSettings();
+      let rows = await this.documentNumberSettingRepository.find();
+      if (!rows.length) {
+        await this.createDefaultDocumentNumberSettings();
+        rows = await this.documentNumberSettingRepository.find();
       }
 
-      const updatedConfigs = await Promise.all(
-        settings.configurations.map(async (config: any) => {
-          let maxNumber = 0;
+      const currentYY = new Date().getFullYear() % 100;
+      const pattern = (prefix: string) => `${prefix}-${String(currentYY).padStart(2, '0')}-%`;
 
-          try {
-            switch (config.documentName) {
-              case 'Sales Orders': {
-                const result = await this.salesOrderRepository
-                  .createQueryBuilder('so')
-                  .select('so.orderNumber')
-                  .where("so.orderNumber LIKE :prefix", { prefix: `${config.prefix}-%` })
-                  .orderBy('so.orderNumber', 'DESC')
-                  .limit(1)
-                  .getOne();
-
-                if (result?.orderNumber) {
-                  const numPart = result.orderNumber.split('-')[1];
-                  maxNumber = parseInt(numPart, 10) || 0;
-                }
-                break;
-              }
-
-              case 'Invoices': {
-                const result = await this.invoiceRepository
-                  .createQueryBuilder('inv')
-                  .select('inv.invoiceNumber')
-                  .where("inv.invoiceNumber LIKE :prefix", { prefix: `${config.prefix}-%` })
-                  .orderBy('inv.invoiceNumber', 'DESC')
-                  .limit(1)
-                  .getOne();
-
-                if (result?.invoiceNumber) {
-                  const numPart = result.invoiceNumber.split('-')[1];
-                  maxNumber = parseInt(numPart, 10) || 0;
-                }
-                break;
-              }
-
-              case 'Payments': {
-                const result = await this.paymentRepository
-                  .createQueryBuilder('pay')
-                  .select('pay.paymentNumber')
-                  .where("pay.paymentNumber LIKE :prefix", { prefix: `${config.prefix}-%` })
-                  .orderBy('pay.paymentNumber', 'DESC')
-                  .limit(1)
-                  .getOne();
-
-                if (result?.paymentNumber) {
-                  const numPart = result.paymentNumber.split('-')[1];
-                  maxNumber = parseInt(numPart, 10) || 0;
-                }
-                break;
-              }
-
-              case 'Purchase Orders': {
-                const result = await this.purchaseOrderRepository
-                  .createQueryBuilder('po')
-                  .select('po.orderNumber')
-                  .where("po.orderNumber LIKE :prefix", { prefix: `${config.prefix}-%` })
-                  .orderBy('po.orderNumber', 'DESC')
-                  .limit(1)
-                  .getOne();
-
-                if (result?.orderNumber) {
-                  const numPart = result.orderNumber.split('-')[1];
-                  maxNumber = parseInt(numPart, 10) || 0;
-                }
-                break;
-              }
-
-              case 'Goods Received': {
-                const result = await this.goodsReceivedNoteRepository
-                  .createQueryBuilder('grn')
-                  .select('grn.grnNumber')
-                  .where("grn.grnNumber LIKE :prefix", { prefix: `${config.prefix}-%` })
-                  .orderBy('grn.grnNumber', 'DESC')
-                  .limit(1)
-                  .getOne();
-
-                if (result?.grnNumber) {
-                  const numPart = result.grnNumber.split('-')[1];
-                  maxNumber = parseInt(numPart, 10) || 0;
-                }
-                break;
-              }
-
-              case 'Vendor Payments': {
-                const result = await this.vendorPaymentRepository
-                  .createQueryBuilder('vp')
-                  .select('vp.paymentNumber')
-                  .where("vp.paymentNumber LIKE :prefix", { prefix: `${config.prefix}-%` })
-                  .orderBy('vp.paymentNumber', 'DESC')
-                  .limit(1)
-                  .getOne();
-
-                if (result?.paymentNumber) {
-                  const numPart = result.paymentNumber.split('-')[1];
-                  maxNumber = parseInt(numPart, 10) || 0;
-                }
-                break;
-              }
-
-              case 'Stock Adjustment': {
-                const result = await this.stockAdjustmentRepository
-                  .createQueryBuilder('sa')
-                  .select('sa.adjustmentNumber')
-                  .where("sa.adjustmentNumber LIKE :prefix", { prefix: `${config.prefix}-%` })
-                  .orderBy('sa.adjustmentNumber', 'DESC')
-                  .limit(1)
-                  .getOne();
-
-                if (result?.adjustmentNumber) {
-                  const numPart = result.adjustmentNumber.split('-')[1];
-                  maxNumber = parseInt(numPart, 10) || 0;
-                }
-                break;
-              }
-
-              default:
-                this.logger.warn(`Unknown document type: ${config.documentName}`);
+      for (const row of rows) {
+        let maxNumber = 0;
+        try {
+          switch (row.documentName) {
+            case 'Sales Orders': {
+              const r = await this.salesOrderRepository
+                .createQueryBuilder('so')
+                .select('so.orderNumber')
+                .where('so.orderNumber LIKE :p', { p: pattern(row.prefix) })
+                .orderBy('so.orderNumber', 'DESC')
+                .limit(1)
+                .getOne();
+              if (r?.orderNumber) maxNumber = parseInt(r.orderNumber.split('-')[2], 10) || 0;
+              break;
             }
-
-            // Update nextNumber to be max + 1
-            const nextNumber = maxNumber + 1;
-
-            this.logger.log(
-              `${config.documentName}: Found max number ${maxNumber}, setting nextNumber to ${nextNumber}`
-            );
-
-            return {
-              ...config,
-              nextNumber: nextNumber,
-            };
-          } catch (error) {
-            this.logger.error(
-              `Failed to sync ${config.documentName}: ${error.message}`,
-              error.stack,
-            );
-            // Keep original config if sync fails
-            return config;
+            case 'Invoices': {
+              const r = await this.invoiceRepository
+                .createQueryBuilder('inv')
+                .select('inv.invoiceNumber')
+                .where('inv.invoiceNumber LIKE :p', { p: pattern(row.prefix) })
+                .orderBy('inv.invoiceNumber', 'DESC')
+                .limit(1)
+                .getOne();
+              if (r?.invoiceNumber) maxNumber = parseInt(r.invoiceNumber.split('-')[2], 10) || 0;
+              break;
+            }
+            case 'Payments': {
+              const r = await this.paymentRepository
+                .createQueryBuilder('pay')
+                .select('pay.paymentNumber')
+                .where('pay.paymentNumber LIKE :p', { p: pattern(row.prefix) })
+                .orderBy('pay.paymentNumber', 'DESC')
+                .limit(1)
+                .getOne();
+              if (r?.paymentNumber) maxNumber = parseInt(r.paymentNumber.split('-')[2], 10) || 0;
+              break;
+            }
+            case 'Purchase Orders': {
+              const r = await this.purchaseOrderRepository
+                .createQueryBuilder('po')
+                .select('po.orderNumber')
+                .where('po.orderNumber LIKE :p', { p: pattern(row.prefix) })
+                .orderBy('po.orderNumber', 'DESC')
+                .limit(1)
+                .getOne();
+              if (r?.orderNumber) maxNumber = parseInt(r.orderNumber.split('-')[2], 10) || 0;
+              break;
+            }
+            case 'Goods Received': {
+              const r = await this.goodsReceivedNoteRepository
+                .createQueryBuilder('grn')
+                .select('grn.grnNumber')
+                .where('grn.grnNumber LIKE :p', { p: pattern(row.prefix) })
+                .orderBy('grn.grnNumber', 'DESC')
+                .limit(1)
+                .getOne();
+              if (r?.grnNumber) maxNumber = parseInt(r.grnNumber.split('-')[2], 10) || 0;
+              break;
+            }
+            case 'Vendor Payments': {
+              const r = await this.vendorPaymentRepository
+                .createQueryBuilder('vp')
+                .select('vp.paymentNumber')
+                .where('vp.paymentNumber LIKE :p', { p: pattern(row.prefix) })
+                .orderBy('vp.paymentNumber', 'DESC')
+                .limit(1)
+                .getOne();
+              if (r?.paymentNumber) maxNumber = parseInt(r.paymentNumber.split('-')[2], 10) || 0;
+              break;
+            }
+            case 'Stock Adjustment': {
+              const r = await this.stockAdjustmentRepository
+                .createQueryBuilder('sa')
+                .select('sa.adjustmentNumber')
+                .where('sa.adjustmentNumber LIKE :p', { p: pattern(row.prefix) })
+                .orderBy('sa.adjustmentNumber', 'DESC')
+                .limit(1)
+                .getOne();
+              if (r?.adjustmentNumber) {
+                maxNumber = parseInt(r.adjustmentNumber.split('-')[2], 10) || 0;
+              }
+              break;
+            }
+            case 'Journal Entries': {
+              const r = await this.journalEntryRepository
+                .createQueryBuilder('je')
+                .select('je.referenceNumber')
+                .where('je.referenceNumber LIKE :p', { p: pattern(row.prefix) })
+                .orderBy('je.referenceNumber', 'DESC')
+                .limit(1)
+                .getOne();
+              if (r?.referenceNumber) maxNumber = parseInt(r.referenceNumber.split('-')[2], 10) || 0;
+              break;
+            }
+            case 'Expenses': {
+              const r = await this.expenseRepository
+                .createQueryBuilder('exp')
+                .select('exp.referenceNumber')
+                .where('exp.referenceNumber LIKE :p', { p: pattern(row.prefix) })
+                .orderBy('exp.referenceNumber', 'DESC')
+                .limit(1)
+                .getOne();
+              if (r?.referenceNumber) maxNumber = parseInt(r.referenceNumber.split('-')[2], 10) || 0;
+              break;
+            }
+            case 'Settlements': {
+              const r = await this.settlementRepository
+                .createQueryBuilder('stl')
+                .select('stl.settlementNumber')
+                .where('stl.settlementNumber LIKE :p', { p: pattern(row.prefix) })
+                .orderBy('stl.settlementNumber', 'DESC')
+                .limit(1)
+                .getOne();
+              if (r?.settlementNumber) maxNumber = parseInt(r.settlementNumber.split('-')[2], 10) || 0;
+              break;
+            }
+            default:
+              this.logger.warn(`Unknown document type in sync: ${row.documentName}`);
           }
-        }),
-      );
 
-      // Save updated settings
-      settings.configurations = updatedConfigs;
-      await this.documentNumberSettingsRepository.save(settings);
+          await this.documentNumberSettingRepository.update(
+            { documentName: row.documentName },
+            { nextNumber: maxNumber + 1, lastResetYear: currentYY },
+          );
+          this.logger.log(`${row.documentName}: synced nextNumber to ${maxNumber + 1}`);
+        } catch (err) {
+          this.logger.error(`Failed to sync ${row.documentName}: ${err.message}`, err.stack);
+        }
+      }
 
       this.logger.log('Document number settings synchronized with database');
     } catch (error) {
-      this.logger.error(
-        `Failed to sync document numbers with database: ${error.message}`,
-        error.stack,
-      );
-      throw new InternalServerErrorException('Failed to sync document number settings');
+      this.logger.error(`Failed to sync document numbers: ${error.message}`, error.stack);
+      throw new InternalServerErrorException('Failed to sync document numbers');
     }
   }
 }

--- a/docs/plans/2026-03-03-document-numbers-implementation.md
+++ b/docs/plans/2026-03-03-document-numbers-implementation.md
@@ -2,9 +2,9 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Replace the JSONB document number settings with a normalized per-row table, adopt `PREFIX-YY-NNN` format across all 10 document types, and integrate accounting module documents (Journal Entries, Expenses, Settlements).
+**Goal:** Replace the JSONB document number settings with a normalized per-row table, adopt `PREFIX-YY-NNN` format across all 11 document types, and integrate accounting module documents (Journal Entries, Expenses, Settlements, Owner Equity).
 
-**Architecture:** The `document_number_settings` table is rewritten from a single-row JSONB design to one row per document type. A TypeORM migration drops/recreates the table and seeds 10 default rows. All number generation goes through `SettingsService.generateDocumentNumber()` which auto-injects the current 2-digit year and resets sequence per-year. Accounting services import `SettingsModule` and call `generateDocumentNumber()` instead of their own hardcoded logic.
+**Architecture:** The `document_number_settings` table is rewritten from a single-row JSONB design to one row per document type. A TypeORM migration drops/recreates the table and seeds 11 default rows. All number generation goes through `SettingsService.generateDocumentNumber()` which auto-injects the current 2-digit year and resets sequence per-year. Accounting services use `SettingsModule` (already imported in `AccountingModule`) and call `generateDocumentNumber()` instead of their own hardcoded logic.
 
 **Tech Stack:** NestJS 11, TypeORM, PostgreSQL, React 18, Material-UI v7, Vitest (frontend tests), Jest (backend tests)
 
@@ -88,7 +88,7 @@ export class NormalizeDocumentNumberSettings1772100000000 implements MigrationIn
       )
     `);
 
-    // Seed the 10 default rows — use current 2-digit year
+    // Seed the 11 default rows — use current 2-digit year
     const currentYear = new Date().getFullYear() % 100;
     const defaults = [
       { name: 'Sales Orders',     prefix: 'SO'  },
@@ -101,6 +101,7 @@ export class NormalizeDocumentNumberSettings1772100000000 implements MigrationIn
       { name: 'Journal Entries',  prefix: 'JE'  },
       { name: 'Expenses',         prefix: 'EXP' },
       { name: 'Settlements',      prefix: 'STL' },
+      { name: 'Owner Equity',     prefix: 'EQ'  },
     ];
 
     for (const row of defaults) {
@@ -281,6 +282,8 @@ private journalEntryRepository: Repository<JournalEntry>,
 private expenseRepository: Repository<Expense>,
 @InjectRepository(Settlement)
 private settlementRepository: Repository<Settlement>,
+@InjectRepository(OwnerEquityTransaction)
+private ownerEquityRepository: Repository<OwnerEquityTransaction>,
 ```
 
 Add imports at top of file:
@@ -288,6 +291,7 @@ Add imports at top of file:
 import { JournalEntry } from '../../database/entities/journal-entry.entity';
 import { Expense } from '../../database/entities/expense.entity';
 import { Settlement } from '../../database/entities/settlement.entity';
+import { OwnerEquityTransaction } from '../../database/entities/owner-equity-transaction.entity';
 ```
 
 **Step 3: Replace `getDocumentNumberSettings()` (lines 370-409)**
@@ -406,6 +410,7 @@ private async createDefaultDocumentNumberSettings(): Promise<void> {
     { documentName: 'Journal Entries',  prefix: 'JE'  },
     { documentName: 'Expenses',         prefix: 'EXP' },
     { documentName: 'Settlements',      prefix: 'STL' },
+    { documentName: 'Owner Equity',     prefix: 'EQ'  },
   ];
 
   for (const d of defaults) {
@@ -534,6 +539,15 @@ async syncDocumentNumbersWithDatabase(): Promise<void> {
             if (r?.settlementNumber) maxNumber = parseInt(r.settlementNumber.split('-')[2], 10) || 0;
             break;
           }
+          case 'Owner Equity': {
+            const r = await this.ownerEquityRepository
+              .createQueryBuilder('eq')
+              .select('eq.referenceNumber')
+              .where('eq.referenceNumber LIKE :p', { p: pattern(row.prefix) })
+              .orderBy('eq.referenceNumber', 'DESC').limit(1).getOne();
+            if (r?.referenceNumber) maxNumber = parseInt(r.referenceNumber.split('-')[2], 10) || 0;
+            break;
+          }
           default:
             this.logger.warn(`Unknown document type in sync: ${row.documentName}`);
         }
@@ -587,6 +601,7 @@ After line 20 (`Settlement` import), add:
 ```typescript
 import { JournalEntry } from '../../database/entities/journal-entry.entity';
 import { Expense } from '../../database/entities/expense.entity';
+import { OwnerEquityTransaction } from '../../database/entities/owner-equity-transaction.entity';
 ```
 
 (Note: `Settlement` is already imported at line 20.)
@@ -611,6 +626,7 @@ TypeOrmModule.forFeature([
   ChartOfAccount,
   JournalEntry,               // new
   Expense,                    // new
+  OwnerEquityTransaction,     // new
 ]),
 ```
 
@@ -890,26 +906,101 @@ git commit -m "feat(accounting): replace hardcoded STL numbering with SettingsSe
 
 ---
 
-## Task 12: Import SettingsModule into AccountingModule
+## Task 12: Remove Hardcoded Numbering from OwnerEquityService
 
 **Files:**
-- Modify: `backend/src/modules/accounting/accounting.module.ts`
+- Modify: `backend/src/modules/accounting/services/owner-equity.service.ts`
+- Modify: `backend/src/database/entities/owner-equity-transaction.entity.ts`
 
-**Step 1: Add SettingsModule import**
+Note: `SettingsModule` is **already imported** in `AccountingModule` — no module change needed.
 
-Add at top of file:
+**Step 1: Add SettingsService import to owner-equity.service.ts**
+
+At the top of the file, after existing imports, add:
+```typescript
+import { SettingsService } from '../../settings/settings.service';
+```
+
+**Step 2: Add SettingsService to constructor**
+
+In the constructor, after the last existing injected service, add:
+```typescript
+private readonly settingsService: SettingsService,
+```
+
+**Step 3: Update `create()` — generate referenceNumber before `ownerEquityRepository.create()`**
+
+```typescript
+// Before
+const transaction = this.ownerEquityRepository.create({
+  transactionDate: new Date(dto.transactionDate),
+  type: dto.type,
+  amount: dto.amount,
+  paymentMethodId: dto.paymentMethodId,
+  description: dto.description,
+  status: OwnerEquityTransactionStatus.DRAFT,
+});
+
+// After
+const referenceNumber = await this.settingsService.generateDocumentNumber('Owner Equity');
+
+const transaction = this.ownerEquityRepository.create({
+  referenceNumber,
+  transactionDate: new Date(dto.transactionDate),
+  type: dto.type,
+  amount: dto.amount,
+  paymentMethodId: dto.paymentMethodId,
+  description: dto.description,
+  status: OwnerEquityTransactionStatus.DRAFT,
+});
+```
+
+**Step 4: Remove `@BeforeInsert` hook from owner-equity-transaction.entity.ts**
+
+Remove lines 86–92:
+```typescript
+// Remove this entire block
+@BeforeInsert()
+generateReferenceNumber() {
+  if (!this.referenceNumber) {
+    const timestamp = Date.now().toString(36).toUpperCase();
+    this.referenceNumber = `EQ-${timestamp}`;
+  }
+}
+```
+
+Also remove `BeforeInsert` from the TypeORM imports on line 7 since it is no longer used.
+
+**Step 5: Commit**
+
+```bash
+git add backend/src/modules/accounting/services/owner-equity.service.ts
+git add backend/src/database/entities/owner-equity-transaction.entity.ts
+git commit -m "feat(accounting): replace hardcoded EQ numbering with SettingsService"
+```
+
+---
+
+## Task 13: Verify AccountingModule Already Has SettingsModule
+
+**Files:**
+- Check: `backend/src/modules/accounting/accounting.module.ts`
+
+**Step 1: Confirm SettingsModule is imported**
+
+```bash
+grep -n "SettingsModule" backend/src/modules/accounting/accounting.module.ts
+```
+
+Expected output: a line showing `SettingsModule` in the imports array. If it is present, no change needed — skip to next task.
+
+**Step 2: If NOT present** (fallback only), add the import:
+
 ```typescript
 import { SettingsModule } from '../settings/settings.module';
 ```
 
-**Step 2: Add to `imports` array** (line 42, after `TypeOrmModule.forFeature([...])`)
-
-```typescript
-imports: [
-  TypeOrmModule.forFeature([...]),
-  SettingsModule,    // add this
-],
-```
+And add `SettingsModule` to the `imports` array.
 
 **Step 3: Run TypeScript check**
 
@@ -919,7 +1010,7 @@ cd backend && npx tsc --noEmit 2>&1 | head -40
 
 Fix any errors.
 
-**Step 4: Commit**
+**Step 4: Commit only if changed**
 
 ```bash
 git add backend/src/modules/accounting/accounting.module.ts
@@ -928,7 +1019,7 @@ git commit -m "feat(accounting): import SettingsModule for document number gener
 
 ---
 
-## Task 13: Backend Integration — Run Tests
+## Task 14: Backend Integration — Run Tests
 
 **Step 1: Run all backend tests**
 
@@ -955,7 +1046,7 @@ git commit -m "fix(settings): resolve type errors after document number refactor
 
 ---
 
-## Task 14: Update Frontend Types
+## Task 15: Update Frontend Types
 
 **Files:**
 - Modify: `frontend/src/services/settingsApi.ts`
@@ -996,7 +1087,7 @@ git commit -m "feat(frontend): update DocumentNumberConfig type for normalized s
 
 ---
 
-## Task 15: Update DocumentNumbersPage
+## Task 16: Update DocumentNumbersPage
 
 **Files:**
 - Modify: `frontend/src/pages/settings/DocumentNumbersPage.tsx`
@@ -1084,7 +1175,7 @@ const MODULE_GROUPS: Record<string, string[]> = {
   Sales: ['Sales Orders', 'Invoices', 'Payments'],
   Purchasing: ['Purchase Orders', 'Goods Received', 'Vendor Payments'],
   Inventory: ['Stock Adjustment'],
-  Accounting: ['Journal Entries', 'Expenses', 'Settlements'],
+  Accounting: ['Journal Entries', 'Expenses', 'Settlements', 'Owner Equity'],
 }
 ```
 
@@ -1184,7 +1275,7 @@ git commit -m "feat(frontend): update DocumentNumbersPage for PREFIX-YY-NNN form
 
 ---
 
-## Task 16: Frontend Tests
+## Task 17: Frontend Tests
 
 **Step 1: Run frontend tests**
 
@@ -1217,7 +1308,7 @@ git commit -m "fix(frontend): update document number tests for new format"
 
 ---
 
-## Task 17: End-to-End Verification
+## Task 18: End-to-End Verification
 
 **Step 1: Start the backend in dev mode**
 
@@ -1235,7 +1326,7 @@ docker exec -it erp2-postgres-1 psql -U postgres -d erp2 -c "\d document_number_
 docker exec -it erp2-postgres-1 psql -U postgres -d erp2 -c "SELECT document_name, prefix, next_number, last_reset_year FROM document_number_settings ORDER BY document_name"
 ```
 
-Expected: 10 rows with correct prefixes.
+Expected: 11 rows with correct prefixes.
 
 **Step 3: Test the GET endpoint**
 
@@ -1243,7 +1334,7 @@ Expected: 10 rows with correct prefixes.
 curl -s -H "Authorization: Bearer <token>" http://localhost:3000/settings/document-numbers | jq .
 ```
 
-Expected: array of 10 configs with `paddingDigits`, `nextNumber`, `lastResetYear`.
+Expected: array of 11 configs with `paddingDigits`, `nextNumber`, `lastResetYear`.
 
 **Step 4: Test number generation**
 

--- a/docs/plans/2026-03-03-document-numbers-overhaul-design.md
+++ b/docs/plans/2026-03-03-document-numbers-overhaul-design.md
@@ -22,7 +22,7 @@ All documents use: `PREFIX-YY-NNN`
 
 **Examples:** `SO-26-001`, `JE-26-042`, `EXP-26-1001`
 
-## Document Types (10 total)
+## Document Types (11 total)
 
 | Module      | Document Name    | Default Prefix |
 |-------------|------------------|----------------|
@@ -36,6 +36,7 @@ All documents use: `PREFIX-YY-NNN`
 | Accounting  | Journal Entries  | `JE`           |
 | Accounting  | Expenses         | `EXP`          |
 | Accounting  | Settlements      | `STL`          |
+| Accounting  | Owner Equity     | `EQ`           |
 
 ## Database Schema
 
@@ -97,7 +98,7 @@ Sequence auto-expands past 999 — no upper limit enforced.
 TypeORM migration file that:
 1. Drops the old `document_number_settings` table
 2. Creates the new normalized table
-3. Seeds all 10 default rows with `nextNumber: 1` and `lastResetYear: currentYY`
+3. Seeds all 11 default rows with `nextNumber: 1` and `lastResetYear: currentYY`
 
 Existing document numbers in other tables (e.g. `sales_orders.order_number`) are unaffected. The sync endpoint `POST /settings/document-numbers/sync` can be called post-deploy to align `nextNumber` from existing records.
 
@@ -111,8 +112,8 @@ Existing document numbers in other tables (e.g. `sales_orders.order_number`) are
 ### `settings.service.ts`
 - `generateDocumentNumber()`: year-reset logic + `PREFIX-YY-NNN` format
 - `previewDocumentNumber()`: same format, no increment
-- `createDefaultDocumentNumberSettings()`: seed 10 rows
-- `syncDocumentNumbersWithDatabase()`: simplified per-row updates, add cases for Journal Entries, Expenses, Settlements
+- `createDefaultDocumentNumberSettings()`: seed 11 rows
+- `syncDocumentNumbersWithDatabase()`: simplified per-row updates, add cases for Journal Entries, Expenses, Settlements, Owner Equity
 - Remove JSONB array manipulation throughout
 
 ### `document-number-settings.dto.ts`
@@ -144,12 +145,20 @@ Existing document numbers in other tables (e.g. `sales_orders.order_number`) are
 - Inject `SettingsService`
 - Call `settingsService.generateDocumentNumber('Settlements')` on create
 
+### `owner-equity-transaction.entity.ts`
+- Remove `@BeforeInsert() generateReferenceNumber()` hook
+- Remove `BeforeInsert` from TypeORM imports
+
+### `owner-equity.service.ts`
+- Inject `SettingsService` (already available — `SettingsModule` is imported in `AccountingModule`)
+- In `create()`, generate `referenceNumber` via `settingsService.generateDocumentNumber('Owner Equity')` before `ownerEquityRepository.create()`
+
 ### `vendor-payment.service.ts`
 - Remove hardcoded `generatePaymentNumber()` method
 - Call `settingsService.generateDocumentNumber('Vendor Payments')` on create
 
 ### `accounting.module.ts`
-- Import `SettingsModule` to make `SettingsService` injectable
+- `SettingsModule` already imported — no change needed
 
 ## Frontend Changes
 
@@ -157,6 +166,7 @@ Existing document numbers in other tables (e.g. `sales_orders.order_number`) are
 - Remove **Number Format** column (padding fixed at 3, not user-editable)
 - Update **Preview** column: shows `PREFIX-YY-NNN` using current year
 - Add module section headers: Sales, Purchasing, Inventory, Accounting
+- Accounting group includes: Journal Entries, Expenses, Settlements, **Owner Equity**
 - Update description text to explain `PREFIX-YY-NNN` format
 
 ### `settingsApi.ts`
@@ -178,8 +188,10 @@ Existing document numbers in other tables (e.g. `sales_orders.order_number`) are
 | `backend/src/database/entities/expense.entity.ts` | Remove BeforeInsert hook |
 | `backend/src/modules/accounting/services/settlement.service.ts` | Add SettingsService |
 | `backend/src/database/entities/settlement.entity.ts` | Remove BeforeInsert hook |
+| `backend/src/modules/accounting/services/owner-equity.service.ts` | Add SettingsService |
+| `backend/src/database/entities/owner-equity-transaction.entity.ts` | Remove BeforeInsert hook |
 | `backend/src/modules/purchasing/services/vendor-payment.service.ts` | Remove hardcoded numbering |
-| `backend/src/modules/accounting/accounting.module.ts` | Import SettingsModule |
+| `backend/src/modules/accounting/accounting.module.ts` | No change (SettingsModule already imported) |
 | `backend/src/database/migrations/XXXXXX-NormalizeDocumentNumberSettings.ts` | New migration |
 | `frontend/src/pages/settings/DocumentNumbersPage.tsx` | Update UI |
 | `frontend/src/services/settingsApi.ts` | Update types |

--- a/frontend/src/pages/settings/DocumentNumbersPage.tsx
+++ b/frontend/src/pages/settings/DocumentNumbersPage.tsx
@@ -26,7 +26,7 @@ const MODULE_GROUPS: Record<string, string[]> = {
   Sales: ['Sales Orders', 'Invoices', 'Payments'],
   Purchasing: ['Purchase Orders', 'Goods Received', 'Vendor Payments'],
   Inventory: ['Stock Adjustment'],
-  Accounting: ['Journal Entries', 'Expenses', 'Settlements'],
+  Accounting: ['Journal Entries', 'Expenses', 'Settlements', 'Owner Equity'],
 }
 
 const DocumentNumbersPage: React.FC = () => {

--- a/frontend/src/pages/settings/DocumentNumbersPage.tsx
+++ b/frontend/src/pages/settings/DocumentNumbersPage.tsx
@@ -22,6 +22,13 @@ import { useNotification } from '@/hooks/useNotification'
 import { settingsApi, type DocumentNumberConfig } from '@/services/settingsApi'
 import { TYPOGRAPHY_STYLES } from '@/constants/typography'
 
+const MODULE_GROUPS: Record<string, string[]> = {
+  Sales: ['Sales Orders', 'Invoices', 'Payments'],
+  Purchasing: ['Purchase Orders', 'Goods Received', 'Vendor Payments'],
+  Inventory: ['Stock Adjustment'],
+  Accounting: ['Journal Entries', 'Expenses', 'Settlements'],
+}
+
 const DocumentNumbersPage: React.FC = () => {
   const { showSuccess, showError } = useNotification()
   const [loading, setLoading] = useState(true)
@@ -35,11 +42,11 @@ const DocumentNumbersPage: React.FC = () => {
   }, [])
 
   useEffect(() => {
-    // Update previews whenever configurations change
+    const currentYY = String(new Date().getFullYear() % 100).padStart(2, '0')
     const newPreviews: Record<string, string> = {}
     configurations.forEach((config) => {
-      const paddedNumber = String(config.nextNumber).padStart(config.numberFormat.length, '0')
-      newPreviews[config.documentName] = `${config.prefix}-${paddedNumber}`
+      const seq = String(config.nextNumber).padStart(config.paddingDigits, '0')
+      newPreviews[config.documentName] = `${config.prefix}-${currentYY}-${seq}`
     })
     setPreviews(newPreviews)
   }, [configurations])
@@ -65,7 +72,7 @@ const DocumentNumbersPage: React.FC = () => {
 
   const handleConfigChange = (
     index: number,
-    field: keyof DocumentNumberConfig,
+    field: 'prefix' | 'nextNumber',
     value: string | number
   ) => {
     const newConfigurations = [...configurations]
@@ -83,7 +90,7 @@ const DocumentNumbersPage: React.FC = () => {
 
       // Validate configurations
       for (const config of configurations) {
-        if (!config.prefix || !config.numberFormat || config.nextNumber < 1) {
+        if (!config.prefix || config.nextNumber < 1) {
           showError('Please fill in all fields with valid values')
           return
         }
@@ -129,83 +136,91 @@ const DocumentNumbersPage: React.FC = () => {
       )}
       <Paper sx={{ p: 4 }}>
         <Typography variant="body2" sx={{ color: 'text.secondary', mb: 1 }}>
-          Configure document numbering patterns for various business documents. The system will automatically
-          generate sequential document numbers based on your settings.
+          Configure document number prefixes for all business documents. Numbers are generated in the format
+          <strong> PREFIX-YY-NNN</strong> (e.g. SO-26-001), where YY is the current year and the sequence resets each year.
         </Typography>
         <Typography variant="body2" sx={{ color: 'text.secondary', mb: 3, fontStyle: 'italic' }}>
-          Note: Use zeros to define the number format length (e.g., 000001 for 6-digit numbers).
+          Note: The sequence auto-expands past 999 (e.g. SO-26-1000). Use the Sync button after changing prefixes.
         </Typography>
 
         <TableContainer>
           <Table>
             <TableHead>
               <TableRow>
-                <TableCell sx={{ fontWeight: 600, width: '25%' }}>Document Name</TableCell>
-                <TableCell sx={{ fontWeight: 600, width: '20%' }}>Prefix</TableCell>
-                <TableCell sx={{ fontWeight: 600, width: '20%' }}>Number Format</TableCell>
-                <TableCell sx={{ fontWeight: 600, width: '15%' }}>Next Number</TableCell>
-                <TableCell sx={{ fontWeight: 600, width: '20%' }}>Preview</TableCell>
+                <TableCell sx={{ fontWeight: 600, width: '30%' }}>Document Name</TableCell>
+                <TableCell sx={{ fontWeight: 600, width: '25%' }}>Prefix</TableCell>
+                <TableCell sx={{ fontWeight: 600, width: '20%' }}>Next Number</TableCell>
+                <TableCell sx={{ fontWeight: 600, width: '25%' }}>Preview</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
-              {configurations.map((config, index) => (
-                <TableRow key={config.documentName}>
-                  <TableCell>
-                    <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                      {config.documentName}
-                    </Typography>
-                  </TableCell>
-                  <TableCell>
-                    <TextField
-                      value={config.prefix}
-                      onChange={(e) => handleConfigChange(index, 'prefix', e.target.value.toUpperCase())}
-                      size="small"
-                      fullWidth
-                      inputProps={{ maxLength: 10 }}
-                    />
-                  </TableCell>
-                  <TableCell>
-                    <TextField
-                      value={config.numberFormat}
-                      onChange={(e) => {
-                        // Only allow numbers (zeros)
-                        const value = e.target.value.replace(/[^0]/g, '0')
-                        if (value.length <= 10) {
-                          handleConfigChange(index, 'numberFormat', value)
-                        }
-                      }}
-                      size="small"
-                      fullWidth
-                      placeholder="000001"
-                    />
-                  </TableCell>
-                  <TableCell>
-                    <TextField
-                      type="number"
-                      value={config.nextNumber}
-                      onChange={(e) => handleConfigChange(index, 'nextNumber', e.target.value)}
-                      size="small"
-                      fullWidth
-                      inputProps={{ min: 1 }}
-                    />
-                  </TableCell>
-                  <TableCell>
-                    <Typography
-                      variant="body2"
+              {Object.entries(MODULE_GROUPS).map(([module, docNames]) => (
+                <React.Fragment key={module}>
+                  <TableRow>
+                    <TableCell
+                      colSpan={4}
                       sx={{
-                        fontFamily: 'monospace',
-                        color: 'primary.main',
-                        fontWeight: 600,
                         backgroundColor: 'action.hover',
-                        px: 2,
+                        fontWeight: 700,
                         py: 1,
-                        borderRadius: 1,
+                        fontSize: '0.75rem',
+                        textTransform: 'uppercase',
+                        letterSpacing: 1,
                       }}
                     >
-                      {previews[config.documentName] || 'N/A'}
-                    </Typography>
-                  </TableCell>
-                </TableRow>
+                      {module}
+                    </TableCell>
+                  </TableRow>
+                  {docNames.map((docName) => {
+                    const index = configurations.findIndex((c) => c.documentName === docName)
+                    if (index === -1) return null
+                    const config = configurations[index]
+                    return (
+                      <TableRow key={config.documentName}>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                            {config.documentName}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <TextField
+                            value={config.prefix}
+                            onChange={(e) => handleConfigChange(index, 'prefix', e.target.value.toUpperCase())}
+                            size="small"
+                            fullWidth
+                            inputProps={{ maxLength: 10 }}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <TextField
+                            type="number"
+                            value={config.nextNumber}
+                            onChange={(e) => handleConfigChange(index, 'nextNumber', e.target.value)}
+                            size="small"
+                            fullWidth
+                            inputProps={{ min: 1 }}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              fontFamily: 'monospace',
+                              color: 'primary.main',
+                              fontWeight: 600,
+                              backgroundColor: 'action.hover',
+                              px: 2,
+                              py: 1,
+                              borderRadius: 1,
+                            }}
+                          >
+                            {previews[config.documentName] || 'N/A'}
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+                </React.Fragment>
               ))}
             </TableBody>
           </Table>

--- a/frontend/src/services/settingsApi.ts
+++ b/frontend/src/services/settingsApi.ts
@@ -53,15 +53,13 @@ interface UpdatePriceCostingSettingsDto {
 export interface DocumentNumberConfig {
   documentName: string
   prefix: string
-  numberFormat: string
+  paddingDigits: number
   nextNumber: number
+  lastResetYear: number
 }
 
 interface DocumentNumberSettings {
-  id: string
   configurations: DocumentNumberConfig[]
-  createdAt: string
-  updatedAt: string
 }
 
 interface UpdateDocumentNumberSettingsDto {


### PR DESCRIPTION
## Summary

- Implement document number normalization with `PREFIX-YY-NNN` format (e.g. `SO-26-001`) across all 11 document types
- Add owner equity (EQ) as the 11th document type with full seed migration and settings integration
- Fix Docker production image by removing npm/npx from runtime; fix migration to use camelCase column names matching BaseEntity conventions

## Test Plan
- [x] All 503 backend unit tests pass
- [x] Document numbers generate correctly in `PREFIX-YY-NNN` format for each document type
- [x] Owner Equity (EQ) document number appears in settings and seeds correctly
- [x] Migrations compile cleanly (TypeScript 0 errors, all migration files load without errors)
- [x] Docker production image removes npm/npx at build stage (runtime uses `node dist/main` directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)