### PR TITLE
fix(inventory): migrate CreateStockAdjustmentPage to RTK Query (fixes #90)

### DIFF
--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -30,6 +30,11 @@ import { useForm, useFieldArray, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import { ApiService } from '@/services/api'
+import {
+  useLazyGetStockAdjustmentQuery,
+  useCreateStockAdjustmentMutation,
+  useUpdateStockAdjustmentMutation,
+} from '@/store/api/inventoryApi'
 import { useProductSearch } from '@/hooks/useProductSearch'
 import { getCurrentDate } from '@/utils/formatters'
 import { useNotification } from '@/hooks/useNotification'
@@ -69,7 +74,10 @@ const CreateStockAdjustmentPage: React.FC = () => {
   const isEditMode = !!id
   const { showSuccess, showError } = useNotification()
   const { products, loadProducts, seedProducts } = useProductSearch()
-  const [loading, setLoading] = useState(false)
+  const [createStockAdjustment, { isLoading: isCreating }] = useCreateStockAdjustmentMutation()
+  const [updateStockAdjustment, { isLoading: isUpdating }] = useUpdateStockAdjustmentMutation()
+  const [triggerGetStockAdjustment] = useLazyGetStockAdjustmentQuery()
+  const loading = isCreating || isUpdating
   const [loadingAdjustment, setLoadingAdjustment] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [adjustmentToLoad, setAdjustmentToLoad] = useState<any>(null)
@@ -111,8 +119,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
   const loadStockAdjustment = async (adjustmentId: string) => {
     setLoadingAdjustment(true)
     try {
-      const response = await ApiService.get(`/inventory/stock-adjustments/${adjustmentId}`)
-      const adjustment = (response as any).data || response
+      const adjustment = await triggerGetStockAdjustment(adjustmentId).unwrap()
 
       // Extract products from adjustment items and add to products state
       if (adjustment.items && adjustment.items.length > 0) {
@@ -126,7 +133,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
       // Store adjustment data to be loaded after products are set
       setAdjustmentToLoad(adjustment)
     } catch (err: any) {
-      showError(err?.response?.data?.message || 'Failed to load stock adjustment')
+      showError(err?.data?.message || err?.message || 'Failed to load stock adjustment')
       setError('Failed to load stock adjustment')
       setLoadingAdjustment(false)
     }
@@ -182,7 +189,6 @@ const CreateStockAdjustmentPage: React.FC = () => {
   }, [JSON.stringify(watchedItems), setValue])
 
   const onSubmit = async (data: CreateAdjustmentFormData) => {
-    setLoading(true)
     setError(null)
 
     try {
@@ -191,7 +197,6 @@ const CreateStockAdjustmentPage: React.FC = () => {
 
       if (itemsWithDifference.length === 0) {
         showError('No changes to record. At least one item must have a difference.')
-        setLoading(false)
         return
       }
 
@@ -207,25 +212,16 @@ const CreateStockAdjustmentPage: React.FC = () => {
         })),
       }
 
-      console.log(isEditMode ? 'Updating stock adjustment:' : 'Creating stock adjustment:', adjustmentData)
-
       if (isEditMode && id) {
         // Edit mode: Update existing adjustment
-        const updateResponse = await ApiService.put(`/inventory/stock-adjustments/${id}`, adjustmentData)
-        const updatedAdjustment = updateResponse as any
+        const updatedAdjustment = await updateStockAdjustment({ id, data: adjustmentData }).unwrap()
         const saNumber = updatedAdjustment?.adjustmentNumber || 'N/A'
 
         showSuccess(`Stock adjustment ${saNumber} updated successfully`)
         navigate('/inventory/stock-adjustments')
       } else {
         // Create mode: Create new adjustment (kept as draft)
-        const createResponse = await ApiService.post('/inventory/stock-adjustments', adjustmentData)
-
-        const adjustment = createResponse as any
-
-        if (!adjustment || !adjustment.id) {
-          throw new Error('Invalid response from server: missing adjustment ID')
-        }
+        const adjustment = await createStockAdjustment(adjustmentData).unwrap()
 
         const saNumber = adjustment?.adjustmentNumber || 'N/A'
         const itemsAdjusted = adjustment?.itemCount || 0
@@ -235,16 +231,8 @@ const CreateStockAdjustmentPage: React.FC = () => {
         navigate('/inventory/stock-adjustments', { state: { newAdjustmentId: adjustment.id } })
       }
     } catch (err: any) {
-      console.error('Error creating stock adjustments:', err)
-      console.error('Error details:', {
-        message: err.message,
-        response: err.response?.data,
-        status: err.response?.status
-      })
-      setError(err.response?.data?.message || err.message || 'Failed to record stock adjustments')
-      showError(err.response?.data?.message || err.message || 'Failed to record stock adjustments')
-    } finally {
-      setLoading(false)
+      setError(err.data?.message || err.message || 'Failed to record stock adjustments')
+      showError(err.data?.message || err.message || 'Failed to record stock adjustments')
     }
   }
 

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router-dom'
 
@@ -8,9 +8,12 @@ import CreateStockAdjustmentPage from '../CreateStockAdjustmentPage'
 
 const replacementSearchTerm = 'B'
 
-const { mockGet, mockParams } = vi.hoisted(() => ({
+const { mockGet, mockParams, mockFetchAdjustment, mockCreateAdjustment, mockUpdateAdjustment } = vi.hoisted(() => ({
   mockGet: vi.fn(),
   mockParams: vi.fn(() => ({})),
+  mockFetchAdjustment: vi.fn(),
+  mockCreateAdjustment: vi.fn(),
+  mockUpdateAdjustment: vi.fn(),
 }))
 
 vi.mock('react-router-dom', async () => {
@@ -38,10 +41,30 @@ vi.mock('@/services/api', () => ({
   },
 }))
 
+vi.mock('@/store/api/inventoryApi', () => ({
+  useLazyGetStockAdjustmentQuery: () => [mockFetchAdjustment],
+  useCreateStockAdjustmentMutation: () => [mockCreateAdjustment, { isLoading: false }],
+  useUpdateStockAdjustmentMutation: () => [mockUpdateAdjustment, { isLoading: false }],
+}))
+
 describe('CreateStockAdjustmentPage product search', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockParams.mockReturnValue({})
+    mockCreateAdjustment.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({
+        id: 'adj-new',
+        adjustmentNumber: 'SA-001',
+        itemCount: 1,
+        status: 'draft',
+      }),
+    })
+    mockUpdateAdjustment.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({
+        id: 'adj-1',
+        adjustmentNumber: 'SA-001',
+      }),
+    })
 
     mockGet.mockImplementation(async (url: string, config?: { params?: { search?: string } }) => {
       if (url.includes('/inventory/products/')) {
@@ -136,11 +159,9 @@ describe('CreateStockAdjustmentPage product search', () => {
     const adjustmentPromise = new Promise((res) => { resolveAdjustment = res })
 
     mockParams.mockReturnValue({ id: 'adj-1' })
+    mockFetchAdjustment.mockReturnValue({ unwrap: () => adjustmentPromise })
 
-    mockGet.mockImplementation(async (url: string) => {
-      if (url === '/inventory/stock-adjustments/adj-1') {
-        return adjustmentPromise
-      }
+    mockGet.mockImplementation(async () => {
       return { data: [{ id: 'product-1', name: 'Alpha Widget', stockQuantity: 10 }] }
     })
 
@@ -154,12 +175,10 @@ describe('CreateStockAdjustmentPage product search', () => {
     expect(screen.queryByRole('form')).not.toBeInTheDocument()
 
     resolveAdjustment({
-      data: {
-        id: 'adj-1',
-        adjustmentDate: '2026-03-01T00:00:00.000Z',
-        reason: 'Recount',
-        items: [],
-      },
+      id: 'adj-1',
+      adjustmentDate: '2026-03-01T00:00:00.000Z',
+      notes: 'Recount',
+      items: [],
     })
 
     await waitFor(() => {
@@ -170,27 +189,24 @@ describe('CreateStockAdjustmentPage product search', () => {
   it('keeps hydrated edit-mode product visible after search replaces options', async () => {
     const user = userEvent.setup()
     mockParams.mockReturnValue({ id: 'adj-1' })
+    mockFetchAdjustment.mockReturnValue({
+      unwrap: async () => ({
+        id: 'adj-1',
+        adjustmentDate: '2026-03-01T00:00:00.000Z',
+        notes: 'Recount',
+        items: [
+          {
+            productId: 'product-9',
+            oldQuantity: 5,
+            newQuantity: 8,
+            difference: 3,
+            product: { id: 'product-9', name: 'Hydrated Product', stockQuantity: 5 },
+          },
+        ],
+      }),
+    })
 
     mockGet.mockImplementation(async (url: string, config?: { params?: { search?: string } }) => {
-      if (url === '/inventory/stock-adjustments/adj-1') {
-        return {
-          data: {
-            id: 'adj-1',
-            adjustmentDate: '2026-03-01T00:00:00.000Z',
-            reason: 'Recount',
-            items: [
-              {
-                productId: 'product-9',
-                oldQuantity: 5,
-                newQuantity: 8,
-                difference: 3,
-                product: { id: 'product-9', name: 'Hydrated Product', stockQuantity: 5 },
-              },
-            ],
-          },
-        }
-      }
-
       if (url.includes('/inventory/products/')) {
         const id = url.split('/').pop()
 
@@ -237,6 +253,124 @@ describe('CreateStockAdjustmentPage product search', () => {
 
     await waitFor(() => {
       expect(firstProductInput).toHaveValue('Hydrated Product')
+    })
+  })
+})
+
+describe('CreateStockAdjustmentPage submit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockParams.mockReturnValue({})
+    mockCreateAdjustment.mockReturnValue({
+      unwrap: async () => ({
+        id: 'adj-new',
+        adjustmentNumber: 'SA-001',
+        itemCount: 1,
+        status: 'draft',
+      }),
+    })
+    mockUpdateAdjustment.mockReturnValue({
+      unwrap: async () => ({
+        id: 'adj-1',
+        adjustmentNumber: 'SA-001',
+      }),
+    })
+
+    mockGet.mockImplementation(async (url: string) => {
+      if (url.includes('/inventory/products/')) {
+        return { data: { id: 'product-1', name: 'Alpha Widget', stockQuantity: 10 } }
+      }
+
+      return { data: [{ id: 'product-1', name: 'Alpha Widget', stockQuantity: 10 }] }
+    })
+  })
+
+  it('calls createStockAdjustment mutation on submit in create mode', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <BrowserRouter>
+        <CreateStockAdjustmentPage />
+      </BrowserRouter>
+    )
+
+    const productInput = screen.getByPlaceholderText('Search by name or barcode...')
+    await user.click(productInput)
+
+    const listbox = await screen.findByRole('listbox')
+    await user.click(within(listbox).getByText('Alpha Widget'))
+
+    await waitFor(() => {
+      expect(productInput).toHaveValue('Alpha Widget')
+    })
+
+    const newQtyInput = screen.getAllByRole('textbox').find(
+      (element) => element !== productInput && (element as HTMLInputElement).value === '10'
+    ) as HTMLInputElement
+
+    fireEvent.change(newQtyInput, { target: { value: '15' } })
+    fireEvent.click(screen.getByRole('button', { name: /create adjustment/i }))
+
+    await waitFor(() => {
+      expect(mockCreateAdjustment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          items: expect.arrayContaining([
+            expect.objectContaining({ productId: 'product-1' }),
+          ]),
+        })
+      )
+    })
+  })
+
+  it('calls updateStockAdjustment mutation on submit in edit mode', async () => {
+    const user = userEvent.setup()
+    mockParams.mockReturnValue({ id: 'adj-1' })
+    mockFetchAdjustment.mockReturnValue({
+      unwrap: async () => ({
+        id: 'adj-1',
+        adjustmentNumber: 'SA-001',
+        adjustmentDate: '2026-03-01T00:00:00.000Z',
+        notes: 'Recount',
+        items: [
+          {
+            productId: 'product-1',
+            oldQuantity: 10,
+            newQuantity: 10,
+            difference: 0,
+            product: { id: 'product-1', name: 'Alpha Widget', stockQuantity: 10 },
+          },
+        ],
+      }),
+    })
+
+    render(
+      <BrowserRouter>
+        <CreateStockAdjustmentPage />
+      </BrowserRouter>
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading stock adjustment...')).not.toBeInTheDocument()
+    })
+
+    const newQtyInput = screen.getAllByRole('textbox').find(
+      (element) => (element as HTMLInputElement).value === '10'
+    ) as HTMLInputElement
+
+    fireEvent.change(newQtyInput, { target: { value: '20' } })
+    fireEvent.click(screen.getByRole('button', { name: /update adjustment/i }))
+
+    await waitFor(() => {
+      expect(mockUpdateAdjustment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'adj-1',
+          data: expect.objectContaining({
+            items: expect.arrayContaining([
+              expect.objectContaining({ productId: 'product-1' }),
+            ]),
+          }),
+        })
+      )
     })
   })
 })

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router-dom'
 
@@ -308,8 +308,9 @@ describe('CreateStockAdjustmentPage submit', () => {
       (element) => element !== productInput && (element as HTMLInputElement).value === '10'
     ) as HTMLInputElement
 
-    fireEvent.change(newQtyInput, { target: { value: '15' } })
-    fireEvent.click(screen.getByRole('button', { name: /create adjustment/i }))
+    await user.clear(newQtyInput)
+    await user.type(newQtyInput, '15')
+    await user.click(screen.getByRole('button', { name: /create adjustment/i }))
 
     await waitFor(() => {
       expect(mockCreateAdjustment).toHaveBeenCalledWith(
@@ -357,8 +358,9 @@ describe('CreateStockAdjustmentPage submit', () => {
       (element) => (element as HTMLInputElement).value === '10'
     ) as HTMLInputElement
 
-    fireEvent.change(newQtyInput, { target: { value: '20' } })
-    fireEvent.click(screen.getByRole('button', { name: /update adjustment/i }))
+    await user.clear(newQtyInput)
+    await user.type(newQtyInput, '20')
+    await user.click(screen.getByRole('button', { name: /update adjustment/i }))
 
     await waitFor(() => {
       expect(mockUpdateAdjustment).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- Replaces `ApiService.post/put` with `useCreateStockAdjustmentMutation` / `useUpdateStockAdjustmentMutation` so the `StockAdjustment` RTK Query tag is invalidated on create/update — fixing the stale list bug
- Replaces `ApiService.get` for edit-mode fetch with `useLazyGetStockAdjustmentQuery`, matching the pattern used in `CreateSalesOrderPage`
- Removes manual `loading` state (replaced by `isCreating || isUpdating` from mutation hooks)
- Updates error catch path from `err.response?.data?.message` → `err.data?.message` for RTK Query error shape
- Removes leftover `console.log` / `console.error` debug statements

## Test plan

- [x] All 6 tests pass (`npx vitest run src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx`)
- [x] Edit-mode GET mock updated to use `useLazyGetStockAdjustmentQuery`
- [x] New tests added for create and update submit paths using `userEvent`
- [x] Manual verify: create a stock adjustment → list page auto-refreshes without manual browser reload
- [x] Manual verify: edit a stock adjustment → list page auto-refreshes without manual browser reload

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)