### PR TITLE
feat: improve customers page to standard ERP UX

### DIFF
--- a/backend/src/modules/sales/services/customer.service.ts
+++ b/backend/src/modules/sales/services/customer.service.ts
@@ -413,6 +413,7 @@ export class CustomerService {
         totalAmount: Number(invoice.totalAmount),
         paidAmount: Number(invoice.paidAmount),
         balanceDue: Number(invoice.balanceDue),
+        salesOrderId: invoice.salesOrderId ?? null,
         // daysPastDue and isOverdue removed as they depend on dueDate
       })),
     };

--- a/frontend/src/pages/sales/CustomerProfilePage.tsx
+++ b/frontend/src/pages/sales/CustomerProfilePage.tsx
@@ -72,6 +72,7 @@ interface SalesOrder {
   isFulfilled: boolean
   isPaid: boolean
   totalAmount: number
+  itemsCount: number
 }
 
 interface OutstandingInvoice {
@@ -79,6 +80,7 @@ interface OutstandingInvoice {
   invoiceNumber: string
   invoiceDate: string
   totalAmount: number
+  paidAmount: number
   balanceDue: number
   salesOrderId: string | null
 }

--- a/frontend/src/pages/sales/CustomerProfilePage.tsx
+++ b/frontend/src/pages/sales/CustomerProfilePage.tsx
@@ -1,0 +1,428 @@
+import React, { useEffect, useState } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Divider,
+  Grid,
+  Paper,
+  Stack,
+  Tab,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tabs,
+  Typography,
+} from '@mui/material'
+import {
+  ArrowBack as BackIcon,
+  Delete as DeleteIcon,
+  Edit as EditIcon,
+  LocationOn as LocationIcon,
+  People as CustomersIcon,
+  Phone as PhoneIcon,
+} from '@mui/icons-material'
+import { useNavigate, useParams } from 'react-router-dom'
+import { useAppDispatch } from '@/hooks/useRedux'
+import { useNotification } from '@/hooks/useNotification'
+import { salesApi } from '@/services/salesApi'
+import { deleteCustomer } from '@/store/slices/customerSlice'
+import type { Customer } from '@/types'
+import { CustomerType } from '@/types'
+import { TABLE_STYLES } from '@/constants/typography'
+import { formatCurrency } from '@/utils/currency'
+import { formatDate } from '@/utils/formatters'
+import ConfirmationDialog from '@/components/common/ConfirmationDialog'
+
+interface TabPanelProps {
+  children?: React.ReactNode
+  index: number
+  value: number
+}
+
+function TabPanel({ children, value, index }: TabPanelProps) {
+  return (
+    <Box role="tabpanel" hidden={value !== index} sx={{ pt: 3 }}>
+      {value === index && children}
+    </Box>
+  )
+}
+
+interface CustomerStatistics {
+  orders: {
+    totalOrders: number
+    totalSales: number
+    averageOrderValue: number
+    firstOrderDate: string | null
+    lastOrderDate: string | null
+  }
+}
+
+interface SalesOrder {
+  id: string
+  orderNumber: string
+  orderDate: string
+  isFulfilled: boolean
+  isPaid: boolean
+  totalAmount: number
+}
+
+interface OutstandingInvoice {
+  id: string
+  invoiceNumber: string
+  invoiceDate: string
+  totalAmount: number
+  balanceDue: number
+  salesOrderId: string | null
+}
+
+const CustomerProfilePage: React.FC = () => {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const dispatch = useAppDispatch()
+  const { showSuccess, showError } = useNotification()
+
+  const [customer, setCustomer] = useState<Customer | null>(null)
+  const [statistics, setStatistics] = useState<CustomerStatistics | null>(null)
+  const [orders, setOrders] = useState<SalesOrder[]>([])
+  const [invoices, setInvoices] = useState<OutstandingInvoice[]>([])
+  const [totalOutstanding, setTotalOutstanding] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [tabValue, setTabValue] = useState(0)
+  const [ordersLoaded, setOrdersLoaded] = useState(false)
+  const [invoicesLoaded, setInvoicesLoaded] = useState(false)
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false)
+  const [deleteLoading, setDeleteLoading] = useState(false)
+
+  useEffect(() => {
+    if (!id) return
+    setLoading(true)
+    Promise.all([salesApi.getCustomer(id), salesApi.getCustomerStatistics(id)])
+      .then(([cust, stats]) => {
+        setCustomer(cust as unknown as Customer)
+        setStatistics(stats as unknown as CustomerStatistics)
+      })
+      .catch(() => setError('Customer not found.'))
+      .finally(() => setLoading(false))
+  }, [id])
+
+  useEffect(() => {
+    if (tabValue === 1 && !ordersLoaded && id) {
+      salesApi
+        .getCustomerSalesHistory(id)
+        .then((res: any) => setOrders(res.orders ?? []))
+        .catch(() => {})
+        .finally(() => setOrdersLoaded(true))
+    }
+  }, [tabValue, ordersLoaded, id])
+
+  useEffect(() => {
+    if (tabValue === 2 && !invoicesLoaded && id) {
+      salesApi
+        .getOutstandingInvoices(id)
+        .then((res: any) => {
+          setInvoices(res.invoices ?? [])
+          setTotalOutstanding(res.totalOutstanding ?? 0)
+        })
+        .catch(() => {})
+        .finally(() => setInvoicesLoaded(true))
+    }
+  }, [tabValue, invoicesLoaded, id])
+
+  const handleDelete = async () => {
+    if (!id) return
+
+    setDeleteLoading(true)
+    try {
+      await dispatch(deleteCustomer(id)).unwrap()
+      showSuccess('Customer deleted successfully.')
+      navigate('/sales/customers')
+    } catch (err: any) {
+      const payload = err?.payload || err
+      const backendError = payload?.response?.data
+      if (backendError?.message) {
+        showError(backendError.message)
+      } else {
+        showError('Failed to delete customer.')
+      }
+    } finally {
+      setDeleteLoading(false)
+      setIsDeleteOpen(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ p: 3, display: 'flex', justifyContent: 'center', pt: 10 }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  if (error || !customer) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error ?? 'Customer not found.'}
+        </Alert>
+        <Button startIcon={<BackIcon />} onClick={() => navigate('/sales/customers')}>
+          Back to Customers
+        </Button>
+      </Box>
+    )
+  }
+
+  const fullAddress = [
+    customer.streetAddress,
+    [customer.city, customer.state, customer.postalCode].filter(Boolean).join(', '),
+    customer.country,
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+        <Button startIcon={<BackIcon />} onClick={() => navigate('/sales/customers')}>
+          Back to Customers
+        </Button>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button
+            variant="outlined"
+            startIcon={<EditIcon />}
+            onClick={() => navigate('/sales/customers', { state: { editCustomerId: customer.id } })}
+          >
+            Edit
+          </Button>
+          <Button variant="outlined" color="error" startIcon={<DeleteIcon />} onClick={() => setIsDeleteOpen(true)}>
+            Delete
+          </Button>
+        </Box>
+      </Box>
+
+      <Paper sx={{ p: 3, mb: 3 }}>
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, mb: 1 }}>
+          <CustomersIcon sx={{ fontSize: 40, color: 'primary.main', mt: 0.5 }} />
+          <Box sx={{ flex: 1 }}>
+            <Typography variant="h4" fontWeight={700} sx={{ mb: 1 }}>
+              {customer.name}
+            </Typography>
+            <Stack direction="row" spacing={1} sx={{ mb: 1 }}>
+              <Chip label={customer.isActive ? 'Active' : 'Inactive'} color={customer.isActive ? 'success' : 'default'} size="small" />
+              <Chip
+                label={customer.type === CustomerType.BUSINESS ? 'Business' : 'Individual'}
+                size="small"
+                variant="outlined"
+              />
+            </Stack>
+            <Stack spacing={0.5}>
+              {customer.phone && (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <PhoneIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                  <Typography variant="body2">{customer.phone}</Typography>
+                </Box>
+              )}
+              {fullAddress && (
+                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+                  <LocationIcon sx={{ fontSize: 16, color: 'text.secondary', mt: 0.2 }} />
+                  <Typography variant="body2" sx={{ whiteSpace: 'pre-line' }}>
+                    {fullAddress}
+                  </Typography>
+                </Box>
+              )}
+            </Stack>
+          </Box>
+        </Box>
+      </Paper>
+
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs value={tabValue} onChange={(_, value) => setTabValue(value)}>
+          <Tab label="Overview" />
+          <Tab label="Orders" />
+          <Tab label="Invoices" />
+        </Tabs>
+      </Box>
+
+      <TabPanel value={tabValue} index={0}>
+        <Grid container spacing={2} sx={{ mb: 3 }}>
+          {[
+            { label: 'Total Orders', value: customer.totalOrders },
+            { label: 'Total Sales', value: formatCurrency(customer.totalSales) },
+            { label: 'Avg Order Value', value: formatCurrency(statistics?.orders.averageOrderValue ?? 0) },
+            { label: 'Last Purchase', value: customer.lastPurchaseDate ? formatDate(customer.lastPurchaseDate) : '—' },
+          ].map(({ label, value }) => (
+            <Grid key={label} size={{ xs: 6, md: 3 }}>
+              <Card variant="outlined">
+                <CardContent sx={{ textAlign: 'center', py: 2 }}>
+                  <Typography variant="h5" fontWeight={700}>
+                    {value}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {label}
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+
+        <Stack spacing={1.5}>
+          {customer.priceList && (
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              <Typography color="text.secondary" sx={{ minWidth: 140 }}>
+                Price List:
+              </Typography>
+              <Chip label={customer.priceList.name} size="small" />
+            </Box>
+          )}
+          {statistics?.orders.firstOrderDate && (
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              <Typography color="text.secondary" sx={{ minWidth: 140 }}>
+                First Purchase:
+              </Typography>
+              <Typography>{formatDate(statistics.orders.firstOrderDate)}</Typography>
+            </Box>
+          )}
+          {customer.notes && (
+            <>
+              <Divider />
+              <Box>
+                <Typography color="text.secondary" gutterBottom>
+                  Notes:
+                </Typography>
+                <Typography>{customer.notes}</Typography>
+              </Box>
+            </>
+          )}
+        </Stack>
+      </TabPanel>
+
+      <TabPanel value={tabValue} index={1}>
+        {!ordersLoaded ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress />
+          </Box>
+        ) : orders.length === 0 ? (
+          <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+            No orders found.
+          </Typography>
+        ) : (
+          <TableContainer component={Paper} variant="outlined">
+            <Table size={TABLE_STYLES.size}>
+              <TableHead>
+                <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50' } }}>
+                  <TableCell>Order #</TableCell>
+                  <TableCell>Date</TableCell>
+                  <TableCell>Status</TableCell>
+                  <TableCell align="right">Total</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {orders.map((order) => (
+                  <TableRow
+                    key={order.id}
+                    hover
+                    sx={{ cursor: 'pointer' }}
+                    onClick={() => navigate(`/sales/orders/${order.id}/edit`)}
+                  >
+                    <TableCell>
+                      <Typography variant="body2" color="primary" fontWeight={600}>
+                        {order.orderNumber}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>{formatDate(order.orderDate)}</TableCell>
+                    <TableCell>
+                      <Chip
+                        label={order.isFulfilled ? 'Fulfilled' : order.isPaid ? 'Paid' : 'Pending'}
+                        size="small"
+                        color={order.isFulfilled ? 'success' : order.isPaid ? 'primary' : 'default'}
+                      />
+                    </TableCell>
+                    <TableCell align="right">{formatCurrency(order.totalAmount)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </TabPanel>
+
+      <TabPanel value={tabValue} index={2}>
+        {!invoicesLoaded ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress />
+          </Box>
+        ) : invoices.length === 0 ? (
+          <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+            No outstanding invoices.
+          </Typography>
+        ) : (
+          <>
+            <Box sx={{ mb: 2, display: 'flex', justifyContent: 'flex-end' }}>
+              <Typography variant="subtitle2" color="text.secondary">
+                Total Outstanding: <strong>{formatCurrency(totalOutstanding)}</strong>
+              </Typography>
+            </Box>
+            <TableContainer component={Paper} variant="outlined">
+              <Table size={TABLE_STYLES.size}>
+                <TableHead>
+                  <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50' } }}>
+                    <TableCell>Invoice #</TableCell>
+                    <TableCell>Date</TableCell>
+                    <TableCell align="right">Total</TableCell>
+                    <TableCell align="right">Balance Due</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {invoices.map((invoice) => (
+                    <TableRow
+                      key={invoice.id}
+                      hover
+                      sx={{ cursor: invoice.salesOrderId ? 'pointer' : 'default' }}
+                      onClick={() => invoice.salesOrderId && navigate(`/sales/orders/${invoice.salesOrderId}/edit`)}
+                    >
+                      <TableCell>
+                        <Typography variant="body2" color={invoice.salesOrderId ? 'primary' : 'text.primary'} fontWeight={600}>
+                          {invoice.invoiceNumber}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>{formatDate(invoice.invoiceDate)}</TableCell>
+                      <TableCell align="right">{formatCurrency(invoice.totalAmount)}</TableCell>
+                      <TableCell align="right">
+                        <Typography fontWeight={600} color="error.main">
+                          {formatCurrency(invoice.balanceDue)}
+                        </Typography>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </>
+        )}
+      </TabPanel>
+
+      <ConfirmationDialog
+        open={isDeleteOpen}
+        title="Confirm Delete"
+        message={`Are you sure you want to delete "${customer.name}"? This will move them to deleted items.`}
+        confirmText="Delete Customer"
+        cancelText="Cancel"
+        onConfirm={handleDelete}
+        onCancel={() => setIsDeleteOpen(false)}
+        severity="warning"
+        loading={deleteLoading}
+      />
+    </Box>
+  )
+}
+
+export default CustomerProfilePage

--- a/frontend/src/pages/sales/CustomersPage.tsx
+++ b/frontend/src/pages/sales/CustomersPage.tsx
@@ -44,7 +44,7 @@ import {
   TrendingUp as SalesIcon,
   LocationOn as LocationIcon,
 } from '@mui/icons-material'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { useForm, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
@@ -103,6 +103,7 @@ interface CustomerFormData {
 const CustomersPage: React.FC = () => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('md'))
+  const location = useLocation()
   const navigate = useNavigate()
   const dispatch = useAppDispatch()
   const { showSuccess, showError } = useNotification()
@@ -228,6 +229,19 @@ const CustomersPage: React.FC = () => {
   useEffect(() => {
     dispatch(fetchCustomers({ ...filters }))
   }, [dispatch, filters.search, filters.type, filters.isActive, filters.priceListId, filters.sortBy, filters.sortOrder])
+
+  useEffect(() => {
+    const state = location.state as { editCustomerId?: string } | null
+    if (!state?.editCustomerId) {
+      return
+    }
+
+    const customerToEdit = customers.find(c => c.id === state.editCustomerId)
+    if (customerToEdit) {
+      handleOpenForm(customerToEdit)
+      navigate('/sales/customers', { replace: true, state: {} })
+    }
+  }, [location.state, customers, navigate])
 
   // Handle form submit
   const handleFormSubmit = async (data: CustomerFormData) => {

--- a/frontend/src/pages/sales/CustomersPage.tsx
+++ b/frontend/src/pages/sales/CustomersPage.tsx
@@ -230,19 +230,6 @@ const CustomersPage: React.FC = () => {
     dispatch(fetchCustomers({ ...filters }))
   }, [dispatch, filters.search, filters.type, filters.isActive, filters.priceListId, filters.sortBy, filters.sortOrder])
 
-  useEffect(() => {
-    const state = location.state as { editCustomerId?: string } | null
-    if (!state?.editCustomerId) {
-      return
-    }
-
-    const customerToEdit = customers.find(c => c.id === state.editCustomerId)
-    if (customerToEdit) {
-      handleOpenForm(customerToEdit)
-      navigate('/sales/customers', { replace: true, state: {} })
-    }
-  }, [location.state, customers, navigate])
-
   // Handle form submit
   const handleFormSubmit = async (data: CustomerFormData) => {
     try {
@@ -325,7 +312,7 @@ const CustomersPage: React.FC = () => {
 
 
   // Form helpers
-  const handleOpenForm = (customer?: Customer) => {
+  const handleOpenForm = useCallback((customer?: Customer) => {
     setPhoneError(null)
     setIsCheckingPhone(false)
     if (customer) {
@@ -360,7 +347,21 @@ const CustomersPage: React.FC = () => {
       })
     }
     setIsFormOpen(true)
-  }
+  }, [reset, setSelectedCustomer, setPhoneValue, setPhoneError, setIsCheckingPhone, setIsFormOpen])
+
+  // Handle edit-from-profile navigation: list page receives editCustomerId in route state
+  useEffect(() => {
+    const state = location.state as { editCustomerId?: string } | null
+    if (!state?.editCustomerId) {
+      return
+    }
+
+    const customerToEdit = customers.find(c => c.id === state.editCustomerId)
+    if (customerToEdit) {
+      handleOpenForm(customerToEdit)
+      navigate('/sales/customers', { replace: true, state: {} })
+    }
+  }, [location.state, customers, navigate, handleOpenForm])
 
   const handleCloseForm = () => {
     setIsFormOpen(false)

--- a/frontend/src/pages/sales/CustomersPage.tsx
+++ b/frontend/src/pages/sales/CustomersPage.tsx
@@ -44,6 +44,7 @@ import {
   TrendingUp as SalesIcon,
   LocationOn as LocationIcon,
 } from '@mui/icons-material'
+import { useNavigate } from 'react-router-dom'
 import { useForm, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
@@ -102,6 +103,7 @@ interface CustomerFormData {
 const CustomersPage: React.FC = () => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('md'))
+  const navigate = useNavigate()
   const dispatch = useAppDispatch()
   const { showSuccess, showError } = useNotification()
 
@@ -114,7 +116,6 @@ const CustomersPage: React.FC = () => {
   // Local state
   const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(null)
   const [isFormOpen, setIsFormOpen] = useState(false)
-  const [isViewOpen, setIsViewOpen] = useState(false)
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false)
   const [isDeletedDialogOpen, setIsDeletedDialogOpen] = useState(false)
   const [phoneValue, setPhoneValue] = useState<string>('')
@@ -357,8 +358,7 @@ const CustomersPage: React.FC = () => {
   }
 
   const handleViewCustomer = (customer: Customer) => {
-    setSelectedCustomer(customer)
-    setIsViewOpen(true)
+    navigate(`/sales/customers/${customer.id}`)
   }
 
   const handleSort = (sortBy: string) => {
@@ -756,9 +756,14 @@ const CustomersPage: React.FC = () => {
                         <Typography variant={TYPOGRAPHY_STYLES.tableCell.primary.variant} sx={{
                           fontWeight: 400,
                           fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize,
-                          lineHeight: TYPOGRAPHY_STYLES.tableCell.primary.lineHeight
+                          lineHeight: TYPOGRAPHY_STYLES.tableCell.primary.lineHeight,
+                          cursor: 'pointer',
+                          color: 'primary.main',
+                          '&:hover': { textDecoration: 'underline' }
                         }}>
-                          {customer.name}
+                          <Box component="span" onClick={() => navigate(`/sales/customers/${customer.id}`)}>
+                            {customer.name}
+                          </Box>
                         </Typography>
                       </Box>
                       {/* Mobile-only type, price level, and active status indicators */}
@@ -1205,129 +1210,6 @@ const CustomersPage: React.FC = () => {
             </Button>
           </DialogActions>
         </form>
-      </Dialog>
-      {/* Customer Details Dialog */}
-      <Dialog
-        open={isViewOpen}
-        onClose={() => setIsViewOpen(false)}
-        maxWidth="md"
-        fullWidth
-      >
-        <DialogTitle>Customer Details</DialogTitle>
-        <DialogContent dividers>
-          {selectedCustomer && (
-            <Grid container spacing={2}>
-              <Grid size={12}>
-                <Box sx={{ mb: 2 }}>
-                  <Typography variant="h5" fontWeight={600} sx={{ mb: 1 }}>
-                    {selectedCustomer.name}
-                  </Typography>
-                  {getActiveStatusChip(selectedCustomer.isActive)}
-                </Box>
-              </Grid>
-
-              <Grid
-                size={{
-                  xs: 12,
-                  md: 6
-                }}>
-                <Typography variant="h6" gutterBottom>Contact Information</Typography>
-                <Stack spacing={1}>
-                  {selectedCustomer.phone && (
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                      <PhoneIcon sx={{ fontSize: 18, color: 'text.secondary' }} />
-                      <Typography>{selectedCustomer.phone}</Typography>
-                    </Box>
-                  )}
-                </Stack>
-              </Grid>
-
-              <Grid
-                size={{
-                  xs: 12,
-                  md: 6
-                }}>
-                <Typography variant="h6" gutterBottom>Address</Typography>
-                <Stack spacing={1}>
-                  {((selectedCustomer as any).streetAddress || (selectedCustomer as any).city || (selectedCustomer as any).state || (selectedCustomer as any).postalCode || (selectedCustomer as any).country) ? (
-                    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
-                      <LocationIcon sx={{ fontSize: 18, color: 'text.secondary', mt: 0.25 }} />
-                      <Box>
-                        {(selectedCustomer as any).streetAddress && (
-                          <Typography>{(selectedCustomer as any).streetAddress}</Typography>
-                        )}
-                        {((selectedCustomer as any).city || (selectedCustomer as any).state || (selectedCustomer as any).postalCode) && (
-                          <Typography>
-                            {[(selectedCustomer as any).city, (selectedCustomer as any).state, (selectedCustomer as any).postalCode]
-                              .filter(Boolean)
-                              .join(', ')}
-                          </Typography>
-                        )}
-                        {(selectedCustomer as any).country && (
-                          <Typography>{(selectedCustomer as any).country}</Typography>
-                        )}
-                      </Box>
-                    </Box>
-                  ) : (
-                    <Typography color="text.secondary" variant="body2">No address provided</Typography>
-                  )}
-                </Stack>
-              </Grid>
-
-              <Grid
-                size={{
-                  xs: 12,
-                  md: 6
-                }}>
-                <Typography variant="h6" gutterBottom>Sales Statistics</Typography>
-                <Stack spacing={1}>
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                    <Typography color="text.secondary">Total Orders:</Typography>
-                    <Typography fontWeight={600}>{selectedCustomer.totalOrders}</Typography>
-                  </Box>
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                    <Typography color="text.secondary">Total Sales:</Typography>
-                    <Typography fontWeight={600}>{formatCurrency(selectedCustomer.totalSales)}</Typography>
-                  </Box>
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                    <Typography color="text.secondary">Average Order:</Typography>
-                    <Typography fontWeight={600}>{formatCurrency(selectedCustomer.averageOrderValue)}</Typography>
-                  </Box>
-                  {selectedCustomer.lastPurchaseDate && (
-                    <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                      <Typography color="text.secondary">Last Purchase:</Typography>
-                      <Typography fontWeight={600}>
-                        {formatDate(selectedCustomer.lastPurchaseDate)}
-                      </Typography>
-                    </Box>
-                  )}
-                </Stack>
-              </Grid>
-
-              {selectedCustomer.notes && (
-                <Grid size={12}>
-                  <Typography variant="h6" gutterBottom>Notes</Typography>
-                  <Typography>{selectedCustomer.notes}</Typography>
-                </Grid>
-              )}
-            </Grid>
-          )}
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setIsViewOpen(false)}>
-            Close
-          </Button>
-          <Button 
-            variant="contained"
-            startIcon={<EditIcon />}
-            onClick={() => {
-              setIsViewOpen(false)
-              selectedCustomer && handleOpenForm(selectedCustomer)
-            }}
-          >
-            Edit
-          </Button>
-        </DialogActions>
       </Dialog>
       {/* Delete Confirmation Dialog */}
       <ConfirmationDialog

--- a/frontend/src/pages/sales/CustomersPage.tsx
+++ b/frontend/src/pages/sales/CustomersPage.tsx
@@ -23,6 +23,7 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  TableSortLabel,
   Alert,
   CircularProgress,
   useTheme,
@@ -225,7 +226,7 @@ const CustomersPage: React.FC = () => {
   // Load customers on mount and when filters change
   useEffect(() => {
     dispatch(fetchCustomers({ ...filters }))
-  }, [dispatch, filters.search, filters.type, filters.priceListId, filters.sortBy, filters.sortOrder])
+  }, [dispatch, filters.search, filters.type, filters.isActive, filters.priceListId, filters.sortBy, filters.sortOrder])
 
   // Handle form submit
   const handleFormSubmit = async (data: CustomerFormData) => {
@@ -358,6 +359,13 @@ const CustomersPage: React.FC = () => {
   const handleViewCustomer = (customer: Customer) => {
     setSelectedCustomer(customer)
     setIsViewOpen(true)
+  }
+
+  const handleSort = (sortBy: string) => {
+    dispatch(setFilters({
+      sortBy,
+      sortOrder: filters.sortBy === sortBy && filters.sortOrder === 'ASC' ? 'DESC' : 'ASC',
+    }))
   }
 
 
@@ -524,6 +532,53 @@ const CustomersPage: React.FC = () => {
             <MenuItem value={CustomerType.BUSINESS} sx={{ fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize }}>Business</MenuItem>
           </Select>
         </FormControl>
+        <FormControl
+          size="medium"
+          sx={{
+            minWidth: isMobile ? 'auto' : 120,
+            flex: 'none'
+          }}
+        >
+          <InputLabel
+            id="customer-status-filter-label"
+            sx={{
+              fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+              '&.MuiInputLabel-shrunk': {
+                fontSize: TYPOGRAPHY_STYLES.tableCell.caption.fontSize
+              }
+            }}
+          >
+            Status
+          </InputLabel>
+          <Select
+            labelId="customer-status-filter-label"
+            id="customer-status-filter"
+            value={filters.isActive === undefined ? 'all' : filters.isActive ? 'active' : 'inactive'}
+            label="Status"
+            onChange={(e) => {
+              const val = e.target.value
+              dispatch(setFilters({
+                isActive: val === 'all' ? undefined : val === 'active'
+              }))
+            }}
+            sx={{
+              height: TYPOGRAPHY_STYLES.searchField.input.height,
+              fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+              '& .MuiSelect-select': {
+                display: 'flex',
+                alignItems: 'center',
+                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                padding: '8.5px 14px',
+                height: TYPOGRAPHY_STYLES.searchField.input.height,
+                boxSizing: 'border-box'
+              },
+            }}
+          >
+            <MenuItem value="all" sx={{ fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize }}>All</MenuItem>
+            <MenuItem value="active" sx={{ fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize }}>Active</MenuItem>
+            <MenuItem value="inactive" sx={{ fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize }}>Inactive</MenuItem>
+          </Select>
+        </FormControl>
       </Box>
       </Paper>
       {/* Error Alert */}
@@ -549,13 +604,18 @@ const CustomersPage: React.FC = () => {
             <TableHead>
               <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50', py: 1 } }}>
                 <TableCell sx={{ width: isMobile ? '35%' : '30%' }}>
-                  <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
-                    fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                    color: TYPOGRAPHY_STYLES.tableHeader.color,
-                    fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
-                  }}>
-                    Customer
-                  </Typography>
+                  <TableSortLabel
+                    active={filters.sortBy === 'name'}
+                    direction={filters.sortBy === 'name' ? (filters.sortOrder?.toLowerCase() as 'asc' | 'desc') : 'asc'}
+                    onClick={() => handleSort('name')}
+                    sx={{
+                      fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
+                      color: TYPOGRAPHY_STYLES.tableHeader.color,
+                      fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
+                    }}
+                  >
+                    Name
+                  </TableSortLabel>
                 </TableCell>
                 {!isMobile && (
                   <TableCell sx={{ width: '10%' }}>
@@ -589,13 +649,61 @@ const CustomersPage: React.FC = () => {
                   </TableCell>
                 )}
                 {!isMobile && (
+                  <TableCell sx={{ width: '8%' }}>
+                    <TableSortLabel
+                      active={filters.sortBy === 'totalOrders'}
+                      direction={filters.sortBy === 'totalOrders' ? (filters.sortOrder?.toLowerCase() as 'asc' | 'desc') : 'asc'}
+                      onClick={() => handleSort('totalOrders')}
+                      sx={{
+                        fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
+                        color: TYPOGRAPHY_STYLES.tableHeader.color,
+                        fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
+                      }}
+                    >
+                      Total Orders
+                    </TableSortLabel>
+                  </TableCell>
+                )}
+                {!isMobile && (
                   <TableCell sx={{ width: '10%' }}>
+                    <TableSortLabel
+                      active={filters.sortBy === 'totalSales'}
+                      direction={filters.sortBy === 'totalSales' ? (filters.sortOrder?.toLowerCase() as 'asc' | 'desc') : 'asc'}
+                      onClick={() => handleSort('totalSales')}
+                      sx={{
+                        fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
+                        color: TYPOGRAPHY_STYLES.tableHeader.color,
+                        fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
+                      }}
+                    >
+                      Total Sales
+                    </TableSortLabel>
+                  </TableCell>
+                )}
+                {!isMobile && (
+                  <TableCell sx={{ width: '10%' }}>
+                    <TableSortLabel
+                      active={filters.sortBy === 'lastPurchaseDate'}
+                      direction={filters.sortBy === 'lastPurchaseDate' ? (filters.sortOrder?.toLowerCase() as 'asc' | 'desc') : 'asc'}
+                      onClick={() => handleSort('lastPurchaseDate')}
+                      sx={{
+                        fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
+                        color: TYPOGRAPHY_STYLES.tableHeader.color,
+                        fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
+                      }}
+                    >
+                      Last Purchase
+                    </TableSortLabel>
+                  </TableCell>
+                )}
+                {!isMobile && (
+                  <TableCell sx={{ width: '8%' }}>
                     <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
                     fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
                     color: TYPOGRAPHY_STYLES.tableHeader.color,
                     fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
                   }}>
-                      Sales
+                      Status
                     </Typography>
                   </TableCell>
                 )}
@@ -728,14 +836,28 @@ const CustomersPage: React.FC = () => {
                     )}
                     {!isMobile && (
                       <TableCell>
-                        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
-                          <Typography variant={TYPOGRAPHY_STYLES.tableCell.caption.variant} color="text.secondary" sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.caption.fontSize }}>
-                            {customer.totalOrders} orders
-                          </Typography>
-                          <Typography variant={TYPOGRAPHY_STYLES.tableCell.caption.variant} color="text.secondary" sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.caption.fontSize }}>
-                            {formatCurrency(customer.totalSales)}
-                          </Typography>
-                        </Box>
+                        <Typography variant={TYPOGRAPHY_STYLES.tableCell.caption.variant} color="text.secondary" sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.caption.fontSize }}>
+                          {customer.totalOrders}
+                        </Typography>
+                      </TableCell>
+                    )}
+                    {!isMobile && (
+                      <TableCell>
+                        <Typography variant={TYPOGRAPHY_STYLES.tableCell.caption.variant} color="text.secondary" sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.caption.fontSize }}>
+                          {formatCurrency(customer.totalSales)}
+                        </Typography>
+                      </TableCell>
+                    )}
+                    {!isMobile && (
+                      <TableCell>
+                        <Typography variant={TYPOGRAPHY_STYLES.tableCell.caption.variant} color="text.secondary" sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.caption.fontSize }}>
+                          {customer.lastPurchaseDate ? formatDate(customer.lastPurchaseDate) : 'Never'}
+                        </Typography>
+                      </TableCell>
+                    )}
+                    {!isMobile && (
+                      <TableCell>
+                        {getActiveStatusChip(customer.isActive)}
                       </TableCell>
                     )}
                     <TableCell align="right">

--- a/frontend/src/pages/sales/__tests__/CustomerProfilePage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CustomerProfilePage.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { configureStore } from '@reduxjs/toolkit'
+import customerReducer from '@/store/slices/customerSlice'
+import CustomerProfilePage from '../CustomerProfilePage'
+
+const mockCustomer = vi.hoisted(() => ({
+  id: 'test-uuid-1',
+  name: 'Acme Corp',
+  type: 'business',
+  phone: '+1 234 567 890',
+  isActive: true,
+  totalOrders: 5,
+  totalSales: 15000,
+  averageOrderValue: 3000,
+  lastPurchaseDate: '2026-01-15T00:00:00Z',
+  firstPurchaseDate: '2025-06-01T00:00:00Z',
+  notes: 'VIP customer',
+  streetAddress: '123 Main St',
+  city: 'New York',
+  state: 'NY',
+  postalCode: '10001',
+  country: 'USA',
+  priceList: null,
+}))
+
+vi.mock('@/hooks/useNotification', () => ({
+  useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
+}))
+
+vi.mock('@/services/salesApi', () => ({
+  salesApi: {
+    getCustomer: vi.fn().mockResolvedValue(mockCustomer),
+    getCustomerStatistics: vi.fn().mockResolvedValue({
+      orders: {
+        totalOrders: 5,
+        totalSales: 15000,
+        averageOrderValue: 3000,
+        firstOrderDate: '2025-06-01',
+        lastOrderDate: '2026-01-15',
+      },
+    }),
+    getCustomerSalesHistory: vi.fn().mockResolvedValue({ orders: [] }),
+    getOutstandingInvoices: vi.fn().mockResolvedValue({ invoices: [], totalOutstanding: 0 }),
+    deleteCustomer: vi.fn(),
+  },
+}))
+
+function makeStore() {
+  return configureStore({ reducer: { customers: customerReducer } })
+}
+
+function renderPage(customerId = 'test-uuid-1') {
+  return render(
+    <Provider store={makeStore()}>
+      <MemoryRouter initialEntries={[`/sales/customers/${customerId}`]}>
+        <Routes>
+          <Route path="/sales/customers/:id" element={<CustomerProfilePage />} />
+          <Route path="/sales/customers" element={<div>Customers List</div>} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('CustomerProfilePage', () => {
+  it('renders customer name after loading', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Acme Corp')).toBeTruthy()
+    })
+  })
+
+  it('shows Overview tab by default', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Total Orders')).toBeTruthy()
+    })
+  })
+
+  it('shows back button', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText(/Back to Customers/i)).toBeTruthy()
+    })
+  })
+})

