### PR TITLE
fix(accounting): fix fund transfer journal entry display issues

### DIFF
--- a/backend/src/modules/accounting/services/fund-transfer.service.ts
+++ b/backend/src/modules/accounting/services/fund-transfer.service.ts
@@ -113,6 +113,8 @@ export class FundTransferService {
       });
 
       savedTransfer = await manager.save(FundTransfer, transfer);
+      savedTransfer.sourceAccount = sourceAccount;
+      savedTransfer.destinationAccount = destinationAccount;
 
       const postedJournalEntry = await this.accountingService.postFundTransferEntry(
         savedTransfer,

--- a/frontend/src/pages/accounting/FundTransfersPage.tsx
+++ b/frontend/src/pages/accounting/FundTransfersPage.tsx
@@ -18,7 +18,6 @@ import {
   DialogTitle,
   FormControl,
   IconButton,
-  InputAdornment,
   InputLabel,
   MenuItem,
   Paper,
@@ -457,11 +456,6 @@ const FundTransfersPage: React.FC = () => {
                   amount: event.target.value,
                 }))
               }
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">$</InputAdornment>
-                ),
-              }}
             />
 
             <TextField

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -72,6 +72,7 @@ const ENTRY_TYPE_LABELS: Record<string, string> = {
   owner_equity_transaction: 'Owner Equity',
   expense: 'Expense',
   opening_balance: 'Opening Balance',
+  fund_transfer: 'Fund Transfer',
 }
 
 const getEntryTypeLabel = (sourceType?: string): string => {
@@ -326,6 +327,9 @@ const JournalEntriesPage: React.FC = () => {
       case 'stock_adjustment':
         navigate(`/inventory/stock-adjustments/${sourceId}/edit`)
         break
+      case 'fund_transfer':
+        navigate('/accounting/fund-transfers')
+        break
       default:
         break
     }
@@ -455,6 +459,7 @@ const JournalEntriesPage: React.FC = () => {
                 <MenuItem value="stock_adjustment">Stock Adjustments</MenuItem>
                 <MenuItem value="owner_equity_transaction">Owner Equity</MenuItem>
                 <MenuItem value="expense">Expense</MenuItem>
+                <MenuItem value="fund_transfer">Fund Transfers</MenuItem>
               </Select>
             </FormControl>
           </GridLegacy>


### PR DESCRIPTION
Fixes #86

## Summary
- Add `fund_transfer` to `ENTRY_TYPE_LABELS` map so entries show "Fund Transfer" instead of "Unknown" in the Entry Type column
- Add `fund_transfer` to the Entry Type filter dropdown
- Add `fund_transfer` case to `navigateToSourceTransaction` — navigates to `/accounting/fund-transfers` (consistent with `expense`/`owner_equity_transaction` which also don't support highlight params)
- Assign already-fetched `sourceAccount` and `destinationAccount` relations onto `savedTransfer` before calling `postFundTransferEntry`, so line memos use account names instead of UUIDs

## Test plan
- [x] Create a fund transfer and verify the Journal Entries list shows "Fund Transfer" in the Entry Type column
- [x] Verify the Entry Type filter dropdown includes "Fund Transfers" and filters correctly
- [x] Click "View Transaction" on a fund transfer entry and verify it navigates to `/accounting/fund-transfers`
- [x] Open the journal entry details and verify line memos show account names (e.g. "Transfer to Bank Account") not UUIDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)