### PR TITLE
feat: update sidebar colors to align with docs/ui.md

### DIFF
--- a/docs/superpowers/plans/2026-03-18-sidebar-colors.md
+++ b/docs/superpowers/plans/2026-03-18-sidebar-colors.md
@@ -1,0 +1,195 @@
+# Sidebar Colors Update Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update `SIDEBAR_COLORS` in `Sidebar.tsx` to match `docs/ui.md` and add a dedicated `icon` token to replace icon-specific uses of the `text` token.
+
+**Architecture:** Single-file change — update the `SIDEBAR_COLORS` constant values and add the `icon` token, then replace the 7 `SIDEBAR_COLORS.text` usages that color icons with `SIDEBAR_COLORS.icon`. No new files. No test changes needed.
+
+**Tech Stack:** React 19, TypeScript, Material-UI v7, Vitest
+
+---
+
+## Chunk 1: Update SIDEBAR_COLORS and migrate icon usages
+
+**Files:**
+- Modify: `frontend/src/components/common/Sidebar.tsx:97-108` (token values + new token)
+- Modify: `frontend/src/components/common/Sidebar.tsx:841,863,961,1003,1047,1076,1149` (icon color usages)
+- Test: `frontend/src/components/common/__tests__/Sidebar.test.tsx` (run only, no changes)
+
+---
+
+### Task 1: Update SIDEBAR_COLORS constant
+
+- [ ] **Step 1: Open `frontend/src/components/common/Sidebar.tsx` and locate `SIDEBAR_COLORS` (lines 97–108)**
+
+Current:
+```ts
+const SIDEBAR_COLORS = {
+  bg: '#0F172A',
+  activeBg: '#1F2937',
+  hoverBg: '#1E293B',
+  text: '#9CA3AF',
+  activeText: '#E5E7EB',
+  hoverText: '#CBD5E1',
+  activeIcon: '#FFFFFF',
+  sectionLabel: '#6B7280',
+  border: '#1F2937',
+  accentBar: '#42a5f5',
+} as const
+```
+
+- [ ] **Step 2: Replace the constant with the updated values and new `icon` token**
+
+```ts
+const SIDEBAR_COLORS = {
+  bg: '#0D0D0D',
+  activeBg: '#1F2937',
+  hoverBg: '#1E1E1E',
+  text: '#9CA3AF',
+  activeText: '#FFFFFF',
+  hoverText: '#CBD5E1',
+  activeIcon: '#3B82F6',
+  icon: '#6B7280',
+  sectionLabel: '#6B7280',
+  border: '#1F2937',
+  accentBar: '#42a5f5',
+} as const
+```
+
+Changes:
+- `bg`: `#0F172A` → `#0D0D0D`
+- `hoverBg`: `#1E293B` → `#1E1E1E`
+- `activeText`: `#E5E7EB` → `#FFFFFF`
+- `activeIcon`: `#FFFFFF` → `#3B82F6`
+- `icon`: *(new)* `#6B7280`
+
+---
+
+### Task 2: Migrate icon-specific `.text` usages to `.icon`
+
+There are 9 total `SIDEBAR_COLORS.text` usages. Migrate 7 (icons); leave 2 (`ListItemText` labels) unchanged.
+
+- [ ] **Step 3: In `renderFlyoutItem` — update `ListItemIcon` color (line ~841)**
+
+Find:
+```ts
+color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.text,
+'& .MuiSvgIcon-root': { fontSize: '1.25rem' },
+transition: 'color 0.18s ease',
+```
+This is inside a `ListItemIcon` `sx` prop in `renderFlyoutItem`. Change to:
+```ts
+color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.icon,
+'& .MuiSvgIcon-root': { fontSize: '1.25rem' },
+transition: 'color 0.18s ease',
+```
+
+- [ ] **Step 4: In `renderFlyoutItem` — update `ExpandMore` chevron color (line ~863)**
+
+Find:
+```ts
+color: SIDEBAR_COLORS.text,
+display: 'flex',
+alignItems: 'center',
+transition: 'transform 0.2s',
+transform: isExpanded ? 'rotate(180deg)' : 'none',
+```
+This is the `Box` wrapping the `ExpandMore` in `renderFlyoutItem`. Change `SIDEBAR_COLORS.text` to `SIDEBAR_COLORS.icon`.
+
+- [ ] **Step 5: In `renderMenuItem` (collapsed+children) — update `ListItemIcon` color (line ~961)**
+
+Find the `ListItemIcon` inside the `collapsed && hasChildren` branch:
+```ts
+color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.text,
+justifyContent: 'center',
+'& .MuiSvgIcon-root': { fontSize: '1.25rem' },
+transition: 'color 0.18s ease',
+```
+Change to:
+```ts
+color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.icon,
+justifyContent: 'center',
+'& .MuiSvgIcon-root': { fontSize: '1.25rem' },
+transition: 'color 0.18s ease',
+```
+
+- [ ] **Step 6: In `renderMenuItem` (collapsed+leaf) — update `ListItemIcon` color (line ~1003)**
+
+Find the `ListItemIcon` inside the `collapsed && !hasChildren` branch:
+```ts
+color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.text,
+justifyContent: 'center',
+'& .MuiSvgIcon-root': { fontSize: '1.25rem' },
+transition: 'color 0.18s ease',
+```
+Change to:
+```ts
+color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.icon,
+justifyContent: 'center',
+'& .MuiSvgIcon-root': { fontSize: '1.25rem' },
+transition: 'color 0.18s ease',
+```
+
+- [ ] **Step 7: In `renderMenuItem` (expanded) — update `ListItemIcon` color (line ~1047)**
+
+Find the `ListItemIcon` in the expanded (non-collapsed) branch of `renderMenuItem`:
+```ts
+color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.text,
+'& .MuiSvgIcon-root': { fontSize: '1.25rem' },
+transition: 'color 0.18s ease',
+```
+Note: this `ListItemIcon` has `minWidth: 40` (distinguishes it from the collapsed ones). Change to:
+```ts
+color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.icon,
+'& .MuiSvgIcon-root': { fontSize: '1.25rem' },
+transition: 'color 0.18s ease',
+```
+
+- [ ] **Step 8: In `renderMenuItem` (expanded) — update `ExpandMore` chevron color (line ~1076)**
+
+Find the `Box` wrapping `ExpandMore` in the expanded branch of `renderMenuItem`:
+```ts
+color: SIDEBAR_COLORS.text,
+display: 'flex',
+alignItems: 'center',
+transition: 'transform 0.2s',
+transform: isExpanded ? 'rotate(180deg)' : 'none',
+```
+Change `SIDEBAR_COLORS.text` to `SIDEBAR_COLORS.icon`.
+
+- [ ] **Step 9: Update sidebar collapse `IconButton` color (line ~1149)**
+
+Find the `IconButton` for sidebar collapse/expand (has `aria-label` for "expand sidebar" / "collapse sidebar"):
+```ts
+color: SIDEBAR_COLORS.text,
+width: 28,
+height: 28,
+'&:hover': { bgcolor: SIDEBAR_COLORS.hoverBg },
+```
+Change `SIDEBAR_COLORS.text` to `SIDEBAR_COLORS.icon`.
+
+---
+
+### Task 3: Verify no regressions
+
+- [ ] **Step 10: Run TypeScript check**
+
+```bash
+cd frontend && npm run type-check
+```
+Expected: no errors
+
+- [ ] **Step 11: Run sidebar tests**
+
+```bash
+cd frontend && npx vitest run src/components/common/__tests__/Sidebar.test.tsx
+```
+Expected: all tests pass (14 tests, no failures)
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add frontend/src/components/common/Sidebar.tsx
+git commit -m "feat: update SIDEBAR_COLORS to align with docs/ui.md (issue #121)"
+```

--- a/docs/superpowers/specs/2026-03-18-sidebar-colors-design.md
+++ b/docs/superpowers/specs/2026-03-18-sidebar-colors-design.md
@@ -1,0 +1,72 @@
+# Sidebar Colors Update — Design Spec
+
+**Issue:** #121
+**Date:** 2026-03-18
+**File:** `frontend/src/components/common/Sidebar.tsx`
+
+---
+
+## Overview
+
+Update `SIDEBAR_COLORS` in `Sidebar.tsx` to align with the dark theme palette defined in `docs/ui.md`. Add a dedicated `icon` token and migrate all icon-specific color usages away from the shared `text` token.
+
+---
+
+## Token Changes
+
+| Token | Before | After | Change |
+|---|---|---|---|
+| `bg` | `#0F172A` | `#0D0D0D` | Sidebar background — deeper per docs/ui.md |
+| `hoverBg` | `#1E293B` | `#1E1E1E` | Hover state |
+| `activeText` | `#E5E7EB` | `#FFFFFF` | Active item text |
+| `activeIcon` | `#FFFFFF` | `#3B82F6` | Active item icon — Primary Blue |
+| `icon` | *(new)* | `#6B7280` | Default icon color (new dedicated token) |
+| `activeBg` | `#1F2937` | `#1F2937` | No change |
+| `text` | `#9CA3AF` | `#9CA3AF` | No change |
+| `hoverText` | `#CBD5E1` | `#CBD5E1` | No change |
+| `sectionLabel` | `#6B7280` | `#6B7280` | No change |
+| `border` | `#1F2937` | `#1F2937` | No change |
+| `accentBar` | `#42a5f5` | `#42a5f5` | No change (not in issue scope) |
+
+---
+
+## Icon Token Migration
+
+The `text` token (`#9CA3AF`) was used for both text labels and icon colors. With the new `icon` token (`#6B7280`), icon-specific usages are separated.
+
+**7 usages** switch from `SIDEBAR_COLORS.text` → `SIDEBAR_COLORS.icon`:
+
+| Location | Context |
+|---|---|
+| `renderFlyoutItem` — `ListItemIcon` (line ~841) | Flyout item icon inactive state |
+| `renderMenuItem` collapsed+children — `ListItemIcon` (line ~961) | Rail icon inactive state |
+| `renderMenuItem` collapsed+leaf — `ListItemIcon` (line ~1003) | Rail leaf icon inactive state |
+| `renderMenuItem` expanded — `ListItemIcon` (line ~1047) | Expanded menu icon inactive state |
+| `renderFlyoutItem` — `ExpandMore` chevron (line ~863) | Flyout expand arrow |
+| `renderMenuItem` expanded — `ExpandMore` chevron (line ~1076) | Sidebar expand arrow |
+| Collapse `IconButton` (line ~1149) | Sidebar collapse/expand toggle button |
+
+Text label usages (`ListItemText`) keep `SIDEBAR_COLORS.text` unchanged.
+
+---
+
+## Approach
+
+**Option A (chosen):** Direct in-place token update. Modify `SIDEBAR_COLORS` and swap icon-specific `.text` usages to `.icon`. No abstraction, no new files.
+
+Rejected alternatives:
+- B: `getSidebarColors()` function — overkill for a one-file update
+- C: Move colors to shared theme file — beyond issue scope
+
+---
+
+## Testing
+
+No test changes required. Existing tests cover behavior and structure, not color values. All tests pass unchanged.
+
+**Verification checklist (manual):**
+- [ ] Sidebar background is `#0D0D0D`
+- [ ] Active items have `#3B82F6` icons and `#FFFFFF` text
+- [ ] Hover states use `#1E1E1E`
+- [ ] Default icons use `#6B7280`
+- [ ] All sidebar tests pass (`frontend/src/components/common/__tests__/Sidebar.test.tsx`)

