### PR TITLE
fix(purchasing): fix product search accumulation in Create Purchase Order (#72)

### DIFF
--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -94,6 +94,7 @@ const CreatePurchaseOrderPage: React.FC = () => {
   const [loadingOrder, setLoadingOrder] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [orderToLoad, setOrderToLoad] = useState<any>(null)
+  const latestProductsRequestRef = React.useRef(0)
   const { data: suppliersResponse } = useGetSuppliersQuery({})
   const [createPurchaseOrder] = useCreatePurchaseOrderMutation()
   const [updatePurchaseOrder] = useUpdatePurchaseOrderMutation()
@@ -250,12 +251,19 @@ const CreatePurchaseOrderPage: React.FC = () => {
   }, [JSON.stringify(watchedItems), setValue])
 
   const loadProducts = async (searchTerm: string = '') => {
+    const requestId = ++latestProductsRequestRef.current
+
     try {
       const params: any = { isActive: true }
       if (searchTerm && searchTerm.trim().length >= 1) {
         params.search = searchTerm.trim()
       }
       const response = await api.get('/inventory/products', { params })
+
+      if (requestId !== latestProductsRequestRef.current) {
+        return
+      }
+
       console.log('Products loaded:', response)
       const newProducts = (response as any).data?.data || []
 

--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -570,8 +570,9 @@ const CreatePurchaseOrderPage: React.FC = () => {
                                 render={({ field: productField }) => (
                                   <Autocomplete
                                     options={products}
-                                    getOptionLabel={(option) => option.name}
-                                    value={products.find(p => p.id === productField.value) || null}
+                                    getOptionLabel={(option) => option?.name || ''}
+                                    isOptionEqualToValue={(option, value) => option.id === value.id}
+                                    value={watchedItems[index]?.product || products.find(p => p.id === productField.value) || null}
                                     onChange={(_, value) => handleProductSelect(index, value)}
                                     onInputChange={(_, value, reason) => {
                                       if (reason === 'input' && value.trim().length >= 1) {

--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -259,12 +259,7 @@ const CreatePurchaseOrderPage: React.FC = () => {
       console.log('Products loaded:', response)
       const newProducts = (response as any).data?.data || []
 
-      // Merge with existing products to preserve order item products
-      setProducts((prevProducts) => {
-        const existingIds = new Set(prevProducts.map(p => p.id))
-        const productsToAdd = newProducts.filter((p: any) => !existingIds.has(p.id))
-        return [...prevProducts, ...productsToAdd]
-      })
+      setProducts(newProducts)
     } catch (err) {
       console.error('Error loading products:', err)
     }

--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -89,6 +89,10 @@ const CreatePurchaseOrderPage: React.FC = () => {
   const { id } = useParams<{ id: string }>()
   const isEditMode = !!id
   const { showSuccess, showError } = useNotification()
+  // Shared options list for all product Autocomplete rows. Replaced (not merged) on each
+  // search so the dropdown shows only current results. Selected values survive options
+  // replacement because each row's `value` prop is sourced from watchedItems, not from
+  // this array — see `isOptionEqualToValue` and the value expression in the Autocomplete.
   const [products, setProducts] = useState<any[]>([])
   const [loading, setLoading] = useState(false)
   const [loadingOrder, setLoadingOrder] = useState(false)

--- a/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
@@ -6,6 +6,8 @@ import { BrowserRouter } from 'react-router-dom'
 
 import CreatePurchaseOrderPage from '../CreatePurchaseOrderPage'
 
+const replacementSearchTerm = 'B'
+
 const {
   mockDispatch,
   mockGet,
@@ -69,7 +71,7 @@ describe('CreatePurchaseOrderPage', () => {
     mockParams.mockReturnValue({})
 
     mockGet.mockImplementation(async (_url: string, config?: { params?: { search?: string } }) => {
-      if (config?.params?.search === 'Beta Gadget') {
+      if (config?.params?.search?.startsWith(replacementSearchTerm)) {
         return {
           data: {
             data: [{ id: 'product-2', name: 'Beta Gadget', baseCost: 22 }],
@@ -101,11 +103,11 @@ describe('CreatePurchaseOrderPage', () => {
     expect(within(initialListbox).getByText('Alpha Widget')).toBeInTheDocument()
 
     await user.clear(productInput)
-    await user.type(productInput, 'Beta Gadget')
+    await user.type(productInput, replacementSearchTerm)
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, search: 'Beta Gadget' },
+        params: { isActive: true, search: replacementSearchTerm },
       })
     })
 
@@ -140,11 +142,11 @@ describe('CreatePurchaseOrderPage', () => {
     const secondProductInput = productInputs[1]
 
     await user.click(secondProductInput)
-    await user.type(secondProductInput, 'Beta Gadget')
+    await user.type(secondProductInput, replacementSearchTerm)
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, search: 'Beta Gadget' },
+        params: { isActive: true, search: replacementSearchTerm },
       })
     })
 
@@ -201,11 +203,11 @@ describe('CreatePurchaseOrderPage', () => {
     const secondProductInput = productInputs[1]
 
     await user.click(secondProductInput)
-    await user.type(secondProductInput, 'Beta Gadget')
+    await user.type(secondProductInput, replacementSearchTerm)
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, search: 'Beta Gadget' },
+        params: { isActive: true, search: replacementSearchTerm },
       })
     })
 

--- a/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
@@ -1,0 +1,113 @@
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BrowserRouter } from 'react-router-dom'
+
+import CreatePurchaseOrderPage from '../CreatePurchaseOrderPage'
+
+const {
+  mockDispatch,
+  mockGet,
+  mockCreatePurchaseOrder,
+  mockUpdatePurchaseOrder,
+  mockFetchPurchaseOrder,
+} = vi.hoisted(() => ({
+  mockDispatch: vi.fn(),
+  mockGet: vi.fn(),
+  mockCreatePurchaseOrder: vi.fn(),
+  mockUpdatePurchaseOrder: vi.fn(),
+  mockFetchPurchaseOrder: vi.fn(),
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+    useParams: () => ({}),
+  }
+})
+
+vi.mock('@/hooks/useRedux', () => ({
+  useAppDispatch: () => mockDispatch,
+}))
+
+vi.mock('@/hooks/useNotification', () => ({
+  useNotification: () => ({
+    showSuccess: vi.fn(),
+    showError: vi.fn(),
+  }),
+}))
+
+vi.mock('@/hooks/useCurrency', () => ({
+  useCurrency: () => ({ currency: '$' }),
+}))
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: mockGet,
+  },
+}))
+
+vi.mock('@/store/api/purchasingApi', () => ({
+  useGetSuppliersQuery: () => ({
+    data: {
+      data: [{ id: 'supplier-1', companyName: 'Acme Supplies' }],
+    },
+  }),
+  useCreatePurchaseOrderMutation: () => [mockCreatePurchaseOrder],
+  useUpdatePurchaseOrderMutation: () => [mockUpdatePurchaseOrder],
+  useLazyGetPurchaseOrderQuery: () => [mockFetchPurchaseOrder],
+}))
+
+describe('CreatePurchaseOrderPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockGet.mockImplementation(async (_url: string, config?: { params?: { search?: string } }) => {
+      if (config?.params?.search === 'Beta Gadget') {
+        return {
+          data: {
+            data: [{ id: 'product-2', name: 'Beta Gadget', baseCost: 22 }],
+          },
+        }
+      }
+
+      return {
+        data: {
+          data: [{ id: 'product-1', name: 'Alpha Widget', baseCost: 11 }],
+        },
+      }
+    })
+  })
+
+  it('replaces the autocomplete options with only the latest product search results', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <BrowserRouter>
+        <CreatePurchaseOrderPage />
+      </BrowserRouter>
+    )
+
+    const productInput = screen.getByPlaceholderText('Search by name or barcode...')
+    await user.click(productInput)
+
+    const initialListbox = await screen.findByRole('listbox')
+    expect(within(initialListbox).getByText('Alpha Widget')).toBeInTheDocument()
+
+    await user.clear(productInput)
+    await user.type(productInput, 'Beta Gadget')
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
+        params: { isActive: true, search: 'Beta Gadget' },
+      })
+    })
+
+    const updatedListbox = await screen.findByRole('listbox')
+    expect(within(updatedListbox).getByText('Beta Gadget')).toBeInTheDocument()
+    expect(within(updatedListbox).queryByText('Alpha Widget')).toBeNull()
+  })
+})

