### PR TITLE
fix: prevent redirect to dashboard on browser refresh

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,7 +7,8 @@ import CssBaseline from '@mui/material/CssBaseline'
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 
-import { store } from './store'
+import { PersistGate } from 'redux-persist/integration/react'
+import { store, persistor } from './store'
 import { router } from './router'
 import { NotificationProvider } from './hooks/useNotification'
 import { WebSocketProvider } from './hooks/useWebSocket'
@@ -43,7 +44,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           <LocalizationProvider dateAdapter={AdapterDateFns}>
             <NotificationProvider>
               <WebSocketProvider>
+                <PersistGate loading={null} persistor={persistor}>
                 <RouterProvider router={router} />
+              </PersistGate>
               </WebSocketProvider>
             </NotificationProvider>
           </LocalizationProvider>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { RouterProvider } from 'react-router-dom'
 import { Provider } from 'react-redux'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import CssBaseline from '@mui/material/CssBaseline'
+import LinearProgress from '@mui/material/LinearProgress'
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 
@@ -43,11 +44,11 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           <CssBaseline />
           <LocalizationProvider dateAdapter={AdapterDateFns}>
             <NotificationProvider>
-              <WebSocketProvider>
-                <PersistGate loading={null} persistor={persistor}>
+              <PersistGate loading={<LinearProgress />} persistor={persistor}>
+                <WebSocketProvider>
                   <RouterProvider router={router} />
-                </PersistGate>
-              </WebSocketProvider>
+                </WebSocketProvider>
+              </PersistGate>
             </NotificationProvider>
           </LocalizationProvider>
         </ThemeWrapper>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -45,8 +45,8 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
             <NotificationProvider>
               <WebSocketProvider>
                 <PersistGate loading={null} persistor={persistor}>
-                <RouterProvider router={router} />
-              </PersistGate>
+                  <RouterProvider router={router} />
+                </PersistGate>
               </WebSocketProvider>
             </NotificationProvider>
           </LocalizationProvider>

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Navigate, createBrowserRouter, redirect } from 'react-router-dom'
 import MainLayout from './components/common/MainLayout'
 import RootLayout from './RootLayout'
-import { store } from './store'
+import { store, persistor } from './store'
 
 const LoginPage = React.lazy(() => import('./pages/auth/LoginPage'))
 const MandatoryPasswordChangePage = React.lazy(() => import('./pages/auth/MandatoryPasswordChangePage'))
@@ -87,7 +87,21 @@ const AccountActivityPage = React.lazy(() => import('./pages/accounting/reports/
 
 const NotFoundPage = React.lazy(() => import('./pages/NotFoundPage'))
 
-function authLoader({ request }: { request: Request }) {
+function waitForRehydration(): Promise<void> {
+  if (persistor.getState().bootstrapped) return Promise.resolve()
+  return new Promise((resolve) => {
+    const unsubscribe = persistor.subscribe(() => {
+      if (persistor.getState().bootstrapped) {
+        unsubscribe()
+        resolve()
+      }
+    })
+  })
+}
+
+async function authLoader({ request }: { request: Request }) {
+  await waitForRehydration()
+
   const { auth } = store.getState()
   const url = new URL(request.url)
 

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -89,7 +89,7 @@ export const store = configureStore({
   devTools: process.env.NODE_ENV !== 'production',
 })
 
-const persistor = persistStore(store)
+export const persistor = persistStore(store)
 
 export type RootState = ReturnType<typeof store.getState>
 export type AppDispatch = typeof store.dispatch


### PR DESCRIPTION
## Summary

- Export `persistor` from the Redux store
- Wrap `RouterProvider` in `PersistGate` so the React tree waits for rehydration
- Make `authLoader` async and wait for redux-persist rehydration before checking auth state — this is the actual fix

## Root Cause

`PersistGate` only delays React rendering. React Router's data loaders run eagerly at router initialization (before any React render), so `authLoader` was reading `store.getState()` while redux-persist hadn't rehydrated yet — `isAuthenticated` was always `false` on refresh, triggering a redirect to `/login` → `/dashboard`.

## Fix

`authLoader` now awaits `waitForRehydration()`, which subscribes to the persistor and resolves once `persistor.getState().bootstrapped` is `true`. Since rehydration reads from `localStorage` synchronously, this adds no perceptible delay.

## Test Plan

- [x] Log in and navigate to any non-dashboard page (e.g. `/inventory/products`)
- [x] Refresh — page stays on `/inventory/products`, no redirect
- [x] Log out and log in — redirects to `/dashboard` as normal
- [x] Clear `localStorage` and refresh — redirects to `/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)