--- a/docs/superpowers/specs/2026-03-18-sidebar-colors-design.md
+++ b/docs/superpowers/specs/2026-03-18-sidebar-colors-design.md
@@ -23,10 +23,10 @@ Update `SIDEBAR_COLORS` in `Sidebar.tsx` to align with the dark theme palette de
 | `icon` | *(new)* | `#6B7280` | Default icon color (new dedicated token) |
 | `activeBg` | `#1F2937` | `#1F2937` | No change |
 | `text` | `#9CA3AF` | `#9CA3AF` | No change |
-| `hoverText` | `#CBD5E1` | `#CBD5E1` | No change |
+| `hoverText` | `#CBD5E1` | `#CBD5E1` | No change — `docs/ui.md` section 8 defines no sidebar hover-text color; intentionally deferred |
 | `sectionLabel` | `#6B7280` | `#6B7280` | No change |
 | `border` | `#1F2937` | `#1F2937` | No change |
-| `accentBar` | `#42a5f5` | `#42a5f5` | No change (not in issue scope) |
+| `accentBar` | `#42a5f5` | `#42a5f5` | No change — `docs/ui.md` defines no sidebar accent-bar color; deferred |
 
 ---
 
@@ -34,19 +34,23 @@ Update `SIDEBAR_COLORS` in `Sidebar.tsx` to align with the dark theme palette de
 
 The `text` token (`#9CA3AF`) was used for both text labels and icon colors. With the new `icon` token (`#6B7280`), icon-specific usages are separated.
 