--- a/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
@@ -12,12 +12,14 @@ const {
   mockCreatePurchaseOrder,
   mockUpdatePurchaseOrder,
   mockFetchPurchaseOrder,
+  mockParams,
 } = vi.hoisted(() => ({
   mockDispatch: vi.fn(),
   mockGet: vi.fn(),
   mockCreatePurchaseOrder: vi.fn(),
   mockUpdatePurchaseOrder: vi.fn(),
   mockFetchPurchaseOrder: vi.fn(),
+  mockParams: vi.fn(() => ({})),
 }))
 
 vi.mock('react-router-dom', async () => {
@@ -25,7 +27,7 @@ vi.mock('react-router-dom', async () => {
   return {
     ...actual,
     useNavigate: () => vi.fn(),
-    useParams: () => ({}),
+    useParams: () => mockParams(),
   }
 })
 
@@ -64,6 +66,7 @@ vi.mock('@/store/api/purchasingApi', () => ({
 describe('CreatePurchaseOrderPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockParams.mockReturnValue({})
 
     mockGet.mockImplementation(async (_url: string, config?: { params?: { search?: string } }) => {
       if (config?.params?.search === 'Beta Gadget') {
@@ -147,6 +150,67 @@ describe('CreatePurchaseOrderPage', () => {
 
     await waitFor(() => {
       expect(firstProductInput).toHaveValue('Alpha Widget')
+    })
+  })
+
+  it('keeps hydrated edit-mode product visible after shared search options are replaced', async () => {
+    const user = userEvent.setup()
+
+    mockParams.mockReturnValue({ id: 'po-1' })
+    mockFetchPurchaseOrder.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({
+        data: {
+          id: 'po-1',
+          supplierId: 'supplier-1',
+          orderDate: '2026-03-01T00:00:00.000Z',
+          shippingAmount: 0,
+          items: [
+            {
+              productId: 'product-9',
+              quantity: 2,
+              unitPrice: 44,
+              discountAmount: 0,
+              discountPercent: 0,
+              totalAmount: 88,
+              product: { id: 'product-9', name: 'Hydrated Product', baseCost: 44 },
+            },
+          ],
+        },
+      }),
+    })
+
+    render(
+      <BrowserRouter>
+        <CreatePurchaseOrderPage />
+      </BrowserRouter>
+    )
+
+    await waitFor(() => {
+      expect(mockFetchPurchaseOrder).toHaveBeenCalledWith('po-1')
+    })
+
+    const [firstProductInput] = await screen.findAllByPlaceholderText('Search by name or barcode...')
+
+    await waitFor(() => {
+      expect(firstProductInput).toHaveValue('Hydrated Product')
+    })
+
+    await user.click(screen.getByRole('button', { name: /add item/i }))
+
+    const productInputs = screen.getAllByPlaceholderText('Search by name or barcode...')
+    const secondProductInput = productInputs[1]
+
+    await user.click(secondProductInput)
+    await user.type(secondProductInput, 'Beta Gadget')
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
+        params: { isActive: true, search: 'Beta Gadget' },
+      })
+    })
+
+    await waitFor(() => {
+      expect(firstProductInput).toHaveValue('Hydrated Product')
     })
   })
 })

--- a/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
@@ -110,4 +110,43 @@ describe('CreatePurchaseOrderPage', () => {
     expect(within(updatedListbox).getByText('Beta Gadget')).toBeInTheDocument()
     expect(within(updatedListbox).queryByText('Alpha Widget')).toBeNull()
   })
+
+  it('keeps the selected product visible when another search replaces the shared options list', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <BrowserRouter>
+        <CreatePurchaseOrderPage />
+      </BrowserRouter>
+    )
+
+    const [firstProductInput] = screen.getAllByPlaceholderText('Search by name or barcode...')
+
+    await user.click(firstProductInput)
+
+    const initialListbox = await screen.findByRole('listbox')
+    await user.click(within(initialListbox).getByText('Alpha Widget'))
+
+    await waitFor(() => {
+      expect(firstProductInput).toHaveValue('Alpha Widget')
+    })
+
+    await user.click(screen.getByRole('button', { name: /add item/i }))
+
+    const productInputs = screen.getAllByPlaceholderText('Search by name or barcode...')
+    const secondProductInput = productInputs[1]
+
+    await user.click(secondProductInput)
+    await user.type(secondProductInput, 'Beta Gadget')
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
+        params: { isActive: true, search: 'Beta Gadget' },
+      })
+    })
+
+    await waitFor(() => {
+      expect(firstProductInput).toHaveValue('Alpha Widget')
+    })
+  })
 })