--- a/frontend/src/pages/sales/__tests__/CustomersPage.filter.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CustomersPage.filter.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { configureStore } from '@reduxjs/toolkit'
+import customerReducer from '@/store/slices/customerSlice'
+import CustomersPage from '../CustomersPage'
+
+vi.mock('@/hooks/useNotification', () => ({
+  useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
+}))
+
+vi.mock('@/services/salesApi', () => ({
+  salesApi: {
+    getCustomers: vi.fn().mockResolvedValue({ data: [], meta: { total: 0, page: 1, limit: 25 } }),
+    getDeletedCustomers: vi.fn().mockResolvedValue({ data: [] }),
+  },
+}))
+
+vi.mock('@/store/slices/customerSlice', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store/slices/customerSlice')>()
+  return {
+    ...actual,
+    fetchCustomers: vi.fn(() => ({
+      type: 'customers/fetchCustomers/fulfilled',
+      payload: { data: [], meta: {} },
+    })),
+  }
+})
+
+function makeStore() {
+  return configureStore({ reducer: { customers: customerReducer } })
+}
+
+function renderPage() {
+  return render(
+    <Provider store={makeStore()}>
+      <MemoryRouter>
+        <CustomersPage />
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('CustomersPage filters', () => {
+  it('renders Status filter with All/Active/Inactive options', async () => {
+    renderPage()
+    const statusSelect = screen.getByLabelText('Status')
+    expect(statusSelect).toBeTruthy()
+  })
+
+  it('Name column header has sort indicator', () => {
+    renderPage()
+    const nameHeader = screen.getByText('Name')
+    expect(nameHeader.closest('th') ?? nameHeader).toBeTruthy()
+  })
+})

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -17,6 +17,7 @@ const CreateStockAdjustmentPage = React.lazy(() => import('./pages/inventory/Cre
 
 const SalesPage = React.lazy(() => import('./pages/sales/SalesPage'))
 const CustomersPage = React.lazy(() => import('./pages/sales/CustomersPage'))
+const CustomerProfilePage = React.lazy(() => import('./pages/sales/CustomerProfilePage'))
 const OrdersPage = React.lazy(() => import('./pages/sales/OrdersPage'))
 const CreateSalesOrderPage = React.lazy(() => import('./pages/sales/CreateSalesOrderPage'))
 const InvoicesPage = React.lazy(() => import('./pages/sales/InvoicesPage'))
@@ -125,6 +126,7 @@ export const router = createBrowserRouter([
 
           { path: '/sales', element: <SalesPage /> },
           { path: '/sales/customers', element: <CustomersPage /> },
+          { path: '/sales/customers/:id', element: <CustomerProfilePage /> },
           { path: '/sales/orders', element: <OrdersPage /> },
           { path: '/sales/orders/create', element: <CreateSalesOrderPage /> },
           { path: '/sales/orders/:id/edit', element: <CreateSalesOrderPage /> },


### PR DESCRIPTION
## Summary

- **New customer profile page** at `/sales/customers/:id` with Overview, Orders, and Invoices tabs — replaces the cramped view dialog
- **List page improvements**: Active/Inactive status filter + sortable columns (Name, Total Orders, Total Sales, Last Purchase)
- **Navigation**: clicking customer name or view icon navigates to profile; Edit button on profile returns to list and auto-opens the edit form
- **Backend fix**: `salesOrderId` added to outstanding invoices response so invoice rows link to their sales order for payment processing

## Changes

| File | Change |
|------|--------|
| `backend/src/modules/sales/services/customer.service.ts` | Add `salesOrderId` to outstanding invoices response |
| `frontend/src/pages/sales/CustomersPage.tsx` | Status filter, sortable columns, navigate on name/view click, remove view dialog, handle edit-from-profile state |
| `frontend/src/pages/sales/CustomerProfilePage.tsx` | New — profile page with Overview/Orders/Invoices tabs |
| `frontend/src/router.tsx` | Add `/sales/customers/:id` route |
| `frontend/src/pages/sales/__tests__/CustomerProfilePage.test.tsx` | New tests |
| `frontend/src/pages/sales/__tests__/CustomersPage.filter.test.tsx` | New tests |

## Test plan

- [x] Customers list: Status filter shows All/Active/Inactive options and filters correctly
- [x] Customers list: clicking Name/Total Orders/Total Sales/Last Purchase headers sorts the table
- [x] Customers list: clicking a customer name or view icon navigates to `/sales/customers/:id`
- [x] Profile page: Overview tab shows stat cards (Total Orders, Total Sales, Avg Order Value, Last Purchase)
- [x] Profile page: Orders tab lazy-loads and each row links to the sales order
- [x] Profile page: Invoices tab shows outstanding invoices; each row links to its sales order
- [x] Profile page: Edit button returns to list and opens the edit form pre-filled
- [x] Profile page: Delete redirects to list after success with error handling for dependencies
- [x] All 327 frontend tests pass, 503 backend tests pass
- [x] TypeScript and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)