### PR TITLE
fix(deps): pin file-type to 21.3.1 to resolve GHSA-5v7r-6r5c-r473

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -6598,9 +6598,9 @@
       }
     },
     "node_modules/file-type": {
-      "version": "21.3.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.0.tgz",
-      "integrity": "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==",
+      "version": "21.3.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.1.tgz",
+      "integrity": "sha512-SrzXX46I/zsRDjTb82eucsGg0ODq2NpGDp4HcsFKApPy8P8vACjpJRDoGGMfEzhFC0ry61ajd7f72J3603anBA==",
       "license": "MIT",
       "dependencies": {
         "@tokenizer/inflate": "^0.4.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -93,6 +93,7 @@
     "js-yaml": "4.1.1",
     "qs": "6.14.2",
     "multer": "2.1.1",
+    "file-type": "21.3.1",
     "@angular-devkit/core": {
       "ajv": "8.18.0"
     }


### PR DESCRIPTION
## Summary

- Adds `"file-type": "21.3.1"` to the `overrides` section in `backend/package.json`
- Forces the patched version of `file-type` (transitive dep via `@nestjs/common`) to resolve a moderate severity vulnerability
- `npm audit` now reports **0 vulnerabilities** in the backend

**Vulnerability:** [GHSA-5v7r-6r5c-r473](https://github.com/advisories/GHSA-5v7r-6r5c-r473) — infinite loop in the ASF parser on malformed input with zero-size sub-header

**Why override instead of `npm audit fix`:** NestJS hasn't released a patched `@nestjs/common` yet — the override is the correct approach and is already used in this project for other transitive deps.

Closes #70

## Test plan

- [x] Run `cd backend && npm audit` — should report 0 vulnerabilities
- [x] Run `cd backend && npm run build` — should succeed
- [x] Run `cd backend && npm run test` — all tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)