--- a/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
@@ -1,12 +1,21 @@
 import '@testing-library/jest-dom/vitest'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router-dom'
 
 import CreatePurchaseOrderPage from '../CreatePurchaseOrderPage'
 
 const replacementSearchTerm = 'B'
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+
+  return { promise, resolve }
+}
 
 const {
   mockDispatch,
@@ -213,6 +222,67 @@ describe('CreatePurchaseOrderPage', () => {
 
     await waitFor(() => {
       expect(firstProductInput).toHaveValue('Hydrated Product')
+    })
+  })
+
+  it('ignores stale earlier product responses that finish after the latest search', async () => {
+    const user = userEvent.setup()
+    const initialProductsRequest = createDeferred<any>()
+    const latestSearchRequest = createDeferred<any>()
+
+    mockGet.mockImplementation(async (_url: string, config?: { params?: { search?: string } }) => {
+      if (config?.params?.search === replacementSearchTerm) {
+        return latestSearchRequest.promise
+      }
+
+      return initialProductsRequest.promise
+    })
+
+    render(
+      <BrowserRouter>
+        <CreatePurchaseOrderPage />
+      </BrowserRouter>
+    )
+
+    const productInput = screen.getByPlaceholderText('Search by name or barcode...')
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
+        params: { isActive: true },
+      })
+    })
+
+    await user.click(productInput)
+    await user.type(productInput, replacementSearchTerm)
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
+        params: { isActive: true, search: replacementSearchTerm },
+      })
+    })
+
+    await act(async () => {
+      latestSearchRequest.resolve({
+        data: {
+          data: [{ id: 'product-2', name: 'Beta Gadget', baseCost: 22 }],
+        },
+      })
+    })
+
+    const listbox = await screen.findByRole('listbox')
+    expect(within(listbox).getByText('Beta Gadget')).toBeInTheDocument()
+
+    await act(async () => {
+      initialProductsRequest.resolve({
+        data: {
+          data: [{ id: 'product-1', name: 'Alpha Widget', baseCost: 11 }],
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(within(listbox).getByText('Beta Gadget')).toBeInTheDocument()
+      expect(within(listbox).queryByText('Alpha Widget')).toBeNull()
     })
   })
 })


### PR DESCRIPTION
## Summary

- Fixes product search dropdown accumulating results from previous searches instead of showing only current matches
- Adds race-condition guard (`latestProductsRequestRef`) so stale slow responses don't overwrite newer fast ones
- Fixes selected product values persisting in rows when the options list is replaced (sourced from form state via `watchedItems` rather than the `products` array)
- Adds 4 Vitest regression tests covering: primary bug, cross-row value persistence, edit-mode hydration, and stale response race condition
- Documents the shared `products` state design with a comment for future maintainers

## Test plan

- [x] All Vitest tests pass: `cd frontend && npx vitest run src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx`
- [x] Search for "A" in the Product field — only matching products appear
- [x] Clear and search "B" — only "B" matches appear, no carryover from "A"
- [x] Open an existing purchase order in edit mode — product names are pre-populated in all line item rows
- [x] TypeScript check passes: `cd frontend && npm run type-check`

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)