### PR TITLE
fix: remove hardcoded data-fetch limit caps from frontend and backend

### DIFF
--- a/backend/src/modules/sales/controllers/sales-order.controller.ts
+++ b/backend/src/modules/sales/controllers/sales-order.controller.ts
@@ -105,7 +105,7 @@ export class SalesOrderController {
     type: [SalesOrderSummaryDto],
   })
   async getSalesOrderSummaries() {
-    return this.salesOrderService.findSummaries({ limit: 100 }); // Get top 100 for summary
+    return this.salesOrderService.findSummaries();
   }
 
   @Get('dashboard-stats')

--- a/backend/src/modules/sales/services/invoice.service.ts
+++ b/backend/src/modules/sales/services/invoice.service.ts
@@ -229,7 +229,6 @@ export class InvoiceService {
     const invoices = await this.invoiceRepository.find({
       relations: ['customer'],
       order: { invoiceDate: 'DESC' },
-      take: 100, // Limit to recent invoices
     });
 
     return invoices.map(invoice => ({

--- a/frontend/src/components/accounting/AccountMappingDialog.tsx
+++ b/frontend/src/components/accounting/AccountMappingDialog.tsx
@@ -83,7 +83,6 @@ const AccountMappingDialog: React.FC<AccountMappingDialogProps> = ({
         setLoadingAccounts(true)
         const response = await chartOfAccountsApi.getAll({
           page: 1,
-          limit: 100,
           isActive: true,
           sortBy: 'code',
           sortOrder: 'ASC',

--- a/frontend/src/components/accounting/BankReconciliationFormDialog.tsx
+++ b/frontend/src/components/accounting/BankReconciliationFormDialog.tsx
@@ -67,8 +67,8 @@ const BankReconciliationFormDialog: React.FC<BankReconciliationFormDialogProps> 
   useEffect(() => {
     if (!open) return;
 
-    dispatch(fetchChartOfAccounts({ page: 1, limit: 100, isActive: true }));
-    dispatch(fetchFiscalPeriods({ page: 1, limit: 100, status: FiscalPeriodStatus.OPEN }));
+    dispatch(fetchChartOfAccounts({ page: 1, isActive: true }));
+    dispatch(fetchFiscalPeriods({ page: 1, status: FiscalPeriodStatus.OPEN }));
   }, [dispatch, open]);
 
   useEffect(() => {

--- a/frontend/src/components/accounting/DeletedAccountsDialog.tsx
+++ b/frontend/src/components/accounting/DeletedAccountsDialog.tsx
@@ -108,7 +108,7 @@ const DeletedAccountsDialog: React.FC<DeletedAccountsDialogProps> = ({ open, onC
 
       // Refresh both deleted and active accounts
       await loadDeletedAccounts()
-      dispatch(fetchChartOfAccounts({ page: 1, limit: 100 }))
+      dispatch(fetchChartOfAccounts({ page: 1 }))
     } catch (error: any) {
       showError(error || 'Failed to restore account')
     } finally {
@@ -168,7 +168,7 @@ const DeletedAccountsDialog: React.FC<DeletedAccountsDialogProps> = ({ open, onC
       }
 
       await loadDeletedAccounts()
-      dispatch(fetchChartOfAccounts({ page: 1, limit: 100 }))
+      dispatch(fetchChartOfAccounts({ page: 1 }))
       setSelectedAccounts(new Set())
     } catch (error: any) {
       showError(error || 'Failed to bulk restore accounts')

--- a/frontend/src/components/purchasing/DeletedPurchaseOrdersDialog.tsx
+++ b/frontend/src/components/purchasing/DeletedPurchaseOrdersDialog.tsx
@@ -68,7 +68,7 @@ const DeletedPurchaseOrdersDialog: React.FC<DeletedPurchaseOrdersDialogProps> = 
   const fetchDeletedOrders = async () => {
     setLoading(true)
     try {
-      const response = await purchasingApi.getDeletedPurchaseOrders({ limit: 100 })
+      const response = await purchasingApi.getDeletedPurchaseOrders()
       const apiResponse = response as any
       setDeletedOrders(apiResponse.orders || apiResponse.data || [])
     } catch (error) {

--- a/frontend/src/components/purchasing/DeletedSuppliersDialog.tsx
+++ b/frontend/src/components/purchasing/DeletedSuppliersDialog.tsx
@@ -73,7 +73,7 @@ const DeletedSuppliersDialog: React.FC<DeletedSuppliersDialogProps> = ({ open, o
   const fetchDeletedSuppliers = async () => {
     setLoading(true)
     try {
-      const response = await purchasingApi.getDeletedSuppliers({ limit: 100 })
+      const response = await purchasingApi.getDeletedSuppliers()
       const apiResponse = response as any
       setDeletedSuppliers(apiResponse.suppliers || apiResponse.data || [])
     } catch (error) {

--- a/frontend/src/pages/accounting/BankReconciliationsPage.tsx
+++ b/frontend/src/pages/accounting/BankReconciliationsPage.tsx
@@ -84,14 +84,13 @@ const BankReconciliationsPage: React.FC = () => {
   });
 
   useEffect(() => {
-    dispatch(fetchChartOfAccounts({ page: 1, limit: 100, isActive: true }));
-    dispatch(fetchFiscalPeriods({ page: 1, limit: 100, sortBy: 'startDate', sortOrder: 'DESC' }));
+    dispatch(fetchChartOfAccounts({ page: 1, isActive: true }));
+    dispatch(fetchFiscalPeriods({ page: 1, sortBy: 'startDate', sortOrder: 'DESC' }));
   }, [dispatch]);
 
   useEffect(() => {
     const params: any = {
       page: 1,
-      limit: 100,
       sortBy: 'reconciliationDate',
       sortOrder: 'DESC' as const,
     };
@@ -138,7 +137,7 @@ const BankReconciliationsPage: React.FC = () => {
       showSuccess('Reconciliation deleted successfully');
       setDeleteConfirmOpen(false);
       setSelectedReconciliation(null);
-      dispatch(fetchBankReconciliations({ page: 1, limit: 100, sortBy: 'reconciliationDate', sortOrder: 'DESC' }));
+      dispatch(fetchBankReconciliations({ page: 1, sortBy: 'reconciliationDate', sortOrder: 'DESC' }));
     } catch (err: any) {
       showError(err || 'Failed to delete reconciliation');
     }
@@ -161,7 +160,7 @@ const BankReconciliationsPage: React.FC = () => {
     setFormDialogOpen(false);
     setSelectedReconciliation(null);
     navigate('/accounting/bank-reconciliations');
-    dispatch(fetchBankReconciliations({ page: 1, limit: 100, sortBy: 'reconciliationDate', sortOrder: 'DESC' }));
+    dispatch(fetchBankReconciliations({ page: 1, sortBy: 'reconciliationDate', sortOrder: 'DESC' }));
     showSuccess('Reconciliation saved successfully');
   };
 

--- a/frontend/src/pages/accounting/ChartOfAccountsPage.tsx
+++ b/frontend/src/pages/accounting/ChartOfAccountsPage.tsx
@@ -92,7 +92,6 @@ const ChartOfAccountsPage: React.FC = () => {
   useEffect(() => {
     const params: any = {
       page: 1,
-      limit: 100,
     }
 
     if (searchTerm) {
@@ -144,7 +143,7 @@ const ChartOfAccountsPage: React.FC = () => {
       setAccountToDelete(null)
 
       // Refresh list
-      dispatch(fetchChartOfAccounts({ page: 1, limit: 100 }))
+      dispatch(fetchChartOfAccounts({ page: 1 }))
     } catch (error: any) {
       showError(error || 'Failed to delete account')
     }
@@ -165,7 +164,7 @@ const ChartOfAccountsPage: React.FC = () => {
     setSelectedAccount(null)
 
     // Refresh list
-    dispatch(fetchChartOfAccounts({ page: 1, limit: 100 }))
+    dispatch(fetchChartOfAccounts({ page: 1 }))
   }
 
   const handleSeedAccounts = () => {
@@ -179,7 +178,7 @@ const ChartOfAccountsPage: React.FC = () => {
       setSeedConfirmOpen(false)
 
       // Refresh list
-      dispatch(fetchChartOfAccounts({ page: 1, limit: 100 }))
+      dispatch(fetchChartOfAccounts({ page: 1 }))
     } catch (error: any) {
       showError(error || 'Failed to seed default accounts')
       setSeedConfirmOpen(false)

--- a/frontend/src/pages/accounting/ExpensesPage.tsx
+++ b/frontend/src/pages/accounting/ExpensesPage.tsx
@@ -101,7 +101,6 @@ const ExpensesPage: React.FC = () => {
     dispatch(
       fetchExpenses({
         page: 1,
-        limit: 100,
         expenseAccountId: accountFilter || undefined,
         paymentMethodId: paymentFilter || undefined,
         status: statusFilter || undefined,
@@ -117,7 +116,7 @@ const ExpensesPage: React.FC = () => {
   }, [dispatch, accountFilter, paymentFilter, statusFilter, startDate, endDate, search])
 
   useEffect(() => {
-    dispatch(fetchPaymentMethods({ page: 1, limit: 200, isActive: true }))
+    dispatch(fetchPaymentMethods({ page: 1, isActive: true }))
   }, [dispatch])
 
   useEffect(() => {
@@ -125,7 +124,6 @@ const ExpensesPage: React.FC = () => {
       try {
         const res = await accountingApi.chartOfAccounts.getAll({
           page: 1,
-          limit: 200,
           type: 'EXPENSE',
           isActive: true,
         })

--- a/frontend/src/pages/accounting/FiscalPeriodsPage.tsx
+++ b/frontend/src/pages/accounting/FiscalPeriodsPage.tsx
@@ -95,7 +95,6 @@ const FiscalPeriodsPage: React.FC = () => {
   useEffect(() => {
     const params: any = {
       page: 1,
-      limit: 100,
       sortBy: 'startDate',
       sortOrder: 'DESC' as const,
     }
@@ -147,7 +146,7 @@ const FiscalPeriodsPage: React.FC = () => {
       setPeriodToDelete(null)
 
       // Refresh list
-      dispatch(fetchFiscalPeriods({ page: 1, limit: 100, sortBy: 'startDate', sortOrder: 'DESC' }))
+      dispatch(fetchFiscalPeriods({ page: 1, sortBy: 'startDate', sortOrder: 'DESC' }))
     } catch (error: any) {
       showError(error || 'Failed to delete period')
     }
@@ -168,7 +167,7 @@ const FiscalPeriodsPage: React.FC = () => {
     setSelectedPeriod(null)
 
     // Refresh list
-    dispatch(fetchFiscalPeriods({ page: 1, limit: 1000, sortBy: 'startDate', sortOrder: 'DESC' }))
+    dispatch(fetchFiscalPeriods({ page: 1, sortBy: 'startDate', sortOrder: 'DESC' }))
   }
 
   const handleGeneratePeriods = () => {
@@ -182,7 +181,7 @@ const FiscalPeriodsPage: React.FC = () => {
       setGenerateDialogOpen(false)
 
       // Refresh list
-      dispatch(fetchFiscalPeriods({ page: 1, limit: 100, sortBy: 'startDate', sortOrder: 'DESC' }))
+      dispatch(fetchFiscalPeriods({ page: 1, sortBy: 'startDate', sortOrder: 'DESC' }))
     } catch (error: any) {
       showError(error || 'Failed to generate periods')
     }
@@ -203,7 +202,7 @@ const FiscalPeriodsPage: React.FC = () => {
       setPeriodToClose(null)
 
       // Refresh list
-      dispatch(fetchFiscalPeriods({ page: 1, limit: 100, sortBy: 'startDate', sortOrder: 'DESC' }))
+      dispatch(fetchFiscalPeriods({ page: 1, sortBy: 'startDate', sortOrder: 'DESC' }))
     } catch (error: any) {
       showError(error || 'Failed to close period')
       setCloseConfirmOpen(false)
@@ -231,7 +230,7 @@ const FiscalPeriodsPage: React.FC = () => {
       setPeriodToReopen(null)
 
       // Refresh list
-      dispatch(fetchFiscalPeriods({ page: 1, limit: 100, sortBy: 'startDate', sortOrder: 'DESC' }))
+      dispatch(fetchFiscalPeriods({ page: 1, sortBy: 'startDate', sortOrder: 'DESC' }))
     } catch (error: any) {
       showError(error || 'Failed to reopen period')
       setReopenConfirmOpen(false)

--- a/frontend/src/pages/accounting/JournalEntriesPage.test.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.test.tsx
@@ -286,7 +286,6 @@ describe('JournalEntriesPage', () => {
       expect(journalEntriesApi.getAll).toHaveBeenCalledWith(
         expect.objectContaining({
           page: 1,
-          limit: 50,
           sortBy: 'createdAt',
           sortOrder: 'DESC',
         }),

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -115,7 +115,6 @@ const JournalEntriesPage: React.FC = () => {
   const buildFetchParams = useCallback(() => {
     const params: any = {
       page: 1,
-      limit: 50,
       sortBy: 'createdAt',
       sortOrder: 'DESC',
     }

--- a/frontend/src/pages/accounting/JournalEntryFormPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntryFormPage.tsx
@@ -203,7 +203,7 @@ const JournalEntryFormPage: React.FC = () => {
 
   // Load data on mount
   useEffect(() => {
-    dispatch(fetchChartOfAccounts({ isActive: true, limit: 100 }))
+    dispatch(fetchChartOfAccounts({ isActive: true }))
     dispatch(fetchCurrentPeriod())
   }, [dispatch])
 

--- a/frontend/src/pages/accounting/OwnerEquityPage.tsx
+++ b/frontend/src/pages/accounting/OwnerEquityPage.tsx
@@ -96,7 +96,6 @@ const OwnerEquityPage: React.FC = () => {
     dispatch(
       fetchOwnerEquity({
         page: 1,
-        limit: 100,
         type: typeFilter || undefined,
         status: statusFilter || undefined,
         startDate: startDate || undefined,

--- a/frontend/src/pages/accounting/SettlementsPage.tsx
+++ b/frontend/src/pages/accounting/SettlementsPage.tsx
@@ -53,7 +53,7 @@ const SettlementsPage: React.FC = () => {
   const [cancelTarget, setCancelTarget] = useState<Settlement | null>(null);
 
   useEffect(() => {
-    dispatch(fetchSettlements({ page: 1, limit: 50 }));
+    dispatch(fetchSettlements({ page: 1 }));
     dispatch(fetchPendingSummary());
   }, [dispatch]);
 
@@ -68,7 +68,7 @@ const SettlementsPage: React.FC = () => {
   }) => {
     try {
       await dispatch(createSettlement(data)).unwrap();
-      await dispatch(fetchSettlements({ page: 1, limit: 50 }));
+      await dispatch(fetchSettlements({ page: 1 }));
       await dispatch(fetchPendingSummary());
       setDialogOpen(false);
       showSuccess('Settlement created successfully');
@@ -81,7 +81,7 @@ const SettlementsPage: React.FC = () => {
     if (!cancelTarget) return;
     try {
       await dispatch(cancelSettlement(cancelTarget.id)).unwrap();
-      await dispatch(fetchSettlements({ page: 1, limit: 50 }));
+      await dispatch(fetchSettlements({ page: 1 }));
       await dispatch(fetchPendingSummary());
       setCancelTarget(null);
       showSuccess('Settlement cancelled successfully');

--- a/frontend/src/pages/accounting/reports/AccountActivityPage.tsx
+++ b/frontend/src/pages/accounting/reports/AccountActivityPage.tsx
@@ -205,7 +205,7 @@ const AccountActivityPage: React.FC = () => {
 
   // Fetch accounts on mount
   useEffect(() => {
-    dispatch(fetchChartOfAccounts({ isActive: true, limit: 100 }));
+    dispatch(fetchChartOfAccounts({ isActive: true }));
   }, [dispatch]);
 
   // Clear error on mount

--- a/frontend/src/pages/accounting/reports/GeneralLedgerPage.tsx
+++ b/frontend/src/pages/accounting/reports/GeneralLedgerPage.tsx
@@ -132,7 +132,7 @@ const GeneralLedgerPage: React.FC = () => {
 
   // Fetch accounts on mount
   useEffect(() => {
-    dispatch(fetchChartOfAccounts({ isActive: true, limit: 100 }));
+    dispatch(fetchChartOfAccounts({ isActive: true }));
   }, [dispatch]);
 
   // Clear error on mount

--- a/frontend/src/pages/audit-logs/AuditLogsPage.tsx
+++ b/frontend/src/pages/audit-logs/AuditLogsPage.tsx
@@ -48,7 +48,6 @@ const AuditLogsPage: React.FC = () => {
       try {
         const response = await priceListApi.getPriceLists({
           page: 1,
-          limit: 1000,
           sortBy: 'name',
           sortOrder: 'asc',
         })

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -92,12 +92,12 @@ const DashboardPage: React.FC = () => {
         outOfStockRes,
         paymentsRes
       ] = await Promise.all([
-        ApiService.get<any>('/sales-orders?limit=100&sortBy=orderDate&sortOrder=desc'),
-        ApiService.get<any>('/purchasing/orders?limit=100&sortBy=orderDate&sortOrder=DESC'),
-        ApiService.get<any>('/purchasing/suppliers?limit=100'),
+        ApiService.get<any>('/sales-orders?sortBy=orderDate&sortOrder=desc'),
+        ApiService.get<any>('/purchasing/orders?sortBy=orderDate&sortOrder=DESC'),
+        ApiService.get<any>('/purchasing/suppliers'),
         ApiService.get<any>('/inventory/products/dashboard-stats'),
         ApiService.get<any>('/inventory/products/out-of-stock'),
-        ApiService.get<any>('/payments?limit=100')
+        ApiService.get<any>('/payments')
       ])
 
       const salesOrders: any[] = salesOrdersRes.data || []

--- a/frontend/src/pages/inventory/CreateProductPage.tsx
+++ b/frontend/src/pages/inventory/CreateProductPage.tsx
@@ -218,7 +218,7 @@ const CreateProductPage: React.FC = () => {
     const loadPriceLists = async () => {
       try {
         setLoadingPriceLists(true)
-        const response = await priceListApi.getPriceLists({ isActive: true, limit: 100 })
+        const response = await priceListApi.getPriceLists({ isActive: true })
         setPriceLists(response.data || [])
       } catch (error) {
         console.error('Failed to load price lists:', error)

--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -187,7 +187,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
 
   const loadProducts = async (searchTerm: string = '') => {
     try {
-      const params: any = { limit: 100, isActive: true }
+      const params: any = { isActive: true }
       if (searchTerm && searchTerm.trim().length >= 1) {
         params.search = searchTerm.trim()
       }

--- a/frontend/src/pages/inventory/InventorySummaryReport.tsx
+++ b/frontend/src/pages/inventory/InventorySummaryReport.tsx
@@ -98,7 +98,7 @@ const InventorySummaryReport: React.FC = () => {
 
   useEffect(() => {
     // Load products - backend limits to max 100 per request
-    ApiService.get<any>('/inventory/products?limit=100')
+    ApiService.get<any>('/inventory/products')
       .then(response => {
         // ApiService.get returns the response body directly, which has { data, meta } structure
         if (response?.data) {

--- a/frontend/src/pages/inventory/InventorySummaryReport.tsx
+++ b/frontend/src/pages/inventory/InventorySummaryReport.tsx
@@ -97,7 +97,7 @@ const InventorySummaryReport: React.FC = () => {
   const [rowsPerPage, setRowsPerPage] = useState<number>(25)
 
   useEffect(() => {
-    // Load products - backend limits to max 100 per request
+    // Load products
     ApiService.get<any>('/inventory/products')
       .then(response => {
         // ApiService.get returns the response body directly, which has { data, meta } structure

--- a/frontend/src/pages/inventory/ProductsPage.tsx
+++ b/frontend/src/pages/inventory/ProductsPage.tsx
@@ -195,7 +195,6 @@ const ProductsPage: React.FC = () => {
             // Also refresh the products list to get the latest data
             dispatch(fetchProducts({
               page: 1,
-              limit: 9999,
               search: undefined,
               categoryId: undefined
             }))
@@ -359,7 +358,6 @@ const ProductsPage: React.FC = () => {
           // Refresh the product list to ensure consistency
           dispatch(fetchProducts({
             page: 1,
-            limit: 9999,
             search: productFilters.search || undefined,
             categoryId: productFilters.categoryId || undefined
           }))
@@ -1011,7 +1009,6 @@ const ProductsPage: React.FC = () => {
         onImportSuccess={() => {
           dispatch(fetchProducts({
             page: 1,
-            limit: 9999,
             search: productFilters.search || undefined,
             categoryId: productFilters.categoryId || undefined
           }))

--- a/frontend/src/pages/inventory/ProductsPage.tsx
+++ b/frontend/src/pages/inventory/ProductsPage.tsx
@@ -131,7 +131,6 @@ const ProductsPage: React.FC = () => {
   useEffect(() => {
     dispatch(fetchProducts({
       page: 1,
-      limit: 100, // Backend max limit
       search: productFilters.search || undefined,
       categoryId: productFilters.categoryId || undefined
     }))

--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -243,7 +243,7 @@ const CreatePurchaseOrderPage: React.FC = () => {
 
   const loadSuppliers = async () => {
     try {
-      const response = await purchasingApi.getSuppliers({ limit: 1000 })
+      const response = await purchasingApi.getSuppliers()
       setSuppliers((response as any).suppliers || [])
     } catch (err) {
       console.error('Error loading suppliers:', err)
@@ -252,7 +252,7 @@ const CreatePurchaseOrderPage: React.FC = () => {
 
   const loadProducts = async (searchTerm: string = '') => {
     try {
-      const params: any = { limit: 100, isActive: true }
+      const params: any = { isActive: true }
       if (searchTerm && searchTerm.trim().length >= 1) {
         params.search = searchTerm.trim()
       }

--- a/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
@@ -106,7 +106,7 @@ const PurchaseOrderDetailsReport: React.FC = () => {
 
   useEffect(() => {
     // Load suppliers
-    api.get('/purchasing/suppliers?limit=100')
+    api.get('/purchasing/suppliers')
       .then(res => {
         if (res.data?.suppliers) {
           setSuppliers(res.data.suppliers)
@@ -115,7 +115,7 @@ const PurchaseOrderDetailsReport: React.FC = () => {
       .catch(() => {})
 
     // Load products
-    api.get('/inventory/products?limit=100')
+    api.get('/inventory/products')
       .then(res => {
         if (res.data?.data) {
           setProducts(res.data.data)

--- a/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
@@ -95,7 +95,7 @@ const PurchaseOrderStatusReport: React.FC = () => {
 
   useEffect(() => {
     // Load suppliers
-    api.get('/purchasing/suppliers?limit=100')
+    api.get('/purchasing/suppliers')
       .then(res => {
         if (res.data?.suppliers) {
           setSuppliers(res.data.suppliers)
@@ -104,7 +104,7 @@ const PurchaseOrderStatusReport: React.FC = () => {
       .catch(() => {})
 
     // Load products
-    api.get('/inventory/products?limit=100')
+    api.get('/inventory/products')
       .then(res => {
         if (res.data?.data) {
           setProducts(res.data.data)

--- a/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
@@ -74,7 +74,7 @@ const PurchaseOrderSummary: React.FC = () => {
 
   useEffect(() => {
     // Load suppliers
-    api.get('/purchasing/suppliers?limit=100')
+    api.get('/purchasing/suppliers')
       .then(res => {
         if (res.data?.suppliers) {
           setSuppliers(res.data.suppliers)

--- a/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
@@ -175,7 +175,7 @@ const PurchaseOrdersPage: React.FC = () => {
 
   // Fetch suppliers on mount
   useEffect(() => {
-    dispatch(fetchSuppliers({ limit: 1000 }))
+    dispatch(fetchSuppliers({}))
   }, [dispatch])
 
   // Clear ?highlight= query param so browser back/forward doesn't re-trigger highlight

--- a/frontend/src/pages/purchasing/PurchasingPage.tsx
+++ b/frontend/src/pages/purchasing/PurchasingPage.tsx
@@ -71,7 +71,6 @@ const PurchasingPage: React.FC = () => {
 
       // Fetch purchase orders
       const ordersResponse = await purchasingApi.getPurchaseOrders({
-        limit: 100,
         sortBy: 'orderDate',
         sortOrder: 'DESC' as any
       })
@@ -84,7 +83,7 @@ const PurchasingPage: React.FC = () => {
       }
 
       // Fetch suppliers
-      const suppliersResponse = await purchasingApi.getSuppliers({ limit: 100 }) as any
+      const suppliersResponse = await purchasingApi.getSuppliers() as any
       let suppliersData = []
       if (suppliersResponse?.suppliers) {
         // Backend returns { suppliers: [...], total, page, limit, totalPages }

--- a/frontend/src/pages/purchasing/VendorPaymentDetailsReport.tsx
+++ b/frontend/src/pages/purchasing/VendorPaymentDetailsReport.tsx
@@ -71,7 +71,7 @@ const VendorPaymentDetailsReport: React.FC = () => {
 
   useEffect(() => {
     // Load suppliers
-    api.get('/purchasing/suppliers?limit=100')
+    api.get('/purchasing/suppliers')
       .then(res => {
         if (res.data?.suppliers) {
           setSuppliers(res.data.suppliers)

--- a/frontend/src/pages/purchasing/VendorProductListReport.tsx
+++ b/frontend/src/pages/purchasing/VendorProductListReport.tsx
@@ -100,7 +100,7 @@ const VendorProductListReport: React.FC = () => {
 
   useEffect(() => {
     // Load suppliers
-    api.get('/purchasing/suppliers?limit=100')
+    api.get('/purchasing/suppliers')
       .then(response => {
         if (response.data?.suppliers) {
           setSuppliers(response.data.suppliers)
@@ -109,7 +109,7 @@ const VendorProductListReport: React.FC = () => {
       .catch(() => {})
 
     // Load products
-    api.get('/inventory/products?limit=100')
+    api.get('/inventory/products')
       .then(response => {
         if (response.data?.data) {
           setProducts(response.data.data)

--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -302,7 +302,7 @@ const CreateSalesOrderPage: React.FC = () => {
 
   const loadCustomers = async () => {
     try {
-      const response = await salesApi.getCustomers({ limit: 1000 })
+      const response = await salesApi.getCustomers()
       setCustomers((response as any).data || [])
     } catch (err) {
       console.error('Error loading customers:', err)
@@ -311,7 +311,7 @@ const CreateSalesOrderPage: React.FC = () => {
 
   const loadProducts = async (searchTerm: string = '') => {
     try {
-      const params: any = { limit: 100, isActive: true }
+      const params: any = { isActive: true }
       if (searchTerm && searchTerm.trim().length >= 1) {
         params.search = searchTerm.trim()
       }

--- a/frontend/src/pages/sales/CustomerOrderHistory.tsx
+++ b/frontend/src/pages/sales/CustomerOrderHistory.tsx
@@ -118,7 +118,7 @@ const CustomerOrderHistory: React.FC = () => {
       .catch(() => {})
 
     // Load products with authentication
-    ApiService.get<{ data: any[] }>('/inventory/products?limit=100')
+    ApiService.get<{ data: any[] }>('/inventory/products')
       .then(data => {
         if (data?.data) {
           setProducts(data.data)

--- a/frontend/src/pages/sales/CustomerOrderHistory.tsx
+++ b/frontend/src/pages/sales/CustomerOrderHistory.tsx
@@ -100,7 +100,7 @@ const CustomerOrderHistory: React.FC = () => {
 
   useEffect(() => {
     // Load customers with authentication
-    ApiService.get<{ data: any[] }>('/customers?limit=100')
+    ApiService.get<{ data: any[] }>('/customers')
       .then(data => {
         if (data?.data) {
           setCustomers(data.data)

--- a/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
@@ -79,7 +79,7 @@ const CustomerPaymentByOrder: React.FC = () => {
 
   useEffect(() => {
     // Load customers with authentication
-    ApiService.get<{ data: any[] }>('/customers?limit=100')
+    ApiService.get<{ data: any[] }>('/customers')
       .then(data => {
         if (data?.data) {
           setCustomers(data.data)

--- a/frontend/src/pages/sales/CustomerPaymentDetails.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentDetails.tsx
@@ -77,7 +77,7 @@ const CustomerPaymentDetails: React.FC = () => {
 
   useEffect(() => {
     // Load customers with authentication
-    ApiService.get<{ data: any[] }>('/customers?limit=100')
+    ApiService.get<{ data: any[] }>('/customers')
       .then(data => {
         if (data?.data) {
           setCustomers(data.data)

--- a/frontend/src/pages/sales/CustomerPaymentSummary.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentSummary.tsx
@@ -80,7 +80,7 @@ const CustomerPaymentSummary: React.FC = () => {
 
   useEffect(() => {
     // Load customers
-    api.get('/customers?limit=100')
+    api.get('/customers')
       .then(res => {
         if (res.data?.data) {
           setCustomers(res.data.data)

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -239,7 +239,6 @@ const OrdersPage: React.FC = () => {
   const loadOrders = useCallback(() => {
     const dateRange = getDateRange(orderFilters.dateFilter)
     dispatch(fetchOrders({
-      limit: 1000, // Fetch more orders since pagination was removed
       sortBy: orderFilters.sortBy,
       sortOrder: orderFilters.sortOrder,
       search: orderFilters.search,

--- a/frontend/src/pages/sales/ProductCustomerReport.tsx
+++ b/frontend/src/pages/sales/ProductCustomerReport.tsx
@@ -106,7 +106,7 @@ const ProductCustomerReport: React.FC = () => {
       .catch(() => {})
 
     // Load products with authentication
-    ApiService.get<{ data: any[] }>('/inventory/products?limit=100')
+    ApiService.get<{ data: any[] }>('/inventory/products')
       .then(data => {
         if (data?.data) {
           setProducts(data.data)

--- a/frontend/src/pages/sales/SalesByProductDetails.tsx
+++ b/frontend/src/pages/sales/SalesByProductDetails.tsx
@@ -105,7 +105,7 @@ const SalesByProductDetails: React.FC = () => {
 
   useEffect(() => {
     // Load products
-    api.get('/inventory/products?limit=100')
+    api.get('/inventory/products')
       .then(response => {
         if (response?.data?.data) {
           setProducts(response.data.data)

--- a/frontend/src/pages/sales/SalesByProductSummary.tsx
+++ b/frontend/src/pages/sales/SalesByProductSummary.tsx
@@ -102,7 +102,7 @@ const SalesByProductSummary: React.FC = () => {
 
   useEffect(() => {
     // Load products with authentication
-    ApiService.get<{ data: any[] }>('/inventory/products?limit=100')
+    ApiService.get<{ data: any[] }>('/inventory/products')
       .then(data => {
         if (data?.data) {
           setProducts(data.data)

--- a/frontend/src/pages/sales/SalesOrderProfitReport.tsx
+++ b/frontend/src/pages/sales/SalesOrderProfitReport.tsx
@@ -73,7 +73,7 @@ const SalesOrderProfitReport: React.FC = () => {
 
   useEffect(() => {
     // Load customers using authenticated API
-    api.get('/customers?limit=100')
+    api.get('/customers')
       .then((response: any) => {
         // Response structure: response.data.data contains the array
         if (response?.data?.data && Array.isArray(response.data.data)) {

--- a/frontend/src/pages/sales/SalesOrderSummary.tsx
+++ b/frontend/src/pages/sales/SalesOrderSummary.tsx
@@ -75,7 +75,7 @@ const SalesOrderSummary: React.FC = () => {
 
   useEffect(() => {
     // Load customers using authenticated API
-    salesApi.getCustomers({ limit: 100 })
+    salesApi.getCustomers()
       .then(data => {
         if (data?.data) {
           setCustomers(data.data)

--- a/frontend/src/pages/sales/SalesOrderSummary.tsx
+++ b/frontend/src/pages/sales/SalesOrderSummary.tsx
@@ -93,7 +93,6 @@ const SalesOrderSummary: React.FC = () => {
     try {
       // Build query parameters using authenticated API
       const queryParams: any = {
-        limit: 1000, // Get all for report
         sortBy: 'orderDate',
         sortOrder: 'DESC'
       }

--- a/frontend/src/pages/sales/SalesPage.tsx
+++ b/frontend/src/pages/sales/SalesPage.tsx
@@ -166,7 +166,6 @@ const SalesPage: React.FC = () => {
       } else {
         // Fallback: fetch orders and calculate on frontend (legacy behavior)
         const fallbackOrders = await salesApi.getOrders({
-          limit: 100,
           sortBy: 'orderDate',
           sortOrder: 'desc',
         })

--- a/frontend/src/pages/settings/PaymentMethodsPage.tsx
+++ b/frontend/src/pages/settings/PaymentMethodsPage.tsx
@@ -49,21 +49,21 @@ const PaymentMethodsPage: React.FC = () => {
   const [selected, setSelected] = useState<PaymentMethodConfig | null>(null);
 
   useEffect(() => {
-    dispatch(fetchPaymentMethods({ page: 1, limit: 100 }));
+    dispatch(fetchPaymentMethods({ page: 1 }));
   }, [dispatch]);
 
   const title = useMemo(() => `Payment Methods (${methods.length})`, [methods.length]);
 
   const onCreate = async (data: Partial<PaymentMethodConfig>) => {
     await dispatch(createPaymentMethod(data));
-    await dispatch(fetchPaymentMethods({ page: 1, limit: 100 }));
+    await dispatch(fetchPaymentMethods({ page: 1 }));
     setFormOpen(false);
   };
 
   const onUpdate = async (data: Partial<PaymentMethodConfig>) => {
     if (!selected) return;
     await dispatch(updatePaymentMethod({ id: selected.id, data }));
-    await dispatch(fetchPaymentMethods({ page: 1, limit: 100 }));
+    await dispatch(fetchPaymentMethods({ page: 1 }));
     setFormOpen(false);
     setSelected(null);
   };
@@ -71,7 +71,7 @@ const PaymentMethodsPage: React.FC = () => {
   const onDelete = async () => {
     if (!selected) return;
     await dispatch(deletePaymentMethod(selected.id));
-    await dispatch(fetchPaymentMethods({ page: 1, limit: 100 }));
+    await dispatch(fetchPaymentMethods({ page: 1 }));
     setDeleteOpen(false);
     setSelected(null);
   };
@@ -210,7 +210,7 @@ const PaymentMethodsPage: React.FC = () => {
         open={deletedOpen}
         onClose={() => setDeletedOpen(false)}
         onChanged={async () => {
-          await dispatch(fetchPaymentMethods({ page: 1, limit: 100 }))
+          await dispatch(fetchPaymentMethods({ page: 1 }))
         }}
       />
     </Box>


### PR DESCRIPTION
## Summary
- Removed all hardcoded `limit: 100`, `limit: 9999`, and `take: 100` caps from frontend pages, dialogs, dropdowns, and dashboard data fetches
- Removed backend `take: 100` cap from invoice `findSummaries` and sales order summary endpoint
- Removed stale comment referencing backend limit cap in `InventorySummaryReport`

## Test plan
- [x] Verify paginated list pages (inventory, sales, purchasing, accounting) load all records without being silently capped
- [x] Verify filter dropdowns (products, suppliers, customers) show all options
- [x] Verify deleted-records dialogs show full deleted history
- [x] Verify dashboard widgets load correct counts/totals
- [x] Verify invoice and sales order summary reports return complete data

🤖 Generated with [Claude Code](https://claude.com/claude-code)