### PR TITLE
fix: standardise toolbar element heights to 40px across all pages (#76)

### DIFF
--- a/frontend/src/pages/purchasing/components/PurchaseOrdersToolbar.tsx
+++ b/frontend/src/pages/purchasing/components/PurchaseOrdersToolbar.tsx
@@ -82,7 +82,19 @@ const PurchaseOrdersToolbar: React.FC<PurchaseOrdersToolbarProps> = ({
             value={filters.search}
             onChange={(event) => onFilterChange({ search: event.target.value })}
             size="medium"
-            sx={{ minWidth: isMobile ? 'auto' : 250, flex: isMobile ? 'none' : 1, maxWidth: isMobile ? 'none' : 400 }}
+            sx={{
+              minWidth: isMobile ? 'auto' : 250,
+              flex: isMobile ? 'none' : 1,
+              maxWidth: isMobile ? 'none' : 400,
+              '& .MuiOutlinedInput-root': {
+                height: TYPOGRAPHY_STYLES.searchField.input.height,
+                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                '& input': {
+                  padding: TYPOGRAPHY_STYLES.searchField.input.padding,
+                  fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                },
+              },
+            }}
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">
@@ -92,7 +104,16 @@ const PurchaseOrdersToolbar: React.FC<PurchaseOrdersToolbarProps> = ({
             }}
           />
 
-          <FormControl size="medium" sx={{ minWidth: isMobile ? 'auto' : 120 }}>
+          <FormControl
+            size="medium"
+            sx={{
+              minWidth: isMobile ? 'auto' : 120,
+              '& .MuiOutlinedInput-root': {
+                height: TYPOGRAPHY_STYLES.searchField.input.height,
+                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+              },
+            }}
+          >
             <InputLabel>Date Filter</InputLabel>
             <Select value={filters.dateFilter} label="Date Filter" onChange={(event) => onFilterChange({ dateFilter: event.target.value })}>
               <MenuItem value="all">All</MenuItem>
@@ -108,12 +129,57 @@ const PurchaseOrdersToolbar: React.FC<PurchaseOrdersToolbarProps> = ({
 
           {filters.dateFilter === 'custom' && (
             <>
-              <TextField label="From Date" type="date" value={filters.customFromDate} onChange={(event) => onFilterChange({ customFromDate: event.target.value })} size="medium" sx={{ minWidth: isMobile ? 'auto' : 120 }} InputLabelProps={{ shrink: true }} />
-              <TextField label="To Date" type="date" value={filters.customToDate} onChange={(event) => onFilterChange({ customToDate: event.target.value })} size="medium" sx={{ minWidth: isMobile ? 'auto' : 120 }} InputLabelProps={{ shrink: true }} />
+              <TextField
+                label="From Date"
+                type="date"
+                value={filters.customFromDate}
+                onChange={(event) => onFilterChange({ customFromDate: event.target.value })}
+                size="medium"
+                sx={{
+                  minWidth: isMobile ? 'auto' : 120,
+                  '& .MuiOutlinedInput-root': {
+                    height: TYPOGRAPHY_STYLES.searchField.input.height,
+                    fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                    '& input': {
+                      padding: TYPOGRAPHY_STYLES.searchField.input.padding,
+                      fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                    },
+                  },
+                }}
+                InputLabelProps={{ shrink: true }}
+              />
+              <TextField
+                label="To Date"
+                type="date"
+                value={filters.customToDate}
+                onChange={(event) => onFilterChange({ customToDate: event.target.value })}
+                size="medium"
+                sx={{
+                  minWidth: isMobile ? 'auto' : 120,
+                  '& .MuiOutlinedInput-root': {
+                    height: TYPOGRAPHY_STYLES.searchField.input.height,
+                    fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                    '& input': {
+                      padding: TYPOGRAPHY_STYLES.searchField.input.padding,
+                      fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                    },
+                  },
+                }}
+                InputLabelProps={{ shrink: true }}
+              />
             </>
           )}
 
-          <FormControl size="medium" sx={{ minWidth: isMobile ? 'auto' : 120 }}>
+          <FormControl
+            size="medium"
+            sx={{
+              minWidth: isMobile ? 'auto' : 120,
+              '& .MuiOutlinedInput-root': {
+                height: TYPOGRAPHY_STYLES.searchField.input.height,
+                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+              },
+            }}
+          >
             <InputLabel>Supplier</InputLabel>
             <Select value={filters.supplierFilter} label="Supplier" onChange={(event) => onFilterChange({ supplierFilter: event.target.value })}>
               <MenuItem value="all">All</MenuItem>
@@ -126,7 +192,12 @@ const PurchaseOrdersToolbar: React.FC<PurchaseOrdersToolbarProps> = ({
           </FormControl>
 
           {hasActiveFilters && (
-            <Button variant="outlined" size="medium" onClick={onClearFilters}>
+            <Button
+              variant="outlined"
+              size="medium"
+              onClick={onClearFilters}
+              sx={{ height: TYPOGRAPHY_STYLES.searchField.input.height, fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize }}
+            >
               Clear Filters
             </Button>
           )}
@@ -136,6 +207,7 @@ const PurchaseOrdersToolbar: React.FC<PurchaseOrdersToolbarProps> = ({
             size="medium"
             startIcon={filters.sortBy === 'orderNumber' ? filters.sortOrder === 'desc' ? <ArrowDownIcon /> : <ArrowUpIcon /> : <SortIcon />}
             onClick={() => onSort('orderNumber')}
+            sx={{ height: TYPOGRAPHY_STYLES.searchField.input.height, fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize }}
           >
             Sort
           </Button>

--- a/frontend/src/pages/sales/components/InvoicesToolbar.tsx
+++ b/frontend/src/pages/sales/components/InvoicesToolbar.tsx
@@ -138,10 +138,10 @@ const InvoicesToolbar: React.FC<InvoicesToolbarProps> = ({
               maxWidth: isMobile ? 'none' : 400,
               '& .MuiOutlinedInput-root': {
                 height: TYPOGRAPHY_STYLES.searchField.input.height,
-                fontSize: '0.875rem',
+                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
                 '& input': {
-                  padding: '8.5px 14px',
-                  fontSize: '0.875rem',
+                  padding: TYPOGRAPHY_STYLES.searchField.input.padding,
+                  fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
                 },
               },
             }}
@@ -160,7 +160,7 @@ const InvoicesToolbar: React.FC<InvoicesToolbarProps> = ({
               minWidth: isMobile ? 'auto' : 120,
               '& .MuiOutlinedInput-root': {
                 height: TYPOGRAPHY_STYLES.searchField.input.height,
-                fontSize: '0.875rem',
+                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
               },
             }}
           >
@@ -170,17 +170,17 @@ const InvoicesToolbar: React.FC<InvoicesToolbarProps> = ({
               label="Date Filter"
               onChange={(event) => onFilterChange({ dateFilter: event.target.value })}
               sx={{
-                fontSize: '0.875rem',
+                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
                 '& .MuiSelect-select': {
-                  padding: '8.5px 14px',
-                  fontSize: '0.875rem',
+                  padding: TYPOGRAPHY_STYLES.searchField.input.padding,
+                  fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
                 },
               }}
               MenuProps={{
                 PaperProps: {
                   sx: {
                     '& .MuiMenuItem-root': {
-                      fontSize: '0.875rem',
+                      fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
                     },
                   },
                 },
@@ -209,7 +209,11 @@ const InvoicesToolbar: React.FC<InvoicesToolbarProps> = ({
                   minWidth: 120,
                   '& .MuiOutlinedInput-root': {
                     height: TYPOGRAPHY_STYLES.searchField.input.height,
-                    fontSize: '0.875rem',
+                    fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                    '& input': {
+                      padding: TYPOGRAPHY_STYLES.searchField.input.padding,
+                      fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                    },
                   },
                 }}
                 InputLabelProps={{ shrink: true }}
@@ -224,7 +228,11 @@ const InvoicesToolbar: React.FC<InvoicesToolbarProps> = ({
                   minWidth: 120,
                   '& .MuiOutlinedInput-root': {
                     height: TYPOGRAPHY_STYLES.searchField.input.height,
-                    fontSize: '0.875rem',
+                    fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                    '& input': {
+                      padding: TYPOGRAPHY_STYLES.searchField.input.padding,
+                      fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                    },
                   },
                 }}
                 InputLabelProps={{ shrink: true }}
@@ -241,7 +249,7 @@ const InvoicesToolbar: React.FC<InvoicesToolbarProps> = ({
                 minWidth: 'auto',
                 px: 2,
                 height: TYPOGRAPHY_STYLES.searchField.input.height,
-                fontSize: '0.875rem',
+                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
               }}
             >
               Clear Filters
@@ -261,7 +269,7 @@ const InvoicesToolbar: React.FC<InvoicesToolbarProps> = ({
             onClick={() => onSort('invoiceNumber')}
             sx={{
               height: TYPOGRAPHY_STYLES.searchField.input.height,
-              fontSize: '0.875rem',
+              fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
               minWidth: 'auto',
               px: 2,
             }}

--- a/frontend/src/pages/sales/components/OrdersToolbar.tsx
+++ b/frontend/src/pages/sales/components/OrdersToolbar.tsx
@@ -167,10 +167,10 @@ const OrdersToolbar: React.FC<OrdersToolbarProps> = ({
               maxWidth: isMobile ? 'none' : 400,
               '& .MuiOutlinedInput-root': {
                 height: TYPOGRAPHY_STYLES.searchField.input.height,
-                fontSize: '0.875rem',
+                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
                 '& input': {
-                  padding: '8.5px 14px',
-                  fontSize: '0.875rem',
+                  padding: TYPOGRAPHY_STYLES.searchField.input.padding,
+                  fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
                 },
               },
             }}
@@ -185,7 +185,16 @@ const OrdersToolbar: React.FC<OrdersToolbarProps> = ({
             }}
           />
 
-          <FormControl size="medium" sx={{ minWidth: isMobile ? 'auto' : 120 }}>
+          <FormControl
+            size="medium"
+            sx={{
+              minWidth: isMobile ? 'auto' : 120,
+              '& .MuiOutlinedInput-root': {
+                height: TYPOGRAPHY_STYLES.searchField.input.height,
+                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+              },
+            }}
+          >
             <InputLabel>Date Filter</InputLabel>
             <Select
               value={orderFilters.dateFilter}
@@ -211,7 +220,17 @@ const OrdersToolbar: React.FC<OrdersToolbarProps> = ({
                 value={orderFilters.customFromDate}
                 onChange={(event) => onFilterChange({ customFromDate: event.target.value })}
                 size="medium"
-                sx={{ minWidth: 120 }}
+                sx={{
+                  minWidth: 120,
+                  '& .MuiOutlinedInput-root': {
+                    height: TYPOGRAPHY_STYLES.searchField.input.height,
+                    fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                    '& input': {
+                      padding: TYPOGRAPHY_STYLES.searchField.input.padding,
+                      fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                    },
+                  },
+                }}
                 slotProps={{ inputLabel: { shrink: true } }}
               />
               <TextField
@@ -220,13 +239,32 @@ const OrdersToolbar: React.FC<OrdersToolbarProps> = ({
                 value={orderFilters.customToDate}
                 onChange={(event) => onFilterChange({ customToDate: event.target.value })}
                 size="medium"
-                sx={{ minWidth: 120 }}
+                sx={{
+                  minWidth: 120,
+                  '& .MuiOutlinedInput-root': {
+                    height: TYPOGRAPHY_STYLES.searchField.input.height,
+                    fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                    '& input': {
+                      padding: TYPOGRAPHY_STYLES.searchField.input.padding,
+                      fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                    },
+                  },
+                }}
                 slotProps={{ inputLabel: { shrink: true } }}
               />
             </>
           )}
 
-          <FormControl size="medium" sx={{ minWidth: isMobile ? 'auto' : 120 }}>
+          <FormControl
+            size="medium"
+            sx={{
+              minWidth: isMobile ? 'auto' : 120,
+              '& .MuiOutlinedInput-root': {
+                height: TYPOGRAPHY_STYLES.searchField.input.height,
+                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+              },
+            }}
+          >
             <InputLabel>Customer</InputLabel>
             <Select
               value={orderFilters.customerId}
@@ -242,7 +280,16 @@ const OrdersToolbar: React.FC<OrdersToolbarProps> = ({
             </Select>
           </FormControl>
 
-          <FormControl size="medium" sx={{ minWidth: isMobile ? 'auto' : 120 }}>
+          <FormControl
+            size="medium"
+            sx={{
+              minWidth: isMobile ? 'auto' : 120,
+              '& .MuiOutlinedInput-root': {
+                height: TYPOGRAPHY_STYLES.searchField.input.height,
+                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+              },
+            }}
+          >
             <InputLabel>Payment Status</InputLabel>
             <Select
               value={orderFilters.paymentStatus}
@@ -257,7 +304,16 @@ const OrdersToolbar: React.FC<OrdersToolbarProps> = ({
             </Select>
           </FormControl>
 
-          <FormControl size="medium" sx={{ minWidth: isMobile ? 'auto' : 120 }}>
+          <FormControl
+            size="medium"
+            sx={{
+              minWidth: isMobile ? 'auto' : 120,
+              '& .MuiOutlinedInput-root': {
+                height: TYPOGRAPHY_STYLES.searchField.input.height,
+                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+              },
+            }}
+          >
             <InputLabel>Fulfillment</InputLabel>
             <Select
               value={orderFilters.fulfillmentStatus}
@@ -271,7 +327,15 @@ const OrdersToolbar: React.FC<OrdersToolbarProps> = ({
           </FormControl>
 
           {hasActiveFilters && (
-            <Button variant="outlined" size="medium" onClick={onClearFilters}>
+            <Button
+              variant="outlined"
+              size="medium"
+              onClick={onClearFilters}
+              sx={{
+                height: TYPOGRAPHY_STYLES.searchField.input.height,
+                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+              }}
+            >
               Clear Filters
             </Button>
           )}
@@ -279,6 +343,10 @@ const OrdersToolbar: React.FC<OrdersToolbarProps> = ({
           <Button
             variant={orderFilters.sortBy === 'orderNumber' ? 'contained' : 'outlined'}
             size="medium"
+            sx={{
+              height: TYPOGRAPHY_STYLES.searchField.input.height,
+              fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+            }}
             startIcon={
               orderFilters.sortBy === 'orderNumber' ? (
                 orderFilters.sortOrder === 'desc' ? <ArrowDownIcon /> : <ArrowUpIcon />


### PR DESCRIPTION
## Summary

- Fixes UI inconsistency (#76): filter-area toolbar elements in Purchase Orders were taller than those on Products, Sales Orders, and Invoices pages
- Applies `TYPOGRAPHY_STYLES.searchField.input` constants (`height: '40px'`, `fontSize: '0.875rem'`, `padding: '8.5px 14px'`) consistently across 3 toolbar files
- Also fixes the same missing overrides in `OrdersToolbar` (Customer, Payment Status, Fulfillment selects; date fields; Sort and Clear Filters buttons)
- Replaces hardcoded values in `InvoicesToolbar` with constants; preserves `MenuProps` font override (MUI default menu item font is 1rem, not 0.875rem)
- `ProductsToolbar` already correct — untouched

## Files changed

- `frontend/src/pages/purchasing/components/PurchaseOrdersToolbar.tsx` — 7 elements fixed
- `frontend/src/pages/sales/components/OrdersToolbar.tsx` — 9 elements fixed
- `frontend/src/pages/sales/components/InvoicesToolbar.tsx` — 6 elements fixed

## Test plan

- [x] Navigate to Purchase Orders — confirm search field, dropdowns, and buttons are 40px tall
- [x] Navigate to Sales Orders — confirm all filter dropdowns and buttons match height
- [x] Navigate to Products — confirm toolbar heights match Purchase Orders side by side
- [x] Set a custom date range on Purchase Orders and Sales Orders — confirm date fields are also 40px

🤖 Generated with [Claude Code](https://claude.com/claude-code)