### PR TITLE
fix: invalidate JournalEntry cache after Owner Equity, Settlement, and Expense actions (issue #105)

### DIFF
--- a/frontend/src/store/api/accountingApi.ts
+++ b/frontend/src/store/api/accountingApi.ts
@@ -606,7 +606,7 @@ export const accountingApiSlice = createApi({
     >({
       query: (body) => ({ url: '/accounting/settlements', method: 'POST', data: body }),
       transformResponse: normalizeSingle<Settlement>,
-      invalidatesTags: ['Settlement', 'AccountingReport'],
+      invalidatesTags: ['Settlement', 'JournalEntry', 'AccountingReport'],
     }),
     cancelSettlement: builder.mutation<Settlement, string>({
       query: (id) => ({ url: `/accounting/settlements/${id}/cancel`, method: 'POST' }),

--- a/frontend/src/store/api/accountingApi.ts
+++ b/frontend/src/store/api/accountingApi.ts
@@ -645,12 +645,12 @@ export const accountingApiSlice = createApi({
     postOwnerEquityTransaction: builder.mutation<OwnerEquityTransaction, string>({
       query: (id) => ({ url: `/accounting/owner-equity/${id}/post`, method: 'POST' }),
       transformResponse: normalizeSingle<OwnerEquityTransaction>,
-      invalidatesTags: (_result, _error, id) => [{ type: 'OwnerEquity', id }, 'OwnerEquity', 'AccountingReport'],
+      invalidatesTags: (_result, _error, id) => [{ type: 'OwnerEquity', id }, 'OwnerEquity', 'JournalEntry', 'AccountingReport'],
     }),
     reverseOwnerEquityTransaction: builder.mutation<OwnerEquityTransaction, string>({
       query: (id) => ({ url: `/accounting/owner-equity/${id}/reverse`, method: 'POST' }),
       transformResponse: normalizeSingle<OwnerEquityTransaction>,
-      invalidatesTags: (_result, _error, id) => [{ type: 'OwnerEquity', id }, 'OwnerEquity', 'AccountingReport'],
+      invalidatesTags: (_result, _error, id) => [{ type: 'OwnerEquity', id }, 'OwnerEquity', 'JournalEntry', 'AccountingReport'],
     }),
     createExpense: builder.mutation<
       ExpenseRecord,

--- a/frontend/src/store/api/accountingApi.ts
+++ b/frontend/src/store/api/accountingApi.ts
@@ -692,11 +692,11 @@ export const accountingApiSlice = createApi({
     postExpense: builder.mutation<ExpenseRecord, string>({
       query: (id) => ({ url: `/accounting/expenses/${id}/post`, method: 'POST' }),
       transformResponse: normalizeSingle<ExpenseRecord>,
-      invalidatesTags: (_result, _error, id) => [{ type: 'Expense', id }, 'Expense', 'AccountingReport'],
+      invalidatesTags: (_result, _error, id) => [{ type: 'Expense', id }, 'Expense', 'JournalEntry', 'AccountingReport'],
     }),
     bulkPostExpenses: builder.mutation<{ posted: number; failed: number }, string[]>({
       query: (ids) => ({ url: '/accounting/expenses/bulk-post', method: 'POST', data: { ids } }),
-      invalidatesTags: ['Expense', 'AccountingReport'],
+      invalidatesTags: ['Expense', 'JournalEntry', 'AccountingReport'],
     }),
     bulkDeleteExpenses: builder.mutation<{ deleted: number; failed: number }, string[]>({
       query: (ids) => ({ url: '/accounting/expenses/bulk-delete', method: 'POST', data: { ids } }),


### PR DESCRIPTION
## Summary

- Added `'JournalEntry'` to `invalidatesTags` for `postOwnerEquityTransaction` and `reverseOwnerEquityTransaction`
- Added `'JournalEntry'` to `invalidatesTags` for `createSettlement`
- Added `'JournalEntry'` to `invalidatesTags` for `postExpense` and `bulkPostExpenses`

## Test Plan

- [x] Post a draft Owner Equity transaction → Journal Entries page auto-refreshes
- [x] Reverse a posted Owner Equity transaction → Journal Entries page auto-refreshes
- [x] Create a Settlement → Journal Entries page auto-refreshes
- [x] Post a draft Expense → Journal Entries page auto-refreshes
- [x] Bulk-post draft Expenses → Journal Entries page auto-refreshes

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)