### PR TITLE
feat(accounting): add owner equity transaction reversal (closes #64)

### DIFF
--- a/backend/src/database/entities/owner-equity-transaction.entity.ts
+++ b/backend/src/database/entities/owner-equity-transaction.entity.ts
@@ -25,6 +25,7 @@ export enum OwnerEquityTransactionType {
 export enum OwnerEquityTransactionStatus {
   DRAFT = 'draft',
   POSTED = 'posted',
+  REVERSED = 'reversed',
 }
 
 @Entity('owner_equity_transactions')

--- a/backend/src/database/migrations/1773300000000-AddReversedStatusToOwnerEquity.ts
+++ b/backend/src/database/migrations/1773300000000-AddReversedStatusToOwnerEquity.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddReversedStatusToOwnerEquity1773300000000
+  implements MigrationInterface
+{
+  name = 'AddReversedStatusToOwnerEquity1773300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TYPE "public"."owner_equity_transactions_status_enum"
+      ADD VALUE IF NOT EXISTS 'reversed'
+    `);
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    // PostgreSQL does not support removing enum values directly.
+    // To revert, recreate the enum without 'reversed' once no rows use it.
+  }
+}

--- a/backend/src/modules/accounting/controllers/owner-equity.controller.ts
+++ b/backend/src/modules/accounting/controllers/owner-equity.controller.ts
@@ -76,6 +76,16 @@ export class OwnerEquityController {
     return this.ownerEquityService.post(id, currentUserId, currentUsername);
   }
 
+  @Post(':id/reverse')
+  @Auth(UserRole.ADMIN, UserRole.MANAGER)
+  reverse(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ) {
+    return this.ownerEquityService.reverse(id, currentUserId, currentUsername);
+  }
+
   @Post('bulk-post')
   @Auth(UserRole.ADMIN, UserRole.MANAGER)
   bulkPost(

--- a/backend/src/modules/accounting/services/owner-equity.service.spec.ts
+++ b/backend/src/modules/accounting/services/owner-equity.service.spec.ts
@@ -19,6 +19,7 @@ describe('OwnerEquityService', () => {
   let paymentMethodRepository: jest.Mocked<Repository<PaymentMethodEntity>>;
   let accountingService: jest.Mocked<AccountingService>;
   let settingsService: jest.Mocked<SettingsService>;
+  let auditLogService: jest.Mocked<AuditLogService>;
 
   const mockQueryBuilder = {
     withDeleted: jest.fn().mockReturnThis(),
@@ -55,6 +56,7 @@ describe('OwnerEquityService', () => {
           provide: AccountingService,
           useValue: {
             postOwnerEquityEntry: jest.fn(),
+            reverseSourceEntries: jest.fn(),
           },
         },
         {
@@ -77,6 +79,7 @@ describe('OwnerEquityService', () => {
     paymentMethodRepository = module.get(getRepositoryToken(PaymentMethodEntity));
     accountingService = module.get(AccountingService);
     settingsService = module.get(SettingsService);
+    auditLogService = module.get(AuditLogService);
 
     settingsService.generateDocumentNumber.mockResolvedValue('EQ-26-001');
 
@@ -250,6 +253,16 @@ describe('OwnerEquityService', () => {
     await expect(service.update('tx-1', { amount: 90 })).rejects.toThrow(BadRequestException);
   });
 
+  it('update throws BadRequestException for reversed transaction', async () => {
+    ownerEquityRepository.findOne.mockResolvedValue({
+      id: 'tx-1',
+      status: 'reversed' as OwnerEquityTransactionStatus,
+      deletedAt: null,
+    } as any);
+
+    await expect(service.update('tx-1', { amount: 90 })).rejects.toThrow(BadRequestException);
+  });
+
   it('remove soft-deletes a draft transaction', async () => {
     ownerEquityRepository.findOne.mockResolvedValue({
       id: 'tx-1',
@@ -264,6 +277,16 @@ describe('OwnerEquityService', () => {
     ownerEquityRepository.findOne.mockResolvedValue({
       id: 'tx-1',
       status: OwnerEquityTransactionStatus.POSTED,
+    } as any);
+
+    await expect(service.remove('tx-1')).rejects.toThrow(BadRequestException);
+  });
+
+  it('remove throws BadRequestException for reversed transaction', async () => {
+    ownerEquityRepository.findOne.mockResolvedValue({
+      id: 'tx-1',
+      status: 'reversed' as OwnerEquityTransactionStatus,
+      deletedAt: null,
     } as any);
 
     await expect(service.remove('tx-1')).rejects.toThrow(BadRequestException);
@@ -316,6 +339,115 @@ describe('OwnerEquityService', () => {
     } as any);
 
     await expect(service.post('tx-1')).rejects.toThrow(BadRequestException);
+  });
+
+  it('post throws BadRequestException for reversed transaction', async () => {
+    ownerEquityRepository.findOne.mockResolvedValue({
+      id: 'tx-1',
+      status: 'reversed' as OwnerEquityTransactionStatus,
+      deletedAt: null,
+    } as any);
+
+    await expect(service.post('tx-1')).rejects.toThrow(BadRequestException);
+  });
+
+  describe('reverse', () => {
+    const postedTransaction = {
+      id: 'oe-1',
+      referenceNumber: 'OE-001',
+      status: OwnerEquityTransactionStatus.POSTED,
+      deletedAt: null,
+      paymentMethod: { id: 'pm-1', code: 'CASH', name: 'Cash' },
+    } as any;
+
+    it('throws NotFoundException when transaction is not found', async () => {
+      ownerEquityRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.reverse('oe-1', 'user-1')).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequestException when status is DRAFT', async () => {
+      ownerEquityRepository.findOne.mockResolvedValue({
+        ...postedTransaction,
+        status: OwnerEquityTransactionStatus.DRAFT,
+      });
+
+      await expect(service.reverse('oe-1', 'user-1')).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when status is already REVERSED', async () => {
+      ownerEquityRepository.findOne.mockResolvedValue({
+        ...postedTransaction,
+        status: 'reversed' as OwnerEquityTransactionStatus,
+      });
+
+      await expect(service.reverse('oe-1', 'user-1')).rejects.toThrow(BadRequestException);
+    });
+
+    it('calls reverseSourceEntries with correct sourceType and id', async () => {
+      const reversedTx = { ...postedTransaction, status: 'reversed' as OwnerEquityTransactionStatus };
+
+      ownerEquityRepository.findOne
+        .mockResolvedValueOnce({ ...postedTransaction })
+        .mockResolvedValueOnce(reversedTx);
+      accountingService.reverseSourceEntries.mockResolvedValue(undefined);
+      ownerEquityRepository.save.mockResolvedValue(reversedTx);
+
+      await service.reverse('oe-1', 'user-1');
+
+      expect(accountingService.reverseSourceEntries).toHaveBeenCalledWith(
+        'owner_equity_transaction',
+        'oe-1',
+        'user-1',
+      );
+    });
+
+    it('sets status to REVERSED and saves', async () => {
+      const tx = { ...postedTransaction };
+      const reversedTx = { ...tx, status: 'reversed' as OwnerEquityTransactionStatus };
+
+      ownerEquityRepository.findOne
+        .mockResolvedValueOnce(tx)
+        .mockResolvedValueOnce(reversedTx);
+      accountingService.reverseSourceEntries.mockResolvedValue(undefined);
+      ownerEquityRepository.save.mockResolvedValue(reversedTx);
+
+      await service.reverse('oe-1', 'user-1');
+
+      expect(ownerEquityRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'reversed' }),
+      );
+    });
+
+    it('calls auditLogService with REVERSE action', async () => {
+      const reversedTx = { ...postedTransaction, status: 'reversed' as OwnerEquityTransactionStatus };
+
+      ownerEquityRepository.findOne
+        .mockResolvedValueOnce({ ...postedTransaction })
+        .mockResolvedValueOnce(reversedTx);
+      accountingService.reverseSourceEntries.mockResolvedValue(undefined);
+      ownerEquityRepository.save.mockResolvedValue(reversedTx);
+
+      await service.reverse('oe-1', 'user-1', 'admin');
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        'REVERSE',
+        'OwnerEquity',
+        expect.stringContaining('OE-001'),
+        expect.objectContaining({ userId: 'user-1', username: 'admin' }),
+      );
+    });
+
+    it('propagates error from reverseSourceEntries without updating status', async () => {
+      const tx = { ...postedTransaction };
+      ownerEquityRepository.findOne.mockResolvedValue(tx);
+      accountingService.reverseSourceEntries.mockRejectedValue(
+        new BadRequestException('No open fiscal period'),
+      );
+
+      await expect(service.reverse('oe-1', 'user-1')).rejects.toThrow('No open fiscal period');
+      expect(ownerEquityRepository.save).not.toHaveBeenCalled();
+    });
   });
 
   it('bulkPost posts multiple transactions and returns count', async () => {

--- a/backend/src/modules/accounting/services/owner-equity.service.ts
+++ b/backend/src/modules/accounting/services/owner-equity.service.ts
@@ -46,7 +46,7 @@ export class OwnerEquityService {
       status,
       startDate,
       endDate,
-      sortBy = 'transactionDate',
+      sortBy = 'referenceNumber',
       sortOrder = 'DESC',
     } = query;
     const parsedPage = Number(rawPage);
@@ -79,8 +79,14 @@ export class OwnerEquityService {
       qb.andWhere('oet.transactionDate <= :endDate', { endDate });
     }
 
-    const allowedSortFields = ['transactionDate', 'createdAt', 'amount', 'type'];
-    const safeSortBy = allowedSortFields.includes(sortBy) ? sortBy : 'transactionDate';
+    const allowedSortFields = [
+      'transactionDate',
+      'createdAt',
+      'amount',
+      'type',
+      'referenceNumber',
+    ];
+    const safeSortBy = allowedSortFields.includes(sortBy) ? sortBy : 'referenceNumber';
     const safeSortOrder = sortOrder === 'ASC' ? 'ASC' : 'DESC';
 
     qb.orderBy(`oet.${safeSortBy}`, safeSortOrder).skip((page - 1) * limit).take(limit);
@@ -161,8 +167,8 @@ export class OwnerEquityService {
       throw new NotFoundException(`Owner equity transaction ${id} not found`);
     }
 
-    if (transaction.status === OwnerEquityTransactionStatus.POSTED) {
-      throw new BadRequestException('Cannot update a posted transaction');
+    if (transaction.status !== OwnerEquityTransactionStatus.DRAFT) {
+      throw new BadRequestException('Cannot update a non-draft transaction');
     }
 
     if (dto.paymentMethodId) {
@@ -199,8 +205,8 @@ export class OwnerEquityService {
       throw new NotFoundException(`Owner equity transaction ${id} not found`);
     }
 
-    if (transaction.status === OwnerEquityTransactionStatus.POSTED) {
-      throw new BadRequestException('Cannot delete a posted transaction');
+    if (transaction.status !== OwnerEquityTransactionStatus.DRAFT) {
+      throw new BadRequestException('Cannot delete a non-draft transaction');
     }
 
     await this.ownerEquityRepository.softDelete(id);
@@ -227,8 +233,8 @@ export class OwnerEquityService {
       throw new NotFoundException(`Owner equity transaction ${id} not found`);
     }
 
-    if (transaction.status === OwnerEquityTransactionStatus.POSTED) {
-      throw new BadRequestException('Transaction is already posted');
+    if (transaction.status !== OwnerEquityTransactionStatus.DRAFT) {
+      throw new BadRequestException('Only draft transactions can be posted');
     }
 
     try {
@@ -252,6 +258,44 @@ export class OwnerEquityService {
       );
       throw error;
     }
+
+    return this.findOne(id);
+  }
+
+  async reverse(
+    id: string,
+    userId?: string,
+    username?: string,
+  ): Promise<OwnerEquityResponseDto> {
+    const transaction = await this.ownerEquityRepository.findOne({
+      where: { id },
+      relations: ['paymentMethod'],
+      withDeleted: true,
+    });
+
+    if (!transaction || transaction.deletedAt) {
+      throw new NotFoundException(`Owner equity transaction ${id} not found`);
+    }
+
+    if (transaction.status !== OwnerEquityTransactionStatus.POSTED) {
+      throw new BadRequestException('Transaction is not posted');
+    }
+
+    await this.accountingService.reverseSourceEntries(
+      'owner_equity_transaction',
+      id,
+      userId ?? 'system',
+    );
+
+    transaction.status = OwnerEquityTransactionStatus.REVERSED;
+    await this.ownerEquityRepository.save(transaction);
+
+    await this.auditLogService.log(
+      'REVERSE',
+      'OwnerEquity',
+      `Reversed owner equity transaction: ${transaction.referenceNumber}`,
+      { entityId: id, userId: userId ?? 'system', username },
+    );
 
     return this.findOne(id);
   }

--- a/frontend/src/pages/accounting/OwnerEquityPage.tsx
+++ b/frontend/src/pages/accounting/OwnerEquityPage.tsx
@@ -34,6 +34,7 @@ import {
   Refresh as RefreshIcon,
   Search as SearchIcon,
   AccountBalanceWallet as OwnerEquityIcon,
+  Undo as UndoIcon,
 } from '@mui/icons-material'
 import { TYPOGRAPHY_STYLES } from '@/constants/typography'
 import { useNotification } from '@/hooks/useNotification'
@@ -45,6 +46,7 @@ import {
   useGetOwnerEquityTransactionsQuery,
   useGetPaymentMethodsQuery,
   usePostOwnerEquityTransactionMutation,
+  useReverseOwnerEquityTransactionMutation,
   useUpdateOwnerEquityTransactionMutation,
 } from '@/store/api/accountingApi'
 import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
@@ -86,6 +88,8 @@ const OwnerEquityPage: React.FC = () => {
   const filters = useMemo(
     () => ({
       page: 1,
+      sortBy: 'referenceNumber',
+      sortOrder: 'DESC',
       type: typeFilter || undefined,
       status: statusFilter || undefined,
       startDate: startDate || undefined,
@@ -101,8 +105,10 @@ const OwnerEquityPage: React.FC = () => {
   const [updateOwnerEquityTransaction] = useUpdateOwnerEquityTransactionMutation()
   const [deleteOwnerEquityTransaction] = useDeleteOwnerEquityTransactionMutation()
   const [postOwnerEquityTransaction] = usePostOwnerEquityTransactionMutation()
+  const [reverseOwnerEquityTransaction] = useReverseOwnerEquityTransactionMutation()
   const [bulkPostOwnerEquityTransactions] = useBulkPostOwnerEquityTransactionsMutation()
   const [bulkDeleteOwnerEquityTransactions] = useBulkDeleteOwnerEquityTransactionsMutation()
+  const [reverseConfirmId, setReverseConfirmId] = useState<string | null>(null)
 
   const filteredRows = useMemo(() => {
     if (!search) return rows
@@ -240,6 +246,18 @@ const OwnerEquityPage: React.FC = () => {
     }
   }
 
+  const onReverse = async () => {
+    if (!reverseConfirmId) return
+    try {
+      await reverseOwnerEquityTransaction(reverseConfirmId).unwrap()
+      showSuccess('Transaction reversed')
+      setReverseConfirmId(null)
+      refetch()
+    } catch (error: any) {
+      showError(String(error))
+    }
+  }
+
   useKeyboardShortcuts({
     onSearch: () => searchRef.current?.focus(),
     onAdd: openCreate,
@@ -315,6 +333,7 @@ const OwnerEquityPage: React.FC = () => {
               <MenuItem value="">All</MenuItem>
               <MenuItem value="draft">Draft</MenuItem>
               <MenuItem value="posted">Posted</MenuItem>
+              <MenuItem value="reversed">Reversed</MenuItem>
             </Select>
           </FormControl>
           <TextField label="Start Date" type="date" size="small" value={startDate} onChange={(e) => setStartDate(e.target.value)} InputLabelProps={{ shrink: true }} />
@@ -387,7 +406,17 @@ const OwnerEquityPage: React.FC = () => {
                     <TableCell>{row.paymentMethod?.name || '-'}</TableCell>
                     <TableCell>{row.description || '-'}</TableCell>
                     <TableCell>
-                      <Chip size="small" label={row.status} color={row.status === 'posted' ? 'success' : 'default'} />
+                      <Chip
+                        size="small"
+                        label={row.status}
+                        color={
+                          row.status === 'posted'
+                            ? 'success'
+                            : row.status === 'reversed'
+                              ? 'error'
+                              : 'default'
+                        }
+                      />
                     </TableCell>
                     <TableCell align="right">
                       {isDraft && (
@@ -402,6 +431,11 @@ const OwnerEquityPage: React.FC = () => {
                             <DeleteIcon fontSize="small" />
                           </IconButton>
                         </>
+                      )}
+                      {row.status === 'posted' && (
+                        <IconButton size="small" color="warning" onClick={() => setReverseConfirmId(row.id)}>
+                          <UndoIcon fontSize="small" />
+                        </IconButton>
                       )}
                     </TableCell>
                   </TableRow>
@@ -446,6 +480,21 @@ const OwnerEquityPage: React.FC = () => {
         <DialogActions>
           <Button onClick={resetDialog}>Cancel</Button>
           <Button variant="contained" onClick={save}>Save</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={!!reverseConfirmId} onClose={() => setReverseConfirmId(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Reverse Transaction</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to reverse this transaction? This will create a reversal journal entry.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setReverseConfirmId(null)}>Cancel</Button>
+          <Button variant="contained" color="error" onClick={onReverse}>
+            Confirm
+          </Button>
         </DialogActions>
       </Dialog>
     </Box>

--- a/frontend/src/pages/accounting/__tests__/OwnerEquityPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/OwnerEquityPage.test.tsx
@@ -26,6 +26,7 @@ const mockedApi = vi.hoisted(() => ({
   useUpdateOwnerEquityTransactionMutation: vi.fn(),
   useDeleteOwnerEquityTransactionMutation: vi.fn(),
   usePostOwnerEquityTransactionMutation: vi.fn(),
+  useReverseOwnerEquityTransactionMutation: vi.fn(),
   useBulkPostOwnerEquityTransactionsMutation: vi.fn(),
   useBulkDeleteOwnerEquityTransactionsMutation: vi.fn(),
 }))
@@ -37,6 +38,7 @@ vi.mock('@/store/api/accountingApi', () => ({
   useUpdateOwnerEquityTransactionMutation: mockedApi.useUpdateOwnerEquityTransactionMutation,
   useDeleteOwnerEquityTransactionMutation: mockedApi.useDeleteOwnerEquityTransactionMutation,
   usePostOwnerEquityTransactionMutation: mockedApi.usePostOwnerEquityTransactionMutation,
+  useReverseOwnerEquityTransactionMutation: mockedApi.useReverseOwnerEquityTransactionMutation,
   useBulkPostOwnerEquityTransactionsMutation: mockedApi.useBulkPostOwnerEquityTransactionsMutation,
   useBulkDeleteOwnerEquityTransactionsMutation: mockedApi.useBulkDeleteOwnerEquityTransactionsMutation,
 }))
@@ -81,6 +83,7 @@ describe('OwnerEquityPage', () => {
     mockedApi.useUpdateOwnerEquityTransactionMutation.mockReturnValue([vi.fn()])
     mockedApi.useDeleteOwnerEquityTransactionMutation.mockReturnValue([vi.fn()])
     mockedApi.usePostOwnerEquityTransactionMutation.mockReturnValue([vi.fn()])
+    mockedApi.useReverseOwnerEquityTransactionMutation.mockReturnValue([vi.fn()])
     mockedApi.useBulkPostOwnerEquityTransactionsMutation.mockReturnValue([vi.fn()])
     mockedApi.useBulkDeleteOwnerEquityTransactionsMutation.mockReturnValue([vi.fn()])
   })

--- a/frontend/src/store/api/accountingApi.ts
+++ b/frontend/src/store/api/accountingApi.ts
@@ -647,6 +647,11 @@ export const accountingApiSlice = createApi({
       transformResponse: normalizeSingle<OwnerEquityTransaction>,
       invalidatesTags: (_result, _error, id) => [{ type: 'OwnerEquity', id }, 'OwnerEquity', 'AccountingReport'],
     }),
+    reverseOwnerEquityTransaction: builder.mutation<OwnerEquityTransaction, string>({
+      query: (id) => ({ url: `/accounting/owner-equity/${id}/reverse`, method: 'POST' }),
+      transformResponse: normalizeSingle<OwnerEquityTransaction>,
+      invalidatesTags: (_result, _error, id) => [{ type: 'OwnerEquity', id }, 'OwnerEquity', 'AccountingReport'],
+    }),
     bulkPostOwnerEquityTransactions: builder.mutation<{ posted: number; failed: number }, string[]>({
       query: (ids) => ({ url: '/accounting/owner-equity/bulk-post', method: 'POST', data: { ids } }),
       invalidatesTags: ['OwnerEquity', 'AccountingReport'],
@@ -794,6 +799,7 @@ export const {
   useUpdateOwnerEquityTransactionMutation,
   useDeleteOwnerEquityTransactionMutation,
   usePostOwnerEquityTransactionMutation,
+  useReverseOwnerEquityTransactionMutation,
   useBulkPostOwnerEquityTransactionsMutation,
   useBulkDeleteOwnerEquityTransactionsMutation,
   useCreateExpenseMutation,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -458,7 +458,7 @@ export interface OwnerEquityTransaction {
     name: string;
   };
   description?: string;
-  status: 'draft' | 'posted';
+  status: 'draft' | 'posted' | 'reversed';
   journalEntryId?: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary
- Adds `REVERSED` status to `OwnerEquityTransactionStatus` enum with DB migration
- Adds `reverse()` service method delegating to `AccountingService.reverseSourceEntries()` + `POST :id/reverse` controller endpoint (Admin + Manager)
- Updates `post()`, `update()`, and `remove()` guards to block all non-draft transactions (not just posted)
- Frontend: red `reversed` chip, reverse confirmation dialog with Undo button on posted rows, `reversed` filter option, default sort by reference number DESC

## Test Plan
- [x] Backend: `npx jest src/modules/accounting/services/owner-equity.service.spec.ts --no-coverage` — 25 tests pass
- [x] Backend: `npm run test` — 566 tests pass
- [x] Frontend: `npm run type-check` and `npm run lint` pass
- [x] Frontend: `npm run test` — 338 tests pass
- [x] Smoke: posted transaction shows Undo button → confirmation dialog → row turns red "reversed", Undo button disappears
- [x] Smoke: reversed transaction cannot be edited, re-posted, or deleted (400 returned)
- [x] Smoke: reversal journal entry appears in Journal Entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)