+There are **9 total** `SIDEBAR_COLORS.text` usages in the file. **7 migrate** to `SIDEBAR_COLORS.icon`; **2 are intentionally kept** as `SIDEBAR_COLORS.text` (the `ListItemText` inactive-state label color in `renderFlyoutItem` and `renderMenuItem`).
+
 **7 usages** switch from `SIDEBAR_COLORS.text` → `SIDEBAR_COLORS.icon`:
 
 | Location | Context |
 |---|---|
 | `renderFlyoutItem` — `ListItemIcon` (line ~841) | Flyout item icon inactive state |
+| `renderFlyoutItem` — `ExpandMore` chevron (line ~863) | Flyout expand arrow |
 | `renderMenuItem` collapsed+children — `ListItemIcon` (line ~961) | Rail icon inactive state |
 | `renderMenuItem` collapsed+leaf — `ListItemIcon` (line ~1003) | Rail leaf icon inactive state |
 | `renderMenuItem` expanded — `ListItemIcon` (line ~1047) | Expanded menu icon inactive state |
-| `renderFlyoutItem` — `ExpandMore` chevron (line ~863) | Flyout expand arrow |
 | `renderMenuItem` expanded — `ExpandMore` chevron (line ~1076) | Sidebar expand arrow |
 | Collapse `IconButton` (line ~1149) | Sidebar collapse/expand toggle button |
 
