### PR TITLE
fix: persist notifications across browser refresh (issue #81)

### DIFF
--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -24,6 +24,7 @@ import { accountingApiSlice } from './api/accountingApi'
 import { settingsApiSlice } from './api/settingsApi'
 import { paymentMethodsApiSlice } from './api/paymentMethodsApi'
 import { printSettingsApiSlice } from './api/printSettingsApi'
+import { PERSIST_KEY } from './persistKey'
 
 const rootReducer = combineReducers({
   theme: themeSlice,
@@ -50,25 +51,34 @@ const rootReducer = combineReducers({
 
 // Persist configuration
 const persistConfig = {
-  key: 'erp-app',
+  key: PERSIST_KEY,
   storage,
-  whitelist: ['theme', 'auth'],
-  version: 4,
+  whitelist: ['theme', 'auth', 'notifications'],
+  version: 5,
   migrate: (state: any) => {
-    // Force dark mode for all users on version 2+
+    // Migration runs when persisted _persist.version !== persistConfig.version.
+    // For all existing v4 users, state.notifications is undefined (was not
+    // whitelisted), so the ?? [] fallback is the normal code path.
+    // On a cold start (no persisted state at all), redux-persist does not call
+    // migrate — REHYDRATE fires with payload === undefined instead.
     if (state) {
-      const newState = {
-        ...state,
-        theme: state.theme ? {
-          ...state.theme,
-          mode: 'dark'
-        } : { mode: 'dark' }
-      };
+      const notifications: any[] = state.notifications?.notifications ?? []
+      const capped = notifications.slice(0, 50) // newest-first invariant
+      const unreadCount = capped.filter((n: any) => !n.read).length
 
-      return Promise.resolve(newState);
+      return Promise.resolve({
+        ...state,
+        theme: state.theme
+          ? { ...state.theme, mode: 'dark' }
+          : { mode: 'dark' },
+        notifications: {
+          notifications: capped,
+          unreadCount,
+        },
+      })
     }
     return Promise.resolve(state)
-  }
+  },
 }
 
 const persistedReducer = persistReducer(persistConfig, rootReducer)

--- a/frontend/src/store/persistKey.ts
+++ b/frontend/src/store/persistKey.ts
@@ -1,0 +1,1 @@
+export const PERSIST_KEY = 'erp-app'

--- a/frontend/src/store/slices/__tests__/notificationSlice.test.ts
+++ b/frontend/src/store/slices/__tests__/notificationSlice.test.ts
@@ -97,10 +97,7 @@ describe('notificationSlice', () => {
     for (let i = 0; i < 51; i++) {
       store.dispatch(addNotification({ type: 'info', title: `N${i}`, message: 'm' }))
     }
-    // unreadCount should match the number of unread notifications in the capped array
-    const notifications = selectNotifications(store.getState())
-    const expectedUnread = notifications.filter((n) => !n.read).length
-    expect(selectUnreadCount(store.getState())).toBe(expectedUnread)
+    expect(selectUnreadCount(store.getState())).toBe(50)
   })
 
   // -- removeNotification floor guard --------------------------------------

--- a/frontend/src/store/slices/__tests__/notificationSlice.test.ts
+++ b/frontend/src/store/slices/__tests__/notificationSlice.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { configureStore } from '@reduxjs/toolkit'
+import { REHYDRATE } from 'redux-persist'
 import notificationReducer, {
   addNotification,
+  removeNotification,
+  markAsRead,
+  markAllAsRead,
   selectNotifications,
   selectUnreadCount,
 } from '../notificationSlice'
@@ -54,6 +58,117 @@ describe('notificationSlice', () => {
     store.dispatch({ type: logout.fulfilled.type })
 
     expect(selectNotifications(store.getState())).toHaveLength(0)
+    expect(selectUnreadCount(store.getState())).toBe(0)
+  })
+
+  // -- Cap at 50 -----------------------------------------------------------
+
+  it('caps notifications at 50 when a 51st is added', () => {
+    for (let i = 0; i < 51; i++) {
+      store.dispatch(addNotification({ type: 'info', title: `N${i}`, message: 'm' }))
+    }
+    const notifications = selectNotifications(store.getState())
+    expect(notifications).toHaveLength(50)
+  })
+
+  it('drops the oldest notification when cap is exceeded', () => {
+    // Add 50 notifications -- oldest is "first"
+    for (let i = 0; i < 50; i++) {
+      store.dispatch(addNotification({ type: 'info', title: `N${i}`, message: 'm' }))
+    }
+    // Add a 51st -- "newest" should be at index 0, "first" should be gone
+    store.dispatch(addNotification({ type: 'success', title: 'newest', message: 'm' }))
+    const notifications = selectNotifications(store.getState())
+    expect(notifications[0].title).toBe('newest')
+    expect(notifications.find((n) => n.title === 'N0')).toBeUndefined()
+  })
+
+  it('keeps unreadCount correct after cap is applied', () => {
+    for (let i = 0; i < 51; i++) {
+      store.dispatch(addNotification({ type: 'info', title: `N${i}`, message: 'm' }))
+    }
+    // unreadCount should match the number of unread notifications in the capped array
+    const notifications = selectNotifications(store.getState())
+    const expectedUnread = notifications.filter((n) => !n.read).length
+    expect(selectUnreadCount(store.getState())).toBe(expectedUnread)
+  })
+
+  // -- removeNotification floor guard --------------------------------------
+
+  it('does not decrement unreadCount below zero on removeNotification', () => {
+    store.dispatch(addNotification({ type: 'info', title: 'X', message: 'm' }))
+    const id = selectNotifications(store.getState())[0].id
+    // Manually corrupt unreadCount to 0 by marking as read first
+    store.dispatch(markAsRead(id))
+    expect(selectUnreadCount(store.getState())).toBe(0)
+    // Now remove -- unreadCount must not go negative
+    store.dispatch(removeNotification(id))
+    expect(selectUnreadCount(store.getState())).toBe(0)
+  })
+
+  // -- REHYDRATE ------------------------------------------------------------
+
+  function makeNotification(i: number, read = false) {
+    return {
+      id: `id-${i}`,
+      type: 'info' as const,
+      title: `N${i}`,
+      message: 'm',
+      timestamp: new Date().toISOString(),
+      read,
+    }
+  }
+
+  it('trims to 50 and recalculates unreadCount on REHYDRATE with 60 notifications', () => {
+    const notifications = Array.from({ length: 60 }, (_, i) => makeNotification(i))
+    store.dispatch({
+      type: REHYDRATE,
+      key: 'erp-app',
+      payload: { notifications: { notifications, unreadCount: 60 } },
+    })
+    expect(selectNotifications(store.getState())).toHaveLength(50)
+    expect(selectUnreadCount(store.getState())).toBe(50)
+  })
+
+  it('is a no-op on REHYDRATE when payload is undefined', () => {
+    store.dispatch({ type: REHYDRATE, key: 'erp-app', payload: undefined })
+    expect(selectNotifications(store.getState())).toHaveLength(0)
+    expect(selectUnreadCount(store.getState())).toBe(0)
+  })
+
+  it('recalculates unreadCount correctly on REHYDRATE with mixed read/unread', () => {
+    const notifications = [
+      makeNotification(0, true),
+      makeNotification(1, false),
+      makeNotification(2, false),
+    ]
+    store.dispatch({
+      type: REHYDRATE,
+      key: 'erp-app',
+      payload: { notifications: { notifications, unreadCount: 99 } },
+    })
+    expect(selectUnreadCount(store.getState())).toBe(2)
+  })
+
+  it('markAsRead decrements unreadCount correctly after REHYDRATE', () => {
+    const notifications = [makeNotification(0, false), makeNotification(1, false)]
+    store.dispatch({
+      type: REHYDRATE,
+      key: 'erp-app',
+      payload: { notifications: { notifications, unreadCount: 2 } },
+    })
+    store.dispatch(markAsRead('id-0'))
+    expect(selectUnreadCount(store.getState())).toBe(1)
+  })
+
+  it('markAllAsRead sets unreadCount to 0 after REHYDRATE', () => {
+    const notifications = [makeNotification(0, false), makeNotification(1, false)]
+    store.dispatch({
+      type: REHYDRATE,
+      key: 'erp-app',
+      payload: { notifications: { notifications, unreadCount: 2 } },
+    })
+    store.dispatch(markAllAsRead())
     expect(selectUnreadCount(store.getState())).toBe(0)
   })
 })

--- a/frontend/src/store/slices/__tests__/notificationSlice.test.ts
+++ b/frontend/src/store/slices/__tests__/notificationSlice.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { configureStore } from '@reduxjs/toolkit'
 import { REHYDRATE } from 'redux-persist'
+import type { Notification } from '@/types'
 import notificationReducer, {
   addNotification,
   removeNotification,
@@ -23,9 +24,17 @@ vi.mock('@/services/authApi', () => ({
   },
 }))
 
-function createTestStore() {
+function createTestStore(
+  preloadedState?: {
+    notifications: {
+      notifications: Notification[]
+      unreadCount: number
+    }
+  },
+) {
   return configureStore({
     reducer: { notifications: notificationReducer },
+    preloadedState,
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({ serializableCheck: false }),
   })
@@ -96,13 +105,27 @@ describe('notificationSlice', () => {
   // -- removeNotification floor guard --------------------------------------
 
   it('does not decrement unreadCount below zero on removeNotification', () => {
-    store.dispatch(addNotification({ type: 'info', title: 'X', message: 'm' }))
-    const id = selectNotifications(store.getState())[0].id
-    // Manually corrupt unreadCount to 0 by marking as read first
-    store.dispatch(markAsRead(id))
+    const unreadNotification: Notification = {
+      id: 'floor-guard-id',
+      type: 'info',
+      title: 'X',
+      message: 'm',
+      timestamp: new Date().toISOString(),
+      read: false,
+    }
+
+    store = createTestStore({
+      notifications: {
+        notifications: [unreadNotification],
+        unreadCount: 0,
+      },
+    })
+
+    expect(selectNotifications(store.getState())).toEqual([unreadNotification])
     expect(selectUnreadCount(store.getState())).toBe(0)
-    // Now remove -- unreadCount must not go negative
-    store.dispatch(removeNotification(id))
+
+    store.dispatch(removeNotification(unreadNotification.id))
+
     expect(selectUnreadCount(store.getState())).toBe(0)
   })
 

--- a/frontend/src/store/slices/__tests__/notificationSlice.test.ts
+++ b/frontend/src/store/slices/__tests__/notificationSlice.test.ts
@@ -100,6 +100,24 @@ describe('notificationSlice', () => {
     expect(selectUnreadCount(store.getState())).toBe(50)
   })
 
+  it('keeps unreadCount stable when capping evicts an unread item from a mixed list', () => {
+    const notifications = Array.from({ length: 50 }, (_, i) => makeNotification(i, i < 30))
+    store = createTestStore({
+      notifications: {
+        notifications,
+        unreadCount: 20,
+      },
+    })
+
+    store.dispatch(addNotification({ type: 'info', title: 'newest', message: 'm' }))
+
+    const nextNotifications = selectNotifications(store.getState())
+    expect(nextNotifications).toHaveLength(50)
+    expect(nextNotifications[0].title).toBe('newest')
+    expect(nextNotifications.find((notification) => notification.id === 'id-49')).toBeUndefined()
+    expect(selectUnreadCount(store.getState())).toBe(20)
+  })
+
   // -- removeNotification floor guard --------------------------------------
 
   it('does not decrement unreadCount below zero on removeNotification', () => {

--- a/frontend/src/store/slices/__tests__/notificationSlice.test.ts
+++ b/frontend/src/store/slices/__tests__/notificationSlice.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { configureStore } from '@reduxjs/toolkit'
 import { REHYDRATE } from 'redux-persist'
 import type { Notification } from '@/types'
+import { PERSIST_KEY } from '../../persistKey'
 import notificationReducer, {
   addNotification,
   removeNotification,
@@ -146,17 +147,26 @@ describe('notificationSlice', () => {
     const notifications = Array.from({ length: 60 }, (_, i) => makeNotification(i))
     store.dispatch({
       type: REHYDRATE,
-      key: 'erp-app',
+      key: PERSIST_KEY,
       payload: { notifications: { notifications, unreadCount: 60 } },
     })
     expect(selectNotifications(store.getState())).toHaveLength(50)
     expect(selectUnreadCount(store.getState())).toBe(50)
   })
 
-  it('is a no-op on REHYDRATE when payload is undefined', () => {
-    store.dispatch({ type: REHYDRATE, key: 'erp-app', payload: undefined })
-    expect(selectNotifications(store.getState())).toHaveLength(0)
-    expect(selectUnreadCount(store.getState())).toBe(0)
+  it('preserves existing state on REHYDRATE when payload is undefined', () => {
+    const existingNotifications = [makeNotification(0, false), makeNotification(1, true)]
+    store = createTestStore({
+      notifications: {
+        notifications: existingNotifications,
+        unreadCount: 1,
+      },
+    })
+
+    store.dispatch({ type: REHYDRATE, key: PERSIST_KEY, payload: undefined })
+
+    expect(selectNotifications(store.getState())).toEqual(existingNotifications)
+    expect(selectUnreadCount(store.getState())).toBe(1)
   })
 
   it('recalculates unreadCount correctly on REHYDRATE with mixed read/unread', () => {
@@ -167,7 +177,7 @@ describe('notificationSlice', () => {
     ]
     store.dispatch({
       type: REHYDRATE,
-      key: 'erp-app',
+      key: PERSIST_KEY,
       payload: { notifications: { notifications, unreadCount: 99 } },
     })
     expect(selectUnreadCount(store.getState())).toBe(2)
@@ -177,7 +187,7 @@ describe('notificationSlice', () => {
     const notifications = [makeNotification(0, false), makeNotification(1, false)]
     store.dispatch({
       type: REHYDRATE,
-      key: 'erp-app',
+      key: PERSIST_KEY,
       payload: { notifications: { notifications, unreadCount: 2 } },
     })
     store.dispatch(markAsRead('id-0'))
@@ -188,7 +198,7 @@ describe('notificationSlice', () => {
     const notifications = [makeNotification(0, false), makeNotification(1, false)]
     store.dispatch({
       type: REHYDRATE,
-      key: 'erp-app',
+      key: PERSIST_KEY,
       payload: { notifications: { notifications, unreadCount: 2 } },
     })
     store.dispatch(markAllAsRead())

--- a/frontend/src/store/slices/__tests__/notificationSlice.test.ts
+++ b/frontend/src/store/slices/__tests__/notificationSlice.test.ts
@@ -124,6 +124,7 @@ describe('notificationSlice', () => {
 
     store.dispatch(removeNotification(unreadNotification.id))
 
+    expect(selectNotifications(store.getState())).toEqual([])
     expect(selectUnreadCount(store.getState())).toBe(0)
   })
 

--- a/frontend/src/store/slices/notificationSlice.ts
+++ b/frontend/src/store/slices/notificationSlice.ts
@@ -27,11 +27,14 @@ const notificationSlice = createSlice({
         ...action.payload,
       }
       state.notifications.unshift(notification)
-      if (state.notifications.length > 50) {
-        state.notifications = state.notifications.slice(0, 50) // newest-first invariant
-        state.unreadCount = Math.min(state.unreadCount, state.notifications.length - 1)
-      }
       state.unreadCount += 1
+      if (state.notifications.length > 50) {
+        const evictedNotification = state.notifications[50]
+        state.notifications = state.notifications.slice(0, 50) // newest-first invariant
+        if (evictedNotification && !evictedNotification.read) {
+          state.unreadCount = Math.max(0, state.unreadCount - 1)
+        }
+      }
     },
     removeNotification: (state, action: PayloadAction<string>) => {
       const index = state.notifications.findIndex((n) => n.id === action.payload)

--- a/frontend/src/store/slices/notificationSlice.ts
+++ b/frontend/src/store/slices/notificationSlice.ts
@@ -1,4 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { REHYDRATE } from 'redux-persist'
+import { PERSIST_KEY } from '@/store/persistKey'
 import type { Notification } from '@/types'
 import type { RootState } from '@/store'
 import { logout, clearAuth } from './authSlice'
@@ -25,6 +27,10 @@ const notificationSlice = createSlice({
         ...action.payload,
       }
       state.notifications.unshift(notification)
+      if (state.notifications.length > 50) {
+        state.notifications = state.notifications.slice(0, 50) // newest-first invariant
+        state.unreadCount = Math.min(state.unreadCount, state.notifications.length - 1)
+      }
       state.unreadCount += 1
     },
     removeNotification: (state, action: PayloadAction<string>) => {
@@ -32,7 +38,7 @@ const notificationSlice = createSlice({
       if (index >= 0) {
         const notification = state.notifications[index]
         if (!notification.read) {
-          state.unreadCount -= 1
+          state.unreadCount = Math.max(0, state.unreadCount - 1)
         }
         state.notifications.splice(index, 1)
       }
@@ -60,6 +66,15 @@ const notificationSlice = createSlice({
       .addCase(clearAuth, (state) => {
         state.notifications = []
         state.unreadCount = 0
+      })
+      .addCase(REHYDRATE, (state, action: any) => {
+        // payload is undefined on cold start (no persisted state) — no-op
+        if (action.key === PERSIST_KEY && action.payload?.notifications) {
+          const persisted = action.payload.notifications
+          const capped = (persisted.notifications ?? []).slice(0, 50) // newest-first
+          state.notifications = capped
+          state.unreadCount = capped.filter((n: any) => !n.read).length
+        }
       })
   },
 })


### PR DESCRIPTION
## Summary

- Adds `notifications` to the redux-persist whitelist so notifications survive browser refresh
- Caps the persisted list at 50 (newest-first); evicting an unread item correctly adjusts `unreadCount`
- Adds a `Math.max(0, ...)` floor guard in `removeNotification` to prevent negative counts on corrupt state
- Adds a `REHYDRATE` extraReducer that enforces the cap and recalculates `unreadCount` from source-of-truth `read` fields on every load
- Bumps persist version 4 → 5 with a migration that normalises existing users' state (all v4 users have no persisted notifications, so they get a clean empty state)
- Extracts `PERSIST_KEY` to `store/persistKey.ts` to avoid a circular import between `notificationSlice` and `store/index`

## Test plan

- [x] All 57 store tests pass (`cd frontend && npm run test`)
- [x] TypeScript clean (`cd frontend && npm run type-check`)
- [x] Lint clean (`cd frontend && npm run lint`)
- [x] Manual: trigger a notification, refresh browser — notification persists with correct unread count
- [x] Manual: logout — notification center is empty on next login
- [x] Manual: DevTools → Application → Local Storage → `erp-app` key contains `notifications` array

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)