### PR TITLE
feat(audit-logs): fix user identity in audit logs — replace 'system' with real usernames

### DIFF
--- a/backend/src/modules/accounting/accounting.module.ts
+++ b/backend/src/modules/accounting/accounting.module.ts
@@ -38,6 +38,7 @@ import { SettlementController } from './controllers/settlement.controller';
 import { OwnerEquityController } from './controllers/owner-equity.controller';
 import { ExpenseController } from './controllers/expense.controller';
 import { SettingsModule } from '../settings/settings.module';
+import { AuditLogsModule } from '../audit-logs/audit-logs.module';
 
 @Module({
   imports: [
@@ -56,6 +57,7 @@ import { SettingsModule } from '../settings/settings.module';
       Expense,
     ]),
     SettingsModule,
+    AuditLogsModule,
   ],
   controllers: [
     ChartOfAccountsController,

--- a/backend/src/modules/accounting/controllers/account-mapping.controller.ts
+++ b/backend/src/modules/accounting/controllers/account-mapping.controller.ts
@@ -13,6 +13,7 @@ import {
 import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { AccountMappingService } from '../services/account-mapping.service';
 import { Auth } from '../../auth/decorators/auth.decorator';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { UserRole } from '../../../database/entities/user.entity';
 import {
   CreateAccountMappingDto,
@@ -80,8 +81,10 @@ export class AccountMappingController {
   @ApiResponse({ status: 409, description: 'Mapping type already exists' })
   async create(
     @Body() createDto: CreateAccountMappingDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<AccountMappingResponseDto> {
-    return this.accountMappingService.create(createDto);
+    return this.accountMappingService.create(createDto, currentUserId, currentUsername);
   }
 
   @Patch(':id')
@@ -97,8 +100,10 @@ export class AccountMappingController {
   async update(
     @Param('id') id: string,
     @Body() updateDto: UpdateAccountMappingDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<AccountMappingResponseDto> {
-    return this.accountMappingService.update(id, updateDto);
+    return this.accountMappingService.update(id, updateDto, currentUserId, currentUsername);
   }
 
   @Delete(':id')
@@ -108,7 +113,11 @@ export class AccountMappingController {
   @ApiParam({ name: 'id', description: 'Mapping ID' })
   @ApiResponse({ status: 204, description: 'Mapping deleted successfully' })
   @ApiResponse({ status: 404, description: 'Mapping not found' })
-  async remove(@Param('id') id: string): Promise<void> {
-    await this.accountMappingService.remove(id);
+  async remove(
+    @Param('id') id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<void> {
+    await this.accountMappingService.remove(id, currentUserId, currentUsername);
   }
 }

--- a/backend/src/modules/accounting/controllers/chart-of-accounts.controller.ts
+++ b/backend/src/modules/accounting/controllers/chart-of-accounts.controller.ts
@@ -263,8 +263,11 @@ export class ChartOfAccountsController {
     status: 400,
     description: 'Chart of accounts already seeded',
   })
-  async seedDefaults(): Promise<{ message: string }> {
-    await this.chartOfAccountsService.seedDefaultChartOfAccounts();
+  async seedDefaults(
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<{ message: string }> {
+    await this.chartOfAccountsService.seedDefaultChartOfAccounts(currentUserId, currentUsername);
     return {
       message:
         'Default chart of accounts seeded successfully with 30+ accounts',

--- a/backend/src/modules/accounting/controllers/chart-of-accounts.controller.ts
+++ b/backend/src/modules/accounting/controllers/chart-of-accounts.controller.ts
@@ -13,6 +13,7 @@ import {
 import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { ChartOfAccountsService } from '../services/chart-of-accounts.service';
 import { Auth } from '../../auth/decorators/auth.decorator';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { UserRole } from '../../../database/entities/user.entity';
 import {
   CreateChartOfAccountDto,
@@ -108,8 +109,10 @@ export class ChartOfAccountsController {
   @ApiResponse({ status: 409, description: 'Account code already exists' })
   async create(
     @Body() createDto: CreateChartOfAccountDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<ChartOfAccountResponseDto> {
-    return this.chartOfAccountsService.create(createDto);
+    return this.chartOfAccountsService.create(createDto, currentUserId, currentUsername);
   }
 
   @Patch(':id')
@@ -130,8 +133,10 @@ export class ChartOfAccountsController {
   async update(
     @Param('id') id: string,
     @Body() updateDto: UpdateChartOfAccountDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<ChartOfAccountResponseDto> {
-    return this.chartOfAccountsService.update(id, updateDto);
+    return this.chartOfAccountsService.update(id, updateDto, currentUserId, currentUsername);
   }
 
   @Delete('bulk-permanent')
@@ -144,6 +149,8 @@ export class ChartOfAccountsController {
   })
   async bulkPermanentDelete(
     @Body() body: BulkChartOfAccountsDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{
     message: string;
     deletedCount: number;
@@ -152,6 +159,8 @@ export class ChartOfAccountsController {
   }> {
     const result = await this.chartOfAccountsService.bulkPermanentDelete(
       body.accountIds,
+      currentUserId,
+      currentUsername,
     );
     return {
       message: `Successfully deleted ${result.deletedCount} of ${body.accountIds.length} accounts`,
@@ -172,8 +181,12 @@ export class ChartOfAccountsController {
     description: 'Account has children or journal entry lines',
   })
   @ApiResponse({ status: 404, description: 'Account not found' })
-  async remove(@Param('id') id: string): Promise<void> {
-    await this.chartOfAccountsService.remove(id);
+  async remove(
+    @Param('id') id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<void> {
+    await this.chartOfAccountsService.remove(id, currentUserId, currentUsername);
   }
 
   @Delete(':id/permanent')
@@ -187,8 +200,12 @@ export class ChartOfAccountsController {
     description: 'Account has children, journal entry lines, or is not soft-deleted',
   })
   @ApiResponse({ status: 404, description: 'Account not found' })
-  async permanentDelete(@Param('id') id: string): Promise<void> {
-    await this.chartOfAccountsService.permanentDelete(id);
+  async permanentDelete(
+    @Param('id') id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<void> {
+    await this.chartOfAccountsService.permanentDelete(id, currentUserId, currentUsername);
   }
 
   @Post(':id/restore')
@@ -203,8 +220,12 @@ export class ChartOfAccountsController {
   @ApiResponse({ status: 400, description: 'Account is not deleted' })
   @ApiResponse({ status: 404, description: 'Account not found' })
   @ApiResponse({ status: 409, description: 'Account code now used by another account' })
-  async restore(@Param('id') id: string): Promise<ChartOfAccountResponseDto> {
-    return this.chartOfAccountsService.restore(id);
+  async restore(
+    @Param('id') id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<ChartOfAccountResponseDto> {
+    return this.chartOfAccountsService.restore(id, currentUserId, currentUsername);
   }
 
   @Post('bulk-restore')
@@ -216,9 +237,13 @@ export class ChartOfAccountsController {
   })
   async bulkRestore(
     @Body() body: BulkChartOfAccountsDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ message: string; restoredCount: number; failedIds: string[] }> {
     const result = await this.chartOfAccountsService.bulkRestore(
       body.accountIds,
+      currentUserId,
+      currentUsername,
     );
     return {
       message: `Successfully restored ${result.restoredCount} of ${body.accountIds.length} accounts`,

--- a/backend/src/modules/accounting/controllers/expense.controller.ts
+++ b/backend/src/modules/accounting/controllers/expense.controller.ts
@@ -10,6 +10,7 @@ import {
   ParseUUIDPipe,
 } from '@nestjs/common';
 import { Auth } from '../../auth/decorators/auth.decorator';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { UserRole } from '../../../database/entities/user.entity';
 import { ExpenseService } from '../services/expense.service';
 import {
@@ -36,37 +37,62 @@ export class ExpenseController {
 
   @Post()
   @Auth(UserRole.ADMIN, UserRole.MANAGER)
-  create(@Body() dto: CreateExpenseDto) {
-    return this.expenseService.create(dto);
+  create(
+    @Body() dto: CreateExpenseDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.expenseService.create(dto, currentUserId, currentUsername);
   }
 
   @Patch(':id')
   @Auth(UserRole.ADMIN, UserRole.MANAGER)
-  update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdateExpenseDto) {
-    return this.expenseService.update(id, dto);
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateExpenseDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.expenseService.update(id, dto, currentUserId, currentUsername);
   }
 
   @Delete(':id')
   @Auth(UserRole.ADMIN)
-  remove(@Param('id', ParseUUIDPipe) id: string) {
-    return this.expenseService.remove(id);
+  remove(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.expenseService.remove(id, currentUserId, currentUsername);
   }
 
   @Post(':id/post')
   @Auth(UserRole.ADMIN, UserRole.MANAGER)
-  post(@Param('id', ParseUUIDPipe) id: string) {
-    return this.expenseService.post(id);
+  post(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.expenseService.post(id, currentUserId, currentUsername);
   }
 
   @Post('bulk-post')
   @Auth(UserRole.ADMIN, UserRole.MANAGER)
-  bulkPost(@Body() dto: BulkExpenseDto) {
-    return this.expenseService.bulkPost(dto);
+  bulkPost(
+    @Body() dto: BulkExpenseDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.expenseService.bulkPost(dto, currentUserId, currentUsername);
   }
 
   @Post('bulk-delete')
   @Auth(UserRole.ADMIN)
-  bulkDelete(@Body() dto: BulkExpenseDto) {
-    return this.expenseService.bulkDelete(dto);
+  bulkDelete(
+    @Body() dto: BulkExpenseDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.expenseService.bulkDelete(dto, currentUserId, currentUsername);
   }
 }

--- a/backend/src/modules/accounting/controllers/fiscal-period.controller.ts
+++ b/backend/src/modules/accounting/controllers/fiscal-period.controller.ts
@@ -13,6 +13,7 @@ import {
 import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { FiscalPeriodService } from '../services/fiscal-period.service';
 import { Auth } from '../../auth/decorators/auth.decorator';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { UserRole } from '../../../database/entities/user.entity';
 import {
   CreateFiscalPeriodDto,
@@ -87,8 +88,10 @@ export class FiscalPeriodController {
   })
   async create(
     @Body() createDto: CreateFiscalPeriodDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<FiscalPeriodResponseDto> {
-    return this.fiscalPeriodService.create(createDto);
+    return this.fiscalPeriodService.create(createDto, currentUserId, currentUsername);
   }
 
   @Patch(':id')
@@ -109,8 +112,10 @@ export class FiscalPeriodController {
   async update(
     @Param('id') id: string,
     @Body() updateDto: UpdateFiscalPeriodDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<FiscalPeriodResponseDto> {
-    return this.fiscalPeriodService.update(id, updateDto);
+    return this.fiscalPeriodService.update(id, updateDto, currentUserId, currentUsername);
   }
 
   @Delete(':id')
@@ -124,8 +129,12 @@ export class FiscalPeriodController {
     description: 'Period has journal entries',
   })
   @ApiResponse({ status: 404, description: 'Fiscal period not found' })
-  async remove(@Param('id') id: string): Promise<void> {
-    await this.fiscalPeriodService.remove(id);
+  async remove(
+    @Param('id') id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<void> {
+    await this.fiscalPeriodService.remove(id, currentUserId, currentUsername);
   }
 
   @Post(':id/restore')
@@ -140,8 +149,12 @@ export class FiscalPeriodController {
   @ApiResponse({ status: 400, description: 'Period is not deleted' })
   @ApiResponse({ status: 404, description: 'Fiscal period not found' })
   @ApiResponse({ status: 409, description: 'Period code now used by another period' })
-  async restore(@Param('id') id: string): Promise<FiscalPeriodResponseDto> {
-    return this.fiscalPeriodService.restore(id);
+  async restore(
+    @Param('id') id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<FiscalPeriodResponseDto> {
+    return this.fiscalPeriodService.restore(id, currentUserId, currentUsername);
   }
 
   @Post('generate')
@@ -176,8 +189,12 @@ export class FiscalPeriodController {
     description: 'Period already closed or has unposted draft entries',
   })
   @ApiResponse({ status: 404, description: 'Fiscal period not found' })
-  async closePeriod(@Param('id') id: string): Promise<FiscalPeriodResponseDto> {
-    return this.fiscalPeriodService.closePeriod(id);
+  async closePeriod(
+    @Param('id') id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<FiscalPeriodResponseDto> {
+    return this.fiscalPeriodService.closePeriod(id, currentUserId, currentUsername);
   }
 
   @Post(':id/reopen')
@@ -196,8 +213,10 @@ export class FiscalPeriodController {
   @ApiResponse({ status: 404, description: 'Fiscal period not found' })
   async reopenPeriod(
     @Param('id') id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<FiscalPeriodResponseDto> {
-    return this.fiscalPeriodService.reopenPeriod(id);
+    return this.fiscalPeriodService.reopenPeriod(id, currentUserId, currentUsername);
   }
 
   @Post('validate')

--- a/backend/src/modules/accounting/controllers/fiscal-period.controller.ts
+++ b/backend/src/modules/accounting/controllers/fiscal-period.controller.ts
@@ -171,8 +171,10 @@ export class FiscalPeriodController {
   })
   async generatePeriods(
     @Body() dto: GenerateFiscalPeriodsDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<FiscalPeriodResponseDto[]> {
-    return this.fiscalPeriodService.generateFiscalPeriods(dto);
+    return this.fiscalPeriodService.generateFiscalPeriods(dto, currentUserId, currentUsername);
   }
 
   @Post(':id/close')

--- a/backend/src/modules/accounting/controllers/journal-entry.controller.ts
+++ b/backend/src/modules/accounting/controllers/journal-entry.controller.ts
@@ -60,8 +60,10 @@ export class JournalEntryController {
   @ApiResponse({ status: 400, description: 'Invalid balances or no open period' })
   async postOpeningBalances(
     @Body() dto: PostOpeningBalancesDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<JournalEntryResponseDto> {
-    return this.accountingService.postOpeningBalances(dto) as any;
+    return this.accountingService.postOpeningBalances(dto, currentUserId, currentUsername) as any;
   }
 
   @Post('bulk-post')

--- a/backend/src/modules/accounting/controllers/journal-entry.controller.ts
+++ b/backend/src/modules/accounting/controllers/journal-entry.controller.ts
@@ -14,6 +14,7 @@ import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { JournalEntryService } from '../services/journal-entry.service';
 import { AccountingService } from '../services/accounting.service';
 import { Auth } from '../../auth/decorators/auth.decorator';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { UserRole } from '../../../database/entities/user.entity';
 import {
   CreateJournalEntryDto,
@@ -71,8 +72,12 @@ export class JournalEntryController {
     description: 'Bulk post results',
     type: BulkOperationResultDto,
   })
-  async bulkPost(@Body() dto: BulkOperationDto): Promise<BulkOperationResultDto> {
-    return this.journalEntryService.bulkPost(dto.ids);
+  async bulkPost(
+    @Body() dto: BulkOperationDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<BulkOperationResultDto> {
+    return this.journalEntryService.bulkPost(dto.ids, currentUserId, currentUsername);
   }
 
   @Post('bulk-delete')
@@ -83,8 +88,12 @@ export class JournalEntryController {
     description: 'Bulk delete results',
     type: BulkOperationResultDto,
   })
-  async bulkDelete(@Body() dto: BulkOperationDto): Promise<BulkOperationResultDto> {
-    return this.journalEntryService.bulkDelete(dto.ids);
+  async bulkDelete(
+    @Body() dto: BulkOperationDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<BulkOperationResultDto> {
+    return this.journalEntryService.bulkDelete(dto.ids, currentUserId, currentUsername);
   }
 
   @Get(':id')
@@ -113,8 +122,10 @@ export class JournalEntryController {
   @ApiResponse({ status: 409, description: 'Reference number already exists' })
   async create(
     @Body() createDto: CreateJournalEntryDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<JournalEntryResponseDto> {
-    return this.journalEntryService.create(createDto);
+    return this.journalEntryService.create(createDto, currentUserId, currentUsername);
   }
 
   @Patch(':id')
@@ -134,8 +145,10 @@ export class JournalEntryController {
   async update(
     @Param('id') id: string,
     @Body() updateDto: UpdateJournalEntryDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<JournalEntryResponseDto> {
-    return this.journalEntryService.update(id, updateDto);
+    return this.journalEntryService.update(id, updateDto, currentUserId, currentUsername);
   }
 
   @Delete(':id')
@@ -149,8 +162,12 @@ export class JournalEntryController {
     description: 'Can only delete DRAFT entries or entry has been reversed',
   })
   @ApiResponse({ status: 404, description: 'Journal entry not found' })
-  async remove(@Param('id') id: string): Promise<void> {
-    await this.journalEntryService.remove(id);
+  async remove(
+    @Param('id') id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<void> {
+    await this.journalEntryService.remove(id, currentUserId, currentUsername);
   }
 
   @Post(':id/post')
@@ -167,8 +184,12 @@ export class JournalEntryController {
     description: 'Entry is not balanced, period is closed, or not a DRAFT entry',
   })
   @ApiResponse({ status: 404, description: 'Journal entry not found' })
-  async postEntry(@Param('id') id: string): Promise<JournalEntryResponseDto> {
-    return this.journalEntryService.postEntry(id);
+  async postEntry(
+    @Param('id') id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<JournalEntryResponseDto> {
+    return this.journalEntryService.postEntry(id, currentUserId, currentUsername);
   }
 
   @Post(':id/reverse')
@@ -185,7 +206,11 @@ export class JournalEntryController {
     description: 'Entry is not POSTED, already reversed, or period is closed',
   })
   @ApiResponse({ status: 404, description: 'Journal entry not found' })
-  async reverseEntry(@Param('id') id: string): Promise<JournalEntryResponseDto> {
-    return this.journalEntryService.reverseEntry(id);
+  async reverseEntry(
+    @Param('id') id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<JournalEntryResponseDto> {
+    return this.journalEntryService.reverseEntry(id, currentUserId, currentUsername);
   }
 }

--- a/backend/src/modules/accounting/controllers/owner-equity.controller.ts
+++ b/backend/src/modules/accounting/controllers/owner-equity.controller.ts
@@ -10,6 +10,7 @@ import {
   ParseUUIDPipe,
 } from '@nestjs/common';
 import { Auth } from '../../auth/decorators/auth.decorator';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { UserRole } from '../../../database/entities/user.entity';
 import { OwnerEquityService } from '../services/owner-equity.service';
 import {
@@ -36,37 +37,62 @@ export class OwnerEquityController {
 
   @Post()
   @Auth(UserRole.ADMIN, UserRole.MANAGER)
-  create(@Body() dto: CreateOwnerEquityDto) {
-    return this.ownerEquityService.create(dto);
+  create(
+    @Body() dto: CreateOwnerEquityDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.ownerEquityService.create(dto, currentUserId, currentUsername);
   }
 
   @Patch(':id')
   @Auth(UserRole.ADMIN, UserRole.MANAGER)
-  update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdateOwnerEquityDto) {
-    return this.ownerEquityService.update(id, dto);
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateOwnerEquityDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.ownerEquityService.update(id, dto, currentUserId, currentUsername);
   }
 
   @Delete(':id')
   @Auth(UserRole.ADMIN)
-  remove(@Param('id', ParseUUIDPipe) id: string) {
-    return this.ownerEquityService.remove(id);
+  remove(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.ownerEquityService.remove(id, currentUserId, currentUsername);
   }
 
   @Post(':id/post')
   @Auth(UserRole.ADMIN, UserRole.MANAGER)
-  post(@Param('id', ParseUUIDPipe) id: string) {
-    return this.ownerEquityService.post(id);
+  post(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.ownerEquityService.post(id, currentUserId, currentUsername);
   }
 
   @Post('bulk-post')
   @Auth(UserRole.ADMIN, UserRole.MANAGER)
-  bulkPost(@Body() dto: BulkOwnerEquityDto) {
-    return this.ownerEquityService.bulkPost(dto);
+  bulkPost(
+    @Body() dto: BulkOwnerEquityDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.ownerEquityService.bulkPost(dto, currentUserId, currentUsername);
   }
 
   @Post('bulk-delete')
   @Auth(UserRole.ADMIN)
-  bulkDelete(@Body() dto: BulkOwnerEquityDto) {
-    return this.ownerEquityService.bulkDelete(dto);
+  bulkDelete(
+    @Body() dto: BulkOwnerEquityDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.ownerEquityService.bulkDelete(dto, currentUserId, currentUsername);
   }
 }

--- a/backend/src/modules/accounting/controllers/reconciliation.controller.ts
+++ b/backend/src/modules/accounting/controllers/reconciliation.controller.ts
@@ -13,6 +13,7 @@ import {
 import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { ReconciliationService } from '../services/reconciliation.service';
 import { Auth } from '../../auth/decorators/auth.decorator';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { UserRole } from '../../../database/entities/user.entity';
 import {
   CreateBankReconciliationDto,
@@ -70,8 +71,10 @@ export class ReconciliationController {
   @ApiResponse({ status: 404, description: 'Account or fiscal period not found' })
   async create(
     @Body() createDto: CreateBankReconciliationDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<BankReconciliationResponseDto> {
-    return this.reconciliationService.create(createDto);
+    return this.reconciliationService.create(createDto, currentUserId, currentUsername);
   }
 
   @Patch(':id')
@@ -88,8 +91,10 @@ export class ReconciliationController {
   async update(
     @Param('id') id: string,
     @Body() updateDto: UpdateBankReconciliationDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<BankReconciliationResponseDto> {
-    return this.reconciliationService.update(id, updateDto);
+    return this.reconciliationService.update(id, updateDto, currentUserId, currentUsername);
   }
 
   @Delete(':id')
@@ -100,8 +105,12 @@ export class ReconciliationController {
   @ApiResponse({ status: 204, description: 'Bank reconciliation deleted' })
   @ApiResponse({ status: 400, description: 'Cannot delete completed reconciliation' })
   @ApiResponse({ status: 404, description: 'Bank reconciliation not found' })
-  async remove(@Param('id') id: string): Promise<void> {
-    await this.reconciliationService.remove(id);
+  async remove(
+    @Param('id') id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<void> {
+    await this.reconciliationService.remove(id, currentUserId, currentUsername);
   }
 
   @Post(':id/mark-cleared')
@@ -151,8 +160,12 @@ export class ReconciliationController {
     status: 400,
     description: 'Reconciliation is not balanced or already completed',
   })
-  async complete(@Param('id') id: string): Promise<BankReconciliationResponseDto> {
-    return this.reconciliationService.complete(id);
+  async complete(
+    @Param('id') id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<BankReconciliationResponseDto> {
+    return this.reconciliationService.complete(id, currentUserId, currentUsername);
   }
 
   @Post(':id/reopen')
@@ -165,7 +178,11 @@ export class ReconciliationController {
     type: BankReconciliationResponseDto,
   })
   @ApiResponse({ status: 400, description: 'Not a completed reconciliation' })
-  async reopen(@Param('id') id: string): Promise<BankReconciliationResponseDto> {
-    return this.reconciliationService.reopen(id);
+  async reopen(
+    @Param('id') id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<BankReconciliationResponseDto> {
+    return this.reconciliationService.reopen(id, currentUserId, currentUsername);
   }
 }

--- a/backend/src/modules/accounting/controllers/reconciliation.controller.ts
+++ b/backend/src/modules/accounting/controllers/reconciliation.controller.ts
@@ -126,8 +126,10 @@ export class ReconciliationController {
   async markCleared(
     @Param('id') id: string,
     @Body() dto: ToggleClearedDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<BankReconciliationResponseDto> {
-    return this.reconciliationService.markCleared(id, dto);
+    return this.reconciliationService.markCleared(id, dto, currentUserId, currentUsername);
   }
 
   @Post(':id/unmark-cleared')
@@ -143,8 +145,10 @@ export class ReconciliationController {
   async unmarkCleared(
     @Param('id') id: string,
     @Body() dto: ToggleClearedDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<BankReconciliationResponseDto> {
-    return this.reconciliationService.unmarkCleared(id, dto);
+    return this.reconciliationService.unmarkCleared(id, dto, currentUserId, currentUsername);
   }
 
   @Post(':id/complete')

--- a/backend/src/modules/accounting/controllers/settlement.controller.ts
+++ b/backend/src/modules/accounting/controllers/settlement.controller.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Auth } from '../../auth/decorators/auth.decorator';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { UserRole } from '../../../database/entities/user.entity';
 import { SettlementService } from '../services/settlement.service';
 import {
@@ -57,8 +58,12 @@ export class SettlementController {
   @Auth(UserRole.ADMIN, UserRole.MANAGER)
   @ApiOperation({ summary: 'Create settlement' })
   @ApiResponse({ status: 201, type: SettlementResponseDto })
-  async create(@Body() dto: CreateSettlementDto): Promise<SettlementResponseDto> {
-    return this.settlementService.create(dto);
+  async create(
+    @Body() dto: CreateSettlementDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<SettlementResponseDto> {
+    return this.settlementService.create(dto, currentUserId, currentUsername);
   }
 
   @Post(':id/cancel')
@@ -66,7 +71,11 @@ export class SettlementController {
   @ApiOperation({ summary: 'Cancel settlement and revert payments to pending' })
   @ApiParam({ name: 'id', description: 'Settlement ID' })
   @ApiResponse({ status: 200, type: SettlementResponseDto })
-  async cancel(@Param('id') id: string): Promise<SettlementResponseDto> {
-    return this.settlementService.cancel(id);
+  async cancel(
+    @Param('id') id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<SettlementResponseDto> {
+    return this.settlementService.cancel(id, currentUserId, currentUsername);
   }
 }

--- a/backend/src/modules/accounting/services/account-mapping.service.spec.ts
+++ b/backend/src/modules/accounting/services/account-mapping.service.spec.ts
@@ -10,6 +10,7 @@ import { AccountMappingService } from './account-mapping.service';
 import { AccountMapping, MappingType } from '../../../database/entities/account-mapping.entity';
 import { ChartOfAccount } from '../../../database/entities/chart-of-account.entity';
 import { PaymentMethodEntity } from '../../../database/entities/payment-method.entity';
+import { AuditLogService } from '../../audit-logs/services';
 import {
   CreateAccountMappingDto,
   UpdateAccountMappingDto,
@@ -79,6 +80,12 @@ describe('AccountMappingService', () => {
           provide: getRepositoryToken(PaymentMethodEntity),
           useValue: {
             find: jest.fn().mockResolvedValue([]),
+          },
+        },
+        {
+          provide: AuditLogService,
+          useValue: {
+            log: jest.fn(),
           },
         },
       ],

--- a/backend/src/modules/accounting/services/account-mapping.service.ts
+++ b/backend/src/modules/accounting/services/account-mapping.service.ts
@@ -179,7 +179,8 @@ export class AccountMappingService {
    */
   async create(
     createDto: CreateAccountMappingDto,
-    userId: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<AccountMappingResponseDto> {
     this.logger.log(
       `Creating account mapping for type: ${createDto.mappingType}`,
@@ -227,7 +228,11 @@ export class AccountMappingService {
           'CREATE',
           'AccountMapping',
           `Created account mapping: ${savedRestoredMapping.mappingType}`,
-          { entityId: savedRestoredMapping.id, userId: userId ?? 'system' },
+          {
+            entityId: savedRestoredMapping.id,
+            userId: userId ?? 'system',
+            username,
+          },
         );
         return this.toResponseDto(mappingWithRelations!);
       }
@@ -255,7 +260,11 @@ export class AccountMappingService {
           'CREATE',
           'AccountMapping',
           `Created account mapping: ${savedReactivatedMapping.mappingType}`,
-          { entityId: savedReactivatedMapping.id, userId: userId ?? 'system' },
+          {
+            entityId: savedReactivatedMapping.id,
+            userId: userId ?? 'system',
+            username,
+          },
         );
         return this.toResponseDto(mappingWithRelations!);
       }
@@ -286,7 +295,7 @@ export class AccountMappingService {
       'CREATE',
       'AccountMapping',
       `Created account mapping: ${savedMapping.mappingType}`,
-      { entityId: savedMapping.id, userId: userId ?? 'system' },
+      { entityId: savedMapping.id, userId: userId ?? 'system', username },
     );
     return this.toResponseDto(mappingWithRelations!);
   }
@@ -297,7 +306,8 @@ export class AccountMappingService {
   async update(
     id: string,
     updateDto: UpdateAccountMappingDto,
-    userId: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<AccountMappingResponseDto> {
     this.logger.log(`Updating account mapping with ID: ${id}`);
 
@@ -338,7 +348,7 @@ export class AccountMappingService {
       'UPDATE',
       'AccountMapping',
       `Updated account mapping: ${updatedMapping.mappingType}`,
-      { entityId: id, userId: userId ?? 'system' },
+      { entityId: id, userId: userId ?? 'system', username },
     );
 
     this.logger.log(`Account mapping updated successfully: ${id}`);
@@ -348,7 +358,7 @@ export class AccountMappingService {
   /**
    * Soft delete an account mapping
    */
-  async remove(id: string, userId: string = 'system'): Promise<void> {
+  async remove(id: string, userId?: string, username?: string): Promise<void> {
     this.logger.log(`Deleting account mapping with ID: ${id}`);
 
     const mapping = await this.mappingRepository.findOne({
@@ -366,7 +376,7 @@ export class AccountMappingService {
       'DELETE',
       'AccountMapping',
       `Deleted account mapping: ${mapping.mappingType}`,
-      { entityId: id, userId: userId ?? 'system' },
+      { entityId: id, userId: userId ?? 'system', username },
     );
 
     this.logger.log(`Account mapping soft-deleted successfully: ${id}`);

--- a/backend/src/modules/accounting/services/account-mapping.service.ts
+++ b/backend/src/modules/accounting/services/account-mapping.service.ts
@@ -20,6 +20,7 @@ import {
   AccountMappingListResponseDto,
   MappingValidationResponseDto,
 } from '../dto/account-mapping.dto';
+import { AuditLogService } from '../../audit-logs/services';
 
 @Injectable()
 export class AccountMappingService {
@@ -32,6 +33,7 @@ export class AccountMappingService {
     private readonly accountRepository: Repository<ChartOfAccount>,
     @InjectRepository(PaymentMethodEntity)
     private readonly paymentMethodRepository: Repository<PaymentMethodEntity>,
+    private readonly auditLogService: AuditLogService,
   ) {}
 
   /**
@@ -221,6 +223,12 @@ export class AccountMappingService {
         this.logger.log(
           `Account mapping restored successfully with ID: ${savedRestoredMapping.id}`,
         );
+        await this.auditLogService.log(
+          'CREATE',
+          'AccountMapping',
+          `Created account mapping: ${savedRestoredMapping.mappingType}`,
+          { entityId: savedRestoredMapping.id, userId: userId ?? 'system' },
+        );
         return this.toResponseDto(mappingWithRelations!);
       }
 
@@ -242,6 +250,12 @@ export class AccountMappingService {
 
         this.logger.log(
           `Account mapping reactivated successfully with ID: ${savedReactivatedMapping.id}`,
+        );
+        await this.auditLogService.log(
+          'CREATE',
+          'AccountMapping',
+          `Created account mapping: ${savedReactivatedMapping.mappingType}`,
+          { entityId: savedReactivatedMapping.id, userId: userId ?? 'system' },
         );
         return this.toResponseDto(mappingWithRelations!);
       }
@@ -267,6 +281,12 @@ export class AccountMappingService {
 
     this.logger.log(
       `Account mapping created successfully with ID: ${savedMapping.id}`,
+    );
+    await this.auditLogService.log(
+      'CREATE',
+      'AccountMapping',
+      `Created account mapping: ${savedMapping.mappingType}`,
+      { entityId: savedMapping.id, userId: userId ?? 'system' },
     );
     return this.toResponseDto(mappingWithRelations!);
   }
@@ -314,6 +334,13 @@ export class AccountMappingService {
       relations: ['account'],
     });
 
+    await this.auditLogService.log(
+      'UPDATE',
+      'AccountMapping',
+      `Updated account mapping: ${updatedMapping.mappingType}`,
+      { entityId: id, userId: userId ?? 'system' },
+    );
+
     this.logger.log(`Account mapping updated successfully: ${id}`);
     return this.toResponseDto(mappingWithRelations!);
   }
@@ -334,6 +361,13 @@ export class AccountMappingService {
 
     // Soft delete the mapping
     await this.mappingRepository.softDelete(id);
+
+    await this.auditLogService.log(
+      'DELETE',
+      'AccountMapping',
+      `Deleted account mapping: ${mapping.mappingType}`,
+      { entityId: id, userId: userId ?? 'system' },
+    );
 
     this.logger.log(`Account mapping soft-deleted successfully: ${id}`);
   }

--- a/backend/src/modules/accounting/services/accounting.service.spec.ts
+++ b/backend/src/modules/accounting/services/accounting.service.spec.ts
@@ -665,8 +665,10 @@ describe('AccountingService', () => {
           description: expect.stringContaining('Opening Balance'),
           sourceType: 'opening_balance',
         }),
+        undefined,
+        undefined,
       );
-      expect(journalEntryService.postEntry).toHaveBeenCalledWith('je-id');
+      expect(journalEntryService.postEntry).toHaveBeenCalledWith('je-id', undefined, undefined);
       expect(result).toEqual({ id: 'je-id', status: 'POSTED' });
     });
 

--- a/backend/src/modules/accounting/services/accounting.service.spec.ts
+++ b/backend/src/modules/accounting/services/accounting.service.spec.ts
@@ -6,6 +6,7 @@ import { AccountMappingService } from './account-mapping.service';
 import { FiscalPeriodService } from './fiscal-period.service';
 import { MappingType } from '../../../database/entities/account-mapping.entity';
 import { FiscalPeriodStatus } from '../../../database/entities/fiscal-period.entity';
+import { AuditLogService } from '../../audit-logs/services';
 
 describe('AccountingService', () => {
   let service: AccountingService;
@@ -71,6 +72,12 @@ describe('AccountingService', () => {
           useValue: {
             validatePeriod: jest.fn(),
             getCurrentPeriod: jest.fn(),
+          },
+        },
+        {
+          provide: AuditLogService,
+          useValue: {
+            log: jest.fn(),
           },
         },
       ],

--- a/backend/src/modules/accounting/services/accounting.service.ts
+++ b/backend/src/modules/accounting/services/accounting.service.ts
@@ -894,7 +894,7 @@ export class AccountingService {
    * Post opening balances as a single balanced journal entry.
    * Positive amounts become debits, negative amounts become credits.
    */
-  async postOpeningBalances(dto: PostOpeningBalancesDto): Promise<JournalEntry> {
+  async postOpeningBalances(dto: PostOpeningBalancesDto, userId?: string, username?: string): Promise<JournalEntry> {
     this.logger.log(`Posting opening balances as of ${dto.asOfDate}`);
 
     const asOfDate = new Date(dto.asOfDate);
@@ -975,16 +975,17 @@ export class AccountingService {
       fiscalPeriodId: periodValidation.period.id,
       sourceType: 'opening_balance',
       lines,
-    });
+    }, userId, username);
 
-    const postedEntry = await this.journalEntryService.postEntry(entry.id);
+    const postedEntry = await this.journalEntryService.postEntry(entry.id, userId, username);
     await this.auditLogService.log(
       'AUTO_POST',
       'JournalEntry',
       'Auto-posted opening balance entry',
       {
         entityId: entry.id,
-        userId: 'system',
+        userId: userId ?? 'system',
+        username,
         metadata: { sourceType: 'opening_balance' },
       },
     );

--- a/backend/src/modules/accounting/services/accounting.service.ts
+++ b/backend/src/modules/accounting/services/accounting.service.ts
@@ -28,6 +28,7 @@ import {
   CreateJournalEntryLineDto,
   PostOpeningBalancesDto,
 } from '../dto/journal-entry.dto';
+import { AuditLogService } from '../../audit-logs/services';
 
 @Injectable()
 export class AccountingService {
@@ -37,6 +38,7 @@ export class AccountingService {
     private readonly journalEntryService: JournalEntryService,
     private readonly accountMappingService: AccountMappingService,
     private readonly fiscalPeriodService: FiscalPeriodService,
+    private readonly auditLogService: AuditLogService,
   ) {}
 
   /**
@@ -132,6 +134,16 @@ export class AccountingService {
     // Create and post the entry
     const entry = await this.journalEntryService.create(entryDto, userId);
     const postedEntry = await this.journalEntryService.postEntry(entry.id, userId);
+    await this.auditLogService.log(
+      'AUTO_POST',
+      'JournalEntry',
+      `Auto-posted sales order journal entry for order: ${salesOrder.orderNumber}`,
+      {
+        entityId: entry.id,
+        userId: userId ?? 'system',
+        metadata: { sourceType: 'sales_order', sourceId: salesOrder.id },
+      },
+    );
 
     this.logger.log(
       `Sales order entry posted successfully: ${postedEntry.referenceNumber}`,
@@ -208,6 +220,16 @@ export class AccountingService {
     // Create and post the entry
     const entry = await this.journalEntryService.create(entryDto, userId);
     const postedEntry = await this.journalEntryService.postEntry(entry.id, userId);
+    await this.auditLogService.log(
+      'AUTO_POST',
+      'JournalEntry',
+      `Auto-posted customer payment journal entry: ${payment.paymentNumber}`,
+      {
+        entityId: entry.id,
+        userId: userId ?? 'system',
+        metadata: { sourceType: 'payment', sourceId: payment.id },
+      },
+    );
 
     this.logger.log(
       `Payment entry posted successfully: ${postedEntry.referenceNumber}`,
@@ -282,6 +304,16 @@ export class AccountingService {
     );
 
     const postedEntry = await this.journalEntryService.postEntry(entry.id, userId);
+    await this.auditLogService.log(
+      'AUTO_POST',
+      'JournalEntry',
+      `Auto-posted settlement journal entry: ${settlement.settlementNumber}`,
+      {
+        entityId: entry.id,
+        userId: userId ?? 'system',
+        metadata: { sourceType: 'settlement', sourceId: settlement.id },
+      },
+    );
     this.logger.log(
       `Settlement entry posted successfully: ${postedEntry.referenceNumber}`,
     );
@@ -353,6 +385,16 @@ export class AccountingService {
     // Create and post the entry
     const entry = await this.journalEntryService.create(entryDto, userId);
     const postedEntry = await this.journalEntryService.postEntry(entry.id, userId);
+    await this.auditLogService.log(
+      'AUTO_POST',
+      'JournalEntry',
+      `Auto-posted goods received journal entry: ${grn.grnNumber}`,
+      {
+        entityId: entry.id,
+        userId: userId ?? 'system',
+        metadata: { sourceType: 'goods_received_note', sourceId: grn.id },
+      },
+    );
 
     this.logger.log(
       `Goods received entry posted successfully: ${postedEntry.referenceNumber}`,
@@ -428,6 +470,16 @@ export class AccountingService {
     // Create and post the entry
     const entry = await this.journalEntryService.create(entryDto, userId);
     const postedEntry = await this.journalEntryService.postEntry(entry.id, userId);
+    await this.auditLogService.log(
+      'AUTO_POST',
+      'JournalEntry',
+      `Auto-posted vendor payment journal entry: ${vendorPayment.paymentNumber}`,
+      {
+        entityId: entry.id,
+        userId: userId ?? 'system',
+        metadata: { sourceType: 'vendor_payment', sourceId: vendorPayment.id },
+      },
+    );
 
     this.logger.log(
       `Vendor payment entry posted successfully: ${postedEntry.referenceNumber}`,
@@ -528,6 +580,16 @@ export class AccountingService {
     // Create and post the entry
     const entry = await this.journalEntryService.create(entryDto, userId);
     const postedEntry = await this.journalEntryService.postEntry(entry.id, userId);
+    await this.auditLogService.log(
+      'AUTO_POST',
+      'JournalEntry',
+      `Auto-posted stock adjustment journal entry: ${adjustment.adjustmentNumber}`,
+      {
+        entityId: entry.id,
+        userId: userId ?? 'system',
+        metadata: { sourceType: 'stock_adjustment', sourceId: adjustment.id },
+      },
+    );
 
     this.logger.log(
       `Stock adjustment entry posted successfully: ${postedEntry.referenceNumber}`,
@@ -627,6 +689,16 @@ export class AccountingService {
     );
 
     const postedEntry = await this.journalEntryService.postEntry(entry.id, userId);
+    await this.auditLogService.log(
+      'AUTO_POST',
+      'JournalEntry',
+      `Auto-posted owner equity journal entry: ${transaction.referenceNumber}`,
+      {
+        entityId: entry.id,
+        userId: userId ?? 'system',
+        metadata: { sourceType: 'owner_equity', sourceId: transaction.id },
+      },
+    );
     this.logger.log(
       `Owner equity entry posted successfully: ${postedEntry.referenceNumber}`,
     );
@@ -705,6 +777,16 @@ export class AccountingService {
     );
 
     const postedEntry = await this.journalEntryService.postEntry(entry.id, userId);
+    await this.auditLogService.log(
+      'AUTO_POST',
+      'JournalEntry',
+      `Auto-posted expense journal entry: ${expense.referenceNumber}`,
+      {
+        entityId: entry.id,
+        userId: userId ?? 'system',
+        metadata: { sourceType: 'expense', sourceId: expense.id },
+      },
+    );
     this.logger.log(`Expense entry posted successfully: ${postedEntry.referenceNumber}`);
     return postedEntry as any;
   }
@@ -896,6 +978,16 @@ export class AccountingService {
     });
 
     const postedEntry = await this.journalEntryService.postEntry(entry.id);
+    await this.auditLogService.log(
+      'AUTO_POST',
+      'JournalEntry',
+      'Auto-posted opening balance entry',
+      {
+        entityId: entry.id,
+        userId: 'system',
+        metadata: { sourceType: 'opening_balance' },
+      },
+    );
     return postedEntry as any;
   }
 

--- a/backend/src/modules/accounting/services/accounting.service.ts
+++ b/backend/src/modules/accounting/services/accounting.service.ts
@@ -48,6 +48,7 @@ export class AccountingService {
   async postSalesOrderEntry(
     salesOrder: SalesOrder,
     userId: string,
+    username?: string,
   ): Promise<JournalEntry> {
     this.logger.log(`Posting sales order entry for ${salesOrder.orderNumber}`);
 
@@ -141,6 +142,7 @@ export class AccountingService {
       {
         entityId: entry.id,
         userId: userId ?? 'system',
+        username,
         metadata: { sourceType: 'sales_order', sourceId: salesOrder.id },
       },
     );
@@ -158,6 +160,7 @@ export class AccountingService {
   async postCustomerPaymentEntry(
     payment: Payment,
     userId: string,
+    username?: string,
   ): Promise<JournalEntry> {
     this.logger.log(`Posting customer payment entry for ${payment.paymentNumber}`);
 
@@ -227,6 +230,7 @@ export class AccountingService {
       {
         entityId: entry.id,
         userId: userId ?? 'system',
+        username,
         metadata: { sourceType: 'payment', sourceId: payment.id },
       },
     );
@@ -246,6 +250,7 @@ export class AccountingService {
     paymentMethod: PaymentMethodEntity,
     amount: number,
     userId: string,
+    username?: string,
   ): Promise<JournalEntry> {
     this.logger.log(`Posting settlement entry for ${settlement.settlementNumber}`);
 
@@ -311,6 +316,7 @@ export class AccountingService {
       {
         entityId: entry.id,
         userId: userId ?? 'system',
+        username,
         metadata: { sourceType: 'settlement', sourceId: settlement.id },
       },
     );
@@ -327,6 +333,7 @@ export class AccountingService {
   async postGoodsReceivedEntry(
     grn: GoodsReceivedNote,
     userId: string,
+    username?: string,
   ): Promise<JournalEntry> {
     this.logger.log(`Posting goods received entry for ${grn.grnNumber}`);
 
@@ -392,6 +399,7 @@ export class AccountingService {
       {
         entityId: entry.id,
         userId: userId ?? 'system',
+        username,
         metadata: { sourceType: 'goods_received_note', sourceId: grn.id },
       },
     );
@@ -409,6 +417,7 @@ export class AccountingService {
   async postVendorPaymentEntry(
     vendorPayment: VendorPayment,
     userId: string,
+    username?: string,
   ): Promise<JournalEntry> {
     this.logger.log(`Posting vendor payment entry for ${vendorPayment.paymentNumber}`);
 
@@ -477,6 +486,7 @@ export class AccountingService {
       {
         entityId: entry.id,
         userId: userId ?? 'system',
+        username,
         metadata: { sourceType: 'vendor_payment', sourceId: vendorPayment.id },
       },
     );
@@ -494,6 +504,7 @@ export class AccountingService {
   async postStockAdjustmentEntry(
     adjustment: StockAdjustment,
     userId: string,
+    username?: string,
   ): Promise<JournalEntry> {
     this.logger.log(`Posting stock adjustment entry for ${adjustment.adjustmentNumber}`);
 
@@ -587,6 +598,7 @@ export class AccountingService {
       {
         entityId: entry.id,
         userId: userId ?? 'system',
+        username,
         metadata: { sourceType: 'stock_adjustment', sourceId: adjustment.id },
       },
     );
@@ -605,6 +617,7 @@ export class AccountingService {
   async postOwnerEquityEntry(
     transaction: OwnerEquityTransaction,
     userId: string,
+    username?: string,
   ): Promise<JournalEntry> {
     this.logger.log(`Posting owner equity entry for ${transaction.referenceNumber}`);
 
@@ -696,6 +709,7 @@ export class AccountingService {
       {
         entityId: entry.id,
         userId: userId ?? 'system',
+        username,
         metadata: { sourceType: 'owner_equity', sourceId: transaction.id },
       },
     );
@@ -709,7 +723,11 @@ export class AccountingService {
    * Post journal entry for expense
    * DR Expense Account, CR Payment Method Account
    */
-  async postExpenseEntry(expense: Expense, userId: string): Promise<JournalEntry> {
+  async postExpenseEntry(
+    expense: Expense,
+    userId: string,
+    username?: string,
+  ): Promise<JournalEntry> {
     this.logger.log(`Posting expense entry for ${expense.referenceNumber}`);
 
     const mappings = await this.accountMappingService.getMappings();
@@ -784,6 +802,7 @@ export class AccountingService {
       {
         entityId: entry.id,
         userId: userId ?? 'system',
+        username,
         metadata: { sourceType: 'expense', sourceId: expense.id },
       },
     );

--- a/backend/src/modules/accounting/services/chart-of-accounts.service.spec.ts
+++ b/backend/src/modules/accounting/services/chart-of-accounts.service.spec.ts
@@ -14,6 +14,7 @@ import {
 import { JournalEntryLine } from '../../../database/entities/journal-entry-line.entity';
 import { AccountMapping } from '../../../database/entities/account-mapping.entity';
 import { BankReconciliation } from '../../../database/entities/bank-reconciliation.entity';
+import { AuditLogService } from '../../audit-logs/services';
 import {
   CreateChartOfAccountDto,
   UpdateChartOfAccountDto,
@@ -89,6 +90,12 @@ describe('ChartOfAccountsService', () => {
           provide: getRepositoryToken(BankReconciliation),
           useValue: {
             count: jest.fn(),
+          },
+        },
+        {
+          provide: AuditLogService,
+          useValue: {
+            log: jest.fn(),
           },
         },
       ],

--- a/backend/src/modules/accounting/services/chart-of-accounts.service.ts
+++ b/backend/src/modules/accounting/services/chart-of-accounts.service.ts
@@ -630,7 +630,7 @@ export class ChartOfAccountsService {
    * Seed default chart of accounts
    * Creates 20+ accounts covering all account types
    */
-  async seedDefaultChartOfAccounts(): Promise<void> {
+  async seedDefaultChartOfAccounts(userId?: string, username?: string): Promise<void> {
     this.logger.log('Seeding default chart of accounts');
 
     // Check if accounts already exist
@@ -673,7 +673,7 @@ export class ChartOfAccountsService {
     // Create all accounts
     for (const accountDto of defaultAccounts) {
       try {
-        await this.create(accountDto, 'system');
+        await this.create(accountDto, userId, username);
         this.logger.log(`Created account: ${accountDto.code} - ${accountDto.name}`);
       } catch (error) {
         this.logger.error(`Failed to create account ${accountDto.code}: ${error.message}`);

--- a/backend/src/modules/accounting/services/chart-of-accounts.service.ts
+++ b/backend/src/modules/accounting/services/chart-of-accounts.service.ts
@@ -425,19 +425,7 @@ export class ChartOfAccountsService {
 
     for (const accountId of accountIds) {
       try {
-        const account = await this.accountRepository.findOne({
-          where: { id: accountId },
-          withDeleted: true,
-        });
         await this.restore(accountId);
-        if (account) {
-          await this.auditLogService.log(
-            'RESTORE',
-            'Account',
-            `Bulk restored account: ${account.code} - ${account.name}`,
-            { entityId: account.id, userId: 'system' },
-          );
-        }
         restoredCount += 1;
       } catch (error: any) {
         failedIds.push(accountId);
@@ -617,19 +605,7 @@ export class ChartOfAccountsService {
 
     for (const accountId of accountIds) {
       try {
-        const account = await this.accountRepository.findOne({
-          where: { id: accountId },
-          withDeleted: true,
-        });
         await this.permanentDelete(accountId);
-        if (account) {
-          await this.auditLogService.log(
-            'PERMANENT_DELETE',
-            'Account',
-            `Bulk permanently deleted account: ${account.code} - ${account.name}`,
-            { entityId: account.id, userId: 'system' },
-          );
-        }
         deletedCount += 1;
       } catch (error: any) {
         const reason = error?.response?.message || error?.message || 'Unknown error';

--- a/backend/src/modules/accounting/services/chart-of-accounts.service.ts
+++ b/backend/src/modules/accounting/services/chart-of-accounts.service.ts
@@ -22,6 +22,7 @@ import {
   ChartOfAccountListResponseDto,
   ChartOfAccountHierarchyDto,
 } from '../dto/chart-of-account.dto';
+import { AuditLogService } from '../../audit-logs/services';
 
 @Injectable()
 export class ChartOfAccountsService {
@@ -36,6 +37,7 @@ export class ChartOfAccountsService {
     private readonly accountMappingRepository: Repository<AccountMapping>,
     @InjectRepository(BankReconciliation)
     private readonly bankReconciliationRepository: Repository<BankReconciliation>,
+    private readonly auditLogService: AuditLogService,
   ) {}
 
   /**
@@ -92,6 +94,13 @@ export class ChartOfAccountsService {
     });
 
     const savedAccount = await this.accountRepository.save(account);
+
+    await this.auditLogService.log(
+      'CREATE',
+      'Account',
+      `Created account: ${savedAccount.code} - ${savedAccount.name}`,
+      { entityId: savedAccount.id, userId: userId ?? 'system' },
+    );
 
     this.logger.log(`Account created successfully with ID: ${savedAccount.id}`);
     return this.toResponseDto(savedAccount);
@@ -271,6 +280,13 @@ export class ChartOfAccountsService {
       relations: ['parent', 'children'],
     });
 
+    await this.auditLogService.log(
+      'UPDATE',
+      'Account',
+      `Updated account: ${account.code} - ${account.name}`,
+      { entityId: id, userId: userId ?? 'system' },
+    );
+
     this.logger.log(`Account updated successfully: ${id}`);
     return this.toResponseDto(accountWithRelations!);
   }
@@ -312,6 +328,13 @@ export class ChartOfAccountsService {
 
     // Soft delete the account
     await this.accountRepository.softDelete(id);
+
+    await this.auditLogService.log(
+      'DELETE',
+      'Account',
+      `Deleted account: ${account.code} - ${account.name}`,
+      { entityId: id, userId: userId ?? 'system' },
+    );
 
     this.logger.log(`Account soft-deleted successfully: ${id}`);
   }
@@ -376,6 +399,13 @@ export class ChartOfAccountsService {
       relations: ['parent', 'children'],
     });
 
+    await this.auditLogService.log(
+      'RESTORE',
+      'Account',
+      `Restored account: ${account.code} - ${account.name}`,
+      { entityId: id, userId: userId ?? 'system' },
+    );
+
     this.logger.log(`Account restored successfully: ${id}`);
     return this.toResponseDto(restoredAccount!);
   }
@@ -395,7 +425,19 @@ export class ChartOfAccountsService {
 
     for (const accountId of accountIds) {
       try {
+        const account = await this.accountRepository.findOne({
+          where: { id: accountId },
+          withDeleted: true,
+        });
         await this.restore(accountId);
+        if (account) {
+          await this.auditLogService.log(
+            'RESTORE',
+            'Account',
+            `Bulk restored account: ${account.code} - ${account.name}`,
+            { entityId: account.id, userId: 'system' },
+          );
+        }
         restoredCount += 1;
       } catch (error: any) {
         failedIds.push(accountId);
@@ -545,6 +587,13 @@ export class ChartOfAccountsService {
     // Hard delete the account
     await this.accountRepository.remove(account);
 
+    await this.auditLogService.log(
+      'PERMANENT_DELETE',
+      'Account',
+      `Permanently deleted account: ${account.code} - ${account.name}`,
+      { entityId: id, userId: userId ?? 'system' },
+    );
+
     this.logger.log(`Account permanently deleted: ${id}`);
   }
 
@@ -568,7 +617,19 @@ export class ChartOfAccountsService {
 
     for (const accountId of accountIds) {
       try {
+        const account = await this.accountRepository.findOne({
+          where: { id: accountId },
+          withDeleted: true,
+        });
         await this.permanentDelete(accountId);
+        if (account) {
+          await this.auditLogService.log(
+            'PERMANENT_DELETE',
+            'Account',
+            `Bulk permanently deleted account: ${account.code} - ${account.name}`,
+            { entityId: account.id, userId: 'system' },
+          );
+        }
         deletedCount += 1;
       } catch (error: any) {
         const reason = error?.response?.message || error?.message || 'Unknown error';

--- a/backend/src/modules/accounting/services/chart-of-accounts.service.ts
+++ b/backend/src/modules/accounting/services/chart-of-accounts.service.ts
@@ -45,7 +45,8 @@ export class ChartOfAccountsService {
    */
   async create(
     createDto: CreateChartOfAccountDto,
-    userId: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<ChartOfAccountResponseDto> {
     this.logger.log(`Creating account with code: ${createDto.code}`);
 
@@ -99,7 +100,7 @@ export class ChartOfAccountsService {
       'CREATE',
       'Account',
       `Created account: ${savedAccount.code} - ${savedAccount.name}`,
-      { entityId: savedAccount.id, userId: userId ?? 'system' },
+      { entityId: savedAccount.id, userId: userId ?? 'system', username },
     );
 
     this.logger.log(`Account created successfully with ID: ${savedAccount.id}`);
@@ -202,7 +203,8 @@ export class ChartOfAccountsService {
   async update(
     id: string,
     updateDto: UpdateChartOfAccountDto,
-    userId: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<ChartOfAccountResponseDto> {
     this.logger.log(`Updating account with ID: ${id}`);
 
@@ -284,7 +286,7 @@ export class ChartOfAccountsService {
       'UPDATE',
       'Account',
       `Updated account: ${account.code} - ${account.name}`,
-      { entityId: id, userId: userId ?? 'system' },
+      { entityId: id, userId: userId ?? 'system', username },
     );
 
     this.logger.log(`Account updated successfully: ${id}`);
@@ -294,7 +296,7 @@ export class ChartOfAccountsService {
   /**
    * Soft delete an account
    */
-  async remove(id: string, userId: string = 'system'): Promise<void> {
+  async remove(id: string, userId?: string, username?: string): Promise<void> {
     this.logger.log(`Deleting account with ID: ${id}`);
 
     const account = await this.accountRepository.findOne({
@@ -333,7 +335,7 @@ export class ChartOfAccountsService {
       'DELETE',
       'Account',
       `Deleted account: ${account.code} - ${account.name}`,
-      { entityId: id, userId: userId ?? 'system' },
+      { entityId: id, userId: userId ?? 'system', username },
     );
 
     this.logger.log(`Account soft-deleted successfully: ${id}`);
@@ -362,7 +364,7 @@ export class ChartOfAccountsService {
   /**
    * Restore a soft-deleted account
    */
-  async restore(id: string, userId: string = 'system'): Promise<ChartOfAccountResponseDto> {
+  async restore(id: string, userId?: string, username?: string): Promise<ChartOfAccountResponseDto> {
     this.logger.log(`Restoring account with ID: ${id}`);
 
     const account = await this.accountRepository.findOne({
@@ -403,7 +405,7 @@ export class ChartOfAccountsService {
       'RESTORE',
       'Account',
       `Restored account: ${account.code} - ${account.name}`,
-      { entityId: id, userId: userId ?? 'system' },
+      { entityId: id, userId: userId ?? 'system', username },
     );
 
     this.logger.log(`Account restored successfully: ${id}`);
@@ -415,6 +417,8 @@ export class ChartOfAccountsService {
    */
   async bulkRestore(
     accountIds: string[],
+    userId?: string,
+    username?: string,
   ): Promise<{ restoredCount: number; failedIds: string[] }> {
     if (!accountIds?.length) {
       return { restoredCount: 0, failedIds: [] };
@@ -425,7 +429,7 @@ export class ChartOfAccountsService {
 
     for (const accountId of accountIds) {
       try {
-        await this.restore(accountId);
+        await this.restore(accountId, userId, username);
         restoredCount += 1;
       } catch (error: any) {
         failedIds.push(accountId);
@@ -505,7 +509,7 @@ export class ChartOfAccountsService {
    * Permanently delete an account (hard delete)
    * Only soft-deleted accounts can be permanently deleted
    */
-  async permanentDelete(id: string, userId: string = 'system'): Promise<void> {
+  async permanentDelete(id: string, userId?: string, username?: string): Promise<void> {
     this.logger.log(`Permanently deleting account with ID: ${id}`);
 
     const account = await this.accountRepository.findOne({
@@ -579,7 +583,7 @@ export class ChartOfAccountsService {
       'PERMANENT_DELETE',
       'Account',
       `Permanently deleted account: ${account.code} - ${account.name}`,
-      { entityId: id, userId: userId ?? 'system' },
+      { entityId: id, userId: userId ?? 'system', username },
     );
 
     this.logger.log(`Account permanently deleted: ${id}`);
@@ -590,6 +594,8 @@ export class ChartOfAccountsService {
    */
   async bulkPermanentDelete(
     accountIds: string[],
+    userId?: string,
+    username?: string,
   ): Promise<{
     deletedCount: number;
     failedIds: string[];
@@ -605,7 +611,7 @@ export class ChartOfAccountsService {
 
     for (const accountId of accountIds) {
       try {
-        await this.permanentDelete(accountId);
+        await this.permanentDelete(accountId, userId, username);
         deletedCount += 1;
       } catch (error: any) {
         const reason = error?.response?.message || error?.message || 'Unknown error';

--- a/backend/src/modules/accounting/services/expense.service.spec.ts
+++ b/backend/src/modules/accounting/services/expense.service.spec.ts
@@ -11,6 +11,7 @@ import {
 import { PaymentMethodEntity } from '../../../database/entities/payment-method.entity';
 import { AccountingService } from './accounting.service';
 import { SettingsService } from '../../settings/settings.service';
+import { AuditLogService } from '../../audit-logs/services';
 
 describe('ExpenseService', () => {
   let service: ExpenseService;
@@ -66,6 +67,12 @@ describe('ExpenseService', () => {
           provide: SettingsService,
           useValue: {
             generateDocumentNumber: jest.fn(),
+          },
+        },
+        {
+          provide: AuditLogService,
+          useValue: {
+            log: jest.fn(),
           },
         },
       ],

--- a/backend/src/modules/accounting/services/expense.service.ts
+++ b/backend/src/modules/accounting/services/expense.service.ts
@@ -22,6 +22,7 @@ import {
   ExpenseResponseDto,
   ExpenseListResponseDto,
 } from '../dto/expense.dto';
+import { AuditLogService } from '../../audit-logs/services';
 
 @Injectable()
 export class ExpenseService {
@@ -36,6 +37,7 @@ export class ExpenseService {
     private readonly chartOfAccountRepository: Repository<ChartOfAccount>,
     private readonly accountingService: AccountingService,
     private readonly settingsService: SettingsService,
+    private readonly auditLogService: AuditLogService,
   ) {}
 
   async findAll(query: QueryExpenseDto): Promise<ExpenseListResponseDto> {
@@ -118,7 +120,6 @@ export class ExpenseService {
   }
 
   async create(dto: CreateExpenseDto, userId = 'system'): Promise<ExpenseResponseDto> {
-    void userId;
     const paymentMethod = await this.paymentMethodRepository.findOne({
       where: { id: dto.paymentMethodId, isActive: true },
     });
@@ -155,6 +156,12 @@ export class ExpenseService {
     });
 
     const saved = await this.expenseRepository.save(expense);
+    await this.auditLogService.log(
+      'CREATE',
+      'Expense',
+      `Created expense: ${saved.referenceNumber}`,
+      { entityId: saved.id, userId: userId ?? 'system' },
+    );
     return this.findOne(saved.id);
   }
 
@@ -163,7 +170,6 @@ export class ExpenseService {
     dto: UpdateExpenseDto,
     userId = 'system',
   ): Promise<ExpenseResponseDto> {
-    void userId;
     const expense = await this.expenseRepository.findOne({
       where: { id },
     });
@@ -207,6 +213,12 @@ export class ExpenseService {
     if (dto.vendor !== undefined) expense.vendor = dto.vendor;
 
     await this.expenseRepository.save(expense);
+    await this.auditLogService.log(
+      'UPDATE',
+      'Expense',
+      `Updated expense: ${expense.referenceNumber}`,
+      { entityId: id, userId: userId ?? 'system' },
+    );
     return this.findOne(id);
   }
 
@@ -224,6 +236,12 @@ export class ExpenseService {
     }
 
     await this.expenseRepository.softDelete(id);
+    await this.auditLogService.log(
+      'DELETE',
+      'Expense',
+      `Deleted expense: ${expense.referenceNumber}`,
+      { entityId: id, userId: 'system' },
+    );
   }
 
   async post(id: string, userId = 'system'): Promise<ExpenseResponseDto> {
@@ -245,6 +263,12 @@ export class ExpenseService {
       expense.status = ExpenseStatus.POSTED;
       expense.journalEntryId = journalEntry.id;
       await this.expenseRepository.save(expense);
+      await this.auditLogService.log(
+        'POST',
+        'Expense',
+        `Posted expense: ${expense.referenceNumber}`,
+        { entityId: id, userId: userId ?? 'system' },
+      );
     } catch (error) {
       this.logger.error(
         `Failed to post expense entry for ${expense.referenceNumber}: ${error.message}`,

--- a/backend/src/modules/accounting/services/expense.service.ts
+++ b/backend/src/modules/accounting/services/expense.service.ts
@@ -119,7 +119,11 @@ export class ExpenseService {
     return this.toResponseDto(expense);
   }
 
-  async create(dto: CreateExpenseDto, userId = 'system'): Promise<ExpenseResponseDto> {
+  async create(
+    dto: CreateExpenseDto,
+    userId?: string,
+    username?: string,
+  ): Promise<ExpenseResponseDto> {
     const paymentMethod = await this.paymentMethodRepository.findOne({
       where: { id: dto.paymentMethodId, isActive: true },
     });
@@ -160,7 +164,7 @@ export class ExpenseService {
       'CREATE',
       'Expense',
       `Created expense: ${saved.referenceNumber}`,
-      { entityId: saved.id, userId: userId ?? 'system' },
+      { entityId: saved.id, userId: userId ?? 'system', username },
     );
     return this.findOne(saved.id);
   }
@@ -168,7 +172,8 @@ export class ExpenseService {
   async update(
     id: string,
     dto: UpdateExpenseDto,
-    userId = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<ExpenseResponseDto> {
     const expense = await this.expenseRepository.findOne({
       where: { id },
@@ -217,12 +222,12 @@ export class ExpenseService {
       'UPDATE',
       'Expense',
       `Updated expense: ${expense.referenceNumber}`,
-      { entityId: id, userId: userId ?? 'system' },
+      { entityId: id, userId: userId ?? 'system', username },
     );
     return this.findOne(id);
   }
 
-  async remove(id: string): Promise<void> {
+  async remove(id: string, userId?: string, username?: string): Promise<void> {
     const expense = await this.expenseRepository.findOne({
       where: { id },
     });
@@ -240,11 +245,11 @@ export class ExpenseService {
       'DELETE',
       'Expense',
       `Deleted expense: ${expense.referenceNumber}`,
-      { entityId: id, userId: 'system' },
+      { entityId: id, userId: userId ?? 'system', username },
     );
   }
 
-  async post(id: string, userId = 'system'): Promise<ExpenseResponseDto> {
+  async post(id: string, userId?: string, username?: string): Promise<ExpenseResponseDto> {
     const expense = await this.expenseRepository.findOne({
       where: { id },
       relations: ['paymentMethod', 'expenseAccount'],
@@ -259,7 +264,11 @@ export class ExpenseService {
     }
 
     try {
-      const journalEntry = await this.accountingService.postExpenseEntry(expense, userId);
+      const journalEntry = await this.accountingService.postExpenseEntry(
+        expense,
+        userId ?? 'system',
+        username,
+      );
       expense.status = ExpenseStatus.POSTED;
       expense.journalEntryId = journalEntry.id;
       await this.expenseRepository.save(expense);
@@ -267,7 +276,7 @@ export class ExpenseService {
         'POST',
         'Expense',
         `Posted expense: ${expense.referenceNumber}`,
-        { entityId: id, userId: userId ?? 'system' },
+        { entityId: id, userId: userId ?? 'system', username },
       );
     } catch (error) {
       this.logger.error(
@@ -281,14 +290,15 @@ export class ExpenseService {
 
   async bulkPost(
     dto: BulkExpenseDto,
-    userId = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<{ posted: number; failed: number }> {
     let posted = 0;
     let failed = 0;
 
     for (const id of dto.ids) {
       try {
-        await this.post(id, userId);
+        await this.post(id, userId, username);
         posted++;
       } catch (error) {
         this.logger.error(`Failed to post expense ${id}: ${error.message}`);
@@ -299,13 +309,17 @@ export class ExpenseService {
     return { posted, failed };
   }
 
-  async bulkDelete(dto: BulkExpenseDto): Promise<{ deleted: number; failed: number }> {
+  async bulkDelete(
+    dto: BulkExpenseDto,
+    userId?: string,
+    username?: string,
+  ): Promise<{ deleted: number; failed: number }> {
     let deleted = 0;
     let failed = 0;
 
     for (const id of dto.ids) {
       try {
-        await this.remove(id);
+        await this.remove(id, userId, username);
         deleted++;
       } catch (error) {
         this.logger.error(`Failed to delete expense ${id}: ${error.message}`);

--- a/backend/src/modules/accounting/services/fiscal-period.service.spec.ts
+++ b/backend/src/modules/accounting/services/fiscal-period.service.spec.ts
@@ -12,6 +12,7 @@ import {
   FiscalPeriodStatus,
 } from '../../../database/entities/fiscal-period.entity';
 import { JournalEntry, JournalEntryStatus } from '../../../database/entities/journal-entry.entity';
+import { AuditLogService } from '../../audit-logs/services';
 import {
   CreateFiscalPeriodDto,
   UpdateFiscalPeriodDto,
@@ -72,6 +73,12 @@ describe('FiscalPeriodService', () => {
           provide: getRepositoryToken(JournalEntry),
           useValue: {
             count: jest.fn(),
+          },
+        },
+        {
+          provide: AuditLogService,
+          useValue: {
+            log: jest.fn(),
           },
         },
       ],

--- a/backend/src/modules/accounting/services/fiscal-period.service.ts
+++ b/backend/src/modules/accounting/services/fiscal-period.service.ts
@@ -412,12 +412,6 @@ export class FiscalPeriodService {
         );
 
         createdPeriods.push(period);
-        await this.auditLogService.log(
-          'GENERATE',
-          'FiscalPeriod',
-          `Generated fiscal period: ${period.code} - ${period.name}`,
-          { entityId: period.id, userId: userId ?? 'system' },
-        );
         this.logger.log(`Created period: ${code} - ${name}`);
       } catch (error) {
         if (error instanceof ConflictException) {

--- a/backend/src/modules/accounting/services/fiscal-period.service.ts
+++ b/backend/src/modules/accounting/services/fiscal-period.service.ts
@@ -468,6 +468,7 @@ export class FiscalPeriodService {
     }
 
     // Close the period
+    const previousStatus = period.status;
     period.status = FiscalPeriodStatus.CLOSED;
     const closedPeriod = await this.fiscalPeriodRepository.save(period);
 
@@ -479,7 +480,8 @@ export class FiscalPeriodService {
         entityId: id,
         userId: userId ?? 'system',
         username,
-        metadata: { status: 'CLOSED' },
+        oldValues: { status: previousStatus },
+        newValues: { status: closedPeriod.status },
       },
     );
 
@@ -529,6 +531,7 @@ export class FiscalPeriodService {
     }
 
     // Reopen the period
+    const previousStatus = period.status;
     period.status = FiscalPeriodStatus.OPEN;
     const reopenedPeriod = await this.fiscalPeriodRepository.save(period);
 
@@ -540,7 +543,8 @@ export class FiscalPeriodService {
         entityId: id,
         userId: userId ?? 'system',
         username,
-        metadata: { status: 'OPEN' },
+        oldValues: { status: previousStatus },
+        newValues: { status: reopenedPeriod.status },
       },
     );
 

--- a/backend/src/modules/accounting/services/fiscal-period.service.ts
+++ b/backend/src/modules/accounting/services/fiscal-period.service.ts
@@ -41,7 +41,8 @@ export class FiscalPeriodService {
    */
   async create(
     createDto: CreateFiscalPeriodDto,
-    userId: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<FiscalPeriodResponseDto> {
     this.logger.log(`Creating fiscal period with code: ${createDto.code}`);
 
@@ -102,7 +103,7 @@ export class FiscalPeriodService {
       'CREATE',
       'FiscalPeriod',
       `Created fiscal period: ${savedPeriod.code} - ${savedPeriod.name}`,
-      { entityId: savedPeriod.id, userId: userId ?? 'system' },
+      { entityId: savedPeriod.id, userId: userId ?? 'system', username },
     );
 
     this.logger.log(`Fiscal period created successfully with ID: ${savedPeriod.id}`);
@@ -199,7 +200,8 @@ export class FiscalPeriodService {
   async update(
     id: string,
     updateDto: UpdateFiscalPeriodDto,
-    userId: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<FiscalPeriodResponseDto> {
     this.logger.log(`Updating fiscal period with ID: ${id}`);
 
@@ -273,7 +275,7 @@ export class FiscalPeriodService {
       'UPDATE',
       'FiscalPeriod',
       `Updated fiscal period: ${updatedPeriod.code} - ${updatedPeriod.name}`,
-      { entityId: id, userId: userId ?? 'system' },
+      { entityId: id, userId: userId ?? 'system', username },
     );
 
     this.logger.log(`Fiscal period updated successfully: ${id}`);
@@ -283,7 +285,7 @@ export class FiscalPeriodService {
   /**
    * Soft delete a fiscal period
    */
-  async remove(id: string, userId: string = 'system'): Promise<void> {
+  async remove(id: string, userId?: string, username?: string): Promise<void> {
     this.logger.log(`Deleting fiscal period with ID: ${id}`);
 
     const period = await this.fiscalPeriodRepository.findOne({
@@ -313,7 +315,7 @@ export class FiscalPeriodService {
       'DELETE',
       'FiscalPeriod',
       `Deleted fiscal period: ${period.code} - ${period.name}`,
-      { entityId: id, userId: userId ?? 'system' },
+      { entityId: id, userId: userId ?? 'system', username },
     );
 
     this.logger.log(`Fiscal period soft-deleted successfully: ${id}`);
@@ -322,7 +324,7 @@ export class FiscalPeriodService {
   /**
    * Restore a soft-deleted fiscal period
    */
-  async restore(id: string, userId: string = 'system'): Promise<FiscalPeriodResponseDto> {
+  async restore(id: string, userId?: string, username?: string): Promise<FiscalPeriodResponseDto> {
     this.logger.log(`Restoring fiscal period with ID: ${id}`);
 
     const period = await this.fiscalPeriodRepository.findOne({
@@ -361,7 +363,7 @@ export class FiscalPeriodService {
       'RESTORE',
       'FiscalPeriod',
       `Restored fiscal period: ${period.code} - ${period.name}`,
-      { entityId: id, userId: userId ?? 'system' },
+      { entityId: id, userId: userId ?? 'system', username },
     );
 
     this.logger.log(`Fiscal period restored successfully: ${id}`);
@@ -374,7 +376,8 @@ export class FiscalPeriodService {
    */
   async generateFiscalPeriods(
     dto: GenerateFiscalPeriodsDto,
-    userId: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<FiscalPeriodResponseDto[]> {
     const { year, startMonth = 1 } = dto;
 
@@ -409,6 +412,7 @@ export class FiscalPeriodService {
             status: FiscalPeriodStatus.OPEN,
           },
           userId,
+          username,
         );
 
         createdPeriods.push(period);
@@ -431,7 +435,7 @@ export class FiscalPeriodService {
    * Close a fiscal period
    * Prevents new journal entries from being posted to this period
    */
-  async closePeriod(id: string, userId: string = 'system'): Promise<FiscalPeriodResponseDto> {
+  async closePeriod(id: string, userId?: string, username?: string): Promise<FiscalPeriodResponseDto> {
     this.logger.log(`Closing fiscal period with ID: ${id}`);
 
     const period = await this.fiscalPeriodRepository.findOne({
@@ -471,7 +475,12 @@ export class FiscalPeriodService {
       'UPDATE',
       'FiscalPeriod',
       `Closed fiscal period: ${closedPeriod.code} - ${closedPeriod.name}`,
-      { entityId: id, userId: userId ?? 'system', metadata: { status: 'CLOSED' } },
+      {
+        entityId: id,
+        userId: userId ?? 'system',
+        username,
+        metadata: { status: 'CLOSED' },
+      },
     );
 
     this.logger.log(`Fiscal period closed successfully: ${id}`);
@@ -482,7 +491,7 @@ export class FiscalPeriodService {
    * Reopen a closed fiscal period
    * Only allows reopening the most recently closed period
    */
-  async reopenPeriod(id: string, userId: string = 'system'): Promise<FiscalPeriodResponseDto> {
+  async reopenPeriod(id: string, userId?: string, username?: string): Promise<FiscalPeriodResponseDto> {
     this.logger.log(`Reopening fiscal period with ID: ${id}`);
 
     const period = await this.fiscalPeriodRepository.findOne({
@@ -527,7 +536,12 @@ export class FiscalPeriodService {
       'UPDATE',
       'FiscalPeriod',
       `Reopened fiscal period: ${reopenedPeriod.code} - ${reopenedPeriod.name}`,
-      { entityId: id, userId: userId ?? 'system', metadata: { status: 'OPEN' } },
+      {
+        entityId: id,
+        userId: userId ?? 'system',
+        username,
+        metadata: { status: 'OPEN' },
+      },
     );
 
     this.logger.log(`Fiscal period reopened successfully: ${id}`);

--- a/backend/src/modules/accounting/services/fiscal-period.service.ts
+++ b/backend/src/modules/accounting/services/fiscal-period.service.ts
@@ -22,6 +22,7 @@ import {
   FiscalPeriodListResponseDto,
   FiscalPeriodValidationResponseDto,
 } from '../dto/fiscal-period.dto';
+import { AuditLogService } from '../../audit-logs/services';
 
 @Injectable()
 export class FiscalPeriodService {
@@ -32,6 +33,7 @@ export class FiscalPeriodService {
     private readonly fiscalPeriodRepository: Repository<FiscalPeriod>,
     @InjectRepository(JournalEntry)
     private readonly journalEntryRepository: Repository<JournalEntry>,
+    private readonly auditLogService: AuditLogService,
   ) {}
 
   /**
@@ -95,6 +97,13 @@ export class FiscalPeriodService {
     });
 
     const savedPeriod = await this.fiscalPeriodRepository.save(fiscalPeriod);
+
+    await this.auditLogService.log(
+      'CREATE',
+      'FiscalPeriod',
+      `Created fiscal period: ${savedPeriod.code} - ${savedPeriod.name}`,
+      { entityId: savedPeriod.id, userId: userId ?? 'system' },
+    );
 
     this.logger.log(`Fiscal period created successfully with ID: ${savedPeriod.id}`);
     return this.toResponseDto(savedPeriod);
@@ -260,6 +269,13 @@ export class FiscalPeriodService {
 
     const updatedPeriod = await this.fiscalPeriodRepository.save(period);
 
+    await this.auditLogService.log(
+      'UPDATE',
+      'FiscalPeriod',
+      `Updated fiscal period: ${updatedPeriod.code} - ${updatedPeriod.name}`,
+      { entityId: id, userId: userId ?? 'system' },
+    );
+
     this.logger.log(`Fiscal period updated successfully: ${id}`);
     return this.toResponseDto(updatedPeriod);
   }
@@ -292,6 +308,13 @@ export class FiscalPeriodService {
 
     // Soft delete the period
     await this.fiscalPeriodRepository.softDelete(id);
+
+    await this.auditLogService.log(
+      'DELETE',
+      'FiscalPeriod',
+      `Deleted fiscal period: ${period.code} - ${period.name}`,
+      { entityId: id, userId: userId ?? 'system' },
+    );
 
     this.logger.log(`Fiscal period soft-deleted successfully: ${id}`);
   }
@@ -333,6 +356,13 @@ export class FiscalPeriodService {
     const restoredPeriod = await this.fiscalPeriodRepository.findOne({
       where: { id },
     });
+
+    await this.auditLogService.log(
+      'RESTORE',
+      'FiscalPeriod',
+      `Restored fiscal period: ${period.code} - ${period.name}`,
+      { entityId: id, userId: userId ?? 'system' },
+    );
 
     this.logger.log(`Fiscal period restored successfully: ${id}`);
     return this.toResponseDto(restoredPeriod!);
@@ -382,6 +412,12 @@ export class FiscalPeriodService {
         );
 
         createdPeriods.push(period);
+        await this.auditLogService.log(
+          'GENERATE',
+          'FiscalPeriod',
+          `Generated fiscal period: ${period.code} - ${period.name}`,
+          { entityId: period.id, userId: userId ?? 'system' },
+        );
         this.logger.log(`Created period: ${code} - ${name}`);
       } catch (error) {
         if (error instanceof ConflictException) {
@@ -437,6 +473,13 @@ export class FiscalPeriodService {
     period.status = FiscalPeriodStatus.CLOSED;
     const closedPeriod = await this.fiscalPeriodRepository.save(period);
 
+    await this.auditLogService.log(
+      'UPDATE',
+      'FiscalPeriod',
+      `Closed fiscal period: ${closedPeriod.code} - ${closedPeriod.name}`,
+      { entityId: id, userId: userId ?? 'system', metadata: { status: 'CLOSED' } },
+    );
+
     this.logger.log(`Fiscal period closed successfully: ${id}`);
     return this.toResponseDto(closedPeriod);
   }
@@ -485,6 +528,13 @@ export class FiscalPeriodService {
     // Reopen the period
     period.status = FiscalPeriodStatus.OPEN;
     const reopenedPeriod = await this.fiscalPeriodRepository.save(period);
+
+    await this.auditLogService.log(
+      'UPDATE',
+      'FiscalPeriod',
+      `Reopened fiscal period: ${reopenedPeriod.code} - ${reopenedPeriod.name}`,
+      { entityId: id, userId: userId ?? 'system', metadata: { status: 'OPEN' } },
+    );
 
     this.logger.log(`Fiscal period reopened successfully: ${id}`);
     return this.toResponseDto(reopenedPeriod);

--- a/backend/src/modules/accounting/services/journal-entry.service.spec.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.spec.ts
@@ -10,6 +10,7 @@ import { JournalEntryService } from './journal-entry.service';
 import { ChartOfAccountsService } from './chart-of-accounts.service';
 import { FiscalPeriodService } from './fiscal-period.service';
 import { SettingsService } from '../../settings/settings.service';
+import { AuditLogService } from '../../audit-logs/services';
 import {
   JournalEntry,
   JournalEntryStatus,
@@ -164,6 +165,12 @@ describe('JournalEntryService', () => {
           provide: SettingsService,
           useValue: {
             generateDocumentNumber: jest.fn(),
+          },
+        },
+        {
+          provide: AuditLogService,
+          useValue: {
+            log: jest.fn(),
           },
         },
       ],

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -614,19 +614,7 @@ export class JournalEntryService {
 
     for (const id of ids) {
       try {
-        const entry = await this.journalEntryRepository.findOne({
-          where: { id },
-          select: ['id', 'referenceNumber'],
-        });
         await this.postEntry(id);
-        if (entry) {
-          await this.auditLogService.log(
-            'POST',
-            'JournalEntry',
-            `Bulk posted journal entry: ${entry.referenceNumber}`,
-            { entityId: entry.id, userId: 'system' },
-          );
-        }
         succeeded.push(id);
       } catch (error: any) {
         failed.push({ id, error: error?.message || 'Unknown error' });
@@ -645,19 +633,7 @@ export class JournalEntryService {
 
     for (const id of ids) {
       try {
-        const entry = await this.journalEntryRepository.findOne({
-          where: { id },
-          select: ['id', 'referenceNumber'],
-        });
         await this.remove(id);
-        if (entry) {
-          await this.auditLogService.log(
-            'DELETE',
-            'JournalEntry',
-            `Bulk deleted journal entry: ${entry.referenceNumber}`,
-            { entityId: entry.id, userId: 'system' },
-          );
-        }
         succeeded.push(id);
       } catch (error: any) {
         failed.push({ id, error: error?.message || 'Unknown error' });

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -25,6 +25,7 @@ import {
 import { ChartOfAccountsService } from './chart-of-accounts.service';
 import { FiscalPeriodService } from './fiscal-period.service';
 import { SettingsService } from '../../settings/settings.service';
+import { AuditLogService } from '../../audit-logs/services';
 
 @Injectable()
 export class JournalEntryService {
@@ -42,6 +43,7 @@ export class JournalEntryService {
     private readonly chartOfAccountsService: ChartOfAccountsService,
     private readonly fiscalPeriodService: FiscalPeriodService,
     private readonly settingsService: SettingsService,
+    private readonly auditLogService: AuditLogService,
   ) {}
 
   /**
@@ -104,6 +106,13 @@ export class JournalEntryService {
     );
 
     await this.journalEntryLineRepository.save(lines);
+
+    await this.auditLogService.log(
+      'CREATE',
+      'JournalEntry',
+      `Created journal entry: ${savedEntry.referenceNumber}`,
+      { entityId: savedEntry.id, userId: userId ?? 'system' },
+    );
 
     this.logger.log(`Journal entry created successfully with ID: ${savedEntry.id}`);
     return this.findOne(savedEntry.id);
@@ -301,6 +310,13 @@ export class JournalEntryService {
       await this.journalEntryLineRepository.save(lines);
     }
 
+    await this.auditLogService.log(
+      'UPDATE',
+      'JournalEntry',
+      `Updated journal entry: ${entry.referenceNumber}`,
+      { entityId: id, userId: userId ?? 'system' },
+    );
+
     this.logger.log(`Journal entry updated successfully: ${id}`);
     return this.findOne(id);
   }
@@ -337,6 +353,13 @@ export class JournalEntryService {
 
     // Soft delete the entry (lines will be cascade deleted)
     await this.journalEntryRepository.softDelete(id);
+
+    await this.auditLogService.log(
+      'DELETE',
+      'JournalEntry',
+      `Deleted journal entry: ${entry.referenceNumber}`,
+      { entityId: id, userId: userId ?? 'system' },
+    );
 
     this.logger.log(`Journal entry soft-deleted successfully: ${id}`);
   }
@@ -395,6 +418,13 @@ export class JournalEntryService {
     // Post the entry
     entry.status = JournalEntryStatus.POSTED;
     const postedEntry = await this.journalEntryRepository.save(entry);
+
+    await this.auditLogService.log(
+      'POST',
+      'JournalEntry',
+      `Posted journal entry: ${entry.referenceNumber}`,
+      { entityId: id, userId: userId ?? 'system' },
+    );
 
     this.logger.log(`Journal entry posted successfully: ${id}`);
     return this.toResponseDto(postedEntry);
@@ -471,6 +501,17 @@ export class JournalEntryService {
     originalEntry.reversedById = savedReversalEntry.id;
     await this.journalEntryRepository.save(originalEntry);
 
+    await this.auditLogService.log(
+      'REVERSE',
+      'JournalEntry',
+      `Reversed journal entry: ${originalEntry.referenceNumber} -> ${savedReversalEntry.referenceNumber}`,
+      {
+        entityId: id,
+        userId: userId ?? 'system',
+        metadata: { reversalEntryId: savedReversalEntry.id },
+      },
+    );
+
     this.logger.log(`Journal entry reversed successfully: ${id} -> ${savedReversalEntry.id}`);
     return this.findOne(savedReversalEntry.id);
   }
@@ -541,6 +582,17 @@ export class JournalEntryService {
     originalEntry.reversedById = savedReversalEntry.id;
     await this.journalEntryRepository.save(originalEntry);
 
+    await this.auditLogService.log(
+      'REVERSE',
+      'JournalEntry',
+      `Reversed journal entry: ${originalEntry.referenceNumber} (into period ${fiscalPeriodId})`,
+      {
+        entityId: id,
+        userId: userId ?? 'system',
+        metadata: { reversalEntryId: savedReversalEntry.id, fiscalPeriodId },
+      },
+    );
+
     this.logger.log(`Journal entry reversed: ${id} -> ${savedReversalEntry.id}`);
     return this.findOne(savedReversalEntry.id);
   }
@@ -562,7 +614,19 @@ export class JournalEntryService {
 
     for (const id of ids) {
       try {
+        const entry = await this.journalEntryRepository.findOne({
+          where: { id },
+          select: ['id', 'referenceNumber'],
+        });
         await this.postEntry(id);
+        if (entry) {
+          await this.auditLogService.log(
+            'POST',
+            'JournalEntry',
+            `Bulk posted journal entry: ${entry.referenceNumber}`,
+            { entityId: entry.id, userId: 'system' },
+          );
+        }
         succeeded.push(id);
       } catch (error: any) {
         failed.push({ id, error: error?.message || 'Unknown error' });
@@ -581,7 +645,19 @@ export class JournalEntryService {
 
     for (const id of ids) {
       try {
+        const entry = await this.journalEntryRepository.findOne({
+          where: { id },
+          select: ['id', 'referenceNumber'],
+        });
         await this.remove(id);
+        if (entry) {
+          await this.auditLogService.log(
+            'DELETE',
+            'JournalEntry',
+            `Bulk deleted journal entry: ${entry.referenceNumber}`,
+            { entityId: entry.id, userId: 'system' },
+          );
+        }
         succeeded.push(id);
       } catch (error: any) {
         failed.push({ id, error: error?.message || 'Unknown error' });

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -51,7 +51,8 @@ export class JournalEntryService {
    */
   async create(
     createDto: CreateJournalEntryDto,
-    userId: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<JournalEntryResponseDto> {
     this.logger.log(`Creating journal entry with date: ${createDto.entryDate}`);
 
@@ -111,7 +112,7 @@ export class JournalEntryService {
       'CREATE',
       'JournalEntry',
       `Created journal entry: ${savedEntry.referenceNumber}`,
-      { entityId: savedEntry.id, userId: userId ?? 'system' },
+      { entityId: savedEntry.id, userId: userId ?? 'system', username },
     );
 
     this.logger.log(`Journal entry created successfully with ID: ${savedEntry.id}`);
@@ -233,7 +234,8 @@ export class JournalEntryService {
   async update(
     id: string,
     updateDto: UpdateJournalEntryDto,
-    userId: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<JournalEntryResponseDto> {
     this.logger.log(`Updating journal entry with ID: ${id}`);
 
@@ -314,7 +316,7 @@ export class JournalEntryService {
       'UPDATE',
       'JournalEntry',
       `Updated journal entry: ${entry.referenceNumber}`,
-      { entityId: id, userId: userId ?? 'system' },
+      { entityId: id, userId: userId ?? 'system', username },
     );
 
     this.logger.log(`Journal entry updated successfully: ${id}`);
@@ -324,7 +326,7 @@ export class JournalEntryService {
   /**
    * Soft delete a journal entry (only if status = DRAFT)
    */
-  async remove(id: string, userId: string = 'system'): Promise<void> {
+  async remove(id: string, userId?: string, username?: string): Promise<void> {
     this.logger.log(`Deleting journal entry with ID: ${id}`);
 
     const entry = await this.journalEntryRepository.findOne({
@@ -358,7 +360,7 @@ export class JournalEntryService {
       'DELETE',
       'JournalEntry',
       `Deleted journal entry: ${entry.referenceNumber}`,
-      { entityId: id, userId: userId ?? 'system' },
+      { entityId: id, userId: userId ?? 'system', username },
     );
 
     this.logger.log(`Journal entry soft-deleted successfully: ${id}`);
@@ -368,7 +370,7 @@ export class JournalEntryService {
    * Post a draft entry
    * Validates: entry is balanced, period is open, changes status to POSTED
    */
-  async postEntry(id: string, userId: string = 'system'): Promise<JournalEntryResponseDto> {
+  async postEntry(id: string, userId?: string, username?: string): Promise<JournalEntryResponseDto> {
     this.logger.log(`Posting journal entry with ID: ${id}`);
 
     const entry = await this.journalEntryRepository.findOne({
@@ -423,7 +425,7 @@ export class JournalEntryService {
       'POST',
       'JournalEntry',
       `Posted journal entry: ${entry.referenceNumber}`,
-      { entityId: id, userId: userId ?? 'system' },
+      { entityId: id, userId: userId ?? 'system', username },
     );
 
     this.logger.log(`Journal entry posted successfully: ${id}`);
@@ -434,7 +436,7 @@ export class JournalEntryService {
    * Reverse a posted entry
    * Creates a new entry that's the mirror of the original
    */
-  async reverseEntry(id: string, userId: string = 'system'): Promise<JournalEntryResponseDto> {
+  async reverseEntry(id: string, userId?: string, username?: string): Promise<JournalEntryResponseDto> {
     this.logger.log(`Reversing journal entry with ID: ${id}`);
 
     const originalEntry = await this.journalEntryRepository.findOne({
@@ -508,6 +510,7 @@ export class JournalEntryService {
       {
         entityId: id,
         userId: userId ?? 'system',
+        username,
         metadata: { reversalEntryId: savedReversalEntry.id },
       },
     );
@@ -519,7 +522,8 @@ export class JournalEntryService {
   async reverseEntryInPeriod(
     id: string,
     fiscalPeriodId: string,
-    userId: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<JournalEntryResponseDto> {
     this.logger.log(`Reversing journal entry ${id} into period ${fiscalPeriodId}`);
 
@@ -589,6 +593,7 @@ export class JournalEntryService {
       {
         entityId: id,
         userId: userId ?? 'system',
+        username,
         metadata: { reversalEntryId: savedReversalEntry.id, fiscalPeriodId },
       },
     );
@@ -605,7 +610,7 @@ export class JournalEntryService {
     });
   }
 
-  async bulkPost(ids: string[]): Promise<{
+  async bulkPost(ids: string[], userId?: string, username?: string): Promise<{
     succeeded: string[];
     failed: { id: string; error: string }[];
   }> {
@@ -614,7 +619,7 @@ export class JournalEntryService {
 
     for (const id of ids) {
       try {
-        await this.postEntry(id);
+        await this.postEntry(id, userId, username);
         succeeded.push(id);
       } catch (error: any) {
         failed.push({ id, error: error?.message || 'Unknown error' });
@@ -624,7 +629,7 @@ export class JournalEntryService {
     return { succeeded, failed };
   }
 
-  async bulkDelete(ids: string[]): Promise<{
+  async bulkDelete(ids: string[], userId?: string, username?: string): Promise<{
     succeeded: string[];
     failed: { id: string; error: string }[];
   }> {
@@ -633,7 +638,7 @@ export class JournalEntryService {
 
     for (const id of ids) {
       try {
-        await this.remove(id);
+        await this.remove(id, userId, username);
         succeeded.push(id);
       } catch (error: any) {
         failed.push({ id, error: error?.message || 'Unknown error' });

--- a/backend/src/modules/accounting/services/owner-equity.service.spec.ts
+++ b/backend/src/modules/accounting/services/owner-equity.service.spec.ts
@@ -11,6 +11,7 @@ import {
 import { PaymentMethodEntity } from '../../../database/entities/payment-method.entity';
 import { AccountingService } from './accounting.service';
 import { SettingsService } from '../../settings/settings.service';
+import { AuditLogService } from '../../audit-logs/services';
 
 describe('OwnerEquityService', () => {
   let service: OwnerEquityService;
@@ -60,6 +61,12 @@ describe('OwnerEquityService', () => {
           provide: SettingsService,
           useValue: {
             generateDocumentNumber: jest.fn(),
+          },
+        },
+        {
+          provide: AuditLogService,
+          useValue: {
+            log: jest.fn(),
           },
         },
       ],

--- a/backend/src/modules/accounting/services/owner-equity.service.ts
+++ b/backend/src/modules/accounting/services/owner-equity.service.ts
@@ -114,7 +114,8 @@ export class OwnerEquityService {
 
   async create(
     dto: CreateOwnerEquityDto,
-    userId = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<OwnerEquityResponseDto> {
     const paymentMethod = await this.paymentMethodRepository.findOne({
       where: { id: dto.paymentMethodId, isActive: true },
@@ -141,7 +142,7 @@ export class OwnerEquityService {
       'CREATE',
       'OwnerEquity',
       `Created owner equity transaction: ${saved.referenceNumber}`,
-      { entityId: saved.id, userId: userId ?? 'system' },
+      { entityId: saved.id, userId: userId ?? 'system', username },
     );
     return this.findOne(saved.id);
   }
@@ -149,7 +150,8 @@ export class OwnerEquityService {
   async update(
     id: string,
     dto: UpdateOwnerEquityDto,
-    userId = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<OwnerEquityResponseDto> {
     const transaction = await this.ownerEquityRepository.findOne({
       where: { id },
@@ -183,12 +185,12 @@ export class OwnerEquityService {
       'UPDATE',
       'OwnerEquity',
       `Updated owner equity transaction: ${transaction.referenceNumber}`,
-      { entityId: id, userId: userId ?? 'system' },
+      { entityId: id, userId: userId ?? 'system', username },
     );
     return this.findOne(id);
   }
 
-  async remove(id: string): Promise<void> {
+  async remove(id: string, userId?: string, username?: string): Promise<void> {
     const transaction = await this.ownerEquityRepository.findOne({
       where: { id },
     });
@@ -206,11 +208,15 @@ export class OwnerEquityService {
       'DELETE',
       'OwnerEquity',
       `Deleted owner equity transaction: ${transaction.referenceNumber}`,
-      { entityId: id, userId: 'system' },
+      { entityId: id, userId: userId ?? 'system', username },
     );
   }
 
-  async post(id: string, userId = 'system'): Promise<OwnerEquityResponseDto> {
+  async post(
+    id: string,
+    userId?: string,
+    username?: string,
+  ): Promise<OwnerEquityResponseDto> {
     const transaction = await this.ownerEquityRepository.findOne({
       where: { id },
       relations: ['paymentMethod'],
@@ -228,7 +234,8 @@ export class OwnerEquityService {
     try {
       const journalEntry = await this.accountingService.postOwnerEquityEntry(
         transaction,
-        userId,
+        userId ?? 'system',
+        username,
       );
       transaction.status = OwnerEquityTransactionStatus.POSTED;
       transaction.journalEntryId = journalEntry.id;
@@ -237,7 +244,7 @@ export class OwnerEquityService {
         'POST',
         'OwnerEquity',
         `Posted owner equity transaction: ${transaction.referenceNumber}`,
-        { entityId: id, userId: userId ?? 'system' },
+        { entityId: id, userId: userId ?? 'system', username },
       );
     } catch (error) {
       this.logger.error(
@@ -251,14 +258,15 @@ export class OwnerEquityService {
 
   async bulkPost(
     dto: BulkOwnerEquityDto,
-    userId = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<{ posted: number; failed: number }> {
     let posted = 0;
     let failed = 0;
 
     for (const id of dto.ids) {
       try {
-        await this.post(id, userId);
+        await this.post(id, userId, username);
         posted++;
       } catch (error) {
         this.logger.error(`Failed to post owner equity ${id}: ${error.message}`);
@@ -269,13 +277,17 @@ export class OwnerEquityService {
     return { posted, failed };
   }
 
-  async bulkDelete(dto: BulkOwnerEquityDto): Promise<{ deleted: number; failed: number }> {
+  async bulkDelete(
+    dto: BulkOwnerEquityDto,
+    userId?: string,
+    username?: string,
+  ): Promise<{ deleted: number; failed: number }> {
     let deleted = 0;
     let failed = 0;
 
     for (const id of dto.ids) {
       try {
-        await this.remove(id);
+        await this.remove(id, userId, username);
         deleted++;
       } catch (error) {
         this.logger.error(`Failed to delete owner equity ${id}: ${error.message}`);

--- a/backend/src/modules/accounting/services/owner-equity.service.ts
+++ b/backend/src/modules/accounting/services/owner-equity.service.ts
@@ -22,6 +22,7 @@ import {
   OwnerEquityResponseDto,
   OwnerEquityListResponseDto,
 } from '../dto/owner-equity.dto';
+import { AuditLogService } from '../../audit-logs/services';
 
 @Injectable()
 export class OwnerEquityService {
@@ -34,6 +35,7 @@ export class OwnerEquityService {
     private readonly paymentMethodRepository: Repository<PaymentMethodEntity>,
     private readonly accountingService: AccountingService,
     private readonly settingsService: SettingsService,
+    private readonly auditLogService: AuditLogService,
   ) {}
 
   async findAll(query: QueryOwnerEquityDto): Promise<OwnerEquityListResponseDto> {
@@ -114,7 +116,6 @@ export class OwnerEquityService {
     dto: CreateOwnerEquityDto,
     userId = 'system',
   ): Promise<OwnerEquityResponseDto> {
-    void userId;
     const paymentMethod = await this.paymentMethodRepository.findOne({
       where: { id: dto.paymentMethodId, isActive: true },
     });
@@ -136,6 +137,12 @@ export class OwnerEquityService {
     });
 
     const saved = await this.ownerEquityRepository.save(transaction);
+    await this.auditLogService.log(
+      'CREATE',
+      'OwnerEquity',
+      `Created owner equity transaction: ${saved.referenceNumber}`,
+      { entityId: saved.id, userId: userId ?? 'system' },
+    );
     return this.findOne(saved.id);
   }
 
@@ -144,7 +151,6 @@ export class OwnerEquityService {
     dto: UpdateOwnerEquityDto,
     userId = 'system',
   ): Promise<OwnerEquityResponseDto> {
-    void userId;
     const transaction = await this.ownerEquityRepository.findOne({
       where: { id },
     });
@@ -173,6 +179,12 @@ export class OwnerEquityService {
     if (dto.description !== undefined) transaction.description = dto.description;
 
     await this.ownerEquityRepository.save(transaction);
+    await this.auditLogService.log(
+      'UPDATE',
+      'OwnerEquity',
+      `Updated owner equity transaction: ${transaction.referenceNumber}`,
+      { entityId: id, userId: userId ?? 'system' },
+    );
     return this.findOne(id);
   }
 
@@ -190,6 +202,12 @@ export class OwnerEquityService {
     }
 
     await this.ownerEquityRepository.softDelete(id);
+    await this.auditLogService.log(
+      'DELETE',
+      'OwnerEquity',
+      `Deleted owner equity transaction: ${transaction.referenceNumber}`,
+      { entityId: id, userId: 'system' },
+    );
   }
 
   async post(id: string, userId = 'system'): Promise<OwnerEquityResponseDto> {
@@ -215,6 +233,12 @@ export class OwnerEquityService {
       transaction.status = OwnerEquityTransactionStatus.POSTED;
       transaction.journalEntryId = journalEntry.id;
       await this.ownerEquityRepository.save(transaction);
+      await this.auditLogService.log(
+        'POST',
+        'OwnerEquity',
+        `Posted owner equity transaction: ${transaction.referenceNumber}`,
+        { entityId: id, userId: userId ?? 'system' },
+      );
     } catch (error) {
       this.logger.error(
         `Failed to post owner equity entry for ${transaction.referenceNumber}: ${error.message}`,

--- a/backend/src/modules/accounting/services/reconciliation.service.spec.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.spec.ts
@@ -14,6 +14,7 @@ import { ReconciledTransaction } from '../../../database/entities/reconciled-tra
 import { JournalEntryLine } from '../../../database/entities/journal-entry-line.entity';
 import { ChartOfAccount } from '../../../database/entities/chart-of-account.entity';
 import { FiscalPeriod, FiscalPeriodStatus } from '../../../database/entities/fiscal-period.entity';
+import { AuditLogService } from '../../audit-logs/services';
 
 describe('ReconciliationService', () => {
   let service: ReconciliationService;
@@ -123,6 +124,12 @@ describe('ReconciliationService', () => {
           provide: getRepositoryToken(FiscalPeriod),
           useValue: {
             findOne: jest.fn(),
+          },
+        },
+        {
+          provide: AuditLogService,
+          useValue: {
+            log: jest.fn(),
           },
         },
       ],

--- a/backend/src/modules/accounting/services/reconciliation.service.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.ts
@@ -49,7 +49,8 @@ export class ReconciliationService {
    */
   async create(
     createDto: CreateBankReconciliationDto,
-    userId: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<BankReconciliationResponseDto> {
     this.logger.log(`Creating bank reconciliation for account: ${createDto.accountId}`);
 
@@ -109,7 +110,7 @@ export class ReconciliationService {
       'CREATE',
       'BankReconciliation',
       `Created bank reconciliation for account: ${saved.accountId}`,
-      { entityId: saved.id, userId: userId ?? 'system' },
+      { entityId: saved.id, userId: userId ?? 'system', username },
     );
 
     this.logger.log(`Bank reconciliation created: ${saved.id}`);
@@ -200,7 +201,8 @@ export class ReconciliationService {
   async update(
     id: string,
     updateDto: UpdateBankReconciliationDto,
-    userId: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<BankReconciliationResponseDto> {
     const reconciliation = await this.reconciliationRepository.findOne({
       where: { id },
@@ -229,7 +231,7 @@ export class ReconciliationService {
       'UPDATE',
       'BankReconciliation',
       'Updated bank reconciliation',
-      { entityId: id, userId: userId ?? 'system' },
+      { entityId: id, userId: userId ?? 'system', username },
     );
 
     return this.findOne(id);
@@ -238,7 +240,7 @@ export class ReconciliationService {
   /**
    * Soft delete a reconciliation (only if IN_PROGRESS)
    */
-  async remove(id: string, userId: string = 'system'): Promise<void> {
+  async remove(id: string, userId?: string, username?: string): Promise<void> {
     const reconciliation = await this.reconciliationRepository.findOne({
       where: { id },
     });
@@ -256,7 +258,7 @@ export class ReconciliationService {
       'DELETE',
       'BankReconciliation',
       'Deleted bank reconciliation',
-      { entityId: id, userId: userId ?? 'system' },
+      { entityId: id, userId: userId ?? 'system', username },
     );
     this.logger.log(`Bank reconciliation soft-deleted: ${id}`);
   }
@@ -344,7 +346,8 @@ export class ReconciliationService {
    */
   async complete(
     id: string,
-    userId: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<BankReconciliationResponseDto> {
     const reconciliation = await this.reconciliationRepository.findOne({
       where: { id },
@@ -384,7 +387,12 @@ export class ReconciliationService {
       'UPDATE',
       'BankReconciliation',
       'Completed bank reconciliation',
-      { entityId: id, userId: userId ?? 'system', metadata: { status: 'COMPLETED' } },
+      {
+        entityId: id,
+        userId: userId ?? 'system',
+        username,
+        metadata: { status: 'COMPLETED' },
+      },
     );
 
     this.logger.log(`Bank reconciliation completed: ${id}`);
@@ -397,7 +405,8 @@ export class ReconciliationService {
    */
   async reopen(
     id: string,
-    userId: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<BankReconciliationResponseDto> {
     const reconciliation = await this.reconciliationRepository.findOne({
       where: { id },
@@ -418,7 +427,12 @@ export class ReconciliationService {
       'UPDATE',
       'BankReconciliation',
       'Reopened bank reconciliation',
-      { entityId: id, userId: userId ?? 'system', metadata: { status: 'IN_PROGRESS' } },
+      {
+        entityId: id,
+        userId: userId ?? 'system',
+        username,
+        metadata: { status: 'IN_PROGRESS' },
+      },
     );
 
     this.logger.log(`Bank reconciliation reopened: ${id}`);

--- a/backend/src/modules/accounting/services/reconciliation.service.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.ts
@@ -24,6 +24,7 @@ import {
   BankReconciliationListResponseDto,
   ReconciledTransactionResponseDto,
 } from '../dto/reconciliation.dto';
+import { AuditLogService } from '../../audit-logs/services';
 
 @Injectable()
 export class ReconciliationService {
@@ -40,6 +41,7 @@ export class ReconciliationService {
     private readonly chartOfAccountRepository: Repository<ChartOfAccount>,
     @InjectRepository(FiscalPeriod)
     private readonly fiscalPeriodRepository: Repository<FiscalPeriod>,
+    private readonly auditLogService: AuditLogService,
   ) {}
 
   /**
@@ -100,11 +102,15 @@ export class ReconciliationService {
 
     const saved = await this.reconciliationRepository.save(reconciliation);
 
-    // Keep signature parity for future user audit trails.
-    void userId;
-
     // Load unreconciled journal entry lines for this account and create transaction records
     await this.loadUnreconciledTransactions(saved.id, createDto.accountId);
+
+    await this.auditLogService.log(
+      'CREATE',
+      'BankReconciliation',
+      `Created bank reconciliation for account: ${saved.accountId}`,
+      { entityId: saved.id, userId: userId ?? 'system' },
+    );
 
     this.logger.log(`Bank reconciliation created: ${saved.id}`);
     return this.findOne(saved.id);
@@ -219,8 +225,12 @@ export class ReconciliationService {
     reconciliation.calculateDifference();
 
     await this.reconciliationRepository.save(reconciliation);
-
-    void userId;
+    await this.auditLogService.log(
+      'UPDATE',
+      'BankReconciliation',
+      'Updated bank reconciliation',
+      { entityId: id, userId: userId ?? 'system' },
+    );
 
     return this.findOne(id);
   }
@@ -242,9 +252,13 @@ export class ReconciliationService {
     }
 
     await this.reconciliationRepository.softDelete(id);
+    await this.auditLogService.log(
+      'DELETE',
+      'BankReconciliation',
+      'Deleted bank reconciliation',
+      { entityId: id, userId: userId ?? 'system' },
+    );
     this.logger.log(`Bank reconciliation soft-deleted: ${id}`);
-
-    void userId;
   }
 
   /**
@@ -366,9 +380,14 @@ export class ReconciliationService {
     updated.status = BankReconciliationStatus.COMPLETED;
     await this.reconciliationRepository.save(updated);
 
-    this.logger.log(`Bank reconciliation completed: ${id}`);
+    await this.auditLogService.log(
+      'UPDATE',
+      'BankReconciliation',
+      'Completed bank reconciliation',
+      { entityId: id, userId: userId ?? 'system', metadata: { status: 'COMPLETED' } },
+    );
 
-    void userId;
+    this.logger.log(`Bank reconciliation completed: ${id}`);
 
     return this.findOne(id);
   }
@@ -395,9 +414,14 @@ export class ReconciliationService {
     reconciliation.status = BankReconciliationStatus.IN_PROGRESS;
     await this.reconciliationRepository.save(reconciliation);
 
-    this.logger.log(`Bank reconciliation reopened: ${id}`);
+    await this.auditLogService.log(
+      'UPDATE',
+      'BankReconciliation',
+      'Reopened bank reconciliation',
+      { entityId: id, userId: userId ?? 'system', metadata: { status: 'IN_PROGRESS' } },
+    );
 
-    void userId;
+    this.logger.log(`Bank reconciliation reopened: ${id}`);
 
     return this.findOne(id);
   }

--- a/backend/src/modules/accounting/services/reconciliation.service.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.ts
@@ -269,7 +269,8 @@ export class ReconciliationService {
   async markCleared(
     id: string,
     dto: ToggleClearedDto,
-    userId: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<BankReconciliationResponseDto> {
     const reconciliation = await this.reconciliationRepository.findOne({
       where: { id },
@@ -298,8 +299,6 @@ export class ReconciliationService {
     // Recalculate book balance from cleared transactions
     await this.recalculateBalances(id);
 
-    void userId;
-
     return this.findOne(id);
   }
 
@@ -309,7 +308,8 @@ export class ReconciliationService {
   async unmarkCleared(
     id: string,
     dto: ToggleClearedDto,
-    userId: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<BankReconciliationResponseDto> {
     const reconciliation = await this.reconciliationRepository.findOne({
       where: { id },
@@ -335,8 +335,6 @@ export class ReconciliationService {
     }
 
     await this.recalculateBalances(id);
-
-    void userId;
 
     return this.findOne(id);
   }

--- a/backend/src/modules/accounting/services/reconciliation.service.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.ts
@@ -378,6 +378,7 @@ export class ReconciliationService {
       );
     }
 
+    const previousStatus = updated.status;
     updated.status = BankReconciliationStatus.COMPLETED;
     await this.reconciliationRepository.save(updated);
 
@@ -389,7 +390,8 @@ export class ReconciliationService {
         entityId: id,
         userId: userId ?? 'system',
         username,
-        metadata: { status: 'COMPLETED' },
+        oldValues: { status: previousStatus },
+        newValues: { status: updated.status },
       },
     );
 
@@ -418,6 +420,7 @@ export class ReconciliationService {
       throw new BadRequestException('Can only reopen completed reconciliations');
     }
 
+    const previousStatus = reconciliation.status;
     reconciliation.status = BankReconciliationStatus.IN_PROGRESS;
     await this.reconciliationRepository.save(reconciliation);
 
@@ -429,7 +432,8 @@ export class ReconciliationService {
         entityId: id,
         userId: userId ?? 'system',
         username,
-        metadata: { status: 'IN_PROGRESS' },
+        oldValues: { status: previousStatus },
+        newValues: { status: reconciliation.status },
       },
     );
 

--- a/backend/src/modules/accounting/services/settlement.service.spec.ts
+++ b/backend/src/modules/accounting/services/settlement.service.spec.ts
@@ -7,6 +7,7 @@ import { PaymentMethodEntity } from '../../../database/entities/payment-method.e
 import { Payment, SettlementStatusEnum } from '../../../database/entities/payment.entity';
 import { AccountingService } from './accounting.service';
 import { SettingsService } from '../../settings/settings.service';
+import { AuditLogService } from '../../audit-logs/services';
 
 describe('SettlementService', () => {
   let service: SettlementService;
@@ -54,6 +55,12 @@ describe('SettlementService', () => {
           provide: SettingsService,
           useValue: {
             generateDocumentNumber: jest.fn(),
+          },
+        },
+        {
+          provide: AuditLogService,
+          useValue: {
+            log: jest.fn(),
           },
         },
       ],

--- a/backend/src/modules/accounting/services/settlement.service.ts
+++ b/backend/src/modules/accounting/services/settlement.service.ts
@@ -18,6 +18,7 @@ import {
 } from '../dto/settlement.dto';
 import { AccountingService } from './accounting.service';
 import { SettingsService } from '../../settings/settings.service';
+import { AuditLogService } from '../../audit-logs/services';
 
 @Injectable()
 export class SettlementService {
@@ -32,6 +33,7 @@ export class SettlementService {
     private readonly paymentRepository: Repository<Payment>,
     private readonly accountingService: AccountingService,
     private readonly settingsService: SettingsService,
+    private readonly auditLogService: AuditLogService,
   ) {}
 
   async findAll(query: QuerySettlementsDto): Promise<SettlementListResponseDto> {
@@ -169,6 +171,13 @@ export class SettlementService {
       );
     }
 
+    await this.auditLogService.log(
+      'CREATE',
+      'Settlement',
+      `Created settlement: ${savedSettlement.settlementNumber}`,
+      { entityId: savedSettlement.id, userId: userId ?? 'system' },
+    );
+
     return this.findOne(savedSettlement.id);
   }
 
@@ -196,6 +205,13 @@ export class SettlementService {
 
     settlement.status = SettlementStatus.CANCELLED;
     const saved = await this.settlementRepository.save(settlement);
+
+    await this.auditLogService.log(
+      'UPDATE',
+      'Settlement',
+      `Cancelled settlement: ${saved.settlementNumber}`,
+      { entityId: id, userId: 'system', metadata: { status: 'CANCELLED' } },
+    );
 
     return this.toResponseDto(saved);
   }

--- a/backend/src/modules/accounting/services/settlement.service.ts
+++ b/backend/src/modules/accounting/services/settlement.service.ts
@@ -208,6 +208,7 @@ export class SettlementService {
       },
     );
 
+    const previousStatus = settlement.status;
     settlement.status = SettlementStatus.CANCELLED;
     const saved = await this.settlementRepository.save(settlement);
 
@@ -219,7 +220,8 @@ export class SettlementService {
         entityId: id,
         userId: userId ?? 'system',
         username,
-        metadata: { status: 'CANCELLED' },
+        oldValues: { status: previousStatus },
+        newValues: { status: saved.status },
       },
     );
 

--- a/backend/src/modules/accounting/services/settlement.service.ts
+++ b/backend/src/modules/accounting/services/settlement.service.ts
@@ -95,7 +95,11 @@ export class SettlementService {
     return this.toResponseDto(settlement);
   }
 
-  async create(dto: CreateSettlementDto, userId = 'system'): Promise<SettlementResponseDto> {
+  async create(
+    dto: CreateSettlementDto,
+    userId?: string,
+    username?: string,
+  ): Promise<SettlementResponseDto> {
     const paymentMethod = await this.paymentMethodRepository.findOne({
       where: { id: dto.paymentMethodId, isActive: true },
     });
@@ -163,7 +167,7 @@ export class SettlementService {
         savedSettlement,
         paymentMethod,
         totalAmount,
-        userId,
+        userId || 'system',
       );
     } catch (error) {
       this.logger.error(
@@ -175,13 +179,13 @@ export class SettlementService {
       'CREATE',
       'Settlement',
       `Created settlement: ${savedSettlement.settlementNumber}`,
-      { entityId: savedSettlement.id, userId: userId ?? 'system' },
+      { entityId: savedSettlement.id, userId: userId ?? 'system', username },
     );
 
     return this.findOne(savedSettlement.id);
   }
 
-  async cancel(id: string): Promise<SettlementResponseDto> {
+  async cancel(id: string, userId?: string, username?: string): Promise<SettlementResponseDto> {
     const settlement = await this.settlementRepository.findOne({
       where: { id },
       relations: ['paymentMethod'],
@@ -210,7 +214,12 @@ export class SettlementService {
       'UPDATE',
       'Settlement',
       `Cancelled settlement: ${saved.settlementNumber}`,
-      { entityId: id, userId: 'system', metadata: { status: 'CANCELLED' } },
+      {
+        entityId: id,
+        userId: userId ?? 'system',
+        username,
+        metadata: { status: 'CANCELLED' },
+      },
     );
 
     return this.toResponseDto(saved);

--- a/backend/src/modules/accounting/services/settlement.service.ts
+++ b/backend/src/modules/accounting/services/settlement.service.ts
@@ -168,6 +168,7 @@ export class SettlementService {
         paymentMethod,
         totalAmount,
         userId || 'system',
+        username,
       );
     } catch (error) {
       this.logger.error(

--- a/backend/src/modules/audit-logs/dto/query-audit-logs.dto.ts
+++ b/backend/src/modules/audit-logs/dto/query-audit-logs.dto.ts
@@ -54,6 +54,11 @@ export class QueryAuditLogsDto {
   @IsString()
   username?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by IP address', example: '192.168.1.1' })
+  @IsOptional()
+  @IsString()
+  ipAddress?: string;
+
   @ApiPropertyOptional({ description: 'Start date', format: 'date-time' })
   @IsOptional()
   @IsDateString()

--- a/backend/src/modules/audit-logs/services/audit-log.service.ts
+++ b/backend/src/modules/audit-logs/services/audit-log.service.ts
@@ -87,6 +87,7 @@ export class AuditLogService {
       entityId,
       userId,
       username,
+      ipAddress,
       startDate,
       endDate,
       sortBy = 'createdAt',
@@ -122,6 +123,10 @@ export class AuditLogService {
 
     if (username) {
       where.username = Like(`%${username}%`);
+    }
+
+    if (ipAddress) {
+      where.ipAddress = ipAddress;
     }
 
     if (startDate && endDate) {

--- a/backend/src/modules/inventory/controllers/category.controller.ts
+++ b/backend/src/modules/inventory/controllers/category.controller.ts
@@ -423,10 +423,10 @@ export class CategoryController {
   })
   async remove(
     @Param('id', ParseUUIDPipe) id: string,
-    @Query('force') force?: boolean,
-    @Query('moveToUncategorized') moveToUncategorized?: boolean,
     @CurrentUser('userId') currentUserId: string,
     @CurrentUser('username') currentUsername: string,
+    @Query('force') force?: boolean,
+    @Query('moveToUncategorized') moveToUncategorized?: boolean,
   ): Promise<{ message: string; moved?: number }> {
     const result = await this.categoryService.remove(
       id,

--- a/backend/src/modules/inventory/controllers/category.controller.ts
+++ b/backend/src/modules/inventory/controllers/category.controller.ts
@@ -425,8 +425,8 @@ export class CategoryController {
     @Param('id', ParseUUIDPipe) id: string,
     @Query('force') force?: boolean,
     @Query('moveToUncategorized') moveToUncategorized?: boolean,
-    @CurrentUser('userId') currentUserId: string = 'system',
-    @CurrentUser('username') currentUsername?: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ message: string; moved?: number }> {
     const result = await this.categoryService.remove(
       id,

--- a/backend/src/modules/inventory/controllers/category.controller.ts
+++ b/backend/src/modules/inventory/controllers/category.controller.ts
@@ -33,6 +33,7 @@ import {
   CategoryStatsDto,
   CategoryAncestorsDto,
 } from '../dto/category.dto';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 
 @ApiTags('Categories')
 @Controller('inventory/categories')
@@ -54,8 +55,10 @@ export class CategoryController {
   @ApiBody({ type: CreateCategoryDto })
   async create(
     @Body() createCategoryDto: CreateCategoryDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<CategoryResponseDto> {
-    return this.categoryService.create(createCategoryDto);
+    return this.categoryService.create(createCategoryDto, currentUserId, currentUsername);
   }
 
   @Get()
@@ -231,8 +234,10 @@ export class CategoryController {
   async update(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateCategoryDto: UpdateCategoryDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<CategoryResponseDto> {
-    return this.categoryService.update(id, updateCategoryDto);
+    return this.categoryService.update(id, updateCategoryDto, currentUserId, currentUsername);
   }
 
   @Patch(':id/move')
@@ -293,8 +298,14 @@ export class CategoryController {
   @HttpCode(HttpStatus.OK)
   async bulkRestore(
     @Body() body: { categoryIds: string[] },
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ message: string; restoredCount: number; failedIds: string[] }> {
-    const result = await this.categoryService.bulkRestore(body.categoryIds);
+    const result = await this.categoryService.bulkRestore(
+      body.categoryIds,
+      currentUserId,
+      currentUsername,
+    );
     return {
       message: `Successfully restored ${result.successCount} of ${body.categoryIds.length} categories`,
       restoredCount: result.successCount,
@@ -314,8 +325,10 @@ export class CategoryController {
   @ApiParam({ name: 'id', description: 'Category ID' })
   async restore(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<CategoryResponseDto> {
-    return this.categoryService.restore(id);
+    return this.categoryService.restore(id, currentUserId, currentUsername);
   }
 
   @Post('bulk-permanent-delete')
@@ -341,8 +354,14 @@ export class CategoryController {
   @HttpCode(HttpStatus.OK)
   async bulkPermanentDelete(
     @Body() body: { categoryIds: string[] },
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ message: string; deletedCount: number; failedIds: string[] }> {
-    const result = await this.categoryService.bulkPermanentDelete(body.categoryIds);
+    const result = await this.categoryService.bulkPermanentDelete(
+      body.categoryIds,
+      currentUserId,
+      currentUsername,
+    );
     return {
       message: `Successfully permanently deleted ${result.successCount} of ${body.categoryIds.length} categories`,
       deletedCount: result.successCount,
@@ -365,8 +384,10 @@ export class CategoryController {
   @HttpCode(HttpStatus.NO_CONTENT)
   async permanentDelete(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<void> {
-    await this.categoryService.permanentDelete(id);
+    await this.categoryService.permanentDelete(id, currentUserId, currentUsername);
   }
 
   @Delete(':id')
@@ -404,11 +425,18 @@ export class CategoryController {
     @Param('id', ParseUUIDPipe) id: string,
     @Query('force') force?: boolean,
     @Query('moveToUncategorized') moveToUncategorized?: boolean,
+    @CurrentUser('userId') currentUserId: string = 'system',
+    @CurrentUser('username') currentUsername?: string,
   ): Promise<{ message: string; moved?: number }> {
-    const result = await this.categoryService.remove(id, 'system', {
-      force: force === true,
-      moveToUncategorized: moveToUncategorized === true
-    });
+    const result = await this.categoryService.remove(
+      id,
+      currentUserId,
+      {
+        force: force === true,
+        moveToUncategorized: moveToUncategorized === true,
+      },
+      currentUsername,
+    );
     return result;
   }
 }

--- a/backend/src/modules/inventory/controllers/product.controller.ts
+++ b/backend/src/modules/inventory/controllers/product.controller.ts
@@ -538,7 +538,9 @@ export class ProductController {
   @HttpCode(HttpStatus.NO_CONTENT)
   async remove(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<void> {
-    await this.productService.remove(id);
+    await this.productService.remove(id, currentUserId, currentUsername);
   }
 }

--- a/backend/src/modules/inventory/controllers/product.controller.ts
+++ b/backend/src/modules/inventory/controllers/product.controller.ts
@@ -38,6 +38,7 @@ import {
   ProductImportDto,
   ProductImportResultDto,
 } from '../dto/product.dto';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 
 @ApiTags('Products')
 @Controller('inventory/products')
@@ -69,8 +70,10 @@ export class ProductController {
   @ApiBody({ type: CreateProductDto })
   async create(
     @Body() createProductDto: CreateProductDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<ProductResponseDto> {
-    return this.productService.create(createProductDto, null);
+    return this.productService.create(createProductDto, currentUserId, currentUsername);
   }
 
   @Get()
@@ -261,8 +264,10 @@ export class ProductController {
   async update(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateProductDto: UpdateProductDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<ProductResponseDto> {
-    return this.productService.update(id, updateProductDto, null);
+    return this.productService.update(id, updateProductDto, currentUserId, currentUsername);
   }
 
   @Post('bulk-update-prices')
@@ -379,8 +384,14 @@ export class ProductController {
   @HttpCode(HttpStatus.OK)
   async bulkRestore(
     @Body() body: { productIds: string[] },
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ message: string; restoredCount: number; failedIds: string[] }> {
-    const result = await this.productService.bulkRestore(body.productIds, null);
+    const result = await this.productService.bulkRestore(
+      body.productIds,
+      currentUserId,
+      currentUsername,
+    );
     return {
       message: `Successfully restored ${result.successCount} of ${body.productIds.length} products`,
       restoredCount: result.successCount,
@@ -401,8 +412,10 @@ export class ProductController {
   @HttpCode(HttpStatus.OK)
   async restore(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<ProductResponseDto> {
-    return this.productService.restore(id, null);
+    return this.productService.restore(id, currentUserId, currentUsername);
   }
 
   @Post('import')
@@ -474,8 +487,14 @@ export class ProductController {
   @HttpCode(HttpStatus.OK)
   async bulkPermanentDelete(
     @Body() body: { productIds: string[] },
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ message: string; deletedCount: number; failedIds: string[] }> {
-    const result = await this.productService.bulkPermanentDelete(body.productIds, null);
+    const result = await this.productService.bulkPermanentDelete(
+      body.productIds,
+      currentUserId,
+      currentUsername,
+    );
     return {
       message: `Successfully permanently deleted ${result.successCount} of ${body.productIds.length} products`,
       deletedCount: result.successCount,
@@ -498,8 +517,10 @@ export class ProductController {
   @HttpCode(HttpStatus.NO_CONTENT)
   async permanentDelete(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<void> {
-    await this.productService.permanentDelete(id, null);
+    await this.productService.permanentDelete(id, currentUserId, currentUsername);
   }
 
   @Delete(':id')

--- a/backend/src/modules/inventory/controllers/stock-adjustment.controller.ts
+++ b/backend/src/modules/inventory/controllers/stock-adjustment.controller.ts
@@ -27,6 +27,7 @@ import {
   StockAdjustmentResponseDto,
   StockAdjustmentListResponseDto,
 } from '../dto/stock-adjustment.dto';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 
 @ApiTags('Stock Adjustments')
 @Controller('inventory/stock-adjustments')
@@ -47,8 +48,10 @@ export class StockAdjustmentController {
   @ApiBody({ type: CreateStockAdjustmentDto })
   async create(
     @Body() createDto: CreateStockAdjustmentDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<StockAdjustmentResponseDto> {
-    return this.stockAdjustmentService.create(createDto);
+    return this.stockAdjustmentService.create(createDto, currentUserId, currentUsername);
   }
 
   @Get('deleted')
@@ -111,8 +114,10 @@ export class StockAdjustmentController {
   async update(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateDto: UpdateStockAdjustmentDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<StockAdjustmentResponseDto> {
-    return this.stockAdjustmentService.update(id, updateDto);
+    return this.stockAdjustmentService.update(id, updateDto, currentUserId, currentUsername);
   }
 
   @Post(':id/complete')
@@ -174,8 +179,10 @@ export class StockAdjustmentController {
   @ApiParam({ name: 'id', description: 'Stock adjustment ID' })
   async restore(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<StockAdjustmentResponseDto> {
-    return this.stockAdjustmentService.restore(id);
+    return this.stockAdjustmentService.restore(id, currentUserId, currentUsername);
   }
 
   @Delete(':id/permanent')
@@ -193,8 +200,10 @@ export class StockAdjustmentController {
   @HttpCode(HttpStatus.NO_CONTENT)
   async permanentDelete(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<void> {
-    await this.stockAdjustmentService.permanentDelete(id);
+    await this.stockAdjustmentService.permanentDelete(id, currentUserId, currentUsername);
   }
 
   @Post('bulk-permanent-delete')
@@ -217,8 +226,14 @@ export class StockAdjustmentController {
   })
   async bulkPermanentDelete(
     @Body() body: { stockAdjustmentIds: string[] },
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<any> {
-    const result = await this.stockAdjustmentService.bulkPermanentDelete(body.stockAdjustmentIds);
+    const result = await this.stockAdjustmentService.bulkPermanentDelete(
+      body.stockAdjustmentIds,
+      currentUserId,
+      currentUsername,
+    );
     return {
       message: `Successfully permanently deleted ${result.successCount} of ${body.stockAdjustmentIds.length} stock adjustments`,
       ...result

--- a/backend/src/modules/inventory/controllers/stock-adjustment.controller.ts
+++ b/backend/src/modules/inventory/controllers/stock-adjustment.controller.ts
@@ -163,8 +163,12 @@ export class StockAdjustmentController {
   @ApiResponse({ status: 400, description: 'Only draft adjustments can be deleted' })
   @ApiResponse({ status: 404, description: 'Stock adjustment not found' })
   @ApiParam({ name: 'id', description: 'Stock adjustment ID' })
-  async remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
-    return this.stockAdjustmentService.remove(id);
+  async remove(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<void> {
+    return this.stockAdjustmentService.remove(id, currentUserId, currentUsername);
   }
 
   @Post(':id/restore')

--- a/backend/src/modules/inventory/services/category.service.ts
+++ b/backend/src/modules/inventory/services/category.service.ts
@@ -748,6 +748,13 @@ export class CategoryService {
           isActive: true,
         });
 
+        await this.auditLogService.log(
+          'RESTORE',
+          'Category',
+          `Restored category: ${category.name}`,
+          { entityId: categoryId, userId: userId || 'system', username }
+        );
+
         successCount++;
         this.logger.log(`Category restored: ${categoryId}`);
       } catch (error) {
@@ -820,6 +827,12 @@ export class CategoryService {
         }
 
         // Perform the permanent deletion
+        await this.auditLogService.log(
+          'PERMANENT_DELETE',
+          'Category',
+          `Permanently deleted category: ${category.name}`,
+          { entityId: categoryId, userId: userId || 'system', username }
+        );
         await this.categoryRepository.remove(category);
 
         successCount++;

--- a/backend/src/modules/inventory/services/category.service.ts
+++ b/backend/src/modules/inventory/services/category.service.ts
@@ -50,7 +50,11 @@ export class CategoryService {
   /**
    * Create a new category
    */
-  async create(createCategoryDto: CreateCategoryDto, userId?: string): Promise<CategoryResponseDto> {
+  async create(
+    createCategoryDto: CreateCategoryDto,
+    userId?: string,
+    username?: string,
+  ): Promise<CategoryResponseDto> {
     this.logger.log(`Creating category: ${createCategoryDto.name}`);
 
     // Check if name already exists at the same level
@@ -90,6 +94,7 @@ export class CategoryService {
       {
         entityId: savedCategory.id,
         userId: userId || 'system',
+        username,
         newValues: {
           name: savedCategory.name,
           parentId: savedCategory.parentId,
@@ -344,7 +349,12 @@ export class CategoryService {
   /**
    * Update a category
    */
-  async update(id: string, updateCategoryDto: UpdateCategoryDto, userId?: string): Promise<CategoryResponseDto> {
+  async update(
+    id: string,
+    updateCategoryDto: UpdateCategoryDto,
+    userId?: string,
+    username?: string,
+  ): Promise<CategoryResponseDto> {
     this.logger.log(`Updating category with ID: ${id}`);
 
     const category = await this.categoryRepository.findOne({ where: { id } });
@@ -439,6 +449,7 @@ export class CategoryService {
         {
           entityId: updatedCategory.id,
           userId: userId || 'system',
+          username,
           oldValues: Object.fromEntries(
             Object.entries(changes).map(([key, val]) => [key, val.from])
           ),
@@ -508,7 +519,7 @@ export class CategoryService {
   async remove(id: string, userId?: string, options?: {
     force?: boolean;
     moveToUncategorized?: boolean;
-  }): Promise<{ message: string; moved?: number }> {
+  }, username?: string): Promise<{ message: string; moved?: number }> {
     this.logger.log(`Deleting category with ID: ${id}`, { options });
 
     const category = await this.categoryRepository.findOne({
@@ -579,6 +590,7 @@ export class CategoryService {
       {
         entityId: category.id,
         userId: userId || 'system',
+        username,
         oldValues: {
           name: category.name,
           parentId: category.parentId,
@@ -594,7 +606,7 @@ export class CategoryService {
   /**
    * Restore a soft-deleted category
    */
-  async restore(id: string, userId?: string): Promise<CategoryResponseDto> {
+  async restore(id: string, userId?: string, username?: string): Promise<CategoryResponseDto> {
     this.logger.log(`Restoring category with ID: ${id}`);
 
     const category = await this.categoryRepository.findOne({
@@ -626,6 +638,7 @@ export class CategoryService {
       {
         entityId: restoredCategory.id,
         userId: userId || 'system',
+        username,
         newValues: {
           name: restoredCategory.name,
           parentId: restoredCategory.parentId,
@@ -641,7 +654,7 @@ export class CategoryService {
   /**
    * Permanently delete a category from database
    */
-  async permanentDelete(id: string, userId?: string): Promise<void> {
+  async permanentDelete(id: string, userId?: string, username?: string): Promise<void> {
     this.logger.log(`Permanently deleting category with ID: ${id}`);
 
     // Find the category (including soft-deleted ones)
@@ -675,6 +688,7 @@ export class CategoryService {
       {
         entityId: id,
         userId: userId || 'system',
+        username,
         oldValues: {
           name: category.name,
           parentId: category.parentId,
@@ -692,7 +706,11 @@ export class CategoryService {
   /**
    * Bulk restore soft-deleted categories
    */
-  async bulkRestore(categoryIds: string[]): Promise<BulkOperationResponse> {
+  async bulkRestore(
+    categoryIds: string[],
+    userId?: string,
+    username?: string,
+  ): Promise<BulkOperationResponse> {
     this.logger.log(`Bulk restoring ${categoryIds.length} categories`);
 
     if (!categoryIds || categoryIds.length === 0) {
@@ -749,7 +767,11 @@ export class CategoryService {
   /**
    * Bulk permanently delete categories from database
    */
-  async bulkPermanentDelete(categoryIds: string[]): Promise<BulkOperationResponse> {
+  async bulkPermanentDelete(
+    categoryIds: string[],
+    userId?: string,
+    username?: string,
+  ): Promise<BulkOperationResponse> {
     this.logger.log(`Bulk permanently deleting ${categoryIds.length} categories`);
 
     if (!categoryIds || categoryIds.length === 0) {

--- a/backend/src/modules/inventory/services/product.service.ts
+++ b/backend/src/modules/inventory/services/product.service.ts
@@ -76,7 +76,11 @@ export class ProductService {
   /**
    * Create a new product
    */
-  async create(createProductDto: CreateProductDto, userId?: string): Promise<ProductResponseDto> {
+  async create(
+    createProductDto: CreateProductDto,
+    userId?: string,
+    username?: string,
+  ): Promise<ProductResponseDto> {
     this.logger.log(`Creating product with barcode: ${createProductDto.barcode}`);
 
     // Check if product name already exists (case-insensitive, including soft-deleted products)
@@ -186,6 +190,7 @@ export class ProductService {
       {
         entityId: savedProduct.id,
         userId: userId || 'system',
+        username,
         newValues: {
           name: savedProduct.name,
           barcode: savedProduct.barcode,
@@ -496,7 +501,7 @@ export class ProductService {
   /**
    * Restore a soft-deleted product
    */
-  async restore(id: string, _userId?: string): Promise<ProductResponseDto> {
+  async restore(id: string, userId?: string, username?: string): Promise<ProductResponseDto> {
     this.logger.log(`Restoring product with ID: ${id}`);
 
     const product = await this.productRepository.findOne({
@@ -540,7 +545,8 @@ export class ProductService {
       `Restored product: ${restoredProduct.name} (${restoredProduct.barcode})`,
       {
         entityId: restoredProduct.id,
-        userId: _userId || 'system',
+        userId: userId || 'system',
+        username,
         newValues: {
           name: restoredProduct.name,
           barcode: restoredProduct.barcode,
@@ -558,7 +564,8 @@ export class ProductService {
    */
   async bulkRestore(
     productIds: string[],
-    userId?: string
+    userId?: string,
+    username?: string,
   ): Promise<BulkOperationResponse> {
     this.logger.log(`Bulk restoring ${productIds.length} products`);
 
@@ -633,7 +640,7 @@ export class ProductService {
   /**
    * Permanently delete a product from database
    */
-  async permanentDelete(id: string, userId?: string): Promise<void> {
+  async permanentDelete(id: string, userId?: string, username?: string): Promise<void> {
     this.logger.log(`Permanently deleting product with ID: ${id}`);
 
     // Find the product (including soft-deleted ones)
@@ -667,6 +674,7 @@ export class ProductService {
       {
         entityId: id,
         userId: userId || 'system',
+        username,
         oldValues: {
           name: product.name,
           barcode: product.barcode,
@@ -687,7 +695,8 @@ export class ProductService {
    */
   async bulkPermanentDelete(
     productIds: string[],
-    userId?: string
+    userId?: string,
+    username?: string,
   ): Promise<BulkOperationResponse> {
     this.logger.log(`Bulk permanently deleting ${productIds.length} products`);
 
@@ -759,7 +768,12 @@ export class ProductService {
   /**
    * Update a product
    */
-  async update(id: string, updateProductDto: UpdateProductDto, userId?: string): Promise<ProductResponseDto> {
+  async update(
+    id: string,
+    updateProductDto: UpdateProductDto,
+    userId?: string,
+    username?: string,
+  ): Promise<ProductResponseDto> {
     this.logger.log(`Updating product with ID: ${id}`);
     console.log('🚀 UPDATE METHOD CALLED - CODE VERSION 2.0');
 
@@ -895,6 +909,7 @@ export class ProductService {
         {
           entityId: productWithCategory.id,
           userId: userId || 'system',
+          username,
           oldValues: Object.fromEntries(
             Object.entries(changes).map(([key, val]) => [key, val.from])
           ),

--- a/backend/src/modules/inventory/services/product.service.ts
+++ b/backend/src/modules/inventory/services/product.service.ts
@@ -621,6 +621,13 @@ export class ProductService {
         // Restore the product
         await this.productRepository.restore(id);
 
+        await this.auditLogService.log(
+          'RESTORE',
+          'Product',
+          `Restored product: ${product.name} (${product.barcode})`,
+          { entityId: id, userId: userId || 'system', username }
+        );
+
         successCount++;
         this.logger.log(`Product restored: ${id}`);
       } catch (error) {
@@ -747,6 +754,12 @@ export class ProductService {
         }
 
         // Hard delete the product from database
+        await this.auditLogService.log(
+          'PERMANENT_DELETE',
+          'Product',
+          `Permanently deleted product: ${product.name} (${product.barcode})`,
+          { entityId: id, userId: userId || 'system', username, oldValues: { name: product.name, barcode: product.barcode } }
+        );
         await this.productRepository.delete(id);
 
         successCount++;
@@ -775,7 +788,6 @@ export class ProductService {
     username?: string,
   ): Promise<ProductResponseDto> {
     this.logger.log(`Updating product with ID: ${id}`);
-    console.log('🚀 UPDATE METHOD CALLED - CODE VERSION 2.0');
 
     const product = await this.productRepository.findOne({
       where: { id },
@@ -855,13 +867,6 @@ export class ProductService {
       this.validatePricing({ ...product, ...updateData } as any);
     }
 
-    // Debug logging
-    console.log('=== PRODUCT UPDATE DEBUG ===');
-    console.log('Current product.categoryId:', product.categoryId);
-    console.log('Original DTO:', updateProductDto);
-    console.log('Transformed updateData:', updateData);
-    console.log('Update DTO categoryId:', updateData.categoryId);
-
     // Track changes for audit (use transformed data)
     const changes: Record<string, { from: any; to: any }> = {};
     Object.keys(updateData).forEach(key => {
@@ -870,35 +875,22 @@ export class ProductService {
       }
     });
 
-    console.log('Detected changes:', changes);
-
     // Update product with transformed data
     Object.assign(product, updateData);
-    
-    console.log('After Object.assign - product.categoryId:', product.categoryId);
-    console.log('=============================');
 
     // Stock status is computed automatically in the entity
 
     // Use direct update with ID string for better control over what gets updated
-    const updateResult = await this.productRepository.update(
+    await this.productRepository.update(
       id,  // Use the ID parameter directly, not product.id
       updateData
     );
-    console.log('UPDATE RESULT:', updateResult);
-
-    const updatedProduct = await this.productRepository.findOne({
-      where: { id },
-    });
-    console.log('POST-UPDATE updatedProduct.categoryId:', updatedProduct?.categoryId);
 
     // Reload the product with category relation to ensure fresh data
     const productWithCategory = await this.productRepository.findOne({
       where: { id },
       relations: ['category'],
     });
-    console.log('RELOADED productWithCategory.categoryId:', productWithCategory?.categoryId);
-    console.log('RELOADED productWithCategory.category:', productWithCategory?.category?.name);
 
     // Log audit trail for update
     if (Object.keys(changes).length > 0) {
@@ -1003,7 +995,7 @@ export class ProductService {
    * Only check for active sales order items to prevent deletion of products
    * currently in pending orders.
    */
-  async remove(id: string): Promise<void> {
+  async remove(id: string, userId?: string, username?: string): Promise<void> {
     this.logger.log(`Deleting product with ID: ${id}`);
 
     const product = await this.productRepository.findOne({
@@ -1040,7 +1032,8 @@ export class ProductService {
       `Deleted product: ${product.name} (${product.barcode})`,
       {
         entityId: product.id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         oldValues: {
           name: product.name,
           barcode: product.barcode,

--- a/backend/src/modules/inventory/services/product.service.ts
+++ b/backend/src/modules/inventory/services/product.service.ts
@@ -912,7 +912,7 @@ export class ProductService {
       );
     }
 
-    this.logger.log(`Product updated successfully: ${updatedProduct.id}`);
+    this.logger.log(`Product updated successfully: ${id}`);
     return this.toResponseDto(productWithCategory!);
   }
 

--- a/backend/src/modules/inventory/services/stock-adjustment.service.spec.ts
+++ b/backend/src/modules/inventory/services/stock-adjustment.service.spec.ts
@@ -186,6 +186,7 @@ describe('StockAdjustmentService', () => {
           adjustmentNumber: mockAdjustment.adjustmentNumber,
         }),
         'system',
+        undefined,
       );
       expect(result).toBeDefined();
       expect(stockMovementService.create).toHaveBeenCalled();
@@ -267,6 +268,7 @@ describe('StockAdjustmentService', () => {
           items: expect.any(Array),
         }),
         'system',
+        undefined,
       );
       expect(result).toBeDefined();
     });

--- a/backend/src/modules/inventory/services/stock-adjustment.service.ts
+++ b/backend/src/modules/inventory/services/stock-adjustment.service.ts
@@ -426,7 +426,11 @@ export class StockAdjustmentService {
     // Auto-post to accounting (don't fail completion on error)
     try {
       const fullAdjustment = await this.findOne(id); // Get adjustment with relations
-      await this.accountingService.postStockAdjustmentEntry(fullAdjustment as any, userId || 'system');
+      await this.accountingService.postStockAdjustmentEntry(
+        fullAdjustment as any,
+        userId || 'system',
+        username,
+      );
       this.logger.log(`Posted accounting entry for stock adjustment ${adjustment.adjustmentNumber}`);
     } catch (error) {
       this.logger.error(

--- a/backend/src/modules/inventory/services/stock-adjustment.service.ts
+++ b/backend/src/modules/inventory/services/stock-adjustment.service.ts
@@ -87,6 +87,8 @@ export class StockAdjustmentService {
    */
   async create(
     createDto: CreateStockAdjustmentDto,
+    userId?: string,
+    username?: string,
   ): Promise<StockAdjustmentResponseDto> {
     this.logger.log(`Creating stock adjustment with ${createDto.items.length} items`);
 
@@ -151,7 +153,8 @@ export class StockAdjustmentService {
       `Created stock adjustment: ${adjustmentNumber} (${items.length} items, RM ${totalValue.toFixed(2)})`,
       {
         entityId: saved.id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         newValues: {
           adjustmentNumber,
           itemCount: items.length,
@@ -251,6 +254,8 @@ export class StockAdjustmentService {
   async update(
     id: string,
     updateDto: UpdateStockAdjustmentDto,
+    userId?: string,
+    username?: string,
   ): Promise<StockAdjustmentResponseDto> {
     const adjustment = await this.stockAdjustmentRepository.findOne({
       where: { id },
@@ -328,7 +333,8 @@ export class StockAdjustmentService {
       `Updated stock adjustment: ${saved.adjustmentNumber}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         newValues: {
           adjustmentNumber: saved.adjustmentNumber,
           itemCount: saved.itemCount,
@@ -343,7 +349,7 @@ export class StockAdjustmentService {
   /**
    * Complete a stock adjustment (post to stock movements)
    */
-  async complete(id: string): Promise<StockAdjustmentResponseDto> {
+  async complete(id: string, userId?: string, username?: string): Promise<StockAdjustmentResponseDto> {
     const adjustment = await this.stockAdjustmentRepository.findOne({
       where: { id },
       relations: ['items', 'items.product'],
@@ -400,7 +406,8 @@ export class StockAdjustmentService {
         `Completed stock adjustment: ${adjustment.adjustmentNumber}`,
         {
           entityId: adjustment.id,
-          userId: 'system',
+          userId: userId || 'system',
+          username,
           oldValues: { status: StockAdjustmentStatus.DRAFT },
           newValues: { status: StockAdjustmentStatus.COMPLETED },
         }
@@ -419,7 +426,7 @@ export class StockAdjustmentService {
     // Auto-post to accounting (don't fail completion on error)
     try {
       const fullAdjustment = await this.findOne(id); // Get adjustment with relations
-      await this.accountingService.postStockAdjustmentEntry(fullAdjustment as any, 'system');
+      await this.accountingService.postStockAdjustmentEntry(fullAdjustment as any, userId || 'system');
       this.logger.log(`Posted accounting entry for stock adjustment ${adjustment.adjustmentNumber}`);
     } catch (error) {
       this.logger.error(
@@ -507,7 +514,7 @@ export class StockAdjustmentService {
   /**
    * Delete a stock adjustment (soft delete, only drafts)
    */
-  async remove(id: string): Promise<void> {
+  async remove(id: string, userId?: string, username?: string): Promise<void> {
     const adjustment = await this.stockAdjustmentRepository.findOne({
       where: { id },
     });
@@ -529,7 +536,8 @@ export class StockAdjustmentService {
       `Deleted stock adjustment: ${adjustment.adjustmentNumber}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         oldValues: {
           adjustmentNumber: adjustment.adjustmentNumber,
           status: adjustment.status,
@@ -584,7 +592,7 @@ export class StockAdjustmentService {
   /**
    * Restore a soft-deleted stock adjustment
    */
-  async restore(id: string): Promise<StockAdjustmentResponseDto> {
+  async restore(id: string, userId?: string, username?: string): Promise<StockAdjustmentResponseDto> {
     const adjustment = await this.stockAdjustmentRepository.findOne({
       where: { id },
       withDeleted: true, // Include soft-deleted records
@@ -610,7 +618,7 @@ export class StockAdjustmentService {
   /**
    * Permanently delete a stock adjustment (hard delete from database)
    */
-  async permanentDelete(id: string): Promise<void> {
+  async permanentDelete(id: string, userId?: string, username?: string): Promise<void> {
     // Find the adjustment (including soft-deleted ones)
     const adjustment = await this.stockAdjustmentRepository.findOne({
       where: { id },
@@ -652,7 +660,8 @@ export class StockAdjustmentService {
       `Permanently deleted stock adjustment: ${adjustment.adjustmentNumber}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         oldValues: {
           adjustmentNumber: adjustment.adjustmentNumber,
           itemCount: adjustment.itemCount,
@@ -671,13 +680,17 @@ export class StockAdjustmentService {
   /**
    * Bulk permanently delete stock adjustments
    */
-  async bulkPermanentDelete(adjustmentIds: string[]): Promise<{ successCount: number; failedIds: string[] }> {
+  async bulkPermanentDelete(
+    adjustmentIds: string[],
+    userId?: string,
+    username?: string,
+  ): Promise<{ successCount: number; failedIds: string[] }> {
     const failedIds: string[] = [];
     let successCount = 0;
 
     for (const id of adjustmentIds) {
       try {
-        await this.permanentDelete(id);
+        await this.permanentDelete(id, userId, username);
         successCount++;
       } catch (error) {
         this.logger.error(`Failed to permanently delete stock adjustment ${id}: ${error.message}`);

--- a/backend/src/modules/inventory/services/stock-adjustment.service.ts
+++ b/backend/src/modules/inventory/services/stock-adjustment.service.ts
@@ -610,6 +610,13 @@ export class StockAdjustmentService {
     // Restore the adjustment
     await this.stockAdjustmentRepository.restore(id);
 
+    await this.auditLogService.log(
+      'RESTORE',
+      'StockAdjustment',
+      `Restored stock adjustment: ${adjustment.adjustmentNumber}`,
+      { entityId: id, userId: userId || 'system', username }
+    );
+
     this.logger.log(`Stock adjustment ${adjustment.adjustmentNumber} restored successfully`);
 
     return this.findOne(id);

--- a/backend/src/modules/purchasing/controllers/goods-received-note.controller.ts
+++ b/backend/src/modules/purchasing/controllers/goods-received-note.controller.ts
@@ -30,6 +30,7 @@ import {
   GoodsReceivedNoteResponseDto,
   GoodsReceivedNoteListResponseDto,
 } from '../dto/goods-received-note.dto';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 
 @ApiTags('Goods Received Notes')
 @Controller('purchasing/goods-received-notes')
@@ -51,9 +52,13 @@ export class GoodsReceivedNoteController {
   })
   @ApiResponse({ status: 400, description: 'Invalid input data' })
   @ApiResponse({ status: 404, description: 'Purchase order not found' })
-  async create(@Body() createDto: CreateGoodsReceivedNoteDto): Promise<GoodsReceivedNoteResponseDto> {
+  async create(
+    @Body() createDto: CreateGoodsReceivedNoteDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<GoodsReceivedNoteResponseDto> {
     this.logger.log(`Creating GRN for PO: ${createDto.purchaseOrderId}`);
-    return await this.grnService.create(createDto);
+    return await this.grnService.create(createDto, currentUserId, currentUsername);
   }
 
   @Get()
@@ -128,9 +133,11 @@ export class GoodsReceivedNoteController {
   async update(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateDto: UpdateGoodsReceivedNoteDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<GoodsReceivedNoteResponseDto> {
     this.logger.log(`Updating GRN: ${id}`);
-    return await this.grnService.update(id, updateDto);
+    return await this.grnService.update(id, updateDto, currentUserId, currentUsername);
   }
 
   @Post(':id/restore')
@@ -145,9 +152,13 @@ export class GoodsReceivedNoteController {
   })
   @ApiResponse({ status: 404, description: 'GRN not found' })
   @ApiParam({ name: 'id', description: 'GRN UUID' })
-  async restore(@Param('id', ParseUUIDPipe) id: string): Promise<GoodsReceivedNoteResponseDto> {
+  async restore(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<GoodsReceivedNoteResponseDto> {
     this.logger.log(`Restoring GRN: ${id}`);
-    return await this.grnService.restore(id);
+    return await this.grnService.restore(id, currentUserId, currentUsername);
   }
 
   @Post('bulk-restore')
@@ -171,9 +182,13 @@ export class GoodsReceivedNoteController {
       }
     }
   })
-  async bulkRestore(@Body() body: { grnIds: string[] }): Promise<{ restoredCount: number; failedIds: string[] }> {
+  async bulkRestore(
+    @Body() body: { grnIds: string[] },
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<{ restoredCount: number; failedIds: string[] }> {
     this.logger.log(`Bulk restoring ${body.grnIds.length} GRNs`);
-    return await this.grnService.bulkRestore(body.grnIds);
+    return await this.grnService.bulkRestore(body.grnIds, currentUserId, currentUsername);
   }
 
   @Post('bulk-permanent-delete')
@@ -197,9 +212,13 @@ export class GoodsReceivedNoteController {
       }
     }
   })
-  async bulkPermanentDelete(@Body() body: { grnIds: string[] }): Promise<{ deletedCount: number; failedIds: string[] }> {
+  async bulkPermanentDelete(
+    @Body() body: { grnIds: string[] },
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<{ deletedCount: number; failedIds: string[] }> {
     this.logger.log(`Bulk permanently deleting ${body.grnIds.length} GRNs`);
-    return await this.grnService.bulkPermanentDelete(body.grnIds);
+    return await this.grnService.bulkPermanentDelete(body.grnIds, currentUserId, currentUsername);
   }
 
   @Delete(':id/permanent')
@@ -210,9 +229,13 @@ export class GoodsReceivedNoteController {
   @ApiResponse({ status: 200, description: 'GRN permanently deleted successfully' })
   @ApiResponse({ status: 404, description: 'GRN not found' })
   @ApiParam({ name: 'id', description: 'GRN UUID' })
-  async permanentDelete(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+  async permanentDelete(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<void> {
     this.logger.log(`Permanently deleting GRN: ${id}`);
-    return await this.grnService.permanentDelete(id);
+    return await this.grnService.permanentDelete(id, currentUserId, currentUsername);
   }
 
   @Delete(':id')
@@ -224,8 +247,12 @@ export class GoodsReceivedNoteController {
   @ApiResponse({ status: 404, description: 'GRN not found' })
   @ApiParam({ name: 'id', description: 'GRN UUID' })
   @HttpCode(HttpStatus.OK)
-  async remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+  async remove(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<void> {
     this.logger.log(`Soft deleting GRN: ${id}`);
-    await this.grnService.remove(id);
+    await this.grnService.remove(id, currentUserId, currentUsername);
   }
 }

--- a/backend/src/modules/purchasing/controllers/purchase-order.controller.ts
+++ b/backend/src/modules/purchasing/controllers/purchase-order.controller.ts
@@ -30,6 +30,7 @@ import {
   PurchaseOrderSummaryDto,
   RecordOrderPaymentsDto,
 } from '../dto';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 
 @ApiTags('Purchase Orders')
 @Controller('purchasing/orders')
@@ -47,8 +48,14 @@ export class PurchaseOrderController {
   @ApiResponse({ status: 404, description: 'Supplier or product not found' })
   async create(
     @Body() createPurchaseOrderDto: CreatePurchaseOrderDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ data: PurchaseOrderResponseDto }> {
-    const data = await this.purchaseOrderService.create(createPurchaseOrderDto, 'system');
+    const data = await this.purchaseOrderService.create(
+      createPurchaseOrderDto,
+      currentUserId,
+      currentUsername,
+    );
     return { data };
   }
 
@@ -128,8 +135,15 @@ export class PurchaseOrderController {
   async update(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updatePurchaseOrderDto: UpdatePurchaseOrderDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ data: PurchaseOrderResponseDto }> {
-    const data = await this.purchaseOrderService.update(id, updatePurchaseOrderDto);
+    const data = await this.purchaseOrderService.update(
+      id,
+      updatePurchaseOrderDto,
+      currentUserId,
+      currentUsername,
+    );
     return { data };
   }
 
@@ -145,8 +159,10 @@ export class PurchaseOrderController {
   @HttpCode(HttpStatus.OK)
   async restore(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ data: PurchaseOrderResponseDto }> {
-    const data = await this.purchaseOrderService.restore(id, 'system');
+    const data = await this.purchaseOrderService.restore(id, currentUserId, currentUsername);
     return { data };
   }
 
@@ -159,8 +175,10 @@ export class PurchaseOrderController {
   @HttpCode(HttpStatus.OK)
   async bulkRestore(
     @Body() body: { orderIds: string[] },
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ restoredCount: number; failedIds: string[] }> {
-    return this.purchaseOrderService.bulkRestore(body.orderIds, 'system');
+    return this.purchaseOrderService.bulkRestore(body.orderIds, currentUserId, currentUsername);
   }
 
   @Post('bulk-permanent-delete')
@@ -172,8 +190,10 @@ export class PurchaseOrderController {
   @HttpCode(HttpStatus.OK)
   async bulkPermanentDelete(
     @Body() body: { orderIds: string[] },
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ deletedCount: number; failedIds: string[] }> {
-    return this.purchaseOrderService.bulkPermanentDelete(body.orderIds);
+    return this.purchaseOrderService.bulkPermanentDelete(body.orderIds, currentUserId, currentUsername);
   }
 
   @Delete(':id/permanent')
@@ -187,8 +207,10 @@ export class PurchaseOrderController {
   @HttpCode(HttpStatus.OK)
   async permanentDelete(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ message: string }> {
-    await this.purchaseOrderService.permanentDelete(id);
+    await this.purchaseOrderService.permanentDelete(id, currentUserId, currentUsername);
     return { message: 'Purchase order permanently deleted successfully' };
   }
 
@@ -331,8 +353,10 @@ export class PurchaseOrderController {
   @HttpCode(HttpStatus.OK)
   async remove(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ message: string }> {
-    await this.purchaseOrderService.remove(id);
+    await this.purchaseOrderService.remove(id, currentUserId, currentUsername);
     return { message: 'Purchase order deleted successfully' };
   }
 }

--- a/backend/src/modules/purchasing/controllers/purchase-order.controller.ts
+++ b/backend/src/modules/purchasing/controllers/purchase-order.controller.ts
@@ -227,8 +227,10 @@ export class PurchaseOrderController {
   @HttpCode(HttpStatus.OK)
   async receiveGoods(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ data: PurchaseOrderResponseDto }> {
-    const data = await this.purchaseOrderService.receiveGoods(id);
+    const data = await this.purchaseOrderService.receiveGoods(id, currentUserId, currentUsername);
     return { data };
   }
 
@@ -245,8 +247,10 @@ export class PurchaseOrderController {
   @HttpCode(HttpStatus.OK)
   async returnGoods(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ data: PurchaseOrderResponseDto }> {
-    const data = await this.purchaseOrderService.returnGoods(id);
+    const data = await this.purchaseOrderService.returnGoods(id, currentUserId, currentUsername);
     return { data };
   }
 

--- a/backend/src/modules/purchasing/controllers/supplier.controller.ts
+++ b/backend/src/modules/purchasing/controllers/supplier.controller.ts
@@ -30,6 +30,7 @@ import {
   SupplierResponseDto,
   SupplierListResponseDto,
 } from '../dto';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 
 @ApiTags('Suppliers')
 @Controller('purchasing/suppliers')
@@ -51,9 +52,13 @@ export class SupplierController {
   })
   @ApiResponse({ status: 400, description: 'Invalid input data' })
   @ApiResponse({ status: 409, description: 'Supplier code or email already exists' })
-  async create(@Body() createSupplierDto: CreateSupplierDto): Promise<SupplierResponseDto> {
+  async create(
+    @Body() createSupplierDto: CreateSupplierDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<SupplierResponseDto> {
     this.logger.log(`Creating supplier: ${createSupplierDto.companyName}`);
-    return await this.supplierService.create(createSupplierDto);
+    return await this.supplierService.create(createSupplierDto, currentUserId, currentUsername);
   }
 
   @Get()
@@ -177,9 +182,11 @@ export class SupplierController {
   async update(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateSupplierDto: UpdateSupplierDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<SupplierResponseDto> {
     this.logger.log(`Updating supplier: ${id}`);
-    return await this.supplierService.update(id, updateSupplierDto);
+    return await this.supplierService.update(id, updateSupplierDto, currentUserId, currentUsername);
   }
 
 
@@ -264,9 +271,13 @@ export class SupplierController {
   })
   @ApiResponse({ status: 404, description: 'Supplier not found' })
   @ApiParam({ name: 'id', description: 'Supplier UUID' })
-  async restore(@Param('id', ParseUUIDPipe) id: string): Promise<SupplierResponseDto> {
+  async restore(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<SupplierResponseDto> {
     this.logger.log(`Restoring supplier: ${id}`);
-    return await this.supplierService.restore(id);
+    return await this.supplierService.restore(id, currentUserId, currentUsername);
   }
 
   @Post('bulk-restore')
@@ -290,9 +301,13 @@ export class SupplierController {
       }
     }
   })
-  async bulkRestore(@Body() body: { supplierIds: string[] }): Promise<{ restoredCount: number; failedIds: string[] }> {
+  async bulkRestore(
+    @Body() body: { supplierIds: string[] },
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<{ restoredCount: number; failedIds: string[] }> {
     this.logger.log(`Bulk restoring ${body.supplierIds.length} suppliers`);
-    return await this.supplierService.bulkRestore(body.supplierIds);
+    return await this.supplierService.bulkRestore(body.supplierIds, currentUserId, currentUsername);
   }
 
   @Post('bulk-permanent-delete')
@@ -316,9 +331,17 @@ export class SupplierController {
       }
     }
   })
-  async bulkPermanentDelete(@Body() body: { supplierIds: string[] }): Promise<{ deletedCount: number; failedIds: string[] }> {
+  async bulkPermanentDelete(
+    @Body() body: { supplierIds: string[] },
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<{ deletedCount: number; failedIds: string[] }> {
     this.logger.log(`Bulk permanently deleting ${body.supplierIds.length} suppliers`);
-    return await this.supplierService.bulkPermanentDelete(body.supplierIds);
+    return await this.supplierService.bulkPermanentDelete(
+      body.supplierIds,
+      currentUserId,
+      currentUsername,
+    );
   }
 
   @Delete(':id/permanent')
@@ -329,9 +352,13 @@ export class SupplierController {
   @ApiResponse({ status: 200, description: 'Supplier permanently deleted successfully' })
   @ApiResponse({ status: 404, description: 'Supplier not found' })
   @ApiParam({ name: 'id', description: 'Supplier UUID' })
-  async permanentDelete(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+  async permanentDelete(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<void> {
     this.logger.log(`Permanently deleting supplier: ${id}`);
-    return await this.supplierService.permanentDelete(id);
+    return await this.supplierService.permanentDelete(id, currentUserId, currentUsername);
   }
 
   @Delete(':id')
@@ -344,8 +371,12 @@ export class SupplierController {
   @ApiResponse({ status: 404, description: 'Supplier not found' })
   @ApiParam({ name: 'id', description: 'Supplier UUID' })
   @HttpCode(HttpStatus.OK)
-  async remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+  async remove(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<void> {
     this.logger.log(`Deactivating supplier: ${id}`);
-    await this.supplierService.remove(id);
+    await this.supplierService.remove(id, currentUserId, currentUsername);
   }
 }

--- a/backend/src/modules/purchasing/controllers/vendor-payment.controller.ts
+++ b/backend/src/modules/purchasing/controllers/vendor-payment.controller.ts
@@ -24,6 +24,7 @@ import {
   UpdateVendorPaymentDto,
   QueryVendorPaymentsDto,
 } from '../dto/vendor-payment.dto';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 
 @ApiTags('Vendor Payments')
 @Controller('purchasing/vendor-payments')
@@ -38,8 +39,12 @@ export class VendorPaymentController {
     description: 'Vendor payment created successfully',
   })
   @ApiResponse({ status: 400, description: 'Invalid input data' })
-  create(@Body() createVendorPaymentDto: CreateVendorPaymentDto) {
-    return this.vendorPaymentService.create(createVendorPaymentDto);
+  create(
+    @Body() createVendorPaymentDto: CreateVendorPaymentDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.vendorPaymentService.create(createVendorPaymentDto, currentUserId, currentUsername);
   }
 
   @Get()
@@ -86,8 +91,10 @@ export class VendorPaymentController {
   update(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateVendorPaymentDto: UpdateVendorPaymentDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ) {
-    return this.vendorPaymentService.update(id, updateVendorPaymentDto);
+    return this.vendorPaymentService.update(id, updateVendorPaymentDto, currentUserId, currentUsername);
   }
 
   @Post(':id/restore')
@@ -98,8 +105,12 @@ export class VendorPaymentController {
     description: 'Vendor payment restored successfully',
   })
   @ApiResponse({ status: 404, description: 'Vendor payment not found' })
-  restore(@Param('id', ParseUUIDPipe) id: string) {
-    return this.vendorPaymentService.restore(id);
+  restore(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.vendorPaymentService.restore(id, currentUserId, currentUsername);
   }
 
   @Post('bulk-restore')
@@ -120,8 +131,12 @@ export class VendorPaymentController {
     status: 200,
     description: 'Vendor payments restored successfully',
   })
-  bulkRestore(@Body('paymentIds') paymentIds: string[]) {
-    return this.vendorPaymentService.bulkRestore(paymentIds);
+  bulkRestore(
+    @Body('paymentIds') paymentIds: string[],
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.vendorPaymentService.bulkRestore(paymentIds, currentUserId, currentUsername);
   }
 
   @Delete(':id')
@@ -133,8 +148,12 @@ export class VendorPaymentController {
     description: 'Vendor payment deleted successfully',
   })
   @ApiResponse({ status: 404, description: 'Vendor payment not found' })
-  remove(@Param('id', ParseUUIDPipe) id: string) {
-    return this.vendorPaymentService.remove(id);
+  remove(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.vendorPaymentService.remove(id, currentUserId, currentUsername);
   }
 
   @Delete(':id/permanent')
@@ -146,8 +165,12 @@ export class VendorPaymentController {
     description: 'Vendor payment permanently deleted successfully',
   })
   @ApiResponse({ status: 404, description: 'Vendor payment not found' })
-  permanentDelete(@Param('id', ParseUUIDPipe) id: string) {
-    return this.vendorPaymentService.permanentDelete(id);
+  permanentDelete(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.vendorPaymentService.permanentDelete(id, currentUserId, currentUsername);
   }
 
   @Post('for-po/:poId')

--- a/backend/src/modules/purchasing/controllers/vendor-payment.controller.ts
+++ b/backend/src/modules/purchasing/controllers/vendor-payment.controller.ts
@@ -181,8 +181,12 @@ export class VendorPaymentController {
     description: 'Vendor payment created successfully for PO',
   })
   @ApiResponse({ status: 404, description: 'Purchase order not found' })
-  createForPurchaseOrder(@Param('poId', ParseUUIDPipe) poId: string) {
-    return this.vendorPaymentService.createForPurchaseOrder(poId);
+  createForPurchaseOrder(
+    @Param('poId', ParseUUIDPipe) poId: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.vendorPaymentService.createForPurchaseOrder(poId, currentUserId, currentUsername);
   }
 
   @Get('for-po/:poId')

--- a/backend/src/modules/purchasing/services/goods-received-note.service.spec.ts
+++ b/backend/src/modules/purchasing/services/goods-received-note.service.spec.ts
@@ -203,6 +203,7 @@ describe('GoodsReceivedNoteService', () => {
       expect(accountingService.postGoodsReceivedEntry).toHaveBeenCalledWith(
         fullGrn,
         'system',
+        undefined,
       );
 
       // Verify it was called exactly once
@@ -279,6 +280,7 @@ describe('GoodsReceivedNoteService', () => {
           purchaseOrder: mockPurchaseOrder,
         }),
         'system',
+        undefined,
       );
     });
 

--- a/backend/src/modules/purchasing/services/goods-received-note.service.ts
+++ b/backend/src/modules/purchasing/services/goods-received-note.service.ts
@@ -84,7 +84,11 @@ export class GoodsReceivedNoteService {
   /**
    * Create a new goods received note
    */
-  async create(createDto: CreateGoodsReceivedNoteDto): Promise<GoodsReceivedNoteResponseDto> {
+  async create(
+    createDto: CreateGoodsReceivedNoteDto,
+    userId?: string,
+    username?: string,
+  ): Promise<GoodsReceivedNoteResponseDto> {
     this.logger.log(`Creating GRN for PO: ${createDto.purchaseOrderId}`);
 
     // Validate purchase order exists
@@ -184,7 +188,8 @@ export class GoodsReceivedNoteService {
         `Created GRN: ${savedGrn.grnNumber}`,
         {
           entityId: savedGrn.id,
-          userId: 'system',
+          userId: userId || 'system',
+          username,
           newValues: {
             grnNumber: savedGrn.grnNumber,
             purchaseOrderId: savedGrn.purchaseOrderId,
@@ -201,7 +206,7 @@ export class GoodsReceivedNoteService {
         });
 
         if (fullGrn) {
-          await this.accountingService.postGoodsReceivedEntry(fullGrn, 'system');
+          await this.accountingService.postGoodsReceivedEntry(fullGrn, userId || 'system', username);
           this.logger.log(`Posted accounting entry for GRN ${fullGrn.grnNumber}`);
         }
       } catch (error) {
@@ -313,7 +318,12 @@ export class GoodsReceivedNoteService {
   /**
    * Update GRN
    */
-  async update(id: string, updateDto: UpdateGoodsReceivedNoteDto): Promise<GoodsReceivedNoteResponseDto> {
+  async update(
+    id: string,
+    updateDto: UpdateGoodsReceivedNoteDto,
+    userId?: string,
+    username?: string,
+  ): Promise<GoodsReceivedNoteResponseDto> {
     this.logger.log(`Updating GRN: ${id}`);
 
     const grn = await this.grnRepository.findOne({ where: { id } });
@@ -337,7 +347,8 @@ export class GoodsReceivedNoteService {
         `Updated GRN: ${updatedGrn.grnNumber}`,
         {
           entityId: id,
-          userId: 'system',
+          userId: userId || 'system',
+          username,
           newValues: {
             grnNumber: updatedGrn.grnNumber,
             status: updatedGrn.status,
@@ -358,7 +369,7 @@ export class GoodsReceivedNoteService {
   /**
    * Soft delete GRN and sync deletedAt with associated PO using same timestamp
    */
-  async remove(id: string): Promise<void> {
+  async remove(id: string, userId?: string, username?: string): Promise<void> {
     this.logger.log(`Soft deleting GRN: ${id}`);
 
     const grn = await this.grnRepository.findOne({
@@ -400,7 +411,8 @@ export class GoodsReceivedNoteService {
         `Deleted GRN: ${grn.grnNumber}`,
         {
           entityId: id,
-          userId: 'system',
+          userId: userId || 'system',
+          username,
           oldValues: {
             grnNumber: grn.grnNumber,
             purchaseOrderId: grn.purchaseOrderId,
@@ -467,7 +479,7 @@ export class GoodsReceivedNoteService {
   /**
    * Restore a soft-deleted GRN and sync deletedAt with associated PO (sets to null)
    */
-  async restore(id: string): Promise<GoodsReceivedNoteResponseDto> {
+  async restore(id: string, userId?: string, username?: string): Promise<GoodsReceivedNoteResponseDto> {
     this.logger.log(`Restoring GRN: ${id}`);
 
     const grn = await this.grnRepository.findOne({
@@ -520,7 +532,8 @@ export class GoodsReceivedNoteService {
         `Restored GRN: ${restoredGrn.grnNumber}`,
         {
           entityId: id,
-          userId: 'system',
+          userId: userId || 'system',
+          username,
           newValues: {
             grnNumber: restoredGrn.grnNumber,
             purchaseOrderId: restoredGrn.purchaseOrderId,
@@ -542,7 +555,11 @@ export class GoodsReceivedNoteService {
   /**
    * Bulk restore GRNs
    */
-  async bulkRestore(grnIds: string[]): Promise<{ restoredCount: number; failedIds: string[] }> {
+  async bulkRestore(
+    grnIds: string[],
+    userId?: string,
+    username?: string,
+  ): Promise<{ restoredCount: number; failedIds: string[] }> {
     this.logger.log(`Bulk restoring ${grnIds.length} GRNs`);
 
     const failedIds: string[] = [];
@@ -550,7 +567,7 @@ export class GoodsReceivedNoteService {
 
     for (const id of grnIds) {
       try {
-        await this.restore(id);
+        await this.restore(id, userId, username);
         restoredCount++;
       } catch (error) {
         this.logger.error(`Failed to restore GRN ${id}:`, error);
@@ -565,7 +582,7 @@ export class GoodsReceivedNoteService {
   /**
    * Permanently delete a GRN
    */
-  async permanentDelete(id: string): Promise<void> {
+  async permanentDelete(id: string, userId?: string, username?: string): Promise<void> {
     this.logger.log(`Permanently deleting GRN: ${id}`);
 
     const grn = await this.grnRepository.findOne({
@@ -588,7 +605,8 @@ export class GoodsReceivedNoteService {
       `Permanently deleted GRN: ${grn.grnNumber}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         oldValues: {
           grnNumber: grn.grnNumber,
           purchaseOrderId: grn.purchaseOrderId,
@@ -611,7 +629,11 @@ export class GoodsReceivedNoteService {
   /**
    * Bulk permanent delete GRNs
    */
-  async bulkPermanentDelete(grnIds: string[]): Promise<{ deletedCount: number; failedIds: string[] }> {
+  async bulkPermanentDelete(
+    grnIds: string[],
+    userId?: string,
+    username?: string,
+  ): Promise<{ deletedCount: number; failedIds: string[] }> {
     this.logger.log(`Bulk permanently deleting ${grnIds.length} GRNs`);
 
     const failedIds: string[] = [];
@@ -619,7 +641,7 @@ export class GoodsReceivedNoteService {
 
     for (const id of grnIds) {
       try {
-        await this.permanentDelete(id);
+        await this.permanentDelete(id, userId, username);
         deletedCount++;
       } catch (error) {
         this.logger.error(`Failed to permanently delete GRN ${id}:`, error);

--- a/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
@@ -240,6 +240,7 @@ describe('PurchaseOrderService', () => {
       expect(accountingService.postGoodsReceivedEntry).toHaveBeenCalledWith(
         mockReceivedGrnWithRelations,
         'system',
+        undefined,
       );
     });
   });

--- a/backend/src/modules/purchasing/services/purchase-order.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.ts
@@ -97,7 +97,7 @@ export class PurchaseOrderService {
    */
   async create(
     createPurchaseOrderDto: CreatePurchaseOrderDto,
-    userId: string = 'system',
+    userId?: string,
     username?: string,
   ): Promise<PurchaseOrderResponseDto> {
     this.logger.log(`Creating purchase order for supplier: ${createPurchaseOrderDto.supplierId}`);
@@ -635,7 +635,7 @@ export class PurchaseOrderService {
   /**
    * Restore a deleted purchase order and its associated GRN (sets deletedAt to null for both)
    */
-  async restore(id: string, userId: string = 'system', username?: string): Promise<PurchaseOrderResponseDto> {
+  async restore(id: string, userId?: string, username?: string): Promise<PurchaseOrderResponseDto> {
     this.logger.log(`Restoring purchase order: ${id}`);
 
     // Check if the order exists in deleted records
@@ -726,7 +726,7 @@ export class PurchaseOrderService {
    */
   async bulkRestore(
     orderIds: string[],
-    userId: string = 'system',
+    userId?: string,
     username?: string,
   ): Promise<{ restoredCount: number; failedIds: string[] }> {
     this.logger.log(`Bulk restoring ${orderIds.length} purchase orders`);
@@ -751,7 +751,7 @@ export class PurchaseOrderService {
   /**
    * Permanently delete a purchase order and its associated GRN
    */
-  async permanentDelete(id: string, userId: string = 'system', username?: string): Promise<void> {
+  async permanentDelete(id: string, userId?: string, username?: string): Promise<void> {
     this.logger.log(`Permanently deleting purchase order: ${id}`);
 
     const purchaseOrder = await this.purchaseOrderRepository.findOne({
@@ -1063,7 +1063,7 @@ export class PurchaseOrderService {
    */
   private async createDraftGrn(
     purchaseOrder: PurchaseOrder,
-    userId: string = 'system',
+    userId?: string,
     username?: string,
   ): Promise<void> {
     try {
@@ -1164,7 +1164,7 @@ export class PurchaseOrderService {
   /**
    * Receive goods - change GRN status to received and update product quantities
    */
-  async receiveGoods(id: string): Promise<PurchaseOrderResponseDto> {
+  async receiveGoods(id: string, userId?: string, username?: string): Promise<PurchaseOrderResponseDto> {
     this.logger.log(`Receiving goods for purchase order: ${id}`);
 
     const purchaseOrder = await this.purchaseOrderRepository.findOne({
@@ -1259,7 +1259,7 @@ export class PurchaseOrderService {
         });
 
         if (fullGrn) {
-          await this.accountingService.postGoodsReceivedEntry(fullGrn, 'system');
+          await this.accountingService.postGoodsReceivedEntry(fullGrn, userId || 'system');
           this.logger.log(`Posted accounting entry for GRN ${fullGrn.grnNumber}`);
         }
       } catch (error) {
@@ -1282,7 +1282,8 @@ export class PurchaseOrderService {
         `Received goods for PO: ${purchaseOrder.orderNumber}`,
         {
           entityId: id,
-          userId: 'system',
+          userId: userId || 'system',
+          username,
           newValues: {
             orderNumber: purchaseOrder.orderNumber,
             status: 'received',
@@ -1302,7 +1303,7 @@ export class PurchaseOrderService {
   /**
    * Return goods - change GRN status to return and revert product quantities
    */
-  async returnGoods(id: string): Promise<PurchaseOrderResponseDto> {
+  async returnGoods(id: string, userId?: string, username?: string): Promise<PurchaseOrderResponseDto> {
     this.logger.log(`Returning goods for purchase order: ${id}`);
 
     const purchaseOrder = await this.purchaseOrderRepository.findOne({
@@ -1401,7 +1402,8 @@ export class PurchaseOrderService {
         `Returned goods for PO: ${purchaseOrder.orderNumber}`,
         {
           entityId: id,
-          userId: 'system',
+          userId: userId || 'system',
+          username,
           newValues: {
             orderNumber: purchaseOrder.orderNumber,
             status: 'draft',

--- a/backend/src/modules/purchasing/services/purchase-order.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.ts
@@ -97,7 +97,8 @@ export class PurchaseOrderService {
    */
   async create(
     createPurchaseOrderDto: CreatePurchaseOrderDto,
-    userId: string = 'system'
+    userId: string = 'system',
+    username?: string,
   ): Promise<PurchaseOrderResponseDto> {
     this.logger.log(`Creating purchase order for supplier: ${createPurchaseOrderDto.supplierId}`);
 
@@ -207,7 +208,7 @@ export class PurchaseOrderService {
       );
 
       // Auto-create GRN in draft status
-      await this.createDraftGrn(savedPurchaseOrder);
+      await this.createDraftGrn(savedPurchaseOrder, userId, username);
 
       // Log audit trail for create
       await this.auditLogService.log(
@@ -216,7 +217,8 @@ export class PurchaseOrderService {
         `Created purchase order: ${savedPurchaseOrder.orderNumber}`,
         {
           entityId: savedPurchaseOrder.id,
-          userId: 'system',
+          userId: userId || 'system',
+          username,
           newValues: {
             orderNumber: savedPurchaseOrder.orderNumber,
             supplierId: supplier.id,
@@ -357,7 +359,9 @@ export class PurchaseOrderService {
    */
   async update(
     id: string,
-    updatePurchaseOrderDto: UpdatePurchaseOrderDto
+    updatePurchaseOrderDto: UpdatePurchaseOrderDto,
+    userId?: string,
+    username?: string,
   ): Promise<PurchaseOrderResponseDto> {
     this.logger.log(`Updating purchase order: ${id}`);
 
@@ -494,7 +498,8 @@ export class PurchaseOrderService {
         `Updated purchase order: ${updatedPurchaseOrder.orderNumber}`,
         {
           entityId: updatedPurchaseOrder.id,
-          userId: 'system',
+          userId: userId || 'system',
+          username,
           newValues: {
             orderNumber: updatedPurchaseOrder.orderNumber,
             totalAmount: updatedPurchaseOrder.totalAmount,
@@ -630,7 +635,7 @@ export class PurchaseOrderService {
   /**
    * Restore a deleted purchase order and its associated GRN (sets deletedAt to null for both)
    */
-  async restore(id: string, userId: string = 'system'): Promise<PurchaseOrderResponseDto> {
+  async restore(id: string, userId: string = 'system', username?: string): Promise<PurchaseOrderResponseDto> {
     this.logger.log(`Restoring purchase order: ${id}`);
 
     // Check if the order exists in deleted records
@@ -670,6 +675,7 @@ export class PurchaseOrderService {
         {
           entityId: grn.id,
           userId,
+          username,
           newValues: {
             grnNumber: grn.grnNumber,
             purchaseOrderId: grn.purchaseOrderId,
@@ -703,6 +709,7 @@ export class PurchaseOrderService {
       {
         entityId: id,
         userId,
+        username,
         newValues: {
           orderNumber: purchaseOrder.orderNumber,
           totalAmount: purchaseOrder.totalAmount,
@@ -717,7 +724,11 @@ export class PurchaseOrderService {
   /**
    * Bulk restore deleted purchase orders
    */
-  async bulkRestore(orderIds: string[], userId: string = 'system'): Promise<{ restoredCount: number; failedIds: string[] }> {
+  async bulkRestore(
+    orderIds: string[],
+    userId: string = 'system',
+    username?: string,
+  ): Promise<{ restoredCount: number; failedIds: string[] }> {
     this.logger.log(`Bulk restoring ${orderIds.length} purchase orders`);
 
     const failedIds: string[] = [];
@@ -725,7 +736,7 @@ export class PurchaseOrderService {
 
     for (const orderId of orderIds) {
       try {
-        await this.restore(orderId, userId);
+        await this.restore(orderId, userId, username);
         successCount++;
       } catch (error) {
         this.logger.error(`Failed to restore purchase order ${orderId}: ${error.message}`);
@@ -740,7 +751,7 @@ export class PurchaseOrderService {
   /**
    * Permanently delete a purchase order and its associated GRN
    */
-  async permanentDelete(id: string): Promise<void> {
+  async permanentDelete(id: string, userId: string = 'system', username?: string): Promise<void> {
     this.logger.log(`Permanently deleting purchase order: ${id}`);
 
     const purchaseOrder = await this.purchaseOrderRepository.findOne({
@@ -778,7 +789,8 @@ export class PurchaseOrderService {
         `Permanently deleted GRN: ${grn.grnNumber} (auto-deleted with PO)`,
         {
           entityId: grn.id,
-          userId: 'system',
+          userId: userId || 'system',
+          username,
           oldValues: {
             grnNumber: grn.grnNumber,
             purchaseOrderId: grn.purchaseOrderId,
@@ -798,7 +810,8 @@ export class PurchaseOrderService {
       `Permanently deleted purchase order: ${purchaseOrder.orderNumber}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         oldValues: {
           orderNumber: purchaseOrder.orderNumber,
           supplierId: purchaseOrder.supplierId,
@@ -817,7 +830,11 @@ export class PurchaseOrderService {
   /**
    * Bulk permanently delete purchase orders
    */
-  async bulkPermanentDelete(orderIds: string[]): Promise<{ deletedCount: number; failedIds: string[] }> {
+  async bulkPermanentDelete(
+    orderIds: string[],
+    userId?: string,
+    username?: string,
+  ): Promise<{ deletedCount: number; failedIds: string[] }> {
     this.logger.log(`Bulk permanently deleting ${orderIds.length} purchase orders`);
 
     const failedIds: string[] = [];
@@ -825,7 +842,7 @@ export class PurchaseOrderService {
 
     for (const orderId of orderIds) {
       try {
-        await this.permanentDelete(orderId);
+        await this.permanentDelete(orderId, userId || 'system', username);
         successCount++;
       } catch (error) {
         this.logger.error(`Failed to permanently delete purchase order ${orderId}: ${error.message}`);
@@ -840,7 +857,7 @@ export class PurchaseOrderService {
   /**
    * Soft delete a purchase order and its associated GRN with same deletedAt timestamp
    */
-  async remove(id: string): Promise<void> {
+  async remove(id: string, userId?: string, username?: string): Promise<void> {
     this.logger.log(`Soft deleting purchase order: ${id}`);
 
     const purchaseOrder = await this.purchaseOrderRepository.findOne({
@@ -889,7 +906,8 @@ export class PurchaseOrderService {
         `Deleted GRN: ${grn.grnNumber} (auto-deleted with PO)`,
         {
           entityId: grn.id,
-          userId: 'system',
+          userId: userId || 'system',
+          username,
           oldValues: {
             grnNumber: grn.grnNumber,
             purchaseOrderId: grn.purchaseOrderId,
@@ -916,7 +934,8 @@ export class PurchaseOrderService {
       `Deleted purchase order: ${purchaseOrder.orderNumber}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         oldValues: {
           orderNumber: purchaseOrder.orderNumber,
           totalAmount: purchaseOrder.totalAmount,
@@ -1042,7 +1061,11 @@ export class PurchaseOrderService {
   /**
    * Create a draft GRN for a new purchase order
    */
-  private async createDraftGrn(purchaseOrder: PurchaseOrder): Promise<void> {
+  private async createDraftGrn(
+    purchaseOrder: PurchaseOrder,
+    userId: string = 'system',
+    username?: string,
+  ): Promise<void> {
     try {
       // Generate sequential GRN number
       const grns = await this.grnRepository.find({
@@ -1092,7 +1115,8 @@ export class PurchaseOrderService {
         `Created GRN: ${savedGrn.grnNumber}`,
         {
           entityId: savedGrn.id,
-          userId: 'system',
+          userId: userId || 'system',
+          username,
           newValues: {
             grnNumber: savedGrn.grnNumber,
             purchaseOrderId: savedGrn.purchaseOrderId,

--- a/backend/src/modules/purchasing/services/purchase-order.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.ts
@@ -1259,7 +1259,7 @@ export class PurchaseOrderService {
         });
 
         if (fullGrn) {
-          await this.accountingService.postGoodsReceivedEntry(fullGrn, userId || 'system');
+          await this.accountingService.postGoodsReceivedEntry(fullGrn, userId || 'system', username);
           this.logger.log(`Posted accounting entry for GRN ${fullGrn.grnNumber}`);
         }
       } catch (error) {

--- a/backend/src/modules/purchasing/services/supplier.service.ts
+++ b/backend/src/modules/purchasing/services/supplier.service.ts
@@ -27,7 +27,11 @@ export class SupplierService {
   /**
    * Create a new supplier
    */
-  async create(createSupplierDto: CreateSupplierDto): Promise<SupplierResponseDto> {
+  async create(
+    createSupplierDto: CreateSupplierDto,
+    userId?: string,
+    username?: string,
+  ): Promise<SupplierResponseDto> {
     this.logger.log(`Creating supplier: ${createSupplierDto.companyName}`);
 
     // Check for duplicate company name (case-insensitive)
@@ -60,7 +64,8 @@ export class SupplierService {
         `Created supplier: ${savedSupplier.companyName}`,
         {
           entityId: savedSupplier.id,
-          userId: 'system',
+          userId: userId || 'system',
+          username,
           newValues: {
             companyName: savedSupplier.companyName,
             contactPerson: savedSupplier.contactPerson,
@@ -168,7 +173,12 @@ export class SupplierService {
   /**
    * Update supplier
    */
-  async update(id: string, updateSupplierDto: UpdateSupplierDto): Promise<SupplierResponseDto> {
+  async update(
+    id: string,
+    updateSupplierDto: UpdateSupplierDto,
+    userId?: string,
+    username?: string,
+  ): Promise<SupplierResponseDto> {
     this.logger.log(`Updating supplier: ${id}`);
 
     const supplier = await this.supplierRepository.findOne({ where: { id } });
@@ -211,7 +221,8 @@ export class SupplierService {
           `Updated supplier: ${updatedSupplier.companyName}`,
           {
             entityId: id,
-            userId: 'system',
+            userId: userId || 'system',
+            username,
             oldValues: Object.fromEntries(
               Object.entries(changes).map(([key, val]) => [key, val.from])
             ),
@@ -264,7 +275,7 @@ export class SupplierService {
   /**
    * Soft delete supplier (deactivate)
    */
-  async remove(id: string): Promise<void> {
+  async remove(id: string, userId?: string, username?: string): Promise<void> {
     this.logger.log(`Deactivating supplier: ${id}`);
 
     const supplier = await this.supplierRepository.findOne({ where: { id } });
@@ -297,7 +308,8 @@ export class SupplierService {
         `Deleted supplier: ${supplier.companyName}`,
         {
           entityId: id,
-          userId: 'system',
+          userId: userId || 'system',
+          username,
           oldValues: {
             companyName: supplier.companyName,
             contactPerson: supplier.contactPerson,
@@ -567,7 +579,7 @@ export class SupplierService {
   /**
    * Restore a soft-deleted supplier
    */
-  async restore(id: string): Promise<SupplierResponseDto> {
+  async restore(id: string, userId?: string, username?: string): Promise<SupplierResponseDto> {
     this.logger.log(`Restoring supplier: ${id}`);
 
     const supplier = await this.supplierRepository.findOne({
@@ -604,7 +616,8 @@ export class SupplierService {
         `Restored supplier: ${restoredSupplier.companyName}`,
         {
           entityId: id,
-          userId: 'system',
+          userId: userId || 'system',
+          username,
           newValues: {
             companyName: restoredSupplier.companyName,
             contactPerson: restoredSupplier.contactPerson,
@@ -627,7 +640,7 @@ export class SupplierService {
   /**
    * Permanently delete a supplier
    */
-  async permanentDelete(id: string): Promise<void> {
+  async permanentDelete(id: string, userId?: string, username?: string): Promise<void> {
     this.logger.log(`Permanently deleting supplier: ${id}`);
 
     const supplier = await this.supplierRepository.findOne({
@@ -650,7 +663,8 @@ export class SupplierService {
       `Permanently deleted supplier: ${supplier.companyName}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         oldValues: {
           companyName: supplier.companyName,
           contactPerson: supplier.contactPerson,
@@ -674,7 +688,11 @@ export class SupplierService {
   /**
    * Bulk restore suppliers
    */
-  async bulkRestore(supplierIds: string[]): Promise<{ restoredCount: number; failedIds: string[] }> {
+  async bulkRestore(
+    supplierIds: string[],
+    userId?: string,
+    username?: string,
+  ): Promise<{ restoredCount: number; failedIds: string[] }> {
     this.logger.log(`Bulk restoring ${supplierIds.length} suppliers`);
 
     const failedIds: string[] = [];
@@ -682,7 +700,7 @@ export class SupplierService {
 
     for (const id of supplierIds) {
       try {
-        await this.restore(id);
+        await this.restore(id, userId, username);
         restoredCount++;
       } catch (error) {
         this.logger.error(`Failed to restore supplier ${id}:`, error);
@@ -697,7 +715,11 @@ export class SupplierService {
   /**
    * Bulk permanent delete suppliers
    */
-  async bulkPermanentDelete(supplierIds: string[]): Promise<{ deletedCount: number; failedIds: string[] }> {
+  async bulkPermanentDelete(
+    supplierIds: string[],
+    userId?: string,
+    username?: string,
+  ): Promise<{ deletedCount: number; failedIds: string[] }> {
     this.logger.log(`Bulk permanently deleting ${supplierIds.length} suppliers`);
 
     const failedIds: string[] = [];
@@ -705,7 +727,7 @@ export class SupplierService {
 
     for (const id of supplierIds) {
       try {
-        await this.permanentDelete(id);
+        await this.permanentDelete(id, userId, username);
         deletedCount++;
       } catch (error) {
         this.logger.error(`Failed to permanently delete supplier ${id}:`, error);

--- a/backend/src/modules/purchasing/services/vendor-payment.service.spec.ts
+++ b/backend/src/modules/purchasing/services/vendor-payment.service.spec.ts
@@ -179,6 +179,7 @@ describe('VendorPaymentService', () => {
       expect(accountingService.postVendorPaymentEntry).toHaveBeenCalledWith(
         fullPayment,
         'test-user',
+        undefined,
       );
 
       // Verify it was called exactly once
@@ -244,6 +245,7 @@ describe('VendorPaymentService', () => {
           supplier: mockSupplier,
         }),
         'test-user',
+        undefined,
       );
     });
 

--- a/backend/src/modules/purchasing/services/vendor-payment.service.ts
+++ b/backend/src/modules/purchasing/services/vendor-payment.service.ts
@@ -40,7 +40,8 @@ export class VendorPaymentService {
    */
   async create(
     createDto: CreateVendorPaymentDto,
-    user: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<VendorPayment> {
     const paymentNumber = await this.settingsService.generateDocumentNumber('Vendor Payments');
     let paymentMethodId = createDto.paymentMethodId;
@@ -85,7 +86,8 @@ export class VendorPaymentService {
       `Created vendor payment: ${savedPayment.paymentNumber}`,
       {
         entityId: savedPayment.id,
-        userId: user,
+        userId: userId || 'system',
+        username,
         newValues: {
           paymentNumber: savedPayment.paymentNumber,
           amount: savedPayment.amount,
@@ -97,7 +99,7 @@ export class VendorPaymentService {
     // Auto-post to accounting (don't fail payment on error)
     try {
       const fullPayment = await this.findOne(savedPayment.id);
-      await this.accountingService.postVendorPaymentEntry(fullPayment, user);
+      await this.accountingService.postVendorPaymentEntry(fullPayment, userId || 'system');
       this.logger.log(`Posted accounting entry for vendor payment ${fullPayment.paymentNumber}`);
     } catch (error) {
       this.logger.error(
@@ -224,13 +226,14 @@ export class VendorPaymentService {
   async update(
     id: string,
     updateDto: UpdateVendorPaymentDto,
-    user: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<VendorPayment> {
     const vendorPayment = await this.findOne(id);
 
     Object.assign(vendorPayment, {
       ...updateDto,
-      updatedBy: user,
+      updatedBy: userId || 'system',
     });
 
     const savedPayment = await this.vendorPaymentRepository.save(vendorPayment);
@@ -248,7 +251,8 @@ export class VendorPaymentService {
       `Updated vendor payment: ${savedPayment.paymentNumber}`,
       {
         entityId: id,
-        userId: user,
+        userId: userId || 'system',
+        username,
         newValues: {
           paymentNumber: savedPayment.paymentNumber,
           amount: savedPayment.amount,
@@ -334,7 +338,7 @@ export class VendorPaymentService {
   /**
    * Restore a soft deleted vendor payment
    */
-  async restore(id: string, user: string = 'system'): Promise<VendorPayment> {
+  async restore(id: string, userId?: string, username?: string): Promise<VendorPayment> {
     const vendorPayment = await this.vendorPaymentRepository.findOne({
       where: { id, isActive: false },
       withDeleted: true,
@@ -356,7 +360,8 @@ export class VendorPaymentService {
       `Restored vendor payment: ${restoredPayment.paymentNumber}`,
       {
         entityId: id,
-        userId: user,
+        userId: userId || 'system',
+        username,
         newValues: {
           paymentNumber: restoredPayment.paymentNumber,
           amount: restoredPayment.amount,
@@ -373,14 +378,15 @@ export class VendorPaymentService {
    */
   async bulkRestore(
     ids: string[],
-    user: string = 'system',
+    userId?: string,
+    username?: string,
   ): Promise<{ restoredCount: number; failedIds: string[] }> {
     const failedIds: string[] = [];
     let restoredCount = 0;
 
     for (const id of ids) {
       try {
-        await this.restore(id, user);
+        await this.restore(id, userId, username);
         restoredCount++;
       } catch (error) {
         failedIds.push(id);
@@ -393,7 +399,7 @@ export class VendorPaymentService {
   /**
    * Soft delete a vendor payment
    */
-  async remove(id: string, user: string = 'system'): Promise<void> {
+  async remove(id: string, userId?: string, username?: string): Promise<void> {
     const vendorPayment = await this.findOne(id);
 
     vendorPayment.isActive = false;
@@ -408,7 +414,8 @@ export class VendorPaymentService {
       `Deleted vendor payment: ${vendorPayment.paymentNumber}`,
       {
         entityId: id,
-        userId: user,
+        userId: userId || 'system',
+        username,
         oldValues: {
           paymentNumber: vendorPayment.paymentNumber,
           amount: vendorPayment.amount,
@@ -439,7 +446,7 @@ export class VendorPaymentService {
   /**
    * Create vendor payment for a purchase order
    */
-  async createForPurchaseOrder(poId: string, user: string = 'system'): Promise<VendorPayment> {
+  async createForPurchaseOrder(poId: string, userId?: string, username?: string): Promise<VendorPayment> {
     // Find the purchase order
     const purchaseOrder = await this.purchaseOrderRepository.findOne({
       where: { id: poId },
@@ -498,7 +505,8 @@ export class VendorPaymentService {
       `Created vendor payment: ${savedPayment.paymentNumber} for PO ${purchaseOrder.orderNumber}`,
       {
         entityId: savedPayment.id,
-        userId: user,
+        userId: userId || 'system',
+        username,
         newValues: {
           paymentNumber: savedPayment.paymentNumber,
           purchaseOrderId: poId,
@@ -539,7 +547,7 @@ export class VendorPaymentService {
   /**
    * Hard delete vendor payment
    */
-  async permanentDelete(id: string): Promise<{ message: string }> {
+  async permanentDelete(id: string, userId?: string, username?: string): Promise<{ message: string }> {
     const vendorPayment = await this.vendorPaymentRepository.findOne({
       where: { id },
       withDeleted: true,
@@ -556,7 +564,8 @@ export class VendorPaymentService {
       `Permanently deleted vendor payment: ${vendorPayment.paymentNumber}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         oldValues: {
           paymentNumber: vendorPayment.paymentNumber,
           amount: vendorPayment.amount,

--- a/backend/src/modules/purchasing/services/vendor-payment.service.ts
+++ b/backend/src/modules/purchasing/services/vendor-payment.service.ts
@@ -99,7 +99,11 @@ export class VendorPaymentService {
     // Auto-post to accounting (don't fail payment on error)
     try {
       const fullPayment = await this.findOne(savedPayment.id);
-      await this.accountingService.postVendorPaymentEntry(fullPayment, userId || 'system');
+      await this.accountingService.postVendorPaymentEntry(
+        fullPayment,
+        userId || 'system',
+        username,
+      );
       this.logger.log(`Posted accounting entry for vendor payment ${fullPayment.paymentNumber}`);
     } catch (error) {
       this.logger.error(

--- a/backend/src/modules/sales/controllers/customer.controller.ts
+++ b/backend/src/modules/sales/controllers/customer.controller.ts
@@ -27,6 +27,7 @@ import {
   CustomerResponseDto,
   CustomerSummaryDto,
 } from '../dto/customer.dto';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 
 @ApiTags('Customers')
 @Controller('customers')
@@ -42,8 +43,12 @@ export class CustomerController {
   })
   @ApiResponse({ status: 400, description: 'Invalid input data' })
   @ApiResponse({ status: 409, description: 'Customer with email already exists' })
-  async createCustomer(@Body() createCustomerDto: CreateCustomerDto): Promise<CustomerResponseDto> {
-    return this.customerService.create(createCustomerDto);
+  async createCustomer(
+    @Body() createCustomerDto: CreateCustomerDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<CustomerResponseDto> {
+    return this.customerService.create(createCustomerDto, currentUserId, currentUsername);
   }
 
   @Get()
@@ -119,8 +124,10 @@ export class CustomerController {
   async updateCustomer(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateCustomerDto: UpdateCustomerDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<CustomerResponseDto> {
-    return this.customerService.update(id, updateCustomerDto);
+    return this.customerService.update(id, updateCustomerDto, currentUserId, currentUsername);
   }
 
   @Delete(':id')
@@ -155,8 +162,12 @@ export class CustomerController {
     }
   })
   @HttpCode(HttpStatus.NO_CONTENT)
-  async deleteCustomer(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
-    return this.customerService.delete(id);
+  async deleteCustomer(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<void> {
+    return this.customerService.delete(id, currentUserId, currentUsername);
   }
 
 
@@ -249,8 +260,10 @@ export class CustomerController {
   @HttpCode(HttpStatus.OK)
   async bulkRestore(
     @Body() body: { customerIds: string[] },
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ message: string; restoredCount: number; failedIds: string[] }> {
-    const result = await this.customerService.bulkRestore(body.customerIds);
+    const result = await this.customerService.bulkRestore(body.customerIds, currentUserId, currentUsername);
     return {
       message: `Successfully restored ${result.successCount} of ${body.customerIds.length} customers`,
       restoredCount: result.successCount,
@@ -281,8 +294,14 @@ export class CustomerController {
   @HttpCode(HttpStatus.OK)
   async bulkPermanentDelete(
     @Body() body: { customerIds: string[] },
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ message: string; deletedCount: number; failedIds: string[] }> {
-    const result = await this.customerService.bulkPermanentDelete(body.customerIds);
+    const result = await this.customerService.bulkPermanentDelete(
+      body.customerIds,
+      currentUserId,
+      currentUsername,
+    );
     return {
       message: `Successfully permanently deleted ${result.successCount} of ${body.customerIds.length} customers`,
       deletedCount: result.successCount,
@@ -299,8 +318,12 @@ export class CustomerController {
     type: CustomerResponseDto,
   })
   @ApiResponse({ status: 404, description: 'Customer not found' })
-  async restoreCustomer(@Param('id', ParseUUIDPipe) id: string): Promise<CustomerResponseDto> {
-    return this.customerService.restore(id);
+  async restoreCustomer(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<CustomerResponseDto> {
+    return this.customerService.restore(id, currentUserId, currentUsername);
   }
 
   @Delete(':id/permanent')
@@ -341,7 +364,9 @@ export class CustomerController {
   @HttpCode(HttpStatus.NO_CONTENT)
   async permanentDelete(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<void> {
-    await this.customerService.permanentDelete(id);
+    await this.customerService.permanentDelete(id, currentUserId, currentUsername);
   }
 }

--- a/backend/src/modules/sales/controllers/invoice.controller.ts
+++ b/backend/src/modules/sales/controllers/invoice.controller.ts
@@ -31,6 +31,7 @@ import {
   InvoicePaymentAllocationDto,
   VoidInvoiceDto,
 } from '../dto/invoice.dto';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 
 @ApiTags('Invoices')
 @Controller('invoices')
@@ -46,8 +47,12 @@ export class InvoiceController {
   })
   @ApiResponse({ status: 400, description: 'Invalid input data' })
   @ApiResponse({ status: 404, description: 'Customer or sales order not found' })
-  async createInvoice(@Body() createInvoiceDto: CreateInvoiceDto): Promise<InvoiceResponseDto> {
-    return this.invoiceService.create(createInvoiceDto);
+  async createInvoice(
+    @Body() createInvoiceDto: CreateInvoiceDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<InvoiceResponseDto> {
+    return this.invoiceService.create(createInvoiceDto, currentUserId, currentUsername);
   }
 
   @Get()
@@ -163,8 +168,10 @@ export class InvoiceController {
   async updateInvoice(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateInvoiceDto: UpdateInvoiceDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<InvoiceResponseDto> {
-    return this.invoiceService.update(id, updateInvoiceDto);
+    return this.invoiceService.update(id, updateInvoiceDto, currentUserId, currentUsername);
   }
 
   @Put(':id/sync-items')
@@ -191,8 +198,12 @@ export class InvoiceController {
   @ApiResponse({ status: 404, description: 'Invoice not found' })
   @ApiResponse({ status: 409, description: 'Cannot delete invoice in current status' })
   @HttpCode(HttpStatus.NO_CONTENT)
-  async deleteInvoice(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
-    return this.invoiceService.delete(id);
+  async deleteInvoice(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<void> {
+    return this.invoiceService.delete(id, currentUserId, currentUsername);
   }
 
   @Post(':id/send')
@@ -348,8 +359,12 @@ export class InvoiceController {
   })
   @ApiResponse({ status: 404, description: 'Invoice not found' })
   @ApiResponse({ status: 409, description: 'Invoice is not deleted' })
-  async restoreInvoice(@Param('id', ParseUUIDPipe) id: string): Promise<InvoiceResponseDto> {
-    return this.invoiceService.restore(id);
+  async restoreInvoice(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<InvoiceResponseDto> {
+    return this.invoiceService.restore(id, currentUserId, currentUsername);
   }
 
   @Post('bulk-restore')
@@ -364,8 +379,14 @@ export class InvoiceController {
     body: {
       invoiceIds: string[];
     },
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ message: string; restoredCount: number; failedIds: string[] }> {
-    const result = await this.invoiceService.bulkRestore(body.invoiceIds);
+    const result = await this.invoiceService.bulkRestore(
+      body.invoiceIds,
+      currentUserId,
+      currentUsername,
+    );
     return {
       message: `Successfully restored ${result.restoredCount} of ${body.invoiceIds.length} invoices`,
       restoredCount: result.restoredCount,

--- a/backend/src/modules/sales/controllers/invoice.controller.ts
+++ b/backend/src/modules/sales/controllers/invoice.controller.ts
@@ -187,8 +187,10 @@ export class InvoiceController {
   @ApiResponse({ status: 409, description: 'Cannot sync items for fully paid invoice' })
   async syncItemsFromSalesOrder(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<InvoiceResponseDto> {
-    return this.invoiceService.syncItemsFromSalesOrder(id);
+    return this.invoiceService.syncItemsFromSalesOrder(id, currentUserId, currentUsername);
   }
 
   @Delete(':id')

--- a/backend/src/modules/sales/controllers/payment.controller.ts
+++ b/backend/src/modules/sales/controllers/payment.controller.ts
@@ -27,6 +27,7 @@ import {
   AllocatePaymentDto,
   PaymentSummaryDto,
 } from '../dto/payment.dto';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 
 @ApiTags('Payments')
 @Controller('payments')
@@ -44,8 +45,10 @@ export class PaymentController {
   @ApiResponse({ status: 404, description: 'Customer or invoice not found' })
   async recordPayment(
     @Body() createPaymentDto: CreatePaymentDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<PaymentResponseDto> {
-    return this.paymentService.create(createPaymentDto);
+    return this.paymentService.create(createPaymentDto, currentUserId, currentUsername);
   }
 
   @Get()
@@ -105,8 +108,10 @@ export class PaymentController {
   async updatePayment(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updatePaymentDto: UpdatePaymentDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<PaymentResponseDto> {
-    return this.paymentService.update(id, updatePaymentDto);
+    return this.paymentService.update(id, updatePaymentDto, currentUserId, currentUsername);
   }
 
   @Put(':id/complete')
@@ -119,8 +124,12 @@ export class PaymentController {
   })
   @ApiResponse({ status: 404, description: 'Payment not found' })
   @ApiResponse({ status: 400, description: 'Payment cannot be completed' })
-  async completePayment(@Param('id', ParseUUIDPipe) id: string): Promise<PaymentResponseDto> {
-    return this.paymentService.complete(id);
+  async completePayment(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<PaymentResponseDto> {
+    return this.paymentService.complete(id, currentUserId, currentUsername);
   }
 
   @Put(':id/fail')
@@ -136,8 +145,10 @@ export class PaymentController {
   async failPayment(
     @Param('id', ParseUUIDPipe) id: string,
     @Body('reason') reason?: string,
+    @CurrentUser('userId') currentUserId?: string,
+    @CurrentUser('username') currentUsername?: string,
   ): Promise<PaymentResponseDto> {
-    return this.paymentService.fail(id, reason);
+    return this.paymentService.fail(id, reason, currentUserId, currentUsername);
   }
 
   @Put(':id/cancel')
@@ -153,8 +164,10 @@ export class PaymentController {
   async cancelPayment(
     @Param('id', ParseUUIDPipe) id: string,
     @Body('reason') reason?: string,
+    @CurrentUser('userId') currentUserId?: string,
+    @CurrentUser('username') currentUsername?: string,
   ): Promise<PaymentResponseDto> {
-    return this.paymentService.cancel(id, reason);
+    return this.paymentService.cancel(id, reason, currentUserId, currentUsername);
   }
 
   @Post('refund')
@@ -168,8 +181,10 @@ export class PaymentController {
   @ApiResponse({ status: 400, description: 'Payment cannot be refunded or invalid amount' })
   async refundPayment(
     @Body() refundDto: RefundPaymentDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<PaymentResponseDto> {
-    return this.paymentService.refund(refundDto);
+    return this.paymentService.refund(refundDto, currentUserId, currentUsername);
   }
 
   @Post('allocate')
@@ -244,8 +259,12 @@ export class PaymentController {
     type: PaymentResponseDto,
   })
   @ApiResponse({ status: 404, description: 'Payment not found' })
-  async restorePayment(@Param('id', ParseUUIDPipe) id: string): Promise<PaymentResponseDto> {
-    return this.paymentService.restore(id);
+  async restorePayment(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<PaymentResponseDto> {
+    return this.paymentService.restore(id, currentUserId, currentUsername);
   }
 
   @Post('bulk-restore')
@@ -254,7 +273,11 @@ export class PaymentController {
     status: 200,
     description: 'Payments restored successfully',
   })
-  async bulkRestorePayments(@Body('paymentIds') paymentIds: string[]) {
-    return this.paymentService.bulkRestore(paymentIds);
+  async bulkRestorePayments(
+    @Body('paymentIds') paymentIds: string[],
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.paymentService.bulkRestore(paymentIds, currentUserId, currentUsername);
   }
 }

--- a/backend/src/modules/sales/controllers/sales-order.controller.ts
+++ b/backend/src/modules/sales/controllers/sales-order.controller.ts
@@ -32,6 +32,7 @@ import {
   SalesOrderSummaryDto,
   RecordPaymentsDto,
 } from '../dto/sales-order.dto';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 
 @ApiTags('Sales Orders')
 @Controller('sales-orders')
@@ -49,8 +50,10 @@ export class SalesOrderController {
   @ApiResponse({ status: 409, description: 'Insufficient inventory or credit limit exceeded' })
   async createSalesOrder(
     @Body() createSalesOrderDto: CreateSalesOrderDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ) {
-    const data = await this.salesOrderService.create(createSalesOrderDto, null); // Auth removed - no user tracking
+    const data = await this.salesOrderService.create(createSalesOrderDto, currentUserId, currentUsername);
     return { data };
   }
 
@@ -160,8 +163,10 @@ export class SalesOrderController {
   async updateSalesOrder(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateSalesOrderDto: UpdateSalesOrderDto,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<SalesOrderResponseDto> {
-    return this.salesOrderService.update(id, updateSalesOrderDto);
+    return this.salesOrderService.update(id, updateSalesOrderDto, currentUserId, currentUsername);
   }
 
   @Delete(':id')
@@ -195,13 +200,17 @@ export class SalesOrderController {
   @ApiResponse({ status: 404, description: 'Sales order not found' })
   @ApiResponse({ status: 400, description: 'Order is fulfilled (unfulfill first) or order is paid (unpay first)' })
   @ApiResponse({ status: 409, description: 'Cannot delete order in current status' })
-  async deleteSalesOrder(@Param('id', ParseUUIDPipe) id: string): Promise<{
+  async deleteSalesOrder(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<{
     data: SalesOrderResponseDto | null;
     message: string;
     deletedOrderNumber: string;
     redirect?: string;
   }> {
-    const result = await this.salesOrderService.delete(id);
+    const result = await this.salesOrderService.delete(id, currentUserId, currentUsername);
 
     if (result.previousOrder) {
       // Return the previous order as the main data to display
@@ -371,8 +380,12 @@ export class SalesOrderController {
   })
   @ApiResponse({ status: 404, description: 'Sales order not found' })
   @ApiResponse({ status: 409, description: 'Cannot fulfill order - payment insufficient or already fulfilled' })
-  async fulfillOrder(@Param('id', ParseUUIDPipe) id: string) {
-    const data = await this.salesOrderService.fulfillOrder(id);
+  async fulfillOrder(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    const data = await this.salesOrderService.fulfillOrder(id, currentUserId, currentUsername);
     return { data };
   }
 
@@ -401,8 +414,12 @@ export class SalesOrderController {
   })
   @ApiResponse({ status: 404, description: 'Sales order not found' })
   @ApiResponse({ status: 409, description: 'Sales order is not deleted' })
-  async restoreSalesOrder(@Param('id', ParseUUIDPipe) id: string): Promise<SalesOrderResponseDto> {
-    return this.salesOrderService.restore(id);
+  async restoreSalesOrder(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<SalesOrderResponseDto> {
+    return this.salesOrderService.restore(id, currentUserId, currentUsername);
   }
 
   @Post('bulk-restore')
@@ -428,8 +445,14 @@ export class SalesOrderController {
   @HttpCode(HttpStatus.OK)
   async bulkRestore(
     @Body() body: { salesOrderIds: string[] },
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ message: string; restoredCount: number; failedIds: string[] }> {
-    const result = await this.salesOrderService.bulkRestore(body.salesOrderIds);
+    const result = await this.salesOrderService.bulkRestore(
+      body.salesOrderIds,
+      currentUserId,
+      currentUsername,
+    );
     return {
       message: `Successfully restored ${result.successCount} of ${body.salesOrderIds.length} sales orders`,
       restoredCount: result.successCount,
@@ -460,8 +483,14 @@ export class SalesOrderController {
   @HttpCode(HttpStatus.OK)
   async bulkPermanentDelete(
     @Body() body: { salesOrderIds: string[] },
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<{ message: string; deletedCount: number; failedIds: string[] }> {
-    const result = await this.salesOrderService.bulkPermanentDelete(body.salesOrderIds);
+    const result = await this.salesOrderService.bulkPermanentDelete(
+      body.salesOrderIds,
+      currentUserId,
+      currentUsername,
+    );
     return {
       message: `Successfully permanently deleted ${result.successCount} of ${body.salesOrderIds.length} sales orders`,
       deletedCount: result.successCount,
@@ -484,8 +513,10 @@ export class SalesOrderController {
   @HttpCode(HttpStatus.NO_CONTENT)
   async permanentDelete(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
   ): Promise<void> {
-    await this.salesOrderService.permanentDelete(id);
+    await this.salesOrderService.permanentDelete(id, currentUserId, currentUsername);
   }
 
 }

--- a/backend/src/modules/sales/services/customer.service.ts
+++ b/backend/src/modules/sales/services/customer.service.ts
@@ -33,7 +33,11 @@ export class CustomerService {
     private readonly auditLogService: AuditLogService,
   ) {}
 
-  async create(createCustomerDto: CreateCustomerDto): Promise<CustomerResponseDto> {
+  async create(
+    createCustomerDto: CreateCustomerDto,
+    userId?: string,
+    username?: string,
+  ): Promise<CustomerResponseDto> {
     // Check for phone number duplicate if phone is provided
     if (createCustomerDto.phone) {
       await this.validatePhoneUniqueness(createCustomerDto.phone);
@@ -53,7 +57,8 @@ export class CustomerService {
       `Created customer: ${savedCustomer.name} (${savedCustomer.phone || 'no phone'})`,
       {
         entityId: savedCustomer.id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         newValues: {
           name: savedCustomer.name,
           phone: savedCustomer.phone,
@@ -191,7 +196,12 @@ export class CustomerService {
   }
 
   
-  async update(id: string, updateCustomerDto: UpdateCustomerDto): Promise<CustomerResponseDto> {
+  async update(
+    id: string,
+    updateCustomerDto: UpdateCustomerDto,
+    userId?: string,
+    username?: string,
+  ): Promise<CustomerResponseDto> {
     const customer = await this.customerRepository.findOne({ where: { id } });
     if (!customer) {
       throw new NotFoundException('Customer not found');
@@ -220,7 +230,8 @@ export class CustomerService {
       `Updated customer: ${savedCustomer.name}`,
       {
         entityId: savedCustomer.id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         oldValues,
         newValues: {
           name: savedCustomer.name,
@@ -234,7 +245,7 @@ export class CustomerService {
     return this.mapToResponseDto(savedCustomer);
   }
 
-  async delete(id: string): Promise<void> {
+  async delete(id: string, userId?: string, username?: string): Promise<void> {
     const customer = await this.customerRepository.findOne({ where: { id } });
     if (!customer) {
       throw new NotFoundException('Customer not found');
@@ -301,7 +312,8 @@ export class CustomerService {
       `Deleted customer: ${customer.name}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         oldValues: {
           name: customer.name,
           phone: customer.phone,
@@ -311,7 +323,7 @@ export class CustomerService {
     );
   }
 
-  async restore(id: string): Promise<CustomerResponseDto> {
+  async restore(id: string, userId?: string, username?: string): Promise<CustomerResponseDto> {
     // Find the customer first to validate
     const customer = await this.customerRepository.findOne({
       where: { id },
@@ -331,7 +343,8 @@ export class CustomerService {
       `Restored customer: ${customer.name}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         newValues: {
           name: customer.name,
           phone: customer.phone,
@@ -461,7 +474,11 @@ export class CustomerService {
     };
   }
 
-  async bulkRestore(customerIds: string[]): Promise<BulkOperationResponse> {
+  async bulkRestore(
+    customerIds: string[],
+    userId?: string,
+    username?: string,
+  ): Promise<BulkOperationResponse> {
     if (!customerIds || customerIds.length === 0) {
       return BulkOperationUtil.createResponse('restored', 'customer', 0, []);
     }
@@ -491,6 +508,20 @@ export class CustomerService {
         }
 
         await this.customerRepository.restore(customerId);
+        await this.auditLogService.log(
+          'RESTORE',
+          'Customer',
+          `Restored customer: ${customer.name}`,
+          {
+            entityId: customerId,
+            userId: userId || 'system',
+            username,
+            newValues: {
+              name: customer.name,
+              phone: customer.phone,
+            },
+          }
+        );
         successCount++;
       } catch (error) {
         BulkOperationUtil.addFailure(
@@ -505,7 +536,11 @@ export class CustomerService {
     return BulkOperationUtil.createResponse('restored', 'customer', successCount, failedItems);
   }
 
-  async bulkPermanentDelete(customerIds: string[]): Promise<BulkOperationResponse> {
+  async bulkPermanentDelete(
+    customerIds: string[],
+    userId?: string,
+    username?: string,
+  ): Promise<BulkOperationResponse> {
     if (!customerIds || customerIds.length === 0) {
       return BulkOperationUtil.createResponse('permanently deleted', 'customer', 0, []);
     }
@@ -603,6 +638,24 @@ export class CustomerService {
           // TODO: Add payment deletion when Payment entity is available
         ]);
 
+        // Log audit trail for permanent delete
+        await this.auditLogService.log(
+          'PERMANENT_DELETE',
+          'Customer',
+          `Permanently deleted customer: ${customer.name}`,
+          {
+            entityId: customerId,
+            userId: userId || 'system',
+            username,
+            oldValues: {
+              name: customer.name,
+              phone: customer.phone,
+              type: customer.type,
+              priceListId: customer.priceListId,
+            },
+          }
+        );
+
         // Perform hard delete
         await this.customerRepository.delete(customerId);
         successCount++;
@@ -620,7 +673,7 @@ export class CustomerService {
   }
 
   @Transactional('Customer permanent deletion with financial integrity validation')
-  async permanentDelete(id: string): Promise<void> {
+  async permanentDelete(id: string, userId?: string, username?: string): Promise<void> {
     // Verify customer exists and is soft-deleted
     console.log(`Looking for customer with ID: ${id}`);
     const customer = await this.customerRepository.findOne({
@@ -733,7 +786,8 @@ export class CustomerService {
       `Permanently deleted customer: ${customer.name}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         oldValues: {
           name: customer.name,
           phone: customer.phone,

--- a/backend/src/modules/sales/services/invoice.service.ts
+++ b/backend/src/modules/sales/services/invoice.service.ts
@@ -71,7 +71,11 @@ export class InvoiceService {
     return `INV-${nextNumber.toString().padStart(6, '0')}`;
   }
 
-  async create(createInvoiceDto: CreateInvoiceDto): Promise<InvoiceResponseDto> {
+  async create(
+    createInvoiceDto: CreateInvoiceDto,
+    userId?: string,
+    username?: string,
+  ): Promise<InvoiceResponseDto> {
     const { customerId, salesOrderId, ...invoiceData } = createInvoiceDto;
 
     // Verify customer exists
@@ -137,7 +141,8 @@ export class InvoiceService {
       `Created invoice: ${savedInvoice.invoiceNumber}`,
       {
         entityId: savedInvoice.id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         newValues: {
           invoiceNumber: savedInvoice.invoiceNumber,
           customerId,
@@ -346,7 +351,12 @@ export class InvoiceService {
     return this.mapToResponseDto(invoice);
   }
 
-  async update(id: string, updateInvoiceDto: UpdateInvoiceDto): Promise<InvoiceResponseDto> {
+  async update(
+    id: string,
+    updateInvoiceDto: UpdateInvoiceDto,
+    userId?: string,
+    username?: string,
+  ): Promise<InvoiceResponseDto> {
     const invoice = await this.invoiceRepository.findOne({ where: { id } });
     if (!invoice) {
       throw new NotFoundException('Invoice not found');
@@ -447,7 +457,7 @@ export class InvoiceService {
     return this.findById(invoice.id);
   }
 
-  async delete(id: string): Promise<void> {
+  async delete(id: string, userId?: string, username?: string): Promise<void> {
     const invoice = await this.invoiceRepository.findOne({ where: { id } });
     if (!invoice) {
       throw new NotFoundException('Invoice not found');
@@ -479,7 +489,8 @@ export class InvoiceService {
       `Deleted invoice: ${invoice.invoiceNumber}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         oldValues: {
           invoiceNumber: invoice.invoiceNumber,
           status: invoice.status,
@@ -840,7 +851,7 @@ export class InvoiceService {
     };
   }
 
-  async restore(id: string): Promise<InvoiceResponseDto> {
+  async restore(id: string, userId?: string, username?: string): Promise<InvoiceResponseDto> {
     const invoice = await this.invoiceRepository.findOne({
       where: { id },
       withDeleted: true, // Include soft-deleted records
@@ -865,7 +876,8 @@ export class InvoiceService {
       `Restored invoice: ${invoice.invoiceNumber}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         newValues: {
           invoiceNumber: invoice.invoiceNumber,
           status: invoice.status,
@@ -883,7 +895,11 @@ export class InvoiceService {
     return this.mapToResponseDto(restoredInvoice);
   }
 
-  async bulkRestore(invoiceIds: string[]): Promise<{ message: string; restoredCount: number; failedIds: string[] }> {
+  async bulkRestore(
+    invoiceIds: string[],
+    userId?: string,
+    username?: string,
+  ): Promise<{ message: string; restoredCount: number; failedIds: string[] }> {
     if (!invoiceIds || invoiceIds.length === 0) {
       return {
         message: 'No invoices to restore',
@@ -897,7 +913,7 @@ export class InvoiceService {
 
     for (const id of invoiceIds) {
       try {
-        await this.restore(id);
+        await this.restore(id, userId, username);
         restoredCount++;
       } catch (error) {
         failedIds.push(id);

--- a/backend/src/modules/sales/services/invoice.service.ts
+++ b/backend/src/modules/sales/services/invoice.service.ts
@@ -372,10 +372,23 @@ export class InvoiceService {
     // No direct field updates in current implementation
 
     const savedInvoice = await this.invoiceRepository.save(invoice);
+
+    await this.auditLogService.log(
+      'UPDATE',
+      'Invoice',
+      `Updated invoice: ${savedInvoice.invoiceNumber}`,
+      {
+        entityId: savedInvoice.id,
+        userId: userId || 'system',
+        username,
+        newValues: updateInvoiceDto,
+      }
+    );
+
     return this.findById(savedInvoice.id);
   }
 
-  async syncItemsFromSalesOrder(invoiceId: string): Promise<InvoiceResponseDto> {
+  async syncItemsFromSalesOrder(invoiceId: string, userId?: string, username?: string): Promise<InvoiceResponseDto> {
     const invoice = await this.invoiceRepository.findOne({
       where: { id: invoiceId }
     });
@@ -446,7 +459,8 @@ export class InvoiceService {
       `Updated invoice: ${invoice.invoiceNumber}`,
       {
         entityId: invoice.id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         newValues: {
           status: invoice.status,
           totalAmount: invoice.totalAmount,

--- a/backend/src/modules/sales/services/payment.service.spec.ts
+++ b/backend/src/modules/sales/services/payment.service.spec.ts
@@ -144,6 +144,7 @@ describe('PaymentService', () => {
           }),
         }),
         'system',
+        undefined,
       );
       expect(result).toBeDefined();
       expect(paymentRepository.save).toHaveBeenCalled();

--- a/backend/src/modules/sales/services/payment.service.ts
+++ b/backend/src/modules/sales/services/payment.service.ts
@@ -117,7 +117,11 @@ export class PaymentService {
     // Auto-post to accounting (don't fail payment on error)
     try {
       const fullPayment = await this.findPaymentWithRelations(savedPayment.id);
-      await this.accountingService.postCustomerPaymentEntry(fullPayment, userId || 'system');
+      await this.accountingService.postCustomerPaymentEntry(
+        fullPayment,
+        userId || 'system',
+        username,
+      );
       this.logger.log(`Posted accounting entry for payment ${fullPayment.paymentNumber}`);
     } catch (error) {
       this.logger.error(

--- a/backend/src/modules/sales/services/payment.service.ts
+++ b/backend/src/modules/sales/services/payment.service.ts
@@ -40,7 +40,11 @@ export class PaymentService {
     private readonly accountingService: AccountingService,
   ) {}
 
-  async create(createPaymentDto: CreatePaymentDto): Promise<PaymentResponseDto> {
+  async create(
+    createPaymentDto: CreatePaymentDto,
+    userId?: string,
+    username?: string,
+  ): Promise<PaymentResponseDto> {
     // Verify customer exists
     const customer = await this.customerRepository.findOne({
       where: { id: createPaymentDto.customerId },
@@ -99,7 +103,8 @@ export class PaymentService {
       `Created payment: ${savedPayment.amount} for ${customer.name}`,
       {
         entityId: savedPayment.id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         newValues: {
           amount: savedPayment.amount,
           paymentMethodId: savedPayment.paymentMethodId,
@@ -112,7 +117,7 @@ export class PaymentService {
     // Auto-post to accounting (don't fail payment on error)
     try {
       const fullPayment = await this.findPaymentWithRelations(savedPayment.id);
-      await this.accountingService.postCustomerPaymentEntry(fullPayment, 'system');
+      await this.accountingService.postCustomerPaymentEntry(fullPayment, userId || 'system');
       this.logger.log(`Posted accounting entry for payment ${fullPayment.paymentNumber}`);
     } catch (error) {
       this.logger.error(
@@ -175,7 +180,12 @@ export class PaymentService {
     return this.mapToResponseDto(payment);
   }
 
-  async update(id: string, updatePaymentDto: UpdatePaymentDto): Promise<PaymentResponseDto> {
+  async update(
+    id: string,
+    updatePaymentDto: UpdatePaymentDto,
+    userId?: string,
+    username?: string,
+  ): Promise<PaymentResponseDto> {
     const payment = await this.findPaymentWithRelations(id);
 
     Object.assign(payment, updatePaymentDto);
@@ -188,7 +198,8 @@ export class PaymentService {
       `Updated payment for ${payment.customer?.name || 'customer'}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         newValues: {
           amount: savedPayment.amount,
           status: savedPayment.status,
@@ -314,7 +325,7 @@ export class PaymentService {
     };
   }
 
-  async complete(id: string): Promise<PaymentResponseDto> {
+  async complete(id: string, userId?: string, username?: string): Promise<PaymentResponseDto> {
     const payment = await this.findPaymentWithRelations(id);
 
     if (payment.status === PaymentStatus.COMPLETED) {
@@ -334,7 +345,8 @@ export class PaymentService {
       `Completed payment ${payment.paymentNumber}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         newValues: { status: PaymentStatus.COMPLETED },
       }
     );
@@ -342,7 +354,7 @@ export class PaymentService {
     return this.mapToResponseDto(await this.findPaymentWithRelations(savedPayment.id));
   }
 
-  async fail(id: string, reason?: string): Promise<PaymentResponseDto> {
+  async fail(id: string, reason?: string, userId?: string, username?: string): Promise<PaymentResponseDto> {
     const payment = await this.findPaymentWithRelations(id);
 
     if (payment.status === PaymentStatus.COMPLETED) {
@@ -363,7 +375,8 @@ export class PaymentService {
       `Marked payment ${payment.paymentNumber} as failed`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         newValues: { status: PaymentStatus.FAILED, reason },
       }
     );
@@ -371,7 +384,7 @@ export class PaymentService {
     return this.mapToResponseDto(await this.findPaymentWithRelations(savedPayment.id));
   }
 
-  async cancel(id: string, reason?: string): Promise<PaymentResponseDto> {
+  async cancel(id: string, reason?: string, userId?: string, username?: string): Promise<PaymentResponseDto> {
     const payment = await this.findPaymentWithRelations(id);
 
     if (payment.status === PaymentStatus.COMPLETED) {
@@ -392,7 +405,8 @@ export class PaymentService {
       `Cancelled payment ${payment.paymentNumber}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         newValues: { status: PaymentStatus.CANCELLED, reason },
       }
     );
@@ -404,7 +418,7 @@ export class PaymentService {
     paymentId: string;
     amount: number;
     reason?: string;
-  }): Promise<PaymentResponseDto> {
+  }, userId?: string, username?: string): Promise<PaymentResponseDto> {
     const originalPayment = await this.findPaymentWithRelations(refundDto.paymentId);
 
     if (originalPayment.status !== PaymentStatus.COMPLETED) {
@@ -442,7 +456,7 @@ export class PaymentService {
     }
 
     try {
-      await this.accountingService.reverseSourceEntries('payment', originalPayment.id, 'system');
+      await this.accountingService.reverseSourceEntries('payment', originalPayment.id, userId || 'system');
     } catch (err) {
       this.logger.error(
         `Failed to post refund accounting entry for payment ${originalPayment.id}: ${err.message}`,
@@ -457,7 +471,8 @@ export class PaymentService {
       `Created refund for payment ${originalPayment.paymentNumber}`,
       {
         entityId: savedRefund.id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         newValues: {
           amount: savedRefund.amount,
           status: savedRefund.status,
@@ -555,7 +570,7 @@ export class PaymentService {
     };
   }
 
-  async restore(id: string): Promise<PaymentResponseDto> {
+  async restore(id: string, userId?: string, username?: string): Promise<PaymentResponseDto> {
     const payment = await this.paymentRepository.findOne({
       where: { id },
       withDeleted: true, // Include soft-deleted records
@@ -573,6 +588,22 @@ export class PaymentService {
     // Restore the payment
     await this.paymentRepository.restore(id);
 
+    await this.auditLogService.log(
+      'RESTORE',
+      'Payment',
+      `Restored payment: ${payment.paymentNumber}`,
+      {
+        entityId: id,
+        userId: userId || 'system',
+        username,
+        newValues: {
+          paymentNumber: payment.paymentNumber,
+          amount: payment.amount,
+          status: payment.status,
+        },
+      }
+    );
+
     // Return the restored payment
     const restoredPayment = await this.paymentRepository.findOne({
       where: { id },
@@ -582,7 +613,11 @@ export class PaymentService {
     return this.mapToResponseDto(restoredPayment);
   }
 
-  async bulkRestore(paymentIds: string[]): Promise<{ restoredCount: number; failedIds: string[] }> {
+  async bulkRestore(
+    paymentIds: string[],
+    userId?: string,
+    username?: string,
+  ): Promise<{ restoredCount: number; failedIds: string[] }> {
     if (!paymentIds || paymentIds.length === 0) {
       return { restoredCount: 0, failedIds: [] };
     }
@@ -592,7 +627,7 @@ export class PaymentService {
 
     for (const id of paymentIds) {
       try {
-        await this.restore(id);
+        await this.restore(id, userId, username);
         successCount++;
       } catch (error) {
         failedIds.push(id);

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -203,6 +203,7 @@ describe('SalesOrderService', () => {
           orderNumber: mockSalesOrder.orderNumber,
         }),
         'system',
+        undefined,
       );
       expect(result).toBeDefined();
       expect(salesOrderRepository.save).toHaveBeenCalled();

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -152,7 +152,11 @@ export class SalesOrderService {
     return previousOrder ? this.mapToResponseDto(previousOrder) : null;
   }
 
-  async create(createSalesOrderDto: CreateSalesOrderDto, userId: string | null): Promise<SalesOrderResponseDto> {
+  async create(
+    createSalesOrderDto: CreateSalesOrderDto,
+    userId?: string,
+    username?: string,
+  ): Promise<SalesOrderResponseDto> {
     const { customerId, items, ...orderData } = createSalesOrderDto;
 
     // Verify customer exists and can purchase
@@ -298,10 +302,11 @@ export class SalesOrderService {
         'CREATE',
         'Invoice',
         `Created invoice: ${invoice.invoiceNumber} for sales order ${orderWithCustomer.orderNumber}`,
-        {
-          entityId: invoice.id,
-          userId: 'system',
-          newValues: {
+          {
+            entityId: invoice.id,
+            userId: userId || 'system',
+            username,
+            newValues: {
             invoiceNumber: invoice.invoiceNumber,
             salesOrderId: orderWithCustomer.id,
             customerId: orderWithCustomer.customerId,
@@ -344,6 +349,7 @@ export class SalesOrderService {
       {
         entityId: savedOrder.id,
         userId: userId || 'system',
+        username,
         newValues: {
           orderNumber: savedOrder.orderNumber,
           customerId: customer.id,
@@ -794,7 +800,12 @@ export class SalesOrderService {
     return this.mapToResponseDto(order);
   }
 
-  async update(id: string, updateSalesOrderDto: UpdateSalesOrderDto): Promise<SalesOrderResponseDto> {
+  async update(
+    id: string,
+    updateSalesOrderDto: UpdateSalesOrderDto,
+    userId?: string,
+    username?: string,
+  ): Promise<SalesOrderResponseDto> {
     const order = await this.salesOrderRepository.findOne({
       where: { id }
     });
@@ -911,7 +922,8 @@ export class SalesOrderService {
         `Updated sales order: ${order.orderNumber}`,
         {
           entityId: id,
-          userId: 'system',
+          userId: userId || 'system',
+          username,
           oldValues: updateData,
           newValues: updateData,
         }
@@ -921,7 +933,11 @@ export class SalesOrderService {
     return this.findById(id);
   }
 
-  async delete(id: string): Promise<{ deletedOrderNumber: string; previousOrder: SalesOrderResponseDto | null }> {
+  async delete(
+    id: string,
+    userId?: string,
+    username?: string,
+  ): Promise<{ deletedOrderNumber: string; previousOrder: SalesOrderResponseDto | null }> {
     const order = await this.salesOrderRepository.findOne({ where: { id } });
     if (!order) {
       throw new NotFoundException('Sales order not found');
@@ -968,7 +984,8 @@ export class SalesOrderService {
             `Deleted invoice: ${invoice.invoiceNumber} (cascaded from sales order ${order.orderNumber})`,
             {
               entityId: invoice.id,
-              userId: 'system',
+              userId: userId || 'system',
+              username,
               oldValues: {
                 invoiceNumber: invoice.invoiceNumber,
                 salesOrderId: id,
@@ -1011,7 +1028,8 @@ export class SalesOrderService {
             `Deleted payment: ${payment.paymentNumber} (cascaded from sales order ${order.orderNumber})`,
             {
               entityId: payment.id,
-              userId: 'system',
+              userId: userId || 'system',
+              username,
               oldValues: {
                 paymentNumber: payment.paymentNumber,
                 salesOrderId: id,
@@ -1036,7 +1054,8 @@ export class SalesOrderService {
       `Deleted sales order: ${order.orderNumber}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         oldValues: {
           orderNumber: order.orderNumber,
           customerId: order.customerId,
@@ -1311,7 +1330,7 @@ export class SalesOrderService {
     };
   }
 
-  async restore(id: string): Promise<SalesOrderResponseDto> {
+  async restore(id: string, userId?: string, username?: string): Promise<SalesOrderResponseDto> {
     const order = await this.salesOrderRepository.findOne({
       where: { id },
       withDeleted: true, // Include soft-deleted records
@@ -1348,7 +1367,8 @@ export class SalesOrderService {
             `Restored invoice: ${invoice.invoiceNumber} (cascaded from sales order ${order.orderNumber})`,
             {
               entityId: invoice.id,
-              userId: 'system',
+              userId: userId || 'system',
+              username,
               newValues: {
                 invoiceNumber: invoice.invoiceNumber,
                 salesOrderId: id,
@@ -1402,7 +1422,8 @@ export class SalesOrderService {
               `Restored payment: ${payment.paymentNumber} (cascaded from sales order ${order.orderNumber})`,
               {
                 entityId: payment.id,
-                userId: 'system',
+                userId: userId || 'system',
+                username,
                 newValues: {
                   paymentNumber: payment.paymentNumber,
                   salesOrderId: id,
@@ -1431,7 +1452,8 @@ export class SalesOrderService {
       `Restored sales order: ${order.orderNumber}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         newValues: {
           orderNumber: order.orderNumber,
           customerId: order.customerId,
@@ -1443,7 +1465,7 @@ export class SalesOrderService {
     return this.mapToResponseDto(restoredOrder);
   }
 
-  async bulkRestore(ids: string[]): Promise<BulkOperationResponse> {
+  async bulkRestore(ids: string[], userId?: string, username?: string): Promise<BulkOperationResponse> {
     if (!ids || ids.length === 0) {
       return BulkOperationUtil.createResponse('restored', 'sales order', 0, []);
     }
@@ -1453,7 +1475,7 @@ export class SalesOrderService {
 
     for (const id of ids) {
       try {
-        await this.restore(id);
+        await this.restore(id, userId, username);
         successCount++;
       } catch (error) {
         BulkOperationUtil.addFailure(
@@ -1468,7 +1490,7 @@ export class SalesOrderService {
     return BulkOperationUtil.createResponse('restored', 'sales order', successCount, failedItems);
   }
 
-  async permanentDelete(id: string): Promise<void> {
+  async permanentDelete(id: string, userId?: string, username?: string): Promise<void> {
     // Find the order (including soft-deleted ones)
     const order = await this.salesOrderRepository.findOne({
       where: { id },
@@ -1504,7 +1526,8 @@ export class SalesOrderService {
             `Permanently deleted invoice: ${invoice.invoiceNumber} (cascaded from sales order ${order.orderNumber})`,
             {
               entityId: invoice.id,
-              userId: 'system',
+              userId: userId || 'system',
+              username,
               oldValues: {
                 invoiceNumber: invoice.invoiceNumber,
                 salesOrderId: id,
@@ -1569,7 +1592,8 @@ export class SalesOrderService {
             `Permanently deleted payment: ${payment.paymentNumber} (cascaded from sales order ${order.orderNumber})`,
             {
               entityId: payment.id,
-              userId: 'system',
+              userId: userId || 'system',
+              username,
               oldValues: {
                 paymentNumber: payment.paymentNumber,
                 salesOrderId: id,
@@ -1600,7 +1624,8 @@ export class SalesOrderService {
       `Permanently deleted sales order: ${order.orderNumber}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         oldValues: {
           orderNumber: order.orderNumber,
           customerId: order.customerId,
@@ -1616,7 +1641,9 @@ export class SalesOrderService {
   }
 
   async bulkPermanentDelete(
-    orderIds: string[]
+    orderIds: string[],
+    userId?: string,
+    username?: string,
   ): Promise<BulkOperationResponse> {
     if (!orderIds || orderIds.length === 0) {
       return BulkOperationUtil.createResponse('permanently deleted', 'sales order', 0, []);
@@ -1683,7 +1710,8 @@ export class SalesOrderService {
                 `Permanently deleted invoice: ${invoice.invoiceNumber} (cascaded from sales order ${order.orderNumber})`,
                 {
                   entityId: invoice.id,
-                  userId: 'system',
+                  userId: userId || 'system',
+                  username,
                   oldValues: {
                     invoiceNumber: invoice.invoiceNumber,
                     salesOrderId: id,
@@ -1753,7 +1781,8 @@ export class SalesOrderService {
                 `Permanently deleted payment: ${payment.paymentNumber} (cascaded from sales order ${order.orderNumber})`,
                 {
                   entityId: payment.id,
-                  userId: 'system',
+                  userId: userId || 'system',
+                  username,
                   oldValues: {
                     paymentNumber: payment.paymentNumber,
                     salesOrderId: id,
@@ -2341,7 +2370,7 @@ export class SalesOrderService {
     return this.findById(savedOrder.id);
   }
 
-  async fulfillOrder(id: string): Promise<SalesOrderResponseDto> {
+  async fulfillOrder(id: string, userId?: string, username?: string): Promise<SalesOrderResponseDto> {
     const order = await this.salesOrderRepository.findOne({
       where: { id },
       relations: ['customer', 'items', 'items.product'],
@@ -2386,7 +2415,8 @@ export class SalesOrderService {
       `Fulfilled sales order: ${order.orderNumber}`,
       {
         entityId: id,
-        userId: 'system',
+        userId: userId || 'system',
+        username,
         oldValues: { isFulfilled: false },
         newValues: { isFulfilled: true, fulfilledDate: order.fulfilledDate },
       }
@@ -2399,7 +2429,7 @@ export class SalesOrderService {
         relations: ['customer', 'items', 'items.product'],
       });
       if (fullOrder) {
-        await this.accountingService.postSalesOrderEntry(fullOrder, 'system');
+        await this.accountingService.postSalesOrderEntry(fullOrder, userId || 'system');
         this.logger.log(`Posted accounting entry for sales order ${fullOrder.orderNumber}`);
       }
     } catch (error) {

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -1806,6 +1806,23 @@ export class SalesOrderService {
         // Hard delete order items first
         await this.salesOrderItemRepository.delete({ salesOrderId: id });
 
+        // Log audit trail for the order itself before permanent deletion
+        await this.auditLogService.log(
+          'PERMANENT_DELETE',
+          'SalesOrder',
+          `Permanently deleted sales order: ${order.orderNumber}`,
+          {
+            entityId: id,
+            userId: userId || 'system',
+            username,
+            oldValues: {
+              orderNumber: order.orderNumber,
+              totalAmount: order.totalAmount,
+              customerId: order.customerId,
+            },
+          }
+        );
+
         // Hard delete the order
         await this.salesOrderRepository.delete(id);
 

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -2446,7 +2446,11 @@ export class SalesOrderService {
         relations: ['customer', 'items', 'items.product'],
       });
       if (fullOrder) {
-        await this.accountingService.postSalesOrderEntry(fullOrder, userId || 'system');
+        await this.accountingService.postSalesOrderEntry(
+          fullOrder,
+          userId || 'system',
+          username,
+        );
         this.logger.log(`Posted accounting entry for sales order ${fullOrder.orderNumber}`);
       }
     } catch (error) {

--- a/docs/plans/2026-03-04-accounting-audit-logging-design.md
+++ b/docs/plans/2026-03-04-accounting-audit-logging-design.md
@@ -1,0 +1,87 @@
+# Accounting Audit Logging — Design
+
+**Date**: 2026-03-04
+**Status**: Approved
+**Scope**: Backend only
+
+## Overview
+
+Add audit logging to all accounting module services so that every create, update, delete, post, reverse, and bulk operation is recorded in the audit log. This brings accounting in line with the existing audit log coverage in the Sales, Purchasing, and Inventory modules.
+
+## What's Not Changing
+
+- No frontend changes — the global audit log page at `/audit-logs` already provides full filtering by entity type and entity ID, so users can find accounting logs through the existing UI.
+- No new entity types or schema changes in the audit log system.
+- No oldValues/newValues diffs — matching the simple description-based logging style used by other modules.
+
+## Architecture
+
+`AuditLogsModule` is already marked `@Global()`, so `AuditLogService` is available application-wide. The accounting module just needs to declare the import once and inject the service into each service file.
+
+### Module Change
+
+`accounting.module.ts` — add `AuditLogsModule` to the `imports` array.
+
+## Services & Audited Events
+
+| Service | Entity Type | Actions to Log |
+|---|---|---|
+| `JournalEntryService` | `JournalEntry` | CREATE, UPDATE, DELETE, BULK_DELETE, POST, BULK_POST, REVERSE |
+| `ChartOfAccountsService` | `Account` | CREATE, UPDATE, DELETE, RESTORE, BULK_RESTORE |
+| `FiscalPeriodService` | `FiscalPeriod` | CREATE, UPDATE, DELETE, RESTORE, GENERATE |
+| `AccountMappingService` | `AccountMapping` | CREATE, UPDATE, DELETE |
+| `ReconciliationService` | `BankReconciliation` | CREATE, UPDATE, DELETE |
+| `SettlementService` | `Settlement` | CREATE |
+| `OwnerEquityService` | `OwnerEquity` | CREATE, UPDATE, DELETE, BULK_DELETE, POST, BULK_POST |
+| `ExpenseService` | `Expense` | CREATE, UPDATE, DELETE, BULK_DELETE, POST, BULK_POST |
+| `AccountingService` | `JournalEntry` | AUTO_POST (system-generated entries for sales, payments, GRN, etc.) |
+
+## Logging Pattern
+
+Following the established pattern from the Purchasing module exactly:
+
+```typescript
+// Injection
+constructor(
+  private readonly auditLogService: AuditLogService,
+) {}
+
+// Per operation
+await this.auditLogService.log(
+  'CREATE',               // action string
+  'JournalEntry',         // entityType
+  `Created journal entry: ${entry.entryNumber}`,  // human-readable description
+  {
+    entityId: entry.id,
+    userId: userId ?? 'system',
+  }
+);
+```
+
+Action strings used:
+- `CREATE`, `UPDATE`, `DELETE`, `RESTORE` — standard CRUD
+- `BULK_DELETE`, `BULK_POST` — batch operations
+- `POST` — posting a draft entry/expense/equity transaction
+- `REVERSE` — reversing a posted journal entry
+- `GENERATE` — generating a batch of fiscal periods
+- `AUTO_POST` — system-generated journal entries (posted by AccountingService on behalf of other modules)
+
+## Files Changed
+
+1. `backend/src/modules/accounting/accounting.module.ts`
+2. `backend/src/modules/accounting/services/journal-entry.service.ts`
+3. `backend/src/modules/accounting/services/chart-of-accounts.service.ts`
+4. `backend/src/modules/accounting/services/fiscal-period.service.ts`
+5. `backend/src/modules/accounting/services/account-mapping.service.ts`
+6. `backend/src/modules/accounting/services/reconciliation.service.ts`
+7. `backend/src/modules/accounting/services/settlement.service.ts`
+8. `backend/src/modules/accounting/services/owner-equity.service.ts`
+9. `backend/src/modules/accounting/services/expense.service.ts`
+10. `backend/src/modules/accounting/services/accounting.service.ts`
+
+## Testing
+
+- Verify audit log entries appear in `/audit-logs` when filtering by each entity type
+- Verify `entityId` is correctly populated so the log row's "Go to entity" link works
+- Verify bulk operations create one log entry per entity (not one total)
+- No unit test changes required — audit log service is a fire-and-forget side effect

--- a/docs/plans/2026-03-04-accounting-audit-logging.md
+++ b/docs/plans/2026-03-04-accounting-audit-logging.md
@@ -1,0 +1,955 @@
+# Accounting Audit Logging Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `auditLogService.log()` calls to all 9 accounting services so every create, update, delete, post, reverse, and bulk operation is recorded in the audit log.
+
+**Architecture:** `AuditLogsModule` is already `@Global()`, so `AuditLogService` is available everywhere. We add it to `accounting.module.ts` imports, then inject and call it in each service after each successful mutation. No schema changes, no frontend changes.
+
+**Tech Stack:** NestJS 11, TypeORM, PostgreSQL. Pattern reference: `backend/src/modules/purchasing/services/purchase-order.service.ts`.
+
+---
+
+## Task 1: Add AuditLogsModule to accounting.module.ts
+
+**Files:**
+- Modify: `backend/src/modules/accounting/accounting.module.ts`
+
+**Step 1: Open the file and locate the imports array**
+
+Read: `backend/src/modules/accounting/accounting.module.ts`
+
+Current imports array only has `SettingsModule`. We need to add `AuditLogsModule`.
+
+**Step 2: Add the import**
+
+Add to the top of the file:
+```typescript
+import { AuditLogsModule } from '../audit-logs/audit-logs.module';
+```
+
+Add `AuditLogsModule` to the `imports` array in `@Module({...})`:
+```typescript
+imports: [
+  TypeOrmModule.forFeature([...]),
+  SettingsModule,
+  AuditLogsModule,  // ADD THIS
+],
+```
+
+**Step 3: Verify TypeScript compiles**
+
+```bash
+cd /home/blur/erp2/backend && npx tsc --noEmit
+```
+Expected: No errors (or same errors as before — there are none currently).
+
+**Step 4: Commit**
+
+```bash
+cd /home/blur/erp2 && git add backend/src/modules/accounting/accounting.module.ts
+git commit -m "feat(accounting): import AuditLogsModule for audit logging"
+```
+
+---
+
+## Task 2: Add audit logging to JournalEntryService
+
+**Files:**
+- Modify: `backend/src/modules/accounting/services/journal-entry.service.ts`
+
+**Step 1: Add import and inject AuditLogService**
+
+Add import at the top (after other imports):
+```typescript
+import { AuditLogService } from '../../audit-logs/services';
+```
+
+In the constructor, add:
+```typescript
+private readonly auditLogService: AuditLogService,
+```
+
+**Step 2: Add log call to `create()` method**
+
+After `await this.journalEntryRepository.save(journalEntry)` (where `journalEntry` is the saved entity with `.id` and `.referenceNumber`), add:
+
+```typescript
+await this.auditLogService.log(
+  'CREATE',
+  'JournalEntry',
+  `Created journal entry: ${savedEntry.referenceNumber}`,
+  { entityId: savedEntry.id, userId: userId ?? 'system' }
+);
+```
+
+Note: The variable name for the saved result may differ — check the existing code. Use whatever variable holds the saved `JournalEntry` entity after the `.save()` call.
+
+**Step 3: Add log call to `update()` method**
+
+After the entity is saved and before returning:
+```typescript
+await this.auditLogService.log(
+  'UPDATE',
+  'JournalEntry',
+  `Updated journal entry: ${entry.referenceNumber}`,
+  { entityId: id, userId: userId ?? 'system' }
+);
+```
+
+**Step 4: Add log call to `remove()` method**
+
+After `await this.journalEntryRepository.softDelete(id)`:
+```typescript
+await this.auditLogService.log(
+  'DELETE',
+  'JournalEntry',
+  `Deleted journal entry: ${entry.referenceNumber}`,
+  { entityId: id, userId: userId ?? 'system' }
+);
+```
+
+**Step 5: Add log call to `postEntry()` method**
+
+After the entry status is updated to POSTED and saved:
+```typescript
+await this.auditLogService.log(
+  'POST',
+  'JournalEntry',
+  `Posted journal entry: ${entry.referenceNumber}`,
+  { entityId: id, userId: userId ?? 'system' }
+);
+```
+
+**Step 6: Add log call to `reverseEntry()` method**
+
+After the reversal entry is saved (the NEW entry created by reversal):
+```typescript
+await this.auditLogService.log(
+  'REVERSE',
+  'JournalEntry',
+  `Reversed journal entry: ${originalEntry.referenceNumber} → ${reversalEntry.referenceNumber}`,
+  { entityId: id, userId: userId ?? 'system', metadata: { reversalEntryId: reversalEntry.id } }
+);
+```
+
+**Step 7: Add log calls to `bulkPost()` method**
+
+Inside the loop where each entry is successfully posted, add per-entry logging:
+```typescript
+await this.auditLogService.log(
+  'POST',
+  'JournalEntry',
+  `Bulk posted journal entry: ${entry.referenceNumber}`,
+  { entityId: entry.id, userId: 'system' }
+);
+```
+
+**Step 8: Add log calls to `bulkDelete()` method**
+
+Inside the loop where each entry is successfully deleted:
+```typescript
+await this.auditLogService.log(
+  'DELETE',
+  'JournalEntry',
+  `Bulk deleted journal entry: ${entry.referenceNumber}`,
+  { entityId: entry.id, userId: 'system' }
+);
+```
+
+**Step 9: Handle `reverseEntryInPeriod()` similarly to `reverseEntry()`**
+
+After reversal entry saved:
+```typescript
+await this.auditLogService.log(
+  'REVERSE',
+  'JournalEntry',
+  `Reversed journal entry: ${originalEntry.referenceNumber} (into period ${fiscalPeriodId})`,
+  { entityId: id, userId: userId ?? 'system', metadata: { reversalEntryId: reversalEntry.id, fiscalPeriodId } }
+);
+```
+
+**Step 10: Verify TypeScript**
+
+```bash
+cd /home/blur/erp2/backend && npx tsc --noEmit
+```
+Expected: No errors.
+
+**Step 11: Commit**
+
+```bash
+cd /home/blur/erp2 && git add backend/src/modules/accounting/services/journal-entry.service.ts
+git commit -m "feat(accounting): add audit logging to JournalEntryService"
+```
+
+---
+
+## Task 3: Add audit logging to ChartOfAccountsService
+
+**Files:**
+- Modify: `backend/src/modules/accounting/services/chart-of-accounts.service.ts`
+
+**Step 1: Add import and inject AuditLogService**
+
+```typescript
+import { AuditLogService } from '../../audit-logs/services';
+```
+
+Add to constructor:
+```typescript
+private readonly auditLogService: AuditLogService,
+```
+
+**Step 2: `create()` — after save**
+
+```typescript
+await this.auditLogService.log(
+  'CREATE',
+  'Account',
+  `Created account: ${account.code} - ${account.name}`,
+  { entityId: account.id, userId: userId ?? 'system' }
+);
+```
+
+**Step 3: `update()` — after save**
+
+```typescript
+await this.auditLogService.log(
+  'UPDATE',
+  'Account',
+  `Updated account: ${account.code} - ${account.name}`,
+  { entityId: id, userId: userId ?? 'system' }
+);
+```
+
+**Step 4: `remove()` — after softDelete**
+
+```typescript
+await this.auditLogService.log(
+  'DELETE',
+  'Account',
+  `Deleted account: ${account.code} - ${account.name}`,
+  { entityId: id, userId: userId ?? 'system' }
+);
+```
+
+**Step 5: `restore()` — after restore/save**
+
+```typescript
+await this.auditLogService.log(
+  'RESTORE',
+  'Account',
+  `Restored account: ${account.code} - ${account.name}`,
+  { entityId: id, userId: userId ?? 'system' }
+);
+```
+
+**Step 6: `bulkRestore()` — inside success loop**
+
+```typescript
+await this.auditLogService.log(
+  'RESTORE',
+  'Account',
+  `Bulk restored account: ${account.code} - ${account.name}`,
+  { entityId: account.id, userId: 'system' }
+);
+```
+
+**Step 7: `permanentDelete()` — after hard delete**
+
+```typescript
+await this.auditLogService.log(
+  'PERMANENT_DELETE',
+  'Account',
+  `Permanently deleted account: ${account.code} - ${account.name}`,
+  { entityId: id, userId: userId ?? 'system' }
+);
+```
+
+**Step 8: `bulkPermanentDelete()` — inside success loop**
+
+```typescript
+await this.auditLogService.log(
+  'PERMANENT_DELETE',
+  'Account',
+  `Bulk permanently deleted account: ${account.code} - ${account.name}`,
+  { entityId: account.id, userId: 'system' }
+);
+```
+
+**Step 9: Verify and commit**
+
+```bash
+cd /home/blur/erp2/backend && npx tsc --noEmit
+cd /home/blur/erp2 && git add backend/src/modules/accounting/services/chart-of-accounts.service.ts
+git commit -m "feat(accounting): add audit logging to ChartOfAccountsService"
+```
+
+---
+
+## Task 4: Add audit logging to FiscalPeriodService
+
+**Files:**
+- Modify: `backend/src/modules/accounting/services/fiscal-period.service.ts`
+
+**Step 1: Add import and inject**
+
+```typescript
+import { AuditLogService } from '../../audit-logs/services';
+```
+Add to constructor: `private readonly auditLogService: AuditLogService,`
+
+**Step 2: `create()` — after save**
+
+```typescript
+await this.auditLogService.log(
+  'CREATE',
+  'FiscalPeriod',
+  `Created fiscal period: ${period.code} - ${period.name}`,
+  { entityId: period.id, userId: userId ?? 'system' }
+);
+```
+
+**Step 3: `update()` — after save**
+
+```typescript
+await this.auditLogService.log(
+  'UPDATE',
+  'FiscalPeriod',
+  `Updated fiscal period: ${period.code} - ${period.name}`,
+  { entityId: id, userId: userId ?? 'system' }
+);
+```
+
+**Step 4: `remove()` — after softDelete**
+
+```typescript
+await this.auditLogService.log(
+  'DELETE',
+  'FiscalPeriod',
+  `Deleted fiscal period: ${period.code} - ${period.name}`,
+  { entityId: id, userId: userId ?? 'system' }
+);
+```
+
+**Step 5: `restore()` — after restore**
+
+```typescript
+await this.auditLogService.log(
+  'RESTORE',
+  'FiscalPeriod',
+  `Restored fiscal period: ${period.code} - ${period.name}`,
+  { entityId: id, userId: userId ?? 'system' }
+);
+```
+
+**Step 6: `generateFiscalPeriods()` — after all periods saved, one log per period**
+
+Inside the save loop:
+```typescript
+await this.auditLogService.log(
+  'GENERATE',
+  'FiscalPeriod',
+  `Generated fiscal period: ${savedPeriod.code} - ${savedPeriod.name}`,
+  { entityId: savedPeriod.id, userId: userId ?? 'system' }
+);
+```
+
+**Step 7: `closePeriod()` — after status saved**
+
+```typescript
+await this.auditLogService.log(
+  'UPDATE',
+  'FiscalPeriod',
+  `Closed fiscal period: ${period.code} - ${period.name}`,
+  { entityId: id, userId: userId ?? 'system', metadata: { status: 'CLOSED' } }
+);
+```
+
+**Step 8: `reopenPeriod()` — after status saved**
+
+```typescript
+await this.auditLogService.log(
+  'UPDATE',
+  'FiscalPeriod',
+  `Reopened fiscal period: ${period.code} - ${period.name}`,
+  { entityId: id, userId: userId ?? 'system', metadata: { status: 'OPEN' } }
+);
+```
+
+**Step 9: Verify and commit**
+
+```bash
+cd /home/blur/erp2/backend && npx tsc --noEmit
+cd /home/blur/erp2 && git add backend/src/modules/accounting/services/fiscal-period.service.ts
+git commit -m "feat(accounting): add audit logging to FiscalPeriodService"
+```
+
+---
+
+## Task 5: Add audit logging to AccountMappingService
+
+**Files:**
+- Modify: `backend/src/modules/accounting/services/account-mapping.service.ts`
+
+**Step 1: Add import and inject**
+
+```typescript
+import { AuditLogService } from '../../audit-logs/services';
+```
+Add to constructor: `private readonly auditLogService: AuditLogService,`
+
+**Step 2: `create()` — after save/restore**
+
+```typescript
+await this.auditLogService.log(
+  'CREATE',
+  'AccountMapping',
+  `Created account mapping: ${mapping.mappingType}`,
+  { entityId: mapping.id, userId: userId ?? 'system' }
+);
+```
+
+**Step 3: `update()` — after save**
+
+```typescript
+await this.auditLogService.log(
+  'UPDATE',
+  'AccountMapping',
+  `Updated account mapping: ${mapping.mappingType}`,
+  { entityId: id, userId: userId ?? 'system' }
+);
+```
+
+**Step 4: `remove()` — after softDelete**
+
+```typescript
+await this.auditLogService.log(
+  'DELETE',
+  'AccountMapping',
+  `Deleted account mapping: ${mapping.mappingType}`,
+  { entityId: id, userId: userId ?? 'system' }
+);
+```
+
+**Step 5: Verify and commit**
+
+```bash
+cd /home/blur/erp2/backend && npx tsc --noEmit
+cd /home/blur/erp2 && git add backend/src/modules/accounting/services/account-mapping.service.ts
+git commit -m "feat(accounting): add audit logging to AccountMappingService"
+```
+
+---
+
+## Task 6: Add audit logging to ReconciliationService
+
+**Files:**
+- Modify: `backend/src/modules/accounting/services/reconciliation.service.ts`
+
+**Step 1: Add import and inject**
+
+```typescript
+import { AuditLogService } from '../../audit-logs/services';
+```
+Add to constructor: `private readonly auditLogService: AuditLogService,`
+
+**Step 2: `create()` — after save**
+
+```typescript
+await this.auditLogService.log(
+  'CREATE',
+  'BankReconciliation',
+  `Created bank reconciliation for account: ${reconciliation.accountId}`,
+  { entityId: reconciliation.id, userId: userId ?? 'system' }
+);
+```
+
+**Step 3: `update()` — after save**
+
+```typescript
+await this.auditLogService.log(
+  'UPDATE',
+  'BankReconciliation',
+  `Updated bank reconciliation`,
+  { entityId: id, userId: userId ?? 'system' }
+);
+```
+
+**Step 4: `remove()` — after softDelete**
+
+```typescript
+await this.auditLogService.log(
+  'DELETE',
+  'BankReconciliation',
+  `Deleted bank reconciliation`,
+  { entityId: id, userId: userId ?? 'system' }
+);
+```
+
+**Step 5: `complete()` — after status saved**
+
+```typescript
+await this.auditLogService.log(
+  'UPDATE',
+  'BankReconciliation',
+  `Completed bank reconciliation`,
+  { entityId: id, userId: userId ?? 'system', metadata: { status: 'COMPLETED' } }
+);
+```
+
+**Step 6: `reopen()` — after status saved**
+
+```typescript
+await this.auditLogService.log(
+  'UPDATE',
+  'BankReconciliation',
+  `Reopened bank reconciliation`,
+  { entityId: id, userId: userId ?? 'system', metadata: { status: 'IN_PROGRESS' } }
+);
+```
+
+**Step 7: Verify and commit**
+
+```bash
+cd /home/blur/erp2/backend && npx tsc --noEmit
+cd /home/blur/erp2 && git add backend/src/modules/accounting/services/reconciliation.service.ts
+git commit -m "feat(accounting): add audit logging to ReconciliationService"
+```
+
+---
+
+## Task 7: Add audit logging to SettlementService
+
+**Files:**
+- Modify: `backend/src/modules/accounting/services/settlement.service.ts`
+
+**Step 1: Add import and inject**
+
+```typescript
+import { AuditLogService } from '../../audit-logs/services';
+```
+Add to constructor: `private readonly auditLogService: AuditLogService,`
+
+**Step 2: `create()` — after settlement saved**
+
+```typescript
+await this.auditLogService.log(
+  'CREATE',
+  'Settlement',
+  `Created settlement: ${settlement.settlementNumber}`,
+  { entityId: settlement.id, userId: userId ?? 'system' }
+);
+```
+
+**Step 3: `cancel()` — after status saved**
+
+Note: `cancel()` may not have a `userId` parameter. Check the method signature. If not available, use `'system'`.
+
+```typescript
+await this.auditLogService.log(
+  'UPDATE',
+  'Settlement',
+  `Cancelled settlement: ${settlement.settlementNumber}`,
+  { entityId: id, userId: 'system', metadata: { status: 'CANCELLED' } }
+);
+```
+
+**Step 4: Verify and commit**
+
+```bash
+cd /home/blur/erp2/backend && npx tsc --noEmit
+cd /home/blur/erp2 && git add backend/src/modules/accounting/services/settlement.service.ts
+git commit -m "feat(accounting): add audit logging to SettlementService"
+```
+
+---
+
+## Task 8: Add audit logging to OwnerEquityService
+
+**Files:**
+- Modify: `backend/src/modules/accounting/services/owner-equity.service.ts`
+
+**Step 1: Add import and inject**
+
+```typescript
+import { AuditLogService } from '../../audit-logs/services';
+```
+Add to constructor: `private readonly auditLogService: AuditLogService,`
+
+**Step 2: `create()` — after save**
+
+```typescript
+await this.auditLogService.log(
+  'CREATE',
+  'OwnerEquity',
+  `Created owner equity transaction: ${transaction.referenceNumber}`,
+  { entityId: transaction.id, userId: userId ?? 'system' }
+);
+```
+
+**Step 3: `update()` — after save**
+
+```typescript
+await this.auditLogService.log(
+  'UPDATE',
+  'OwnerEquity',
+  `Updated owner equity transaction: ${transaction.referenceNumber}`,
+  { entityId: id, userId: userId ?? 'system' }
+);
+```
+
+**Step 4: `remove()` — after softDelete**
+
+Note: Check if `remove()` has `userId`. If not, use `'system'`.
+
+```typescript
+await this.auditLogService.log(
+  'DELETE',
+  'OwnerEquity',
+  `Deleted owner equity transaction: ${transaction.referenceNumber}`,
+  { entityId: id, userId: 'system' }
+);
+```
+
+**Step 5: `post()` — after posting**
+
+```typescript
+await this.auditLogService.log(
+  'POST',
+  'OwnerEquity',
+  `Posted owner equity transaction: ${transaction.referenceNumber}`,
+  { entityId: id, userId: userId ?? 'system' }
+);
+```
+
+**Step 6: `bulkPost()` — inside success loop**
+
+```typescript
+await this.auditLogService.log(
+  'POST',
+  'OwnerEquity',
+  `Bulk posted owner equity transaction: ${transaction.referenceNumber}`,
+  { entityId: transaction.id, userId: userId ?? 'system' }
+);
+```
+
+**Step 7: `bulkDelete()` — inside success loop**
+
+```typescript
+await this.auditLogService.log(
+  'DELETE',
+  'OwnerEquity',
+  `Bulk deleted owner equity transaction: ${transaction.referenceNumber}`,
+  { entityId: transaction.id, userId: 'system' }
+);
+```
+
+**Step 8: Verify and commit**
+
+```bash
+cd /home/blur/erp2/backend && npx tsc --noEmit
+cd /home/blur/erp2 && git add backend/src/modules/accounting/services/owner-equity.service.ts
+git commit -m "feat(accounting): add audit logging to OwnerEquityService"
+```
+
+---
+
+## Task 9: Add audit logging to ExpenseService
+
+**Files:**
+- Modify: `backend/src/modules/accounting/services/expense.service.ts`
+
+**Step 1: Add import and inject**
+
+```typescript
+import { AuditLogService } from '../../audit-logs/services';
+```
+Add to constructor: `private readonly auditLogService: AuditLogService,`
+
+**Step 2: `create()` — after save**
+
+```typescript
+await this.auditLogService.log(
+  'CREATE',
+  'Expense',
+  `Created expense: ${expense.referenceNumber}`,
+  { entityId: expense.id, userId: userId ?? 'system' }
+);
+```
+
+**Step 3: `update()` — after save**
+
+```typescript
+await this.auditLogService.log(
+  'UPDATE',
+  'Expense',
+  `Updated expense: ${expense.referenceNumber}`,
+  { entityId: id, userId: userId ?? 'system' }
+);
+```
+
+**Step 4: `remove()` — after softDelete**
+
+```typescript
+await this.auditLogService.log(
+  'DELETE',
+  'Expense',
+  `Deleted expense: ${expense.referenceNumber}`,
+  { entityId: id, userId: 'system' }
+);
+```
+
+**Step 5: `post()` — after posting**
+
+```typescript
+await this.auditLogService.log(
+  'POST',
+  'Expense',
+  `Posted expense: ${expense.referenceNumber}`,
+  { entityId: id, userId: userId ?? 'system' }
+);
+```
+
+**Step 6: `bulkPost()` — inside success loop**
+
+```typescript
+await this.auditLogService.log(
+  'POST',
+  'Expense',
+  `Bulk posted expense: ${expense.referenceNumber}`,
+  { entityId: expense.id, userId: userId ?? 'system' }
+);
+```
+
+**Step 7: `bulkDelete()` — inside success loop**
+
+```typescript
+await this.auditLogService.log(
+  'DELETE',
+  'Expense',
+  `Bulk deleted expense: ${expense.referenceNumber}`,
+  { entityId: expense.id, userId: 'system' }
+);
+```
+
+**Step 8: Verify and commit**
+
+```bash
+cd /home/blur/erp2/backend && npx tsc --noEmit
+cd /home/blur/erp2 && git add backend/src/modules/accounting/services/expense.service.ts
+git commit -m "feat(accounting): add audit logging to ExpenseService"
+```
+
+---
+
+## Task 10: Add audit logging to AccountingService (auto-posts)
+
+**Files:**
+- Modify: `backend/src/modules/accounting/services/accounting.service.ts`
+
+**Step 1: Add import and inject**
+
+```typescript
+import { AuditLogService } from '../../audit-logs/services';
+```
+Add to constructor: `private readonly auditLogService: AuditLogService,`
+
+**Step 2: `postSalesOrderEntry()` — after journal entry created**
+
+```typescript
+await this.auditLogService.log(
+  'AUTO_POST',
+  'JournalEntry',
+  `Auto-posted sales order journal entry for order: ${salesOrder.orderNumber}`,
+  { entityId: createdEntry.id, userId: userId ?? 'system', metadata: { sourceType: 'sales_order', sourceId: salesOrder.id } }
+);
+```
+
+**Step 3: `postCustomerPaymentEntry()` — after entry created**
+
+```typescript
+await this.auditLogService.log(
+  'AUTO_POST',
+  'JournalEntry',
+  `Auto-posted customer payment journal entry: ${payment.paymentNumber}`,
+  { entityId: createdEntry.id, userId: userId ?? 'system', metadata: { sourceType: 'payment', sourceId: payment.id } }
+);
+```
+
+**Step 4: `postSettlementEntry()` — after entry created**
+
+```typescript
+await this.auditLogService.log(
+  'AUTO_POST',
+  'JournalEntry',
+  `Auto-posted settlement journal entry: ${settlement.settlementNumber}`,
+  { entityId: createdEntry.id, userId: userId ?? 'system', metadata: { sourceType: 'settlement', sourceId: settlement.id } }
+);
+```
+
+**Step 5: `postGoodsReceivedEntry()` — after entry created**
+
+```typescript
+await this.auditLogService.log(
+  'AUTO_POST',
+  'JournalEntry',
+  `Auto-posted goods received journal entry: ${grn.grnNumber}`,
+  { entityId: createdEntry.id, userId: userId ?? 'system', metadata: { sourceType: 'goods_received_note', sourceId: grn.id } }
+);
+```
+
+**Step 6: `postVendorPaymentEntry()` — after entry created**
+
+```typescript
+await this.auditLogService.log(
+  'AUTO_POST',
+  'JournalEntry',
+  `Auto-posted vendor payment journal entry: ${vendorPayment.paymentNumber}`,
+  { entityId: createdEntry.id, userId: userId ?? 'system', metadata: { sourceType: 'vendor_payment', sourceId: vendorPayment.id } }
+);
+```
+
+**Step 7: `postStockAdjustmentEntry()` — after entry created**
+
+```typescript
+await this.auditLogService.log(
+  'AUTO_POST',
+  'JournalEntry',
+  `Auto-posted stock adjustment journal entry: ${adjustment.adjustmentNumber}`,
+  { entityId: createdEntry.id, userId: userId ?? 'system', metadata: { sourceType: 'stock_adjustment', sourceId: adjustment.id } }
+);
+```
+
+**Step 8: `postOwnerEquityEntry()` — after entry created**
+
+```typescript
+await this.auditLogService.log(
+  'AUTO_POST',
+  'JournalEntry',
+  `Auto-posted owner equity journal entry: ${transaction.referenceNumber}`,
+  { entityId: createdEntry.id, userId: userId ?? 'system', metadata: { sourceType: 'owner_equity', sourceId: transaction.id } }
+);
+```
+
+**Step 9: `postExpenseEntry()` — after entry created**
+
+```typescript
+await this.auditLogService.log(
+  'AUTO_POST',
+  'JournalEntry',
+  `Auto-posted expense journal entry: ${expense.referenceNumber}`,
+  { entityId: createdEntry.id, userId: userId ?? 'system', metadata: { sourceType: 'expense', sourceId: expense.id } }
+);
+```
+
+**Step 10: Note on `reverseSourceEntries()` and `reversePaymentEntry()`**
+
+These call `journalEntryService.reverseEntry()` internally, which already logs as `REVERSE` after Task 2. No duplicate logging needed here.
+
+**Step 11: Note on `postOpeningBalances()`**
+
+After opening balance entry created:
+```typescript
+await this.auditLogService.log(
+  'AUTO_POST',
+  'JournalEntry',
+  `Auto-posted opening balance entry`,
+  { entityId: createdEntry.id, userId: 'system', metadata: { sourceType: 'opening_balance' } }
+);
+```
+
+**Step 12: Verify TypeScript**
+
+```bash
+cd /home/blur/erp2/backend && npx tsc --noEmit
+```
+Expected: No errors.
+
+**Step 13: Commit**
+
+```bash
+cd /home/blur/erp2 && git add backend/src/modules/accounting/services/accounting.service.ts
+git commit -m "feat(accounting): add audit logging to AccountingService auto-posts"
+```
+
+---
+
+## Task 11: Update LogRow entity type mapping for new entity types
+
+**Files:**
+- Modify: `frontend/src/pages/audit-logs/components/LogRow.tsx`
+
+The `getEntityLink()` function currently only maps `Account` and `JournalEntry` from accounting. Add the remaining entity types so the "Go to entity" link in audit log rows works correctly.
+
+**Step 1: Read the current mapping**
+
+Read: `frontend/src/pages/audit-logs/components/LogRow.tsx`
+
+Find the `getEntityLink()` function and the `map` object inside it.
+
+**Step 2: Add missing accounting entity types**
+
+Add these entries to the map:
+```typescript
+FiscalPeriod: '/accounting/fiscal-periods',
+AccountMapping: '/accounting/account-mappings',
+BankReconciliation: '/accounting/bank-reconciliations',
+Settlement: '/accounting/settlements',
+OwnerEquity: '/accounting/owner-equity',
+Expense: '/accounting/expenses',
+```
+
+Note: These entity types don't have individual detail pages — they link to the list page. This is the same pattern used for `Account` and `Category` already.
+
+**Step 3: Verify TypeScript (frontend)**
+
+```bash
+cd /home/blur/erp2/frontend && npm run type-check
+```
+Expected: No errors.
+
+**Step 4: Commit**
+
+```bash
+cd /home/blur/erp2 && git add frontend/src/pages/audit-logs/components/LogRow.tsx
+git commit -m "feat(audit-logs): add entity links for accounting entity types"
+```
+
+---
+
+## Task 12: Manual verification
+
+**Step 1: Start backend**
+
+```bash
+cd /home/blur/erp2/backend && npm run start:dev
+```
+
+**Step 2: Create a journal entry via the UI or API**
+
+Navigate to `/accounting/journal-entries` and create a journal entry.
+
+**Step 3: Verify audit log entry appears**
+
+Navigate to `/audit-logs`, filter by `Entity Type = JournalEntry`. Verify:
+- A `CREATE` entry appears with the correct `referenceNumber` in the description
+- `entityId` is populated
+- Clicking "Go to entity" navigates to the correct journal entry page
+
+**Step 4: Test post and reverse**
+
+Post the journal entry. Verify a `POST` entry appears in the audit log.
+Reverse it. Verify a `REVERSE` entry appears.
+
+**Step 5: Test other entities**
+
+Repeat for at least:
+- Chart of Accounts: create an account → `CREATE` entry appears
+- Fiscal Periods: close a period → `UPDATE` with `status: CLOSED` metadata
+- Expenses: post an expense → `POST` entry appears
+
+**Step 6: Verify entity type links in audit log rows**
+
+Expand an `AccountMapping` audit log entry. Verify the "Go to AccountMapping" link navigates to `/accounting/account-mappings`.

--- a/docs/plans/2026-03-04-audit-log-username-fix-design.md
+++ b/docs/plans/2026-03-04-audit-log-username-fix-design.md
@@ -1,0 +1,107 @@
+# Design: Fix User Name Display in Audit Logs
+
+**Date:** 2026-03-04
+**Status:** Approved
+**Branch:** feat/audit-log-ui-redesign-2026-03-04
+
+## Problem
+
+All audit log entries show `userId: 'system'` and `username: null` because controllers never extract the authenticated user from the JWT and pass it through to services. The frontend falls back to displaying `'system'` when `username` is null.
+
+## Approach
+
+Option A — Fix controllers one by one (chosen). Add `@CurrentUser` params to every mutating controller method and thread `userId` + `username` through to `auditLogService.log()`. No infrastructure changes needed.
+
+## What Doesn't Change
+
+- `AuditLogService` — already accepts `username` in its options object
+- Audit log entity — `username` column already exists
+- Frontend — already displays `username` when present (`log.username || log.userId`)
+- Historical logs — remain as `'system'`; only new logs get real usernames
+
+## Changes Per Layer
+
+### Controllers
+Add two `@CurrentUser` params to every mutating method:
+```typescript
+@CurrentUser('userId') currentUserId: string,
+@CurrentUser('username') currentUsername: string,
+```
+Pass both to the service call.
+
+### Services
+Add `username?: string` alongside `userId?: string`, then include it in every `auditLogService.log()` call:
+```typescript
+{ userId: userId || 'system', username, ... }
+```
+
+## Full Scope
+
+### Inventory Module
+| Controller | Service | Methods |
+|---|---|---|
+| `product.controller.ts` | `product.service.ts` | create, update, remove, restore, permanentDelete, bulkRestore, bulkPermanentDelete |
+| `category.controller.ts` | `category.service.ts` | create, update, remove, restore, permanentDelete, bulkRestore, bulkPermanentDelete, move |
+| `stock-adjustment.controller.ts` | `stock-adjustment.service.ts` | create, update, remove, restore, permanentDelete, bulkPermanentDelete |
+
+### Sales Module
+| Controller | Service | Methods |
+|---|---|---|
+| `sales-order.controller.ts` | `sales-order.service.ts` | create, update, remove, restore, permanentDelete, bulkRestore, bulkPermanentDelete, fulfill |
+| `customer.controller.ts` | `customer.service.ts` | create, update, remove, restore, permanentDelete, bulkRestore, bulkPermanentDelete |
+| `invoice.controller.ts` | `invoice.service.ts` | create, update, remove, restore, bulkRestore |
+| `payment.controller.ts` | `payment.service.ts` | create, update (complete/fail/cancel), refund |
+
+### Purchasing Module
+| Controller | Service | Methods |
+|---|---|---|
+| `purchase-order.controller.ts` | `purchase-order.service.ts` | create, update, remove, restore, permanentDelete, bulkRestore, bulkPermanentDelete |
+| `supplier.controller.ts` | `supplier.service.ts` | create, update, remove, restore, permanentDelete, bulkRestore, bulkPermanentDelete |
+| `goods-received-note.controller.ts` | `goods-received-note.service.ts` | create, update, remove, restore, permanentDelete, bulkRestore, bulkPermanentDelete |
+| `vendor-payment.controller.ts` | `vendor-payment.service.ts` | create, update, remove, restore, permanentDelete, bulkRestore |
+
+### Accounting Module
+| Controller | Service | Methods |
+|---|---|---|
+| `journal-entry.controller.ts` | `journal-entry.service.ts` | create, update, remove, postEntry, reverseEntry, bulkPost, bulkDelete |
+| `account-mapping.controller.ts` | `account-mapping.service.ts` | create, update, remove |
+| `fiscal-period.controller.ts` | `fiscal-period.service.ts` | create, update, remove, restore, closePeriod, reopenPeriod |
+| `chart-of-accounts.controller.ts` | `chart-of-accounts.service.ts` | create, update, remove, restore, permanentDelete, bulkRestore, bulkPermanentDelete |
+| `reconciliation.controller.ts` | `reconciliation.service.ts` | create, update, remove, complete, reopen |
+| `settlement.controller.ts` | `settlement.service.ts` | create, cancel |
+| `expense.controller.ts` | `expense.service.ts` | create, update, remove, post, bulkPost, bulkDelete |
+| `owner-equity.controller.ts` | `owner-equity.service.ts` | create, update, remove, post, bulkPost, bulkDelete |
+
+### Additional Fixes (hardcoded 'system' in accounting services)
+- `accounting.service.ts` → `postOpeningBalances()`: add `userId` + `username` param
+- `expense.service.ts` → `remove()`: use param instead of hardcoded `'system'`
+- `owner-equity.service.ts` → `remove()`: use param instead of hardcoded `'system'`
+- `settlement.service.ts` → `cancel()`: use param instead of hardcoded `'system'`
+
+## Reference Pattern (Users Module — already correct)
+
+```typescript
+// Controller
+async create(
+  @Body(ValidationPipe) createUserDto: CreateUserDto,
+  @CurrentUser('userId') currentUserId: string,
+  @CurrentUser('username') currentUsername: string,
+): Promise<UserResponseDto> {
+  return await this.usersService.create(createUserDto, currentUserId, currentUsername);
+}
+
+// Service
+async create(dto: CreateUserDto, userId?: string, username?: string) {
+  await this.auditLogService.log('CREATE', 'User', '...', {
+    entityId: saved.id,
+    userId: userId || 'system',
+    username,
+    newValues: { ... },
+  });
+}
+```
+
+## Not In Scope
+- Settings, print-settings, price-lists, backup, dashboard — no audit logging
+- Accounting module services (already implemented) — just need controller + username wiring
+- Frontend changes — already handles `username` display correctly

--- a/docs/plans/2026-03-04-audit-log-username-fix.md
+++ b/docs/plans/2026-03-04-audit-log-username-fix.md
@@ -1,0 +1,879 @@
+# Audit Log Username Fix Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix all audit log entries that show `'system'` as the user by threading the authenticated user's `userId` and `username` from JWT through every mutating controller method and service in the codebase.
+
+**Architecture:** Add `@CurrentUser('userId')` and `@CurrentUser('username')` params to each controller's mutating methods, add `username?: string` to service method signatures alongside existing `userId`, and pass `username` into every `auditLogService.log()` options object. The `AuditLogService` and frontend already support this — no changes needed there.
+
+**Tech Stack:** NestJS 11, TypeScript, `@CurrentUser` decorator at `src/modules/auth/decorators/current-user.decorator.ts`
+
+---
+
+## Reference Pattern
+
+The Users module already does this correctly. Use it as the template for every task below.
+
+**Controller:**
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+
+async create(
+  @Body() dto: CreateUserDto,
+  @CurrentUser('userId') currentUserId: string,
+  @CurrentUser('username') currentUsername: string,
+): Promise<UserResponseDto> {
+  return this.usersService.create(dto, currentUserId, currentUsername);
+}
+```
+
+**Service method signature:**
+```typescript
+async create(dto: CreateUserDto, userId?: string, username?: string): Promise<UserResponseDto> {
+  await this.auditLogService.log('CREATE', 'User', '...', {
+    entityId: saved.id,
+    userId: userId || 'system',
+    username,
+    newValues: { ... },
+  });
+}
+```
+
+**Import path for CurrentUser** (relative to each controller's location):
+- Inventory/Sales/Purchasing controllers: `'../../auth/decorators/current-user.decorator'`
+- Accounting controllers: `'../../auth/decorators/current-user.decorator'`
+
+---
+
+## How to verify after each task
+
+```bash
+cd /home/blur/erp2/frontend && npm run type-check
+cd /home/blur/erp2/backend && npm run lint
+```
+
+There are no unit tests for these controller/service methods, so lint + type-check is the verification step.
+
+---
+
+## Task 1: Inventory — Product
+
+**Files:**
+- Modify: `backend/src/modules/inventory/controllers/product.controller.ts`
+- Modify: `backend/src/modules/inventory/services/product.service.ts`
+
+### Step 1: Update product.controller.ts
+
+Add `CurrentUser` to imports (after existing imports at top of file):
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Update these methods — add `@CurrentUser('userId') currentUserId: string, @CurrentUser('username') currentUsername: string` as params and pass to service:
+
+**create** (currently line ~70):
+```typescript
+async create(
+  @Body() createProductDto: CreateProductDto,
+  @CurrentUser('userId') currentUserId: string,
+  @CurrentUser('username') currentUsername: string,
+): Promise<ProductResponseDto> {
+  return this.productService.create(createProductDto, currentUserId, currentUsername);
+}
+```
+
+**update** (currently line ~261):
+```typescript
+async update(
+  @Param('id', ParseUUIDPipe) id: string,
+  @Body() updateProductDto: UpdateProductDto,
+  @CurrentUser('userId') currentUserId: string,
+  @CurrentUser('username') currentUsername: string,
+): Promise<ProductResponseDto> {
+  return this.productService.update(id, updateProductDto, currentUserId, currentUsername);
+}
+```
+
+**restore** (currently line ~402):
+```typescript
+async restore(
+  @Param('id', ParseUUIDPipe) id: string,
+  @CurrentUser('userId') currentUserId: string,
+  @CurrentUser('username') currentUsername: string,
+): Promise<ProductResponseDto> {
+  return this.productService.restore(id, currentUserId, currentUsername);
+}
+```
+
+**permanentDelete** (currently line ~499):
+```typescript
+async permanentDelete(
+  @Param('id', ParseUUIDPipe) id: string,
+  @CurrentUser('userId') currentUserId: string,
+  @CurrentUser('username') currentUsername: string,
+): Promise<void> {
+  await this.productService.permanentDelete(id, currentUserId, currentUsername);
+}
+```
+
+**bulkRestore** (currently line ~380):
+```typescript
+async bulkRestore(
+  @Body() body: { productIds: string[] },
+  @CurrentUser('userId') currentUserId: string,
+  @CurrentUser('username') currentUsername: string,
+): Promise<{ message: string; restoredCount: number; failedIds: string[] }> {
+  return this.productService.bulkRestore(body.productIds, currentUserId, currentUsername);
+}
+```
+
+**bulkPermanentDelete** (currently line ~475):
+```typescript
+async bulkPermanentDelete(
+  @Body() body: { productIds: string[] },
+  @CurrentUser('userId') currentUserId: string,
+  @CurrentUser('username') currentUsername: string,
+): Promise<{ message: string; deletedCount: number; failedIds: string[] }> {
+  return this.productService.bulkPermanentDelete(body.productIds, currentUserId, currentUsername);
+}
+```
+
+**remove** (currently line ~518) — service's `remove()` doesn't accept userId, skip for now.
+
+### Step 2: Update product.service.ts
+
+For each method that calls `auditLogService.log()`, add `username?: string` to the signature and add `username` to the log options.
+
+**create** signature: `async create(createProductDto: CreateProductDto, userId?: string, username?: string)`
+In the `auditLogService.log()` call, add `username` to options:
+```typescript
+{ entityId: savedProduct.id, userId: userId || 'system', username, newValues: { ... } }
+```
+
+**update** signature: `async update(id: string, updateProductDto: UpdateProductDto, userId?: string, username?: string)`
+Add `username` to each `auditLogService.log()` call inside.
+
+**restore** signature: `async restore(id: string, userId?: string, username?: string)`
+Add `username` to `auditLogService.log()` call.
+
+**permanentDelete** signature: `async permanentDelete(id: string, userId?: string, username?: string)`
+Add `username` to `auditLogService.log()` call.
+
+**bulkRestore** — find the method, add `username?: string` param, pass it to the internal `restore()` call.
+
+**bulkPermanentDelete** — same pattern, pass to internal `permanentDelete()` call.
+
+### Step 3: Verify
+```bash
+cd /home/blur/erp2/backend && npm run lint
+```
+Expected: no new errors.
+
+### Step 4: Commit
+```bash
+git add backend/src/modules/inventory/controllers/product.controller.ts \
+        backend/src/modules/inventory/services/product.service.ts
+git commit -m "feat(audit-logs): thread userId+username through product controller/service"
+```
+
+---
+
+## Task 2: Inventory — Category
+
+**Files:**
+- Modify: `backend/src/modules/inventory/controllers/category.controller.ts`
+- Modify: `backend/src/modules/inventory/services/category.service.ts`
+
+### Step 1: Update category.controller.ts
+
+Add import:
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Update mutating methods. Note: `remove` already passes `'system'` as userId — replace that with real user.
+
+**create** (currently line ~55):
+```typescript
+async create(
+  @Body() createCategoryDto: CreateCategoryDto,
+  @CurrentUser('userId') currentUserId: string,
+  @CurrentUser('username') currentUsername: string,
+): Promise<CategoryResponseDto> {
+  return this.categoryService.create(createCategoryDto, currentUserId, currentUsername);
+}
+```
+
+**update** (currently line ~231):
+```typescript
+async update(
+  @Param('id', ParseUUIDPipe) id: string,
+  @Body() updateCategoryDto: UpdateCategoryDto,
+  @CurrentUser('userId') currentUserId: string,
+  @CurrentUser('username') currentUsername: string,
+): Promise<CategoryResponseDto> {
+  return this.categoryService.update(id, updateCategoryDto, currentUserId, currentUsername);
+}
+```
+
+**remove** (currently line ~403) — replace hardcoded `'system'`:
+```typescript
+async remove(
+  @Param('id', ParseUUIDPipe) id: string,
+  @Query('force') force?: boolean,
+  @Query('moveToUncategorized') moveToUncategorized?: boolean,
+  @CurrentUser('userId') currentUserId: string = 'system',
+  @CurrentUser('username') currentUsername?: string,
+): Promise<{ message: string; moved?: number }> {
+  return this.categoryService.remove(id, currentUserId, { force: force === true, moveToUncategorized: moveToUncategorized === true }, currentUsername);
+}
+```
+
+**restore** (currently line ~315):
+```typescript
+async restore(
+  @Param('id', ParseUUIDPipe) id: string,
+  @CurrentUser('userId') currentUserId: string,
+  @CurrentUser('username') currentUsername: string,
+): Promise<CategoryResponseDto> {
+  return this.categoryService.restore(id, currentUserId, currentUsername);
+}
+```
+
+**permanentDelete** (currently line ~366):
+```typescript
+async permanentDelete(
+  @Param('id', ParseUUIDPipe) id: string,
+  @CurrentUser('userId') currentUserId: string,
+  @CurrentUser('username') currentUsername: string,
+): Promise<void> {
+  return this.categoryService.permanentDelete(id, currentUserId, currentUsername);
+}
+```
+
+**bulkRestore** (currently line ~294):
+```typescript
+async bulkRestore(
+  @Body() body: { categoryIds: string[] },
+  @CurrentUser('userId') currentUserId: string,
+  @CurrentUser('username') currentUsername: string,
+): Promise<{ message: string; restoredCount: number; failedIds: string[] }> {
+  return this.categoryService.bulkRestore(body.categoryIds, currentUserId, currentUsername);
+}
+```
+
+**bulkPermanentDelete** (currently line ~342):
+```typescript
+async bulkPermanentDelete(
+  @Body() body: { categoryIds: string[] },
+  @CurrentUser('userId') currentUserId: string,
+  @CurrentUser('username') currentUsername: string,
+): Promise<{ message: string; deletedCount: number; failedIds: string[] }> {
+  return this.categoryService.bulkPermanentDelete(body.categoryIds, currentUserId, currentUsername);
+}
+```
+
+### Step 2: Update category.service.ts
+
+Current `remove` signature: `async remove(id: string, userId: string, options?)` — add `username?: string` after options.
+
+For each method with `auditLogService.log()`, add `username?: string` to signature and `username` to log options.
+
+**create**: `async create(dto: CreateCategoryDto, userId?: string, username?: string)`
+**update**: `async update(id: string, dto: UpdateCategoryDto, userId?: string, username?: string)`
+**remove**: `async remove(id: string, userId: string, options?, username?: string)` — add `username` to log call
+**restore**: `async restore(id: string, userId?: string, username?: string)`
+**permanentDelete**: `async permanentDelete(id: string, userId?: string, username?: string)`
+**bulkRestore/bulkPermanentDelete**: add `username` param, pass to internal calls
+
+### Step 3: Verify
+```bash
+cd /home/blur/erp2/backend && npm run lint
+```
+
+### Step 4: Commit
+```bash
+git add backend/src/modules/inventory/controllers/category.controller.ts \
+        backend/src/modules/inventory/services/category.service.ts
+git commit -m "feat(audit-logs): thread userId+username through category controller/service"
+```
+
+---
+
+## Task 3: Inventory — Stock Adjustment
+
+**Files:**
+- Modify: `backend/src/modules/inventory/controllers/stock-adjustment.controller.ts`
+- Modify: `backend/src/modules/inventory/services/stock-adjustment.service.ts`
+
+### Step 1: Update stock-adjustment.controller.ts
+
+Add import:
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Add `@CurrentUser('userId') currentUserId: string, @CurrentUser('username') currentUsername: string` to: create, update, restore, permanentDelete, bulkPermanentDelete.
+
+Pass `currentUserId, currentUsername` to each service call.
+
+### Step 2: Update stock-adjustment.service.ts
+
+For each method that calls `auditLogService.log()`, add `userId?: string, username?: string` to signature and `username` to log options object.
+
+### Step 3: Verify
+```bash
+cd /home/blur/erp2/backend && npm run lint
+```
+
+### Step 4: Commit
+```bash
+git add backend/src/modules/inventory/controllers/stock-adjustment.controller.ts \
+        backend/src/modules/inventory/services/stock-adjustment.service.ts
+git commit -m "feat(audit-logs): thread userId+username through stock-adjustment controller/service"
+```
+
+---
+
+## Task 4: Sales — Sales Order
+
+**Files:**
+- Modify: `backend/src/modules/sales/controllers/sales-order.controller.ts`
+- Modify: `backend/src/modules/sales/services/sales-order.service.ts`
+
+### Step 1: Update sales-order.controller.ts
+
+Add import:
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Add `@CurrentUser` params to: create, update, remove (deleteSalesOrder), restore, bulkRestore, bulkPermanentDelete, permanentDelete.
+
+Note: `create` currently passes `null` — replace with `currentUserId, currentUsername`.
+
+### Step 2: Update sales-order.service.ts
+
+Add `username?: string` alongside `userId` in every method signature that calls `auditLogService.log()`. Pass `username` in log options.
+
+Methods to update: create, update, delete, restore, bulkRestore, permanentDelete, bulkPermanentDelete, fulfill (if it logs).
+
+### Step 3: Verify
+```bash
+cd /home/blur/erp2/backend && npm run lint
+```
+
+### Step 4: Commit
+```bash
+git add backend/src/modules/sales/controllers/sales-order.controller.ts \
+        backend/src/modules/sales/services/sales-order.service.ts
+git commit -m "feat(audit-logs): thread userId+username through sales-order controller/service"
+```
+
+---
+
+## Task 5: Sales — Customer
+
+**Files:**
+- Modify: `backend/src/modules/sales/controllers/customer.controller.ts`
+- Modify: `backend/src/modules/sales/services/customer.service.ts`
+
+### Step 1: Update customer.controller.ts
+
+Add import:
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Add `@CurrentUser` params to: create (createCustomer), update (updateCustomer), remove (deleteCustomer), restore (restoreCustomer), bulkRestore, bulkPermanentDelete, permanentDelete.
+
+### Step 2: Update customer.service.ts
+
+Add `userId?: string, username?: string` to: create, update, delete, restore, bulkRestore, permanentDelete, bulkPermanentDelete. Add `username` to each `auditLogService.log()` call.
+
+### Step 3: Verify + Commit
+```bash
+cd /home/blur/erp2/backend && npm run lint
+git add backend/src/modules/sales/controllers/customer.controller.ts \
+        backend/src/modules/sales/services/customer.service.ts
+git commit -m "feat(audit-logs): thread userId+username through customer controller/service"
+```
+
+---
+
+## Task 6: Sales — Invoice
+
+**Files:**
+- Modify: `backend/src/modules/sales/controllers/invoice.controller.ts`
+- Modify: `backend/src/modules/sales/services/invoice.service.ts`
+
+### Step 1: Update invoice.controller.ts
+
+Add import:
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Add `@CurrentUser` params to: create (createInvoice), update (updateInvoice), remove (deleteInvoice), restore (restoreInvoice), bulkRestore (bulkRestoreInvoices).
+
+### Step 2: Update invoice.service.ts
+
+Add `userId?: string, username?: string` to: create, update, delete, restore, bulkRestore. Add `username` to each `auditLogService.log()` call.
+
+### Step 3: Verify + Commit
+```bash
+cd /home/blur/erp2/backend && npm run lint
+git add backend/src/modules/sales/controllers/invoice.controller.ts \
+        backend/src/modules/sales/services/invoice.service.ts
+git commit -m "feat(audit-logs): thread userId+username through invoice controller/service"
+```
+
+---
+
+## Task 7: Sales — Payment
+
+**Files:**
+- Modify: `backend/src/modules/sales/controllers/payment.controller.ts`
+- Modify: `backend/src/modules/sales/services/payment.service.ts`
+
+### Step 1: Update payment.controller.ts
+
+Add import:
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Add `@CurrentUser` params to: create (recordPayment), update (updatePayment), completePayment, failPayment, cancelPayment, refundPayment, restore (restorePayment), bulkRestore (bulkRestorePayments).
+
+### Step 2: Update payment.service.ts
+
+Add `userId?: string, username?: string` to: create, update, complete, fail, cancel, refund, restore, bulkRestore. Add `username` to each `auditLogService.log()` call.
+
+### Step 3: Verify + Commit
+```bash
+cd /home/blur/erp2/backend && npm run lint
+git add backend/src/modules/sales/controllers/payment.controller.ts \
+        backend/src/modules/sales/services/payment.service.ts
+git commit -m "feat(audit-logs): thread userId+username through payment controller/service"
+```
+
+---
+
+## Task 8: Purchasing — Purchase Order
+
+**Files:**
+- Modify: `backend/src/modules/purchasing/controllers/purchase-order.controller.ts`
+- Modify: `backend/src/modules/purchasing/services/purchase-order.service.ts`
+
+### Step 1: Update purchase-order.controller.ts
+
+Add import:
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Add `@CurrentUser` params to: create, update, restore, bulkRestore, bulkPermanentDelete, permanentDelete, remove.
+
+Note: create currently passes `'system'` — replace with `currentUserId, currentUsername`. restore and bulkRestore pass `'system'` — replace too.
+
+### Step 2: Update purchase-order.service.ts
+
+Current `create` signature: `async create(dto, userId?: string)` — add `username?: string`.
+Current `restore` signature: `async restore(id, userId: string = 'system')` — add `username?: string`.
+Current `bulkRestore` signature: `async bulkRestore(orderIds, userId: string = 'system')` — add `username?: string`.
+
+Add `username` to each `auditLogService.log()` call.
+
+Also add `username` to: update, remove, permanentDelete, bulkPermanentDelete where they call `auditLogService.log()`.
+
+### Step 3: Verify + Commit
+```bash
+cd /home/blur/erp2/backend && npm run lint
+git add backend/src/modules/purchasing/controllers/purchase-order.controller.ts \
+        backend/src/modules/purchasing/services/purchase-order.service.ts
+git commit -m "feat(audit-logs): thread userId+username through purchase-order controller/service"
+```
+
+---
+
+## Task 9: Purchasing — Supplier
+
+**Files:**
+- Modify: `backend/src/modules/purchasing/controllers/supplier.controller.ts`
+- Modify: `backend/src/modules/purchasing/services/supplier.service.ts`
+
+### Step 1: Update supplier.controller.ts
+
+Add import:
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Add `@CurrentUser` params to: create, update, remove, restore, bulkRestore, bulkPermanentDelete, permanentDelete.
+
+### Step 2: Update supplier.service.ts
+
+Add `userId?: string, username?: string` to: create, update, remove, restore, bulkRestore, permanentDelete, bulkPermanentDelete. Add `username` to `auditLogService.log()` calls.
+
+### Step 3: Verify + Commit
+```bash
+cd /home/blur/erp2/backend && npm run lint
+git add backend/src/modules/purchasing/controllers/supplier.controller.ts \
+        backend/src/modules/purchasing/services/supplier.service.ts
+git commit -m "feat(audit-logs): thread userId+username through supplier controller/service"
+```
+
+---
+
+## Task 10: Purchasing — Goods Received Note
+
+**Files:**
+- Modify: `backend/src/modules/purchasing/controllers/goods-received-note.controller.ts`
+- Modify: `backend/src/modules/purchasing/services/goods-received-note.service.ts`
+
+### Step 1: Update goods-received-note.controller.ts
+
+Add import:
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Add `@CurrentUser` params to: create, update, remove, restore, bulkRestore, bulkPermanentDelete, permanentDelete.
+
+### Step 2: Update goods-received-note.service.ts
+
+Add `userId?: string, username?: string` to all mutating methods that call `auditLogService.log()`. Add `username` to log options.
+
+### Step 3: Verify + Commit
+```bash
+cd /home/blur/erp2/backend && npm run lint
+git add backend/src/modules/purchasing/controllers/goods-received-note.controller.ts \
+        backend/src/modules/purchasing/services/goods-received-note.service.ts
+git commit -m "feat(audit-logs): thread userId+username through goods-received-note controller/service"
+```
+
+---
+
+## Task 11: Purchasing — Vendor Payment
+
+**Files:**
+- Modify: `backend/src/modules/purchasing/controllers/vendor-payment.controller.ts`
+- Modify: `backend/src/modules/purchasing/services/vendor-payment.service.ts`
+
+### Step 1: Update vendor-payment.controller.ts
+
+Add import:
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Add `@CurrentUser` params to: create, update, remove, restore, bulkRestore, permanentDelete.
+
+### Step 2: Update vendor-payment.service.ts
+
+Current `create` signature: `async create(dto, user: string = 'system')` — this uses `user` not `userId`. Change to: `async create(dto: CreateVendorPaymentDto, userId?: string, username?: string)` and update the `auditLogService.log()` call to use `userId || 'system'` and add `username`.
+
+Add `username` to all other methods' `auditLogService.log()` calls.
+
+### Step 3: Verify + Commit
+```bash
+cd /home/blur/erp2/backend && npm run lint
+git add backend/src/modules/purchasing/controllers/vendor-payment.controller.ts \
+        backend/src/modules/purchasing/services/vendor-payment.service.ts
+git commit -m "feat(audit-logs): thread userId+username through vendor-payment controller/service"
+```
+
+---
+
+## Task 12: Accounting — Journal Entry
+
+**Files:**
+- Modify: `backend/src/modules/accounting/controllers/journal-entry.controller.ts`
+- Modify: `backend/src/modules/accounting/services/journal-entry.service.ts`
+
+### Step 1: Update journal-entry.controller.ts
+
+Add import:
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Add `@CurrentUser` params to: create, update, remove, postEntry, reverseEntry, bulkPost, bulkDelete.
+
+### Step 2: Update journal-entry.service.ts
+
+Current `create` signature: `async create(dto: CreateJournalEntryDto, userId: string = 'system')` — add `username?: string`.
+
+Add `username` param to: create, update, remove, postEntry, reverseEntry, bulkPost, bulkDelete. Add `username` to all `auditLogService.log()` calls.
+
+### Step 3: Verify + Commit
+```bash
+cd /home/blur/erp2/backend && npm run lint
+git add backend/src/modules/accounting/controllers/journal-entry.controller.ts \
+        backend/src/modules/accounting/services/journal-entry.service.ts
+git commit -m "feat(audit-logs): thread userId+username through journal-entry controller/service"
+```
+
+---
+
+## Task 13: Accounting — Account Mapping
+
+**Files:**
+- Modify: `backend/src/modules/accounting/controllers/account-mapping.controller.ts`
+- Modify: `backend/src/modules/accounting/services/account-mapping.service.ts`
+
+### Step 1: Update account-mapping.controller.ts
+
+Add import:
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Add `@CurrentUser` params to: create, update, remove.
+
+### Step 2: Update account-mapping.service.ts
+
+Add `userId?: string, username?: string` to: create, update, remove. Add `username` to `auditLogService.log()` calls.
+
+### Step 3: Verify + Commit
+```bash
+cd /home/blur/erp2/backend && npm run lint
+git add backend/src/modules/accounting/controllers/account-mapping.controller.ts \
+        backend/src/modules/accounting/services/account-mapping.service.ts
+git commit -m "feat(audit-logs): thread userId+username through account-mapping controller/service"
+```
+
+---
+
+## Task 14: Accounting — Fiscal Period
+
+**Files:**
+- Modify: `backend/src/modules/accounting/controllers/fiscal-period.controller.ts`
+- Modify: `backend/src/modules/accounting/services/fiscal-period.service.ts`
+
+### Step 1: Update fiscal-period.controller.ts
+
+Add import:
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Add `@CurrentUser` params to: create, update, remove, restore, closePeriod, reopenPeriod.
+
+### Step 2: Update fiscal-period.service.ts
+
+Add `username?: string` to: create, update, remove, restore, closePeriod, reopenPeriod. Add `username` to `auditLogService.log()` calls.
+
+### Step 3: Verify + Commit
+```bash
+cd /home/blur/erp2/backend && npm run lint
+git add backend/src/modules/accounting/controllers/fiscal-period.controller.ts \
+        backend/src/modules/accounting/services/fiscal-period.service.ts
+git commit -m "feat(audit-logs): thread userId+username through fiscal-period controller/service"
+```
+
+---
+
+## Task 15: Accounting — Chart of Accounts
+
+**Files:**
+- Modify: `backend/src/modules/accounting/controllers/chart-of-accounts.controller.ts`
+- Modify: `backend/src/modules/accounting/services/chart-of-accounts.service.ts`
+
+### Step 1: Update chart-of-accounts.controller.ts
+
+Add import:
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Add `@CurrentUser` params to: create, update, remove, permanentDelete, restore, bulkRestore, bulkPermanentDelete.
+
+### Step 2: Update chart-of-accounts.service.ts
+
+Add `userId?: string, username?: string` to all mutating methods. Add `username` to `auditLogService.log()` calls.
+
+### Step 3: Verify + Commit
+```bash
+cd /home/blur/erp2/backend && npm run lint
+git add backend/src/modules/accounting/controllers/chart-of-accounts.controller.ts \
+        backend/src/modules/accounting/services/chart-of-accounts.service.ts
+git commit -m "feat(audit-logs): thread userId+username through chart-of-accounts controller/service"
+```
+
+---
+
+## Task 16: Accounting — Reconciliation
+
+**Files:**
+- Modify: `backend/src/modules/accounting/controllers/reconciliation.controller.ts`
+- Modify: `backend/src/modules/accounting/services/reconciliation.service.ts`
+
+### Step 1: Update reconciliation.controller.ts
+
+Add import:
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Add `@CurrentUser` params to: create, update, remove, complete, reopen.
+
+### Step 2: Update reconciliation.service.ts
+
+Add `username?: string` to: create, update, remove, complete, reopen. Add `username` to `auditLogService.log()` calls.
+
+### Step 3: Verify + Commit
+```bash
+cd /home/blur/erp2/backend && npm run lint
+git add backend/src/modules/accounting/controllers/reconciliation.controller.ts \
+        backend/src/modules/accounting/services/reconciliation.service.ts
+git commit -m "feat(audit-logs): thread userId+username through reconciliation controller/service"
+```
+
+---
+
+## Task 17: Accounting — Settlement
+
+**Files:**
+- Modify: `backend/src/modules/accounting/controllers/settlement.controller.ts`
+- Modify: `backend/src/modules/accounting/services/settlement.service.ts`
+
+### Step 1: Update settlement.controller.ts
+
+Add import:
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Add `@CurrentUser` params to: create.
+
+Also find the `cancel` endpoint (if it exists as a controller method) and add `@CurrentUser` there too.
+
+### Step 2: Update settlement.service.ts
+
+**create**: add `username?: string`, add to `auditLogService.log()` call.
+
+**cancel**: currently hardcodes `'system'` — add `userId?: string, username?: string` params and replace hardcoded value.
+
+### Step 3: Verify + Commit
+```bash
+cd /home/blur/erp2/backend && npm run lint
+git add backend/src/modules/accounting/controllers/settlement.controller.ts \
+        backend/src/modules/accounting/services/settlement.service.ts
+git commit -m "feat(audit-logs): thread userId+username through settlement controller/service"
+```
+
+---
+
+## Task 18: Accounting — Expense
+
+**Files:**
+- Modify: `backend/src/modules/accounting/controllers/expense.controller.ts`
+- Modify: `backend/src/modules/accounting/services/expense.service.ts`
+
+### Step 1: Update expense.controller.ts
+
+Add import:
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Add `@CurrentUser` params to: create, update, remove, post, bulkPost, bulkDelete.
+
+### Step 2: Update expense.service.ts
+
+**remove**: currently hardcodes `'system'` — add `userId?: string, username?: string` and replace hardcoded value.
+
+For all methods: add `username?: string`, add `username` to `auditLogService.log()` calls.
+
+### Step 3: Verify + Commit
+```bash
+cd /home/blur/erp2/backend && npm run lint
+git add backend/src/modules/accounting/controllers/expense.controller.ts \
+        backend/src/modules/accounting/services/expense.service.ts
+git commit -m "feat(audit-logs): thread userId+username through expense controller/service"
+```
+
+---
+
+## Task 19: Accounting — Owner Equity
+
+**Files:**
+- Modify: `backend/src/modules/accounting/controllers/owner-equity.controller.ts`
+- Modify: `backend/src/modules/accounting/services/owner-equity.service.ts`
+
+### Step 1: Update owner-equity.controller.ts
+
+Add import:
+```typescript
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+```
+
+Add `@CurrentUser` params to: create, update, remove, post, bulkPost, bulkDelete.
+
+### Step 2: Update owner-equity.service.ts
+
+**remove**: currently hardcodes `'system'` — add `userId?: string, username?: string` and replace.
+
+For all methods: add `username?: string`, add `username` to `auditLogService.log()` calls.
+
+### Step 3: Verify + Commit
+```bash
+cd /home/blur/erp2/backend && npm run lint
+git add backend/src/modules/accounting/controllers/owner-equity.controller.ts \
+        backend/src/modules/accounting/services/owner-equity.service.ts
+git commit -m "feat(audit-logs): thread userId+username through owner-equity controller/service"
+```
+
+---
+
+## Task 20: Fix accounting.service.ts — postOpeningBalances
+
+**Files:**
+- Modify: `backend/src/modules/accounting/services/accounting.service.ts`
+- Modify: `backend/src/modules/accounting/controllers/journal-entry.controller.ts` (postOpeningBalances endpoint)
+
+### Step 1: Update accounting.service.ts
+
+Find `postOpeningBalances` — it already has `userId?: string` but no `username`. Add `username?: string` and add to the `auditLogService.log()` call.
+
+All other auto-posting methods (postSalesOrderEntry, postCustomerPaymentEntry, postSettlementEntry, postGoodsReceivedEntry, postVendorPaymentEntry, postStockAdjustmentEntry, postOwnerEquityEntry, postExpenseEntry) — these are called internally from other services, not from controllers directly. Add `username?: string` to their signatures and pass through to `auditLogService.log()`.
+
+### Step 2: Update journal-entry.controller.ts — postOpeningBalances endpoint
+
+Find the `postOpeningBalances` controller method and add `@CurrentUser` params, pass to service.
+
+### Step 3: Verify + Commit
+```bash
+cd /home/blur/erp2/backend && npm run lint
+git add backend/src/modules/accounting/services/accounting.service.ts \
+        backend/src/modules/accounting/controllers/journal-entry.controller.ts
+git commit -m "feat(audit-logs): thread userId+username through accounting.service postOpeningBalances"
+```
+
+---
+
+## Task 21: Final verification
+
+### Step 1: Full lint check
+```bash
+cd /home/blur/erp2/backend && npm run lint
+```
+Expected: no errors.
+
+### Step 2: TypeScript check
+```bash
+cd /home/blur/erp2/frontend && npm run type-check
+```
+Expected: no errors (frontend unchanged, but verify nothing broke).
+
+### Step 3: Backend build check
+```bash
+cd /home/blur/erp2/backend && npx tsc --noEmit
+```
+Expected: no type errors.
+
+### Step 4: Final commit if anything left unstaged
+```bash
+git status
+```

--- a/frontend/src/pages/audit-logs/AuditLogsPage.tsx
+++ b/frontend/src/pages/audit-logs/AuditLogsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   Box, Typography, Tabs, Tab, Stack,
 } from '@mui/material'
@@ -16,6 +16,7 @@ import FilterSidebar from './components/FilterSidebar'
 import LogsTab from './components/LogsTab'
 import AnalyticsTab from './components/AnalyticsTab'
 import ExportButton from './components/ExportButton'
+import { priceListApi } from '@/services/priceListApi'
 
 const AuditLogsPage: React.FC = () => {
   const dispatch = useAppDispatch()
@@ -23,6 +24,7 @@ const AuditLogsPage: React.FC = () => {
     auditLogs, statistics, loading, error,
     pagination, filters, activeTab, sidebarCollapsed,
   } = useAppSelector((state) => state.auditLogs)
+  const [priceListNameById, setPriceListNameById] = useState<Record<string, string>>({})
 
   useEffect(() => {
     dispatch(fetchAuditLogs({
@@ -40,6 +42,83 @@ const AuditLogsPage: React.FC = () => {
       endDate: filters.endDate,
     }))
   }, [filters.startDate, filters.endDate])
+
+  useEffect(() => {
+    const loadPriceLists = async () => {
+      try {
+        const response = await priceListApi.getPriceLists({
+          page: 1,
+          limit: 1000,
+          sortBy: 'name',
+          sortOrder: 'asc',
+        })
+        const data = response.data ?? []
+        const map: Record<string, string> = {}
+        data.forEach((pl) => {
+          map[pl.id] = pl.name
+        })
+        setPriceListNameById(map)
+      } catch (error) {
+        // Ignore lookup failures; audit logs can still render with raw IDs.
+        console.error('Failed to load price list names for audit logs:', error)
+      }
+    }
+
+    loadPriceLists()
+  }, [])
+
+  useEffect(() => {
+    const extractPriceListIds = (value: unknown, result: Set<string>) => {
+      if (!value) return
+      if (Array.isArray(value)) {
+        value.forEach((item) => extractPriceListIds(item, result))
+        return
+      }
+      if (typeof value !== 'object') return
+
+      const record = value as Record<string, unknown>
+      Object.entries(record).forEach(([key, val]) => {
+        if (key === 'priceListId' && typeof val === 'string') {
+          result.add(val)
+          return
+        }
+        extractPriceListIds(val, result)
+      })
+    }
+
+    const resolveMissingPriceListNames = async () => {
+      const idsInLogs = new Set<string>()
+      auditLogs.forEach((log) => {
+        extractPriceListIds(log.oldValues, idsInLogs)
+        extractPriceListIds(log.newValues, idsInLogs)
+      })
+
+      const missingIds = Array.from(idsInLogs).filter((id) => !priceListNameById[id])
+      if (missingIds.length === 0) return
+
+      const entries = await Promise.all(
+        missingIds.map(async (id): Promise<[string, string]> => {
+          try {
+            const priceList = await priceListApi.getPriceList(id)
+            return [id, priceList.name]
+          } catch {
+            // Cache fallback to avoid repeating failed lookups.
+            return [id, id]
+          }
+        }),
+      )
+
+      setPriceListNameById((prev) => {
+        const next = { ...prev }
+        entries.forEach(([id, name]) => {
+          next[id] = name
+        })
+        return next
+      })
+    }
+
+    resolveMissingPriceListNames()
+  }, [auditLogs, priceListNameById])
 
   const handleApply = () => {
     dispatch(setPage(1))
@@ -99,6 +178,7 @@ const AuditLogsPage: React.FC = () => {
             logs={auditLogs}
             loading={loading}
             error={error}
+            priceListNameById={priceListNameById}
             total={pagination.total}
             page={pagination.page}
             limit={pagination.limit}

--- a/frontend/src/pages/audit-logs/AuditLogsPage.tsx
+++ b/frontend/src/pages/audit-logs/AuditLogsPage.tsx
@@ -1,532 +1,124 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import {
-  Box,
-  Paper,
-  Typography,
-  TextField,
-  MenuItem,
-  Button,
-  Chip,
-  IconButton,
-  TableContainer,
-  Table,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableBody,
-  TablePagination,
-  CircularProgress,
-  Alert,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Stack,
-  GridLegacy as Grid,
+  Box, Typography, Tabs, Tab, Stack,
 } from '@mui/material'
-import {
-  Search,
-  Refresh,
-  FilterList,
-  Visibility,
-  GetApp,
-  History as AuditIcon,
-} from '@mui/icons-material'
+import { History as AuditIcon } from '@mui/icons-material'
 import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import {
   fetchAuditLogs,
   fetchAuditLogStatistics,
-  setFilters,
-  clearFilters,
   setPage,
   setLimit,
-  setSelectedAuditLog,
+  setActiveTab,
 } from '@/store/slices/auditLogSlice'
-import { AuditAction, type AuditLog } from '@/types'
-import { format } from 'date-fns'
 import { TYPOGRAPHY_STYLES } from '@/constants/typography'
+import FilterSidebar from './components/FilterSidebar'
+import LogsTab from './components/LogsTab'
+import AnalyticsTab from './components/AnalyticsTab'
+import ExportButton from './components/ExportButton'
 
 const AuditLogsPage: React.FC = () => {
   const dispatch = useAppDispatch()
   const {
-    auditLogs,
-    selectedAuditLog,
-    statistics,
-    loading,
-    error,
-    pagination,
-    filters,
+    auditLogs, statistics, loading, error,
+    pagination, filters, activeTab, sidebarCollapsed,
   } = useAppSelector((state) => state.auditLogs)
 
-  const [localSearch, setLocalSearch] = useState(filters.search || '')
-  const [showFilters, setShowFilters] = useState(false)
-  const [detailsOpen, setDetailsOpen] = useState(false)
+  const fetchLogs = () => {
+    dispatch(fetchAuditLogs({
+      page: pagination.page,
+      limit: pagination.limit,
+      ...filters,
+      sortBy: 'createdAt',
+      sortOrder: 'DESC',
+    }))
+  }
 
-  // Fetch audit logs on mount and when filters/pagination change
+  const fetchStats = () => {
+    dispatch(fetchAuditLogStatistics({
+      startDate: filters.startDate,
+      endDate: filters.endDate,
+    }))
+  }
+
   useEffect(() => {
-    handleFetchAuditLogs()
+    fetchLogs()
   }, [pagination.page, pagination.limit])
 
-  // Fetch statistics on mount
   useEffect(() => {
-    dispatch(fetchAuditLogStatistics({}))
-  }, [dispatch])
+    fetchStats()
+  }, [filters.startDate, filters.endDate])
 
-  const handleFetchAuditLogs = () => {
-    dispatch(
-      fetchAuditLogs({
-        page: pagination.page,
-        limit: pagination.limit,
-        ...filters,
-        sortBy: 'createdAt',
-        sortOrder: 'DESC',
-      })
-    )
-  }
-
-  const handleSearch = () => {
-    dispatch(setFilters({ search: localSearch }))
+  const handleApply = () => {
     dispatch(setPage(1))
-    handleFetchAuditLogs()
+    fetchLogs()
+    fetchStats()
   }
 
-  const handleClearFilters = () => {
-    setLocalSearch('')
-    dispatch(clearFilters())
-    dispatch(setPage(1))
-    handleFetchAuditLogs()
+  const handlePageChange = (page: number) => {
+    dispatch(setPage(page))
   }
 
-  const handlePageChange = (_event: unknown, newPage: number) => {
-    dispatch(setPage(newPage + 1))
-  }
-
-  const handleRowsPerPageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    dispatch(setLimit(parseInt(event.target.value, 10)))
+  const handleLimitChange = (limit: number) => {
+    dispatch(setLimit(limit))
     dispatch(setPage(1))
   }
 
-  const handleViewDetails = (log: AuditLog) => {
-    dispatch(setSelectedAuditLog(log))
-    setDetailsOpen(true)
-  }
-
-  const handleCloseDetails = () => {
-    setDetailsOpen(false)
-    dispatch(setSelectedAuditLog(null))
-  }
-
-  const getActionColor = (action: string): "default" | "primary" | "secondary" | "error" | "info" | "success" | "warning" => {
-    switch (action) {
-      case 'CREATE':
-        return 'success'
-      case 'UPDATE':
-        return 'info'
-      case 'DELETE':
-      case 'BULK_DELETE':
-        return 'error'
-      case 'RESTORE':
-      case 'BULK_RESTORE':
-        return 'warning'
-      case 'EXPORT':
-      case 'IMPORT':
-        return 'primary'
-      default:
-        return 'default'
-    }
-  }
-
-  const formatDate = (date: Date | string) => {
-    try {
-      return format(new Date(date), 'MMM dd, yyyy HH:mm:ss')
-    } catch {
-      return 'Invalid date'
-    }
-  }
+  const entityTypes = statistics?.byEntityType.map((e) => e.entityType) ?? []
 
   return (
-    <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{ mb: 3 }}>
-        <Typography variant={TYPOGRAPHY_STYLES.pageHeader.variant} sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight, mb: 1, display: 'flex', alignItems: 'center', gap: 2 }}>
-          <AuditIcon sx={{ fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize, color: TYPOGRAPHY_STYLES.pageHeader.icon.color }} />
-          Audit Logs
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          View all system changes and user activities
-        </Typography>
+    <Box sx={{ display: 'flex', height: '100%', gap: 2, p: 3 }}>
+      {/* Sidebar */}
+      <Box sx={{ flexShrink: 0, width: sidebarCollapsed ? 48 : 260, transition: 'width 0.2s' }}>
+        <FilterSidebar entityTypes={entityTypes} onApply={handleApply} />
       </Box>
 
-      {/* Statistics */}
-      {statistics && (
-        <Grid container spacing={2} sx={{ mb: 3 }}>
-          <Grid item xs={12} sm={6} md={3}>
-            <Paper sx={{ p: 2 }}>
-              <Typography variant="body2" color="text.secondary">
-                Total Logs
-              </Typography>
-              <Typography variant="h4">{statistics.total.toLocaleString()}</Typography>
-            </Paper>
-          </Grid>
-          <Grid item xs={12} sm={6} md={3}>
-            <Paper sx={{ p: 2 }}>
-              <Typography variant="body2" color="text.secondary">
-                Actions
-              </Typography>
-              <Typography variant="h4">{statistics.byAction.length}</Typography>
-            </Paper>
-          </Grid>
-          <Grid item xs={12} sm={6} md={3}>
-            <Paper sx={{ p: 2 }}>
-              <Typography variant="body2" color="text.secondary">
-                Entity Types
-              </Typography>
-              <Typography variant="h4">{statistics.byEntityType.length}</Typography>
-            </Paper>
-          </Grid>
-          <Grid item xs={12} sm={6} md={3}>
-            <Paper sx={{ p: 2 }}>
-              <Typography variant="body2" color="text.secondary">
-                Active Users
-              </Typography>
-              <Typography variant="h4">{statistics.topUsers.length}</Typography>
-            </Paper>
-          </Grid>
-        </Grid>
-      )}
-
-      {/* Filters */}
-      <Paper sx={{ p: 2, mb: 2 }}>
-        <Stack direction="row" spacing={2} alignItems="center">
-          <TextField
-            size="small"
-            placeholder="Search descriptions..."
-            value={localSearch}
-            onChange={(e) => setLocalSearch(e.target.value)}
-            onKeyPress={(e) => e.key === 'Enter' && handleSearch()}
-            sx={{ flexGrow: 1 }}
-            slotProps={{
-              input: {
-                startAdornment: <Search sx={{ mr: 1, color: 'text.secondary' }} />,
-              },
-            }}
-          />
-          <Button
-            variant="outlined"
-            startIcon={<FilterList />}
-            onClick={() => setShowFilters(!showFilters)}
-          >
-            Filters
-          </Button>
-          <Button variant="contained" onClick={handleSearch}>
-            Search
-          </Button>
-          <Button variant="outlined" onClick={handleClearFilters}>
-            Clear
-          </Button>
-          <IconButton onClick={handleFetchAuditLogs} title="Refresh">
-            <Refresh />
-          </IconButton>
+      {/* Main content */}
+      <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2 }}>
+        {/* Header */}
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Box>
+            <Typography
+              variant={TYPOGRAPHY_STYLES.pageHeader.variant}
+              sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight, display: 'flex', alignItems: 'center', gap: 1 }}
+            >
+              <AuditIcon sx={{ fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize, color: TYPOGRAPHY_STYLES.pageHeader.icon.color }} />
+              Audit Logs
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              View all system changes and user activities
+            </Typography>
+          </Box>
+          <ExportButton logs={auditLogs} disabled={loading} />
         </Stack>
 
-        {/* Advanced Filters */}
-        {showFilters && (
-          <Box sx={{ mt: 2 }}>
-            <Grid container spacing={2}>
-              <Grid item xs={12} sm={6} md={3}>
-                <TextField
-                  select
-                  fullWidth
-                  size="small"
-                  label="Action"
-                  value={filters.action || ''}
-                  onChange={(e) => dispatch(setFilters({ action: e.target.value as AuditAction }))}
-                >
-                  <MenuItem value="">All Actions</MenuItem>
-                  {Object.values(AuditAction).map((action) => (
-                    <MenuItem key={action} value={action}>
-                      {action}
-                    </MenuItem>
-                  ))}
-                </TextField>
-              </Grid>
-              <Grid item xs={12} sm={6} md={3}>
-                <TextField
-                  fullWidth
-                  size="small"
-                  label="Entity Type"
-                  value={filters.entityType || ''}
-                  onChange={(e) => dispatch(setFilters({ entityType: e.target.value }))}
-                  placeholder="e.g., Product, Customer"
-                />
-              </Grid>
-              <Grid item xs={12} sm={6} md={3}>
-                <TextField
-                  fullWidth
-                  size="small"
-                  label="User ID"
-                  value={filters.userId || ''}
-                  onChange={(e) => dispatch(setFilters({ userId: e.target.value }))}
-                  placeholder="e.g., system"
-                />
-              </Grid>
-              <Grid item xs={12} sm={6} md={3}>
-                <TextField
-                  fullWidth
-                  size="small"
-                  label="Username"
-                  value={filters.username || ''}
-                  onChange={(e) => dispatch(setFilters({ username: e.target.value }))}
-                  placeholder="Filter by username"
-                />
-              </Grid>
-              <Grid item xs={12} sm={6} md={3}>
-                <TextField
-                  fullWidth
-                  size="small"
-                  type="date"
-                  label="Start Date"
-                  value={filters.startDate || ''}
-                  onChange={(e) => dispatch(setFilters({ startDate: e.target.value }))}
-                  InputLabelProps={{ shrink: true }}
-                />
-              </Grid>
-              <Grid item xs={12} sm={6} md={3}>
-                <TextField
-                  fullWidth
-                  size="small"
-                  type="date"
-                  label="End Date"
-                  value={filters.endDate || ''}
-                  onChange={(e) => dispatch(setFilters({ endDate: e.target.value }))}
-                  InputLabelProps={{ shrink: true }}
-                />
-              </Grid>
-            </Grid>
-          </Box>
+        {/* Tabs */}
+        <Tabs
+          value={activeTab}
+          onChange={(_e, val) => dispatch(setActiveTab(val))}
+          sx={{ borderBottom: 1, borderColor: 'divider' }}
+        >
+          <Tab label="Logs" value="logs" />
+          <Tab label="Analytics" value="analytics" />
+        </Tabs>
+
+        {/* Tab content */}
+        {activeTab === 'logs' && (
+          <LogsTab
+            logs={auditLogs}
+            loading={loading}
+            error={error}
+            total={pagination.total}
+            page={pagination.page}
+            limit={pagination.limit}
+            onPageChange={handlePageChange}
+            onLimitChange={handleLimitChange}
+          />
         )}
-      </Paper>
-
-      {/* Error */}
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
-      )}
-
-      {/* Table */}
-      <Paper>
-        <TableContainer>
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell>Date & Time</TableCell>
-                <TableCell>Action</TableCell>
-                <TableCell>Entity Type</TableCell>
-                <TableCell>User</TableCell>
-                <TableCell>Description</TableCell>
-                <TableCell align="center">Actions</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {loading ? (
-                <TableRow>
-                  <TableCell colSpan={6} align="center">
-                    <CircularProgress />
-                  </TableCell>
-                </TableRow>
-              ) : auditLogs.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={6} align="center">
-                    <Typography variant="body2" color="text.secondary">
-                      No audit logs found
-                    </Typography>
-                  </TableCell>
-                </TableRow>
-              ) : (
-                auditLogs.map((log) => (
-                  <TableRow key={log.id} hover>
-                    <TableCell sx={{ whiteSpace: 'nowrap' }}>
-                      {formatDate(log.createdAt)}
-                    </TableCell>
-                    <TableCell>
-                      <Chip
-                        label={log.action}
-                        color={getActionColor(log.action)}
-                        size="small"
-                      />
-                    </TableCell>
-                    <TableCell>{log.entityType}</TableCell>
-                    <TableCell>
-                      <Box>
-                        <Typography variant="body2">
-                          {log.username || log.userId}
-                        </Typography>
-                        {log.username && (
-                          <Typography variant="caption" color="text.secondary">
-                            {log.userId}
-                          </Typography>
-                        )}
-                      </Box>
-                    </TableCell>
-                    <TableCell sx={{ maxWidth: 400 }}>
-                      <Typography
-                        variant="body2"
-                        sx={{
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
-                        }}
-                      >
-                        {log.description}
-                      </Typography>
-                    </TableCell>
-                    <TableCell align="center">
-                      <IconButton
-                        size="small"
-                        onClick={() => handleViewDetails(log)}
-                        title="View Details"
-                      >
-                        <Visibility />
-                      </IconButton>
-                    </TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
-        <TablePagination
-          rowsPerPageOptions={[10, 20, 50, 100]}
-          component="div"
-          count={pagination.total}
-          rowsPerPage={pagination.limit}
-          page={pagination.page - 1}
-          onPageChange={handlePageChange}
-          onRowsPerPageChange={handleRowsPerPageChange}
-        />
-      </Paper>
-
-      {/* Details Dialog */}
-      <Dialog
-        open={detailsOpen}
-        onClose={handleCloseDetails}
-        maxWidth="md"
-        fullWidth
-      >
-        <DialogTitle>Audit Log Details</DialogTitle>
-        <DialogContent>
-          {selectedAuditLog && (
-            <Box sx={{ mt: 1 }}>
-              <Grid container spacing={2}>
-                <Grid item xs={12} sm={6}>
-                  <Typography variant="subtitle2" color="text.secondary">
-                    Action
-                  </Typography>
-                  <Chip
-                    label={selectedAuditLog.action}
-                    color={getActionColor(selectedAuditLog.action)}
-                    size="small"
-                  />
-                </Grid>
-                <Grid item xs={12} sm={6}>
-                  <Typography variant="subtitle2" color="text.secondary">
-                    Date & Time
-                  </Typography>
-                  <Typography variant="body1">
-                    {formatDate(selectedAuditLog.createdAt)}
-                  </Typography>
-                </Grid>
-                <Grid item xs={12} sm={6}>
-                  <Typography variant="subtitle2" color="text.secondary">
-                    Entity Type
-                  </Typography>
-                  <Typography variant="body1">{selectedAuditLog.entityType}</Typography>
-                </Grid>
-                <Grid item xs={12} sm={6}>
-                  <Typography variant="subtitle2" color="text.secondary">
-                    Entity ID
-                  </Typography>
-                  <Typography variant="body1" sx={{ fontFamily: 'monospace', fontSize: '0.875rem' }}>
-                    {selectedAuditLog.entityId || 'N/A'}
-                  </Typography>
-                </Grid>
-                <Grid item xs={12} sm={6}>
-                  <Typography variant="subtitle2" color="text.secondary">
-                    User
-                  </Typography>
-                  <Typography variant="body1">
-                    {selectedAuditLog.username || selectedAuditLog.userId}
-                  </Typography>
-                </Grid>
-                <Grid item xs={12} sm={6}>
-                  <Typography variant="subtitle2" color="text.secondary">
-                    IP Address
-                  </Typography>
-                  <Typography variant="body1">
-                    {selectedAuditLog.ipAddress || 'N/A'}
-                  </Typography>
-                </Grid>
-                <Grid item xs={12}>
-                  <Typography variant="subtitle2" color="text.secondary">
-                    Description
-                  </Typography>
-                  <Typography variant="body1">{selectedAuditLog.description}</Typography>
-                </Grid>
-                {selectedAuditLog.oldValues && (
-                  <Grid item xs={12}>
-                    <Typography variant="subtitle2" color="text.secondary">
-                      Previous Values
-                    </Typography>
-                    <Paper variant="outlined" sx={{ p: 2, mt: 1, bgcolor: 'background.default' }}>
-                      <pre style={{ margin: 0, fontSize: '0.75rem', overflow: 'auto' }}>
-                        {JSON.stringify(selectedAuditLog.oldValues, null, 2)}
-                      </pre>
-                    </Paper>
-                  </Grid>
-                )}
-                {selectedAuditLog.newValues && (
-                  <Grid item xs={12}>
-                    <Typography variant="subtitle2" color="text.secondary">
-                      New Values
-                    </Typography>
-                    <Paper variant="outlined" sx={{ p: 2, mt: 1, bgcolor: 'background.default' }}>
-                      <pre style={{ margin: 0, fontSize: '0.75rem', overflow: 'auto' }}>
-                        {JSON.stringify(selectedAuditLog.newValues, null, 2)}
-                      </pre>
-                    </Paper>
-                  </Grid>
-                )}
-                {selectedAuditLog.metadata && (
-                  <Grid item xs={12}>
-                    <Typography variant="subtitle2" color="text.secondary">
-                      Metadata
-                    </Typography>
-                    <Paper variant="outlined" sx={{ p: 2, mt: 1, bgcolor: 'background.default' }}>
-                      <pre style={{ margin: 0, fontSize: '0.75rem', overflow: 'auto' }}>
-                        {JSON.stringify(selectedAuditLog.metadata, null, 2)}
-                      </pre>
-                    </Paper>
-                  </Grid>
-                )}
-                {selectedAuditLog.userAgent && (
-                  <Grid item xs={12}>
-                    <Typography variant="subtitle2" color="text.secondary">
-                      User Agent
-                    </Typography>
-                    <Typography variant="body2" sx={{ fontSize: '0.75rem', wordBreak: 'break-all' }}>
-                      {selectedAuditLog.userAgent}
-                    </Typography>
-                  </Grid>
-                )}
-              </Grid>
-            </Box>
-          )}
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCloseDetails}>Close</Button>
-        </DialogActions>
-      </Dialog>
+        {activeTab === 'analytics' && (
+          <AnalyticsTab statistics={statistics} loading={loading} />
+        )}
+      </Box>
     </Box>
   )
 }

--- a/frontend/src/pages/audit-logs/AuditLogsPage.tsx
+++ b/frontend/src/pages/audit-logs/AuditLogsPage.tsx
@@ -24,7 +24,7 @@ const AuditLogsPage: React.FC = () => {
     pagination, filters, activeTab, sidebarCollapsed,
   } = useAppSelector((state) => state.auditLogs)
 
-  const fetchLogs = () => {
+  useEffect(() => {
     dispatch(fetchAuditLogs({
       page: pagination.page,
       limit: pagination.limit,
@@ -32,27 +32,18 @@ const AuditLogsPage: React.FC = () => {
       sortBy: 'createdAt',
       sortOrder: 'DESC',
     }))
-  }
+  }, [pagination.page, pagination.limit, filters])
 
-  const fetchStats = () => {
+  useEffect(() => {
     dispatch(fetchAuditLogStatistics({
       startDate: filters.startDate,
       endDate: filters.endDate,
     }))
-  }
-
-  useEffect(() => {
-    fetchLogs()
-  }, [pagination.page, pagination.limit])
-
-  useEffect(() => {
-    fetchStats()
   }, [filters.startDate, filters.endDate])
 
   const handleApply = () => {
     dispatch(setPage(1))
-    fetchLogs()
-    fetchStats()
+    // effects above will re-run due to state changes
   }
 
   const handlePageChange = (page: number) => {

--- a/frontend/src/pages/audit-logs/components/AnalyticsTab.tsx
+++ b/frontend/src/pages/audit-logs/components/AnalyticsTab.tsx
@@ -1,0 +1,156 @@
+import React from 'react'
+import {
+  Box, Paper, Typography, GridLegacy as Grid, CircularProgress,
+} from '@mui/material'
+import {
+  Chart as ChartJS,
+  CategoryScale, LinearScale, BarElement, ArcElement,
+  Title, Tooltip, Legend,
+} from 'chart.js'
+import { Bar, Doughnut } from 'react-chartjs-2'
+import type { AuditLogStatistics } from '@/services/auditLogApi'
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, ArcElement, Title, Tooltip, Legend)
+
+const ACTION_COLORS: Record<string, string> = {
+  CREATE: '#4caf50',
+  UPDATE: '#2196f3',
+  DELETE: '#f44336',
+  RESTORE: '#ff9800',
+  BULK_DELETE: '#e91e63',
+  BULK_RESTORE: '#ff5722',
+  EXPORT: '#9c27b0',
+  IMPORT: '#00bcd4',
+}
+
+interface AnalyticsTabProps {
+  statistics: AuditLogStatistics | null
+  loading: boolean
+}
+
+const AnalyticsTab: React.FC<AnalyticsTabProps> = ({ statistics, loading }) => {
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  if (!statistics) {
+    return (
+      <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+        No statistics available.
+      </Typography>
+    )
+  }
+
+  const actionLabels = statistics.byAction.map((a) => a.action)
+  const actionCounts = statistics.byAction.map((a) => Number(a.count))
+  const actionColors = actionLabels.map((l) => ACTION_COLORS[l] ?? '#9e9e9e')
+
+  const entityLabels = statistics.byEntityType.map((e) => e.entityType)
+  const entityCounts = statistics.byEntityType.map((e) => Number(e.count))
+
+  const userLabels = statistics.topUsers.map((u) => u.username || u.userId)
+  const userCounts = statistics.topUsers.map((u) => Number(u.count))
+
+  const barOptions = {
+    responsive: true,
+    plugins: { legend: { display: false } },
+    scales: { x: { ticks: { font: { size: 11 } } } },
+  }
+
+  const horizontalBarOptions = {
+    indexAxis: 'y' as const,
+    responsive: true,
+    plugins: { legend: { display: false } },
+    scales: { x: { ticks: { font: { size: 11 } } } },
+  }
+
+  return (
+    <Grid container spacing={3}>
+      {/* Actions Breakdown */}
+      <Grid item xs={12} md={6}>
+        <Paper sx={{ p: 2 }}>
+          <Typography variant="subtitle1" fontWeight={600} gutterBottom>
+            Actions Breakdown
+          </Typography>
+          <Doughnut
+            data={{
+              labels: actionLabels,
+              datasets: [{
+                data: actionCounts,
+                backgroundColor: actionColors,
+                borderWidth: 1,
+              }],
+            }}
+            options={{ responsive: true, plugins: { legend: { position: 'right' } } }}
+          />
+        </Paper>
+      </Grid>
+
+      {/* Activity by Action (bar) */}
+      <Grid item xs={12} md={6}>
+        <Paper sx={{ p: 2 }}>
+          <Typography variant="subtitle1" fontWeight={600} gutterBottom>
+            Activity by Action
+          </Typography>
+          <Bar
+            data={{
+              labels: actionLabels,
+              datasets: [{
+                label: 'Count',
+                data: actionCounts,
+                backgroundColor: actionColors,
+              }],
+            }}
+            options={barOptions}
+          />
+        </Paper>
+      </Grid>
+
+      {/* Top Users */}
+      <Grid item xs={12} md={6}>
+        <Paper sx={{ p: 2 }}>
+          <Typography variant="subtitle1" fontWeight={600} gutterBottom>
+            Top Users
+          </Typography>
+          <Bar
+            data={{
+              labels: userLabels,
+              datasets: [{
+                label: 'Actions',
+                data: userCounts,
+                backgroundColor: '#2196f3',
+              }],
+            }}
+            options={horizontalBarOptions}
+          />
+        </Paper>
+      </Grid>
+
+      {/* Activity by Entity Type */}
+      <Grid item xs={12} md={6}>
+        <Paper sx={{ p: 2 }}>
+          <Typography variant="subtitle1" fontWeight={600} gutterBottom>
+            Activity by Entity Type
+          </Typography>
+          <Bar
+            data={{
+              labels: entityLabels,
+              datasets: [{
+                label: 'Count',
+                data: entityCounts,
+                backgroundColor: '#9c27b0',
+              }],
+            }}
+            options={horizontalBarOptions}
+          />
+        </Paper>
+      </Grid>
+    </Grid>
+  )
+}
+
+export default AnalyticsTab

--- a/frontend/src/pages/audit-logs/components/DiffViewer.test.tsx
+++ b/frontend/src/pages/audit-logs/components/DiffViewer.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import DiffViewer from './DiffViewer'
+
+describe('DiffViewer column sizing', () => {
+  test('uses consistent fixed-width columns in create mode', () => {
+    const { container } = render(
+      <DiffViewer
+        newValues={{
+          name: 'Very long value that would otherwise force different column widths',
+          status: 'ACTIVE',
+        }}
+      />
+    )
+
+    const cols = container.querySelectorAll('col')
+    expect(cols).toHaveLength(2)
+    expect(cols[0]).toHaveAttribute('style', expect.stringContaining('35%'))
+    expect(cols[1]).toHaveAttribute('style', expect.stringContaining('65%'))
+
+    expect(screen.getByText('Field')).toBeInTheDocument()
+    expect(screen.getByText('Value')).toBeInTheDocument()
+  })
+
+  test('uses consistent fixed-width columns in update mode', () => {
+    const { container } = render(
+      <DiffViewer
+        oldValues={{ name: 'Short' }}
+        newValues={{ name: 'A much longer updated value to challenge auto layout sizing' }}
+      />
+    )
+
+    const cols = container.querySelectorAll('col')
+    expect(cols).toHaveLength(3)
+    expect(cols[0]).toHaveAttribute('style', expect.stringContaining('35%'))
+    expect(cols[1]).toHaveAttribute('style', expect.stringContaining('32.5%'))
+    expect(cols[2]).toHaveAttribute('style', expect.stringContaining('32.5%'))
+
+    expect(screen.getByText('Old Value')).toBeInTheDocument()
+    expect(screen.getByText('New Value')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/audit-logs/components/DiffViewer.tsx
+++ b/frontend/src/pages/audit-logs/components/DiffViewer.tsx
@@ -39,8 +39,8 @@ const DiffViewer: React.FC<DiffViewerProps> = ({ oldValues, newValues }) => {
         <TableBody>
           {Object.entries(newValues).map(([key, val]) => (
             <TableRow key={key}>
-              <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>{key}</TableCell>
-              <TableCell sx={(theme) => ({ bgcolor: toneBackground(theme, 'success'), fontFamily: 'monospace', fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' })}>
+              <TableCell sx={{ fontSize: '0.8rem' }}>{key}</TableCell>
+              <TableCell sx={(theme) => ({ bgcolor: toneBackground(theme, 'success'), fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' })}>
                 {formatValue(val)}
               </TableCell>
             </TableRow>
@@ -62,8 +62,8 @@ const DiffViewer: React.FC<DiffViewerProps> = ({ oldValues, newValues }) => {
         <TableBody>
           {Object.entries(oldValues).map(([key, val]) => (
             <TableRow key={key}>
-              <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>{key}</TableCell>
-              <TableCell sx={(theme) => ({ bgcolor: toneBackground(theme, 'error'), fontFamily: 'monospace', fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' })}>
+              <TableCell sx={{ fontSize: '0.8rem' }}>{key}</TableCell>
+              <TableCell sx={(theme) => ({ bgcolor: toneBackground(theme, 'error'), fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' })}>
                 {formatValue(val)}
               </TableCell>
             </TableRow>
@@ -96,11 +96,11 @@ const DiffViewer: React.FC<DiffViewerProps> = ({ oldValues, newValues }) => {
           const changed = JSON.stringify(oldVal) !== JSON.stringify(newVal)
           return (
             <TableRow key={key} sx={{ opacity: changed ? 1 : 0.45 }}>
-              <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>{key}</TableCell>
-              <TableCell sx={(theme) => ({ bgcolor: changed ? toneBackground(theme, 'error') : undefined, fontFamily: 'monospace', fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' })}>
+              <TableCell sx={{ fontSize: '0.8rem' }}>{key}</TableCell>
+              <TableCell sx={(theme) => ({ bgcolor: changed ? toneBackground(theme, 'error') : undefined, fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' })}>
                 {formatValue(oldVal)}
               </TableCell>
-              <TableCell sx={(theme) => ({ bgcolor: changed ? toneBackground(theme, 'success') : undefined, fontFamily: 'monospace', fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' })}>
+              <TableCell sx={(theme) => ({ bgcolor: changed ? toneBackground(theme, 'success') : undefined, fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' })}>
                 {formatValue(newVal)}
               </TableCell>
             </TableRow>

--- a/frontend/src/pages/audit-logs/components/DiffViewer.tsx
+++ b/frontend/src/pages/audit-logs/components/DiffViewer.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import { Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material'
+
+interface DiffViewerProps {
+  oldValues?: Record<string, unknown> | null
+  newValues?: Record<string, unknown> | null
+}
+
+function formatValue(val: unknown): string {
+  if (val === null || val === undefined) return '—'
+  if (typeof val === 'object') return JSON.stringify(val, null, 2)
+  return String(val)
+}
+
+const DiffViewer: React.FC<DiffViewerProps> = ({ oldValues, newValues }) => {
+  // Single-side: CREATE (newValues only) or DELETE (oldValues only)
+  if (!oldValues && newValues) {
+    return (
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell><strong>Field</strong></TableCell>
+            <TableCell sx={{ bgcolor: 'success.light' }}><strong>Value</strong></TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {Object.entries(newValues).map(([key, val]) => (
+            <TableRow key={key}>
+              <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>{key}</TableCell>
+              <TableCell sx={{ bgcolor: 'success.light', fontFamily: 'monospace', fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+                {formatValue(val)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    )
+  }
+
+  if (oldValues && !newValues) {
+    return (
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell><strong>Field</strong></TableCell>
+            <TableCell sx={{ bgcolor: 'error.light' }}><strong>Value</strong></TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {Object.entries(oldValues).map(([key, val]) => (
+            <TableRow key={key}>
+              <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>{key}</TableCell>
+              <TableCell sx={{ bgcolor: 'error.light', fontFamily: 'monospace', fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+                {formatValue(val)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    )
+  }
+
+  if (!oldValues && !newValues) {
+    return <Typography variant="body2" color="text.secondary">No value changes recorded.</Typography>
+  }
+
+  // Both sides: show diff
+  const allKeys = Array.from(new Set([...Object.keys(oldValues), ...Object.keys(newValues)]))
+
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell><strong>Field</strong></TableCell>
+          <TableCell sx={{ bgcolor: 'error.light' }}><strong>Old Value</strong></TableCell>
+          <TableCell sx={{ bgcolor: 'success.light' }}><strong>New Value</strong></TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {allKeys.map((key) => {
+          const oldVal = oldValues[key]
+          const newVal = newValues[key]
+          const changed = JSON.stringify(oldVal) !== JSON.stringify(newVal)
+          return (
+            <TableRow key={key} sx={{ opacity: changed ? 1 : 0.45 }}>
+              <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>{key}</TableCell>
+              <TableCell sx={{ bgcolor: changed ? 'error.light' : undefined, fontFamily: 'monospace', fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+                {formatValue(oldVal)}
+              </TableCell>
+              <TableCell sx={{ bgcolor: changed ? 'success.light' : undefined, fontFamily: 'monospace', fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+                {formatValue(newVal)}
+              </TableCell>
+            </TableRow>
+          )
+        })}
+      </TableBody>
+    </Table>
+  )
+}
+
+export default DiffViewer

--- a/frontend/src/pages/audit-logs/components/DiffViewer.tsx
+++ b/frontend/src/pages/audit-logs/components/DiffViewer.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material'
+import { alpha, type Theme } from '@mui/material/styles'
 
 interface DiffViewerProps {
   oldValues?: Record<string, unknown> | null
@@ -12,6 +13,18 @@ function formatValue(val: unknown): string {
   return String(val)
 }
 
+function toneBackground(theme: Theme, tone: 'success' | 'error'): string {
+  if (tone === 'success') {
+    return theme.palette.mode === 'dark'
+      ? alpha(theme.palette.success.main, 0.22)
+      : theme.palette.success.light
+  }
+
+  return theme.palette.mode === 'dark'
+    ? alpha(theme.palette.error.main, 0.22)
+    : theme.palette.error.light
+}
+
 const DiffViewer: React.FC<DiffViewerProps> = ({ oldValues, newValues }) => {
   // Single-side: CREATE (newValues only) or DELETE (oldValues only)
   if (!oldValues && newValues) {
@@ -20,14 +33,14 @@ const DiffViewer: React.FC<DiffViewerProps> = ({ oldValues, newValues }) => {
         <TableHead>
           <TableRow>
             <TableCell><strong>Field</strong></TableCell>
-            <TableCell sx={{ bgcolor: 'success.light' }}><strong>Value</strong></TableCell>
+            <TableCell sx={(theme) => ({ bgcolor: toneBackground(theme, 'success') })}><strong>Value</strong></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
           {Object.entries(newValues).map(([key, val]) => (
             <TableRow key={key}>
               <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>{key}</TableCell>
-              <TableCell sx={{ bgcolor: 'success.light', fontFamily: 'monospace', fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+              <TableCell sx={(theme) => ({ bgcolor: toneBackground(theme, 'success'), fontFamily: 'monospace', fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' })}>
                 {formatValue(val)}
               </TableCell>
             </TableRow>
@@ -43,14 +56,14 @@ const DiffViewer: React.FC<DiffViewerProps> = ({ oldValues, newValues }) => {
         <TableHead>
           <TableRow>
             <TableCell><strong>Field</strong></TableCell>
-            <TableCell sx={{ bgcolor: 'error.light' }}><strong>Value</strong></TableCell>
+            <TableCell sx={(theme) => ({ bgcolor: toneBackground(theme, 'error') })}><strong>Value</strong></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
           {Object.entries(oldValues).map(([key, val]) => (
             <TableRow key={key}>
               <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>{key}</TableCell>
-              <TableCell sx={{ bgcolor: 'error.light', fontFamily: 'monospace', fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+              <TableCell sx={(theme) => ({ bgcolor: toneBackground(theme, 'error'), fontFamily: 'monospace', fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' })}>
                 {formatValue(val)}
               </TableCell>
             </TableRow>
@@ -72,8 +85,8 @@ const DiffViewer: React.FC<DiffViewerProps> = ({ oldValues, newValues }) => {
       <TableHead>
         <TableRow>
           <TableCell><strong>Field</strong></TableCell>
-          <TableCell sx={{ bgcolor: 'error.light' }}><strong>Old Value</strong></TableCell>
-          <TableCell sx={{ bgcolor: 'success.light' }}><strong>New Value</strong></TableCell>
+          <TableCell sx={(theme) => ({ bgcolor: toneBackground(theme, 'error') })}><strong>Old Value</strong></TableCell>
+          <TableCell sx={(theme) => ({ bgcolor: toneBackground(theme, 'success') })}><strong>New Value</strong></TableCell>
         </TableRow>
       </TableHead>
       <TableBody>
@@ -84,10 +97,10 @@ const DiffViewer: React.FC<DiffViewerProps> = ({ oldValues, newValues }) => {
           return (
             <TableRow key={key} sx={{ opacity: changed ? 1 : 0.45 }}>
               <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>{key}</TableCell>
-              <TableCell sx={{ bgcolor: changed ? 'error.light' : undefined, fontFamily: 'monospace', fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+              <TableCell sx={(theme) => ({ bgcolor: changed ? toneBackground(theme, 'error') : undefined, fontFamily: 'monospace', fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' })}>
                 {formatValue(oldVal)}
               </TableCell>
-              <TableCell sx={{ bgcolor: changed ? 'success.light' : undefined, fontFamily: 'monospace', fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+              <TableCell sx={(theme) => ({ bgcolor: changed ? toneBackground(theme, 'success') : undefined, fontFamily: 'monospace', fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' })}>
                 {formatValue(newVal)}
               </TableCell>
             </TableRow>

--- a/frontend/src/pages/audit-logs/components/DiffViewer.tsx
+++ b/frontend/src/pages/audit-logs/components/DiffViewer.tsx
@@ -5,10 +5,23 @@ import { alpha, type Theme } from '@mui/material/styles'
 interface DiffViewerProps {
   oldValues?: Record<string, unknown> | null
   newValues?: Record<string, unknown> | null
+  priceListNameById?: Record<string, string>
 }
 
-function formatValue(val: unknown): string {
+function formatFieldName(key: string): string {
+  if (key === 'priceListId') return 'priceList'
+  return key
+}
+
+function formatValue(
+  key: string,
+  val: unknown,
+  priceListNameById?: Record<string, string>,
+): string {
   if (val === null || val === undefined) return '—'
+  if (key === 'priceListId' && typeof val === 'string') {
+    return priceListNameById?.[val] || val
+  }
   if (typeof val === 'object') return JSON.stringify(val, null, 2)
   return String(val)
 }
@@ -25,7 +38,11 @@ function toneBackground(theme: Theme, tone: 'success' | 'error'): string {
     : theme.palette.error.light
 }
 
-const DiffViewer: React.FC<DiffViewerProps> = ({ oldValues, newValues }) => {
+const DiffViewer: React.FC<DiffViewerProps> = ({
+  oldValues,
+  newValues,
+  priceListNameById,
+}) => {
   // Single-side: CREATE (newValues only) or DELETE (oldValues only)
   if (!oldValues && newValues) {
     return (
@@ -43,9 +60,9 @@ const DiffViewer: React.FC<DiffViewerProps> = ({ oldValues, newValues }) => {
         <TableBody>
           {Object.entries(newValues).map(([key, val]) => (
             <TableRow key={key}>
-              <TableCell sx={{ fontSize: '0.8rem' }}>{key}</TableCell>
+              <TableCell sx={{ fontSize: '0.8rem' }}>{formatFieldName(key)}</TableCell>
               <TableCell sx={(theme) => ({ bgcolor: toneBackground(theme, 'success'), fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' })}>
-                {formatValue(val)}
+                {formatValue(key, val, priceListNameById)}
               </TableCell>
             </TableRow>
           ))}
@@ -70,9 +87,9 @@ const DiffViewer: React.FC<DiffViewerProps> = ({ oldValues, newValues }) => {
         <TableBody>
           {Object.entries(oldValues).map(([key, val]) => (
             <TableRow key={key}>
-              <TableCell sx={{ fontSize: '0.8rem' }}>{key}</TableCell>
+              <TableCell sx={{ fontSize: '0.8rem' }}>{formatFieldName(key)}</TableCell>
               <TableCell sx={(theme) => ({ bgcolor: toneBackground(theme, 'error'), fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' })}>
-                {formatValue(val)}
+                {formatValue(key, val, priceListNameById)}
               </TableCell>
             </TableRow>
           ))}
@@ -109,12 +126,12 @@ const DiffViewer: React.FC<DiffViewerProps> = ({ oldValues, newValues }) => {
           const changed = JSON.stringify(oldVal) !== JSON.stringify(newVal)
           return (
             <TableRow key={key} sx={{ opacity: changed ? 1 : 0.45 }}>
-              <TableCell sx={{ fontSize: '0.8rem' }}>{key}</TableCell>
+              <TableCell sx={{ fontSize: '0.8rem' }}>{formatFieldName(key)}</TableCell>
               <TableCell sx={(theme) => ({ bgcolor: changed ? toneBackground(theme, 'error') : undefined, fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' })}>
-                {formatValue(oldVal)}
+                {formatValue(key, oldVal, priceListNameById)}
               </TableCell>
               <TableCell sx={(theme) => ({ bgcolor: changed ? toneBackground(theme, 'success') : undefined, fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' })}>
-                {formatValue(newVal)}
+                {formatValue(key, newVal, priceListNameById)}
               </TableCell>
             </TableRow>
           )

--- a/frontend/src/pages/audit-logs/components/DiffViewer.tsx
+++ b/frontend/src/pages/audit-logs/components/DiffViewer.tsx
@@ -29,7 +29,11 @@ const DiffViewer: React.FC<DiffViewerProps> = ({ oldValues, newValues }) => {
   // Single-side: CREATE (newValues only) or DELETE (oldValues only)
   if (!oldValues && newValues) {
     return (
-      <Table size="small">
+      <Table size="small" sx={{ tableLayout: 'fixed', width: '100%' }}>
+        <colgroup>
+          <col style={{ width: '35%' }} />
+          <col style={{ width: '65%' }} />
+        </colgroup>
         <TableHead>
           <TableRow>
             <TableCell><strong>Field</strong></TableCell>
@@ -52,7 +56,11 @@ const DiffViewer: React.FC<DiffViewerProps> = ({ oldValues, newValues }) => {
 
   if (oldValues && !newValues) {
     return (
-      <Table size="small">
+      <Table size="small" sx={{ tableLayout: 'fixed', width: '100%' }}>
+        <colgroup>
+          <col style={{ width: '35%' }} />
+          <col style={{ width: '65%' }} />
+        </colgroup>
         <TableHead>
           <TableRow>
             <TableCell><strong>Field</strong></TableCell>
@@ -81,7 +89,12 @@ const DiffViewer: React.FC<DiffViewerProps> = ({ oldValues, newValues }) => {
   const allKeys = Array.from(new Set([...Object.keys(oldValues), ...Object.keys(newValues)]))
 
   return (
-    <Table size="small">
+    <Table size="small" sx={{ tableLayout: 'fixed', width: '100%' }}>
+      <colgroup>
+        <col style={{ width: '35%' }} />
+        <col style={{ width: '32.5%' }} />
+        <col style={{ width: '32.5%' }} />
+      </colgroup>
       <TableHead>
         <TableRow>
           <TableCell><strong>Field</strong></TableCell>

--- a/frontend/src/pages/audit-logs/components/ExportButton.tsx
+++ b/frontend/src/pages/audit-logs/components/ExportButton.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react'
+import {
+  Button, Menu, MenuItem, CircularProgress,
+} from '@mui/material'
+import { GetApp, KeyboardArrowDown } from '@mui/icons-material'
+import * as XLSX from 'xlsx'
+import jsPDF from 'jspdf'
+import autoTable from 'jspdf-autotable'
+import { format } from 'date-fns'
+import type { AuditLog } from '@/types'
+
+interface ExportButtonProps {
+  logs: AuditLog[]
+  disabled?: boolean
+}
+
+const COLUMNS = ['Date', 'Action', 'Entity Type', 'Entity ID', 'User', 'Description', 'IP Address']
+
+function toRows(logs: AuditLog[]) {
+  return logs.map((log) => [
+    format(new Date(log.createdAt), 'yyyy-MM-dd HH:mm:ss'),
+    log.action,
+    log.entityType,
+    log.entityId ?? '',
+    log.username || log.userId,
+    log.description,
+    log.ipAddress ?? '',
+  ])
+}
+
+const ExportButton: React.FC<ExportButtonProps> = ({ logs, disabled }) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+  const [exporting, setExporting] = useState(false)
+  const open = Boolean(anchorEl)
+
+  const handleOpen = (e: React.MouseEvent<HTMLButtonElement>) => setAnchorEl(e.currentTarget)
+  const handleClose = () => setAnchorEl(null)
+
+  const exportCSV = () => {
+    handleClose()
+    const rows = toRows(logs)
+    const ws = XLSX.utils.aoa_to_sheet([COLUMNS, ...rows])
+    const wb = XLSX.utils.book_new()
+    XLSX.utils.book_append_sheet(wb, ws, 'Audit Logs')
+    XLSX.writeFile(wb, `audit-logs-${format(new Date(), 'yyyy-MM-dd')}.csv`, { bookType: 'csv' })
+  }
+
+  const exportExcel = () => {
+    handleClose()
+    const rows = toRows(logs)
+    const ws = XLSX.utils.aoa_to_sheet([COLUMNS, ...rows])
+    const wb = XLSX.utils.book_new()
+    XLSX.utils.book_append_sheet(wb, ws, 'Audit Logs')
+    XLSX.writeFile(wb, `audit-logs-${format(new Date(), 'yyyy-MM-dd')}.xlsx`)
+  }
+
+  const exportPDF = () => {
+    handleClose()
+    setExporting(true)
+    try {
+      const doc = new jsPDF({ orientation: 'landscape' })
+      doc.setFontSize(14)
+      doc.text('Audit Logs', 14, 15)
+      doc.setFontSize(10)
+      doc.text(`Exported: ${format(new Date(), 'yyyy-MM-dd HH:mm')}`, 14, 22)
+      autoTable(doc, {
+        head: [COLUMNS],
+        body: toRows(logs),
+        startY: 28,
+        styles: { fontSize: 8 },
+        headStyles: { fillColor: [33, 150, 243] },
+      })
+      doc.save(`audit-logs-${format(new Date(), 'yyyy-MM-dd')}.pdf`)
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant="outlined"
+        startIcon={exporting ? <CircularProgress size={16} /> : <GetApp />}
+        endIcon={<KeyboardArrowDown />}
+        onClick={handleOpen}
+        disabled={disabled || exporting || logs.length === 0}
+      >
+        Export
+      </Button>
+      <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
+        <MenuItem onClick={exportCSV}>Export as CSV</MenuItem>
+        <MenuItem onClick={exportExcel}>Export as Excel (.xlsx)</MenuItem>
+        <MenuItem onClick={exportPDF}>Export as PDF</MenuItem>
+      </Menu>
+    </>
+  )
+}
+
+export default ExportButton

--- a/frontend/src/pages/audit-logs/components/FilterSidebar.tsx
+++ b/frontend/src/pages/audit-logs/components/FilterSidebar.tsx
@@ -192,7 +192,7 @@ const FilterSidebar: React.FC<FilterSidebarProps> = ({ entityTypes, onApply }) =
       {/* IP Address */}
       <TextField
         fullWidth size="small" label="IP Address"
-        value={(filters as any).ipAddress || ''}
+        value={filters.ipAddress || ''}
         onChange={(e) => handleFilter({ ipAddress: e.target.value })}
         sx={{ mb: 2 }}
       />

--- a/frontend/src/pages/audit-logs/components/FilterSidebar.tsx
+++ b/frontend/src/pages/audit-logs/components/FilterSidebar.tsx
@@ -1,0 +1,264 @@
+import React, { useEffect, useState } from 'react'
+import {
+  Box, Button, Chip, Collapse, Divider, IconButton, MenuItem,
+  Paper, Stack, TextField, Tooltip, Typography, Autocomplete,
+  Dialog, DialogTitle, DialogContent, DialogActions,
+} from '@mui/material'
+import {
+  ChevronLeft, ChevronRight, FilterList, Save, Clear,
+} from '@mui/icons-material'
+import { format, subDays, startOfMonth } from 'date-fns'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
+import {
+  setFilters, clearFilters, setSidebarCollapsed,
+} from '@/store/slices/auditLogSlice'
+import { AuditAction } from '@/types'
+
+const STORAGE_KEY_COLLAPSED = 'audit-logs-sidebar-collapsed'
+const STORAGE_KEY_PRESETS = 'audit-logs-filter-presets'
+
+interface FilterPreset {
+  name: string
+  filters: Record<string, string>
+}
+
+const DATE_PRESETS: Array<{ label: string; getValue: () => { startDate?: string; endDate?: string } }> = [
+  { label: 'Today', getValue: () => ({ startDate: format(new Date(), 'yyyy-MM-dd'), endDate: format(new Date(), 'yyyy-MM-dd') }) },
+  { label: 'Yesterday', getValue: () => ({ startDate: format(subDays(new Date(), 1), 'yyyy-MM-dd'), endDate: format(subDays(new Date(), 1), 'yyyy-MM-dd') }) },
+  { label: 'Last 7 days', getValue: () => ({ startDate: format(subDays(new Date(), 7), 'yyyy-MM-dd'), endDate: format(new Date(), 'yyyy-MM-dd') }) },
+  { label: 'Last 30 days', getValue: () => ({ startDate: format(subDays(new Date(), 30), 'yyyy-MM-dd'), endDate: format(new Date(), 'yyyy-MM-dd') }) },
+  { label: 'This month', getValue: () => ({ startDate: format(startOfMonth(new Date()), 'yyyy-MM-dd'), endDate: format(new Date(), 'yyyy-MM-dd') }) },
+  { label: 'Custom', getValue: () => ({}) },
+]
+
+interface FilterSidebarProps {
+  entityTypes: string[]
+  onApply: () => void
+}
+
+const FilterSidebar: React.FC<FilterSidebarProps> = ({ entityTypes, onApply }) => {
+  const dispatch = useAppDispatch()
+  const { filters, sidebarCollapsed } = useAppSelector((state) => state.auditLogs)
+
+  const [presets, setPresets] = useState<FilterPreset[]>([])
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false)
+  const [presetName, setPresetName] = useState('')
+  const [activeDatePreset, setActiveDatePreset] = useState<string | null>(null)
+
+  // Load saved presets and sidebar state from localStorage on mount
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY_PRESETS)
+    if (stored) setPresets(JSON.parse(stored))
+    const collapsed = localStorage.getItem(STORAGE_KEY_COLLAPSED)
+    if (collapsed !== null) dispatch(setSidebarCollapsed(collapsed === 'true'))
+  }, [])
+
+  const handleCollapse = (val: boolean) => {
+    dispatch(setSidebarCollapsed(val))
+    localStorage.setItem(STORAGE_KEY_COLLAPSED, String(val))
+  }
+
+  const handleFilter = (patch: Record<string, string | undefined>) => {
+    dispatch(setFilters(patch as any))
+  }
+
+  const handleDatePreset = (label: string) => {
+    const preset = DATE_PRESETS.find((p) => p.label === label)
+    if (!preset) return
+    setActiveDatePreset(label)
+    if (label !== 'Custom') {
+      const { startDate, endDate } = preset.getValue()
+      dispatch(setFilters({ startDate, endDate }))
+    }
+  }
+
+  const handleClear = () => {
+    dispatch(clearFilters())
+    setActiveDatePreset(null)
+    onApply()
+  }
+
+  const handleSavePreset = () => {
+    const updated = [...presets, { name: presetName, filters: filters as any }]
+    setPresets(updated)
+    localStorage.setItem(STORAGE_KEY_PRESETS, JSON.stringify(updated))
+    setSaveDialogOpen(false)
+    setPresetName('')
+  }
+
+  const handleLoadPreset = (preset: FilterPreset) => {
+    dispatch(clearFilters())
+    dispatch(setFilters(preset.filters as any))
+  }
+
+  const handleDeletePreset = (name: string) => {
+    const updated = presets.filter((p) => p.name !== name)
+    setPresets(updated)
+    localStorage.setItem(STORAGE_KEY_PRESETS, JSON.stringify(updated))
+  }
+
+  if (sidebarCollapsed) {
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', pt: 1 }}>
+        <Tooltip title="Expand filters" placement="right">
+          <IconButton onClick={() => handleCollapse(false)}>
+            <ChevronRight />
+          </IconButton>
+        </Tooltip>
+        <FilterList sx={{ color: 'text.secondary', mt: 1 }} />
+      </Box>
+    )
+  }
+
+  return (
+    <Paper sx={{ p: 2, height: '100%', minWidth: 240 }}>
+      {/* Header */}
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+        <Typography variant="subtitle1" fontWeight={600}>
+          <FilterList sx={{ mr: 0.5, fontSize: 18, verticalAlign: 'middle' }} />
+          Filters
+        </Typography>
+        <Tooltip title="Collapse sidebar">
+          <IconButton size="small" onClick={() => handleCollapse(true)}>
+            <ChevronLeft />
+          </IconButton>
+        </Tooltip>
+      </Stack>
+
+      {/* Saved presets */}
+      {presets.length > 0 && (
+        <>
+          <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
+            Saved Presets
+          </Typography>
+          <Stack spacing={0.5} sx={{ mb: 2, mt: 0.5 }}>
+            {presets.map((p) => (
+              <Stack key={p.name} direction="row" justifyContent="space-between" alignItems="center">
+                <Button size="small" variant="text" onClick={() => handleLoadPreset(p)} sx={{ textAlign: 'left', justifyContent: 'flex-start' }}>
+                  {p.name}
+                </Button>
+                <IconButton size="small" onClick={() => handleDeletePreset(p.name)} title="Delete preset">
+                  <Clear fontSize="small" />
+                </IconButton>
+              </Stack>
+            ))}
+          </Stack>
+          <Divider sx={{ mb: 2 }} />
+        </>
+      )}
+
+      {/* Search */}
+      <TextField
+        fullWidth size="small" label="Search description"
+        value={filters.search || ''}
+        onChange={(e) => handleFilter({ search: e.target.value })}
+        sx={{ mb: 2 }}
+      />
+
+      {/* Action chips */}
+      <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>Action</Typography>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5, mb: 2 }}>
+        {Object.values(AuditAction).map((a) => (
+          <Chip
+            key={a}
+            label={a}
+            size="small"
+            clickable
+            color={filters.action === a ? 'primary' : 'default'}
+            onClick={() => handleFilter({ action: filters.action === a ? undefined : a })}
+          />
+        ))}
+      </Box>
+
+      {/* Entity Type */}
+      <Autocomplete
+        freeSolo
+        size="small"
+        options={entityTypes}
+        value={filters.entityType || ''}
+        onInputChange={(_e, val) => handleFilter({ entityType: val })}
+        renderInput={(params) => <TextField {...params} label="Entity Type" />}
+        sx={{ mb: 2 }}
+      />
+
+      {/* User */}
+      <TextField
+        fullWidth size="small" label="Username"
+        value={filters.username || ''}
+        onChange={(e) => handleFilter({ username: e.target.value })}
+        sx={{ mb: 2 }}
+      />
+
+      {/* IP Address */}
+      <TextField
+        fullWidth size="small" label="IP Address"
+        value={(filters as any).ipAddress || ''}
+        onChange={(e) => handleFilter({ ipAddress: e.target.value })}
+        sx={{ mb: 2 }}
+      />
+
+      {/* Date range presets */}
+      <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>Date Range</Typography>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5, mb: 1 }}>
+        {DATE_PRESETS.map((p) => (
+          <Chip
+            key={p.label}
+            label={p.label}
+            size="small"
+            clickable
+            color={activeDatePreset === p.label ? 'primary' : 'default'}
+            onClick={() => handleDatePreset(p.label)}
+          />
+        ))}
+      </Box>
+
+      {(activeDatePreset === 'Custom' || (!activeDatePreset && (filters.startDate || filters.endDate))) && (
+        <Stack spacing={1} sx={{ mb: 2 }}>
+          <TextField
+            fullWidth size="small" type="date" label="Start Date"
+            value={filters.startDate || ''}
+            onChange={(e) => handleFilter({ startDate: e.target.value })}
+            InputLabelProps={{ shrink: true }}
+          />
+          <TextField
+            fullWidth size="small" type="date" label="End Date"
+            value={filters.endDate || ''}
+            onChange={(e) => handleFilter({ endDate: e.target.value })}
+            InputLabelProps={{ shrink: true }}
+          />
+        </Stack>
+      )}
+
+      {/* Action buttons */}
+      <Divider sx={{ my: 2 }} />
+      <Stack spacing={1}>
+        <Button variant="contained" fullWidth onClick={onApply}>Apply</Button>
+        <Button variant="outlined" fullWidth startIcon={<Save />} onClick={() => setSaveDialogOpen(true)}>
+          Save Preset
+        </Button>
+        <Button variant="text" fullWidth startIcon={<Clear />} onClick={handleClear}>
+          Clear All
+        </Button>
+      </Stack>
+
+      {/* Save preset dialog */}
+      <Dialog open={saveDialogOpen} onClose={() => setSaveDialogOpen(false)}>
+        <DialogTitle>Save Filter Preset</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus fullWidth size="small" label="Preset name"
+            value={presetName}
+            onChange={(e) => setPresetName(e.target.value)}
+            sx={{ mt: 1 }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setSaveDialogOpen(false)}>Cancel</Button>
+          <Button variant="contained" onClick={handleSavePreset} disabled={!presetName.trim()}>Save</Button>
+        </DialogActions>
+      </Dialog>
+    </Paper>
+  )
+}
+
+export default FilterSidebar

--- a/frontend/src/pages/audit-logs/components/LogRow.tsx
+++ b/frontend/src/pages/audit-logs/components/LogRow.tsx
@@ -38,6 +38,12 @@ function getEntityLink(entityType: string, entityId?: string | null): string | n
     PurchaseOrder: id ? `/purchasing/orders/${id}/edit` : '/purchasing/orders',
     Account: '/accounting/chart-of-accounts',
     JournalEntry: id ? `/accounting/journal-entries/${id}` : '/accounting/journal-entries',
+    FiscalPeriod: '/accounting/fiscal-periods',
+    AccountMapping: '/accounting/account-mappings',
+    BankReconciliation: '/accounting/bank-reconciliations',
+    Settlement: '/accounting/settlements',
+    OwnerEquity: '/accounting/owner-equity',
+    Expense: '/accounting/expenses',
   }
   return map[entityType] ?? null
 }

--- a/frontend/src/pages/audit-logs/components/LogRow.tsx
+++ b/frontend/src/pages/audit-logs/components/LogRow.tsx
@@ -5,6 +5,7 @@ import {
 } from '@mui/material'
 import { KeyboardArrowDown, KeyboardArrowRight, OpenInNew } from '@mui/icons-material'
 import { format } from 'date-fns'
+import { useNavigate } from 'react-router-dom'
 import type { AuditLog } from '@/types'
 import DiffViewer from './DiffViewer'
 
@@ -65,6 +66,7 @@ function parseUserAgent(ua?: string | null): string {
 
 const LogRow: React.FC<LogRowProps> = ({ log }) => {
   const [expanded, setExpanded] = useState(false)
+  const navigate = useNavigate()
   const entityLink = getEntityLink(log.entityType, log.entityId)
   const hasDiff = log.oldValues || log.newValues
 
@@ -122,10 +124,10 @@ const LogRow: React.FC<LogRowProps> = ({ log }) => {
                 )}
                 {entityLink && (
                   <Link
-                    href={entityLink}
+                    component="button"
                     variant="caption"
                     sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
-                    onClick={(e) => e.stopPropagation()}
+                    onClick={(e) => { e.stopPropagation(); navigate(entityLink) }}
                   >
                     Go to {log.entityType} <OpenInNew sx={{ fontSize: 12 }} />
                   </Link>

--- a/frontend/src/pages/audit-logs/components/LogRow.tsx
+++ b/frontend/src/pages/audit-logs/components/LogRow.tsx
@@ -11,6 +11,7 @@ import DiffViewer from './DiffViewer'
 
 interface LogRowProps {
   log: AuditLog
+  priceListNameById: Record<string, string>
 }
 
 function getActionColor(action: string): 'default' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning' {
@@ -70,7 +71,7 @@ function parseUserAgent(ua?: string | null): string {
   return parts.length ? parts.join(' / ') : 'Unknown'
 }
 
-const LogRow: React.FC<LogRowProps> = ({ log }) => {
+const LogRow: React.FC<LogRowProps> = ({ log, priceListNameById }) => {
   const [expanded, setExpanded] = useState(false)
   const navigate = useNavigate()
   const entityLink = getEntityLink(log.entityType, log.entityId)
@@ -97,9 +98,6 @@ const LogRow: React.FC<LogRowProps> = ({ log }) => {
         <TableCell>{log.entityType}</TableCell>
         <TableCell>
           <Typography variant="body2">{log.username || log.userId}</Typography>
-          {log.username && (
-            <Typography variant="caption" color="text.secondary">{log.userId}</Typography>
-          )}
         </TableCell>
         <TableCell sx={{ maxWidth: 360 }}>
           <Typography variant="body2" noWrap>{log.description}</Typography>
@@ -144,7 +142,11 @@ const LogRow: React.FC<LogRowProps> = ({ log }) => {
 
               {/* Diff viewer */}
               {hasDiff ? (
-                <DiffViewer oldValues={log.oldValues as any} newValues={log.newValues as any} />
+                <DiffViewer
+                  oldValues={log.oldValues as any}
+                  newValues={log.newValues as any}
+                  priceListNameById={priceListNameById}
+                />
               ) : (
                 <Typography variant="body2" color="text.secondary">{log.description}</Typography>
               )}

--- a/frontend/src/pages/audit-logs/components/LogRow.tsx
+++ b/frontend/src/pages/audit-logs/components/LogRow.tsx
@@ -118,7 +118,7 @@ const LogRow: React.FC<LogRowProps> = ({ log }) => {
                   </Typography>
                 )}
                 {log.entityId && (
-                  <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+                  <Typography variant="caption" color="text.secondary">
                     Entity ID: {log.entityId}
                   </Typography>
                 )}
@@ -149,7 +149,7 @@ const LogRow: React.FC<LogRowProps> = ({ log }) => {
                   <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
                     Metadata
                   </Typography>
-                  <Box component="pre" sx={{ fontSize: '0.75rem', mt: 0.5, overflow: 'auto' }}>
+                  <Box sx={{ fontSize: '0.75rem', mt: 0.5, overflow: 'auto', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
                     {JSON.stringify(log.metadata, null, 2)}
                   </Box>
                 </Box>

--- a/frontend/src/pages/audit-logs/components/LogRow.tsx
+++ b/frontend/src/pages/audit-logs/components/LogRow.tsx
@@ -1,0 +1,163 @@
+import React, { useState } from 'react'
+import {
+  TableRow, TableCell, Chip, Box, Typography, Collapse,
+  IconButton, Link, Divider, Stack,
+} from '@mui/material'
+import { KeyboardArrowDown, KeyboardArrowRight, OpenInNew } from '@mui/icons-material'
+import { format } from 'date-fns'
+import type { AuditLog } from '@/types'
+import DiffViewer from './DiffViewer'
+
+interface LogRowProps {
+  log: AuditLog
+}
+
+function getActionColor(action: string): 'default' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning' {
+  switch (action) {
+    case 'CREATE': return 'success'
+    case 'UPDATE': return 'info'
+    case 'DELETE': case 'BULK_DELETE': return 'error'
+    case 'RESTORE': case 'BULK_RESTORE': return 'warning'
+    case 'EXPORT': case 'IMPORT': return 'primary'
+    default: return 'default'
+  }
+}
+
+function getEntityLink(entityType: string, entityId?: string | null): string | null {
+  const id = entityId
+  const map: Record<string, string> = {
+    Product: id ? `/inventory/products/${id}/edit` : '/inventory/products',
+    Category: '/inventory/categories',
+    StockAdjustment: id ? `/inventory/stock-adjustments/${id}/edit` : '/inventory/stock-adjustments',
+    Customer: '/sales/customers',
+    Order: id ? `/sales/orders/${id}/edit` : '/sales/orders',
+    SalesOrder: id ? `/sales/orders/${id}/edit` : '/sales/orders',
+    Invoice: '/sales/invoices',
+    Supplier: '/purchasing/suppliers',
+    PurchaseOrder: id ? `/purchasing/orders/${id}/edit` : '/purchasing/orders',
+    Account: '/accounting/chart-of-accounts',
+    JournalEntry: id ? `/accounting/journal-entries/${id}` : '/accounting/journal-entries',
+  }
+  return map[entityType] ?? null
+}
+
+function parseUserAgent(ua?: string | null): string {
+  if (!ua) return 'Unknown'
+  const browsers = [
+    [/Chrome\/(\S+)/, 'Chrome'],
+    [/Firefox\/(\S+)/, 'Firefox'],
+    [/Safari\/(\S+)/, 'Safari'],
+    [/Edge\/(\S+)/, 'Edge'],
+  ] as [RegExp, string][]
+  const os = [
+    [/Windows NT/, 'Windows'],
+    [/Mac OS X/, 'macOS'],
+    [/Linux/, 'Linux'],
+    [/Android/, 'Android'],
+    [/iPhone|iPad/, 'iOS'],
+  ] as [RegExp, string][]
+
+  const browser = browsers.find(([re]) => re.test(ua))
+  const operatingSystem = os.find(([re]) => re.test(ua))
+  const parts = [browser?.[1], operatingSystem?.[1]].filter(Boolean)
+  return parts.length ? parts.join(' / ') : 'Unknown'
+}
+
+const LogRow: React.FC<LogRowProps> = ({ log }) => {
+  const [expanded, setExpanded] = useState(false)
+  const entityLink = getEntityLink(log.entityType, log.entityId)
+  const hasDiff = log.oldValues || log.newValues
+
+  return (
+    <>
+      <TableRow
+        hover
+        onClick={() => setExpanded((v) => !v)}
+        sx={{ cursor: 'pointer', '& > *': { borderBottom: expanded ? 'none' : undefined } }}
+      >
+        <TableCell sx={{ width: 32, p: 0.5 }}>
+          <IconButton size="small">
+            {expanded ? <KeyboardArrowDown /> : <KeyboardArrowRight />}
+          </IconButton>
+        </TableCell>
+        <TableCell sx={{ whiteSpace: 'nowrap' }}>
+          {format(new Date(log.createdAt), 'MMM dd, yyyy HH:mm:ss')}
+        </TableCell>
+        <TableCell>
+          <Chip label={log.action} color={getActionColor(log.action)} size="small" />
+        </TableCell>
+        <TableCell>{log.entityType}</TableCell>
+        <TableCell>
+          <Typography variant="body2">{log.username || log.userId}</Typography>
+          {log.username && (
+            <Typography variant="caption" color="text.secondary">{log.userId}</Typography>
+          )}
+        </TableCell>
+        <TableCell sx={{ maxWidth: 360 }}>
+          <Typography variant="body2" noWrap>{log.description}</Typography>
+        </TableCell>
+      </TableRow>
+
+      {/* Expanded detail row */}
+      <TableRow>
+        <TableCell colSpan={6} sx={{ p: 0, border: expanded ? undefined : 'none' }}>
+          <Collapse in={expanded} unmountOnExit>
+            <Box sx={{ p: 2, bgcolor: 'background.default' }}>
+              {/* Metadata strip */}
+              <Stack direction="row" spacing={3} sx={{ mb: 2 }} flexWrap="wrap">
+                {log.ipAddress && (
+                  <Typography variant="caption" color="text.secondary">
+                    IP: <strong>{log.ipAddress}</strong>
+                  </Typography>
+                )}
+                {log.userAgent && (
+                  <Typography variant="caption" color="text.secondary">
+                    Browser: <strong>{parseUserAgent(log.userAgent)}</strong>
+                  </Typography>
+                )}
+                {log.entityId && (
+                  <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+                    Entity ID: {log.entityId}
+                  </Typography>
+                )}
+                {entityLink && (
+                  <Link
+                    href={entityLink}
+                    variant="caption"
+                    sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    Go to {log.entityType} <OpenInNew sx={{ fontSize: 12 }} />
+                  </Link>
+                )}
+              </Stack>
+
+              <Divider sx={{ mb: 2 }} />
+
+              {/* Diff viewer */}
+              {hasDiff ? (
+                <DiffViewer oldValues={log.oldValues as any} newValues={log.newValues as any} />
+              ) : (
+                <Typography variant="body2" color="text.secondary">{log.description}</Typography>
+              )}
+
+              {/* Metadata */}
+              {log.metadata && (
+                <Box sx={{ mt: 2 }}>
+                  <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
+                    Metadata
+                  </Typography>
+                  <Box component="pre" sx={{ fontSize: '0.75rem', mt: 0.5, overflow: 'auto' }}>
+                    {JSON.stringify(log.metadata, null, 2)}
+                  </Box>
+                </Box>
+              )}
+            </Box>
+          </Collapse>
+        </TableCell>
+      </TableRow>
+    </>
+  )
+}
+
+export default LogRow

--- a/frontend/src/pages/audit-logs/components/LogsTab.tsx
+++ b/frontend/src/pages/audit-logs/components/LogsTab.tsx
@@ -10,6 +10,7 @@ interface LogsTabProps {
   logs: AuditLog[]
   loading: boolean
   error: string | null
+  priceListNameById: Record<string, string>
   total: number
   page: number          // 1-based
   limit: number
@@ -19,6 +20,7 @@ interface LogsTabProps {
 
 const LogsTab: React.FC<LogsTabProps> = ({
   logs, loading, error, total, page, limit, onPageChange, onLimitChange,
+  priceListNameById,
 }) => {
   return (
     <>
@@ -52,7 +54,9 @@ const LogsTab: React.FC<LogsTabProps> = ({
                   </TableCell>
                 </TableRow>
               ) : (
-                logs.map((log) => <LogRow key={log.id} log={log} />)
+                logs.map((log) => (
+                  <LogRow key={log.id} log={log} priceListNameById={priceListNameById} />
+                ))
               )}
             </TableBody>
           </Table>

--- a/frontend/src/pages/audit-logs/components/LogsTab.tsx
+++ b/frontend/src/pages/audit-logs/components/LogsTab.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import {
+  Paper, Table, TableBody, TableCell, TableContainer, TableHead,
+  TablePagination, TableRow, CircularProgress, Typography, Alert,
+} from '@mui/material'
+import type { AuditLog } from '@/types'
+import LogRow from './LogRow'
+
+interface LogsTabProps {
+  logs: AuditLog[]
+  loading: boolean
+  error: string | null
+  total: number
+  page: number          // 1-based
+  limit: number
+  onPageChange: (page: number) => void
+  onLimitChange: (limit: number) => void
+}
+
+const LogsTab: React.FC<LogsTabProps> = ({
+  logs, loading, error, total, page, limit, onPageChange, onLimitChange,
+}) => {
+  return (
+    <>
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+      <Paper>
+        <TableContainer>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ width: 32 }} />
+                <TableCell>Date & Time</TableCell>
+                <TableCell>Action</TableCell>
+                <TableCell>Entity Type</TableCell>
+                <TableCell>User</TableCell>
+                <TableCell>Description</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {loading ? (
+                <TableRow>
+                  <TableCell colSpan={6} align="center" sx={{ py: 6 }}>
+                    <CircularProgress />
+                  </TableCell>
+                </TableRow>
+              ) : logs.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} align="center" sx={{ py: 6 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      No audit logs found
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                logs.map((log) => <LogRow key={log.id} log={log} />)
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <TablePagination
+          rowsPerPageOptions={[10, 20, 50, 100]}
+          component="div"
+          count={total}
+          rowsPerPage={limit}
+          page={page - 1}
+          onPageChange={(_e, p) => onPageChange(p + 1)}
+          onRowsPerPageChange={(e) => onLimitChange(parseInt(e.target.value, 10))}
+        />
+      </Paper>
+    </>
+  )
+}
+
+export default LogsTab

--- a/frontend/src/services/auditLogApi.ts
+++ b/frontend/src/services/auditLogApi.ts
@@ -14,6 +14,7 @@ export interface AuditLogFilters {
   endDate?: string
   sortBy?: string
   sortOrder?: 'ASC' | 'DESC'
+  ipAddress?: string
 }
 
 export interface AuditLogStatistics {

--- a/frontend/src/store/slices/auditLogSlice.ts
+++ b/frontend/src/store/slices/auditLogSlice.ts
@@ -21,9 +21,12 @@ interface AuditLogState {
     entityId?: string
     userId?: string
     username?: string
+    ipAddress?: string
     startDate?: string
     endDate?: string
   }
+  activeTab: 'logs' | 'analytics'
+  sidebarCollapsed: boolean
 }
 
 const initialState: AuditLogState = {
@@ -41,6 +44,8 @@ const initialState: AuditLogState = {
   filters: {
     search: '',
   },
+  activeTab: 'logs' as const,
+  sidebarCollapsed: false,
 }
 
 // Async thunks
@@ -90,6 +95,12 @@ const auditLogSlice = createSlice({
     setLimit: (state, action: PayloadAction<number>) => {
       state.pagination.limit = action.payload
     },
+    setActiveTab: (state, action: PayloadAction<'logs' | 'analytics'>) => {
+      state.activeTab = action.payload
+    },
+    setSidebarCollapsed: (state, action: PayloadAction<boolean>) => {
+      state.sidebarCollapsed = action.payload
+    },
   },
   extraReducers: (builder) => {
     // Fetch audit logs
@@ -131,6 +142,8 @@ export const {
   clearFilters,
   setPage,
   setLimit,
+  setActiveTab,
+  setSidebarCollapsed,
 } = auditLogSlice.actions
 
 export default auditLogSlice.reducer


### PR DESCRIPTION
## Summary

- All audit log entries previously showed `userId: 'system'` and `username: null` because controllers never extracted the authenticated user from the JWT. The frontend fell back to displaying `'system'` for every action.
- Added `@CurrentUser('userId')` and `@CurrentUser('username')` to every mutating controller method across all modules (Inventory, Sales, Purchasing, Accounting — 19 controller/service pairs, ~45 service methods).
- Threaded both values through service method signatures into every `auditLogService.log()` options object. The `AuditLogService`, audit log entity, and frontend already supported `username` — no changes needed there.
- Fixed several pre-existing gaps found during review: missing audit logs in bulk loops, hardcoded `'system'` in domain actions (`receiveGoods`, `returnGoods`, `cancel`, `remove`, `postOpeningBalances`, `seedDefaults`), misleading `= 'system'` defaults on service signatures.
- Updated 8 test specs to reflect the new `username` argument on auto-post accounting calls. Fixed a dangling `updatedProduct` reference left from debug log cleanup.

## Modules covered

| Module | Controllers updated |
|---|---|
| Inventory | product, category, stock-adjustment |
| Sales | sales-order, customer, invoice, payment |
| Purchasing | purchase-order (incl. receiveGoods/returnGoods), supplier, goods-received-note, vendor-payment |
| Accounting | journal-entry, account-mapping, fiscal-period, chart-of-accounts, reconciliation, settlement, expense, owner-equity |
| Accounting auto-post | postSalesOrderEntry, postCustomerPaymentEntry, postSettlementEntry, postGoodsReceivedEntry, postVendorPaymentEntry, postStockAdjustmentEntry, postOwnerEquityEntry, postExpenseEntry, postOpeningBalances |

## Known gaps (follow-on work)

- `sales-order`: `unfulfillOrder`, `recordPayment`, `recordPayments`, `unpayOrder` — still hardcoded `'system'`
- `purchase-order`: `markAsPaid`, `markAsUnpaid`, `recordPayment`, `recordOrderPayments` — no user context
- `payment`: `processPayment()` calls `create()` without user identity

## Test plan

- [x] `npm run test` — 28/28 suites, 503/503 tests passing
- [x] `npm run lint` — no errors
- [ ] Deploy and verify audit log UI shows real usernames instead of `system` for new actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)