-Text label usages (`ListItemText`) keep `SIDEBAR_COLORS.text` unchanged.
+**2 usages kept as `SIDEBAR_COLORS.text`** (text labels, not icons):
+- `renderFlyoutItem` — `ListItemText` inactive color (line ~854)
+- `renderMenuItem` expanded — `ListItemText` inactive color (line ~1060)
 
 ---
 

--- a/frontend/src/components/common/Sidebar.tsx
+++ b/frontend/src/components/common/Sidebar.tsx
@@ -95,13 +95,14 @@ interface MenuItem {
 }
 
 const SIDEBAR_COLORS = {
-  bg: '#0F172A',
+  bg: '#0D0D0D',
   activeBg: '#1F2937',
-  hoverBg: '#1E293B',
+  hoverBg: '#1E1E1E',
   text: '#9CA3AF',
-  activeText: '#E5E7EB',
+  activeText: '#FFFFFF',
   hoverText: '#CBD5E1',
-  activeIcon: '#FFFFFF',
+  activeIcon: '#3B82F6',
+  icon: '#6B7280',
   sectionLabel: '#6B7280',
   border: '#1F2937',
   accentBar: '#42a5f5',
@@ -838,7 +839,7 @@ const Sidebar: React.FC<SidebarProps> = ({
           <ListItemIcon
             sx={{
               minWidth: 32,
-              color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.text,
+              color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.icon,
               '& .MuiSvgIcon-root': { fontSize: '1.25rem' },
               transition: 'color 0.18s ease',
             }}
@@ -860,7 +861,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             <Box
               component="span"
               sx={{
-                color: SIDEBAR_COLORS.text,
+                color: SIDEBAR_COLORS.icon,
                 display: 'flex',
                 alignItems: 'center',
                 transition: 'transform 0.2s',
@@ -958,7 +959,7 @@ const Sidebar: React.FC<SidebarProps> = ({
               <ListItemIcon
                 sx={{
                   minWidth: 0,
-                  color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.text,
+                  color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.icon,
                   justifyContent: 'center',
                   '& .MuiSvgIcon-root': { fontSize: '1.25rem' },
                   transition: 'color 0.18s ease',
@@ -1000,7 +1001,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                 <ListItemIcon
                   sx={{
                     minWidth: 0,
-                    color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.text,
+                    color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.icon,
                     justifyContent: 'center',
                     '& .MuiSvgIcon-root': { fontSize: '1.25rem' },
                     transition: 'color 0.18s ease',
@@ -1044,7 +1045,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             <ListItemIcon
               sx={{
                 minWidth: 40,
-                color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.text,
+                color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.icon,
                 '& .MuiSvgIcon-root': { fontSize: '1.25rem' },
                 transition: 'color 0.18s ease',
               }}
@@ -1073,7 +1074,7 @@ const Sidebar: React.FC<SidebarProps> = ({
               <Box
                 component="span"
                 sx={{
-                  color: SIDEBAR_COLORS.text,
+                  color: SIDEBAR_COLORS.icon,
                   display: 'flex',
                   alignItems: 'center',
                   transition: 'transform 0.2s',
@@ -1146,7 +1147,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             size="small"
             sx={{
               display: { xs: 'none', lg: 'flex' },
-              color: SIDEBAR_COLORS.text,
+              color: SIDEBAR_COLORS.icon,
               width: 28,
               height: 28,
               '&:hover': { bgcolor: SIDEBAR_COLORS.hoverBg },


### PR DESCRIPTION
Closes #121

## Summary
- Updates `SIDEBAR_COLORS` in `Sidebar.tsx` to match the dark theme palette in `docs/ui.md`
- Adds dedicated `icon` token (`#6B7280`) and migrates 7 icon-specific `.text` usages to `.icon`
- Leaves 2 `ListItemText` label usages as `.text` (correct — text ≠ icon)

## Token changes
| Token | Before | After |
|---|---|---|
| `bg` | `#0F172A` | `#0D0D0D` |
| `hoverBg` | `#1E293B` | `#1E1E1E` |
| `activeText` | `#E5E7EB` | `#FFFFFF` |
| `activeIcon` | `#FFFFFF` | `#3B82F6` |
| `icon` | *(new)* | `#6B7280` |

## Verification
- `npm run type-check` — exit 0
- Vitest: 16/16 sidebar tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)