### PR TITLE
feat: category-first Reports flyout in collapsed sidebar mode

### DIFF
--- a/frontend/src/components/common/Sidebar.tsx
+++ b/frontend/src/components/common/Sidebar.tsx
@@ -96,6 +96,7 @@ interface MenuItem {
   badge?: number | string
   group?: string
   children?: MenuItem[]
+  flyoutMode?: 'category-first'
 }
 
 const SIDEBAR_COLORS = {
@@ -317,6 +318,7 @@ const menuSections: MenuSection[] = [
         id: 'reports',
         title: 'Reports',
         icon: <AssessmentIcon />,
+        flyoutMode: 'category-first',
         children: [
           {
             id: 'sales-by-product-summary',
@@ -671,6 +673,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   const [flyoutItemId, setFlyoutItemId] = React.useState<string | null>(null)
   const [flyoutAnchorEl, setFlyoutAnchorEl] = React.useState<HTMLElement | null>(null)
   const [flyoutExpandedIds, setFlyoutExpandedIds] = React.useState<string[]>([])
+  const [flyoutExpandedGroup, setFlyoutExpandedGroup] = React.useState<string | null>(null)
   const [flyoutOpen, setFlyoutOpen] = React.useState(false)
   const openTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
   const closeTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -710,6 +713,12 @@ const Sidebar: React.FC<SidebarProps> = ({
     }
 
     setFlyoutExpandedIds(autoExpanded)
+    if (item?.flyoutMode === 'category-first' && item.children) {
+      const activeChild = item.children.find(child => isItemActive(child))
+      setFlyoutExpandedGroup(activeChild?.group?.toLowerCase() ?? null)
+    } else {
+      setFlyoutExpandedGroup(null)
+    }
     setFlyoutItemId(itemId)
     setFlyoutAnchorEl(anchorEl)
     setFlyoutOpen(true)
@@ -724,6 +733,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       setFlyoutItemId(null)
       setFlyoutAnchorEl(null)
       setFlyoutExpandedIds([])
+      setFlyoutExpandedGroup(null)
       clearFlyoutStateTimerRef.current = null
     }, 80)
   }, [])
@@ -758,6 +768,7 @@ const Sidebar: React.FC<SidebarProps> = ({
     setFlyoutItemId(null)
     setFlyoutAnchorEl(null)
     setFlyoutExpandedIds([])
+    setFlyoutExpandedGroup(null)
     if (openTimerRef.current) clearTimeout(openTimerRef.current)
     if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
     if (clearFlyoutStateTimerRef.current) clearTimeout(clearFlyoutStateTimerRef.current)
@@ -1307,8 +1318,10 @@ const Sidebar: React.FC<SidebarProps> = ({
                 onMouseLeave={handleFlyoutMouseLeave}
                 sx={{
                   bgcolor: SIDEBAR_COLORS.hoverBg,
-                  minWidth: 200,
-                  maxWidth: 240,
+                  minWidth: 240,
+                  maxWidth: 280,
+                  maxHeight: 'calc(100vh - 24px)',
+                  overflowY: 'auto',
                   py: 1,
                   borderRadius: 1,
                   boxShadow: '0 4px 20px rgba(0,0,0,0.4)',
@@ -1319,16 +1332,100 @@ const Sidebar: React.FC<SidebarProps> = ({
                   animation: 'flyoutEnter 0.12s ease-out',
                 }}
               >
-                <List disablePadding>
-                  {flyoutItem.children.map((child, idx, arr) => (
-                    <React.Fragment key={child.id}>
-                      {child.group && (idx === 0 || child.group !== arr[idx - 1].group)
-                        ? renderGroupLabel(child.group)
-                        : null}
-                      {renderFlyoutItem(child, 0, idx === 0)}
-                    </React.Fragment>
-                  ))}
-                </List>
+                {flyoutItem.flyoutMode === 'category-first'
+                  ? (() => {
+                      const groups: string[] = []
+
+                      flyoutItem.children.forEach(child => {
+                        if (child.group && !groups.includes(child.group)) {
+                          groups.push(child.group)
+                        }
+                      })
+
+                      return (
+                        <List disablePadding>
+                          {groups.map((group, groupIdx) => {
+                            const slug = group.toLowerCase()
+                            const groupChildren = flyoutItem.children?.filter(
+                              child => child.group === group
+                            ) ?? []
+                            const isGroupActive = groupChildren.some(child => isItemActive(child))
+                            const isExpanded = flyoutExpandedGroup === slug
+
+                            return (
+                              <React.Fragment key={group}>
+                                <ListItemButton
+                                  {...(groupIdx === 0 ? { 'data-flyout-first': 'true' } : {})}
+                                  selected={isGroupActive}
+                                  aria-expanded={isExpanded}
+                                  onClick={() => {
+                                    setFlyoutExpandedGroup(prev => (prev === slug ? null : slug))
+                                  }}
+                                  sx={{
+                                    px: 2,
+                                    py: 0.75,
+                                    minHeight: 40,
+                                    color: isGroupActive
+                                      ? SIDEBAR_COLORS.activeText
+                                      : SIDEBAR_COLORS.text,
+                                    '&.Mui-selected': {
+                                      bgcolor: SIDEBAR_COLORS.activeBg,
+                                      color: SIDEBAR_COLORS.activeText,
+                                    },
+                                    '&.Mui-selected:hover': {
+                                      bgcolor: SIDEBAR_COLORS.activeBg,
+                                    },
+                                    '&:hover': {
+                                      bgcolor: SIDEBAR_COLORS.hoverBg,
+                                    },
+                                  }}
+                                >
+                                  <ListItemText
+                                    primary={group}
+                                    primaryTypographyProps={{
+                                      variant: 'body2',
+                                      fontWeight: isGroupActive ? 600 : 500,
+                                    }}
+                                  />
+                                  <Box
+                                    component="span"
+                                    sx={{
+                                      color: isGroupActive
+                                        ? SIDEBAR_COLORS.activeText
+                                        : SIDEBAR_COLORS.icon,
+                                      display: 'flex',
+                                      alignItems: 'center',
+                                      transition: 'transform 0.2s',
+                                      transform: isExpanded ? 'rotate(180deg)' : 'none',
+                                    }}
+                                  >
+                                    <ExpandMore fontSize="small" />
+                                  </Box>
+                                </ListItemButton>
+
+                                <Collapse in={isExpanded} timeout={200} unmountOnExit>
+                                  <List component="div" disablePadding>
+                                    {groupChildren.map(child => renderFlyoutItem(child, 1))}
+                                  </List>
+                                </Collapse>
+                              </React.Fragment>
+                            )
+                          })}
+                        </List>
+                      )
+                    })()
+                  : (
+                    <List disablePadding>
+                      {flyoutItem.children.map((child, idx, arr) => (
+                        <React.Fragment key={child.id}>
+                          {child.group && (idx === 0 || child.group !== arr[idx - 1].group)
+                            ? renderGroupLabel(child.group)
+                            : null}
+                          {renderFlyoutItem(child, 0, idx === 0)}
+                        </React.Fragment>
+                      ))}
+                    </List>
+                  )}
               </Paper>
             </Fade>
           </Popper>

--- a/frontend/src/components/common/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/common/__tests__/Sidebar.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, useLocation } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import Sidebar from '../Sidebar'
 
@@ -42,6 +42,22 @@ describe('Sidebar', () => {
   const getSectionList = (sectionTitle: string) => {
     const sectionHeader = screen.getByText(sectionTitle, { selector: '.MuiTypography-overline' })
     return sectionHeader.nextElementSibling as HTMLElement
+  }
+
+  const openCollapsedFlyout = async (itemId: string) => {
+    const button = document.getElementById(`rail-item-${itemId}`) as HTMLElement
+    fireEvent.mouseEnter(button)
+
+    await waitFor(() => {
+      expect(document.getElementById(`flyout-panel-${itemId}`)).toBeInTheDocument()
+    }, { timeout: 500 })
+
+    return document.getElementById(`flyout-panel-${itemId}`) as HTMLElement
+  }
+
+  const LocationDisplay = () => {
+    const location = useLocation()
+    return <div data-testid="location-display">{location.pathname}</div>
   }
 
   it('collapses expanded groups when navigating to a route without a parent group', async () => {
@@ -337,6 +353,163 @@ describe('Sidebar', () => {
     await waitFor(() => {
       expect(screen.queryByText('Customers')).not.toBeInTheDocument()
     }, { timeout: 500 })
+  })
+
+  describe('reports flyout category-first mode', () => {
+    it('shows only category headers when the collapsed Reports flyout first opens', async () => {
+      render(
+        <MemoryRouter initialEntries={['/dashboard']}>
+          <Sidebar collapsed={true} />
+        </MemoryRouter>
+      )
+
+      const flyout = await openCollapsedFlyout('reports')
+
+      expect(within(flyout).getByRole('button', { name: 'Sales' })).toBeInTheDocument()
+      expect(within(flyout).getByRole('button', { name: 'Purchasing' })).toBeInTheDocument()
+      expect(within(flyout).getByRole('button', { name: 'Inventory' })).toBeInTheDocument()
+      expect(within(flyout).getByRole('button', { name: 'Accounting' })).toBeInTheDocument()
+      expect(within(flyout).queryByRole('button', { name: 'Product Summary' })).not.toBeInTheDocument()
+      expect(within(flyout).queryByRole('button', { name: 'Trial Balance' })).not.toBeInTheDocument()
+    })
+
+    it('expands a report category to show its items inline', async () => {
+      render(
+        <MemoryRouter initialEntries={['/dashboard']}>
+          <Sidebar collapsed={true} />
+        </MemoryRouter>
+      )
+
+      const flyout = await openCollapsedFlyout('reports')
+
+      expect(within(flyout).queryByRole('button', { name: 'Product Summary' })).not.toBeInTheDocument()
+
+      fireEvent.click(within(flyout).getByRole('button', { name: 'Sales' }))
+
+      await waitFor(() => {
+        expect(within(flyout).getByRole('button', { name: 'Product Summary' })).toBeInTheDocument()
+        expect(within(flyout).getByRole('button', { name: 'Product Details' })).toBeInTheDocument()
+      })
+    })
+
+    it('keeps only one report category expanded at a time', async () => {
+      render(
+        <MemoryRouter initialEntries={['/dashboard']}>
+          <Sidebar collapsed={true} />
+        </MemoryRouter>
+      )
+
+      const flyout = await openCollapsedFlyout('reports')
+
+      fireEvent.click(within(flyout).getByRole('button', { name: 'Sales' }))
+
+      await waitFor(() => {
+        expect(within(flyout).getByRole('button', { name: 'Product Summary' })).toBeInTheDocument()
+      })
+
+      fireEvent.click(within(flyout).getByRole('button', { name: 'Purchasing' }))
+
+      await waitFor(() => {
+        expect(within(flyout).getByRole('button', { name: 'Sales' })).toHaveAttribute('aria-expanded', 'false')
+        expect(within(flyout).getByRole('button', { name: 'Purchasing' })).toHaveAttribute('aria-expanded', 'true')
+        expect(screen.getByRole('button', { name: 'Order Details' })).toBeInTheDocument()
+      })
+    })
+
+    it('collapses an expanded report category when clicked again', async () => {
+      render(
+        <MemoryRouter initialEntries={['/dashboard']}>
+          <Sidebar collapsed={true} />
+        </MemoryRouter>
+      )
+
+      const flyout = await openCollapsedFlyout('reports')
+
+      fireEvent.click(within(flyout).getByRole('button', { name: 'Sales' }))
+
+      await waitFor(() => {
+        expect(within(flyout).getByRole('button', { name: 'Product Summary' })).toBeInTheDocument()
+      })
+
+      fireEvent.click(within(flyout).getByRole('button', { name: 'Sales' }))
+
+      await waitFor(() => {
+        expect(within(flyout).getByRole('button', { name: 'Sales' })).toHaveAttribute('aria-expanded', 'false')
+      })
+    })
+
+    it('navigates to a report item and closes the flyout', async () => {
+      render(
+        <MemoryRouter initialEntries={['/dashboard']}>
+          <Sidebar collapsed={true} />
+          <LocationDisplay />
+        </MemoryRouter>
+      )
+
+      const flyout = await openCollapsedFlyout('reports')
+
+      fireEvent.click(within(flyout).getByRole('button', { name: 'Sales' }))
+
+      await waitFor(() => {
+        expect(within(flyout).getByRole('button', { name: 'Product Summary' })).toBeInTheDocument()
+      })
+
+      fireEvent.click(within(flyout).getByRole('button', { name: 'Product Summary' }))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('location-display')).toHaveTextContent('/reports/sales/product-summary')
+        expect(document.getElementById('flyout-panel-reports')).not.toBeInTheDocument()
+      })
+    })
+
+    it('auto-expands the active report category when opening the flyout', async () => {
+      render(
+        <MemoryRouter initialEntries={['/reports/sales/product-summary']}>
+          <Sidebar collapsed={true} />
+        </MemoryRouter>
+      )
+
+      const flyout = await openCollapsedFlyout('reports')
+
+      await waitFor(() => {
+        expect(within(flyout).getByRole('button', { name: 'Sales' })).toHaveAttribute('aria-expanded', 'true')
+        expect(within(flyout).getByRole('button', { name: 'Product Summary' })).toBeInTheDocument()
+      })
+    })
+
+    it('moves keyboard focus into the first report category when opening from the rail', async () => {
+      render(
+        <MemoryRouter initialEntries={['/dashboard']}>
+          <Sidebar collapsed={true} />
+        </MemoryRouter>
+      )
+
+      const reportsButton = document.getElementById('rail-item-reports') as HTMLElement
+      reportsButton.focus()
+
+      fireEvent.keyDown(reportsButton, { key: 'Enter' })
+
+      await waitFor(() => {
+        const firstFlyoutButton = document.querySelector('[data-flyout-first="true"]') as HTMLElement
+        expect(firstFlyoutButton).toHaveTextContent('Sales')
+        expect(firstFlyoutButton).toHaveFocus()
+      })
+    })
+
+    it('keeps non-Reports flyouts on the existing flat grouped layout', async () => {
+      render(
+        <MemoryRouter initialEntries={['/dashboard']}>
+          <Sidebar collapsed={true} />
+        </MemoryRouter>
+      )
+
+      const flyout = await openCollapsedFlyout('settings')
+
+      expect(within(flyout).getByText('Business')).toBeInTheDocument()
+      expect(within(flyout).queryByRole('button', { name: 'Business' })).not.toBeInTheDocument()
+      expect(within(flyout).getByRole('button', { name: 'Users' })).toBeInTheDocument()
+      expect(within(flyout).getByRole('button', { name: 'Backup & Restore' })).toBeInTheDocument()
+    })
   })
 
   describe('brand header', () => {


### PR DESCRIPTION
Closes #130

## Summary

- Redesigns the collapsed sidebar Reports flyout from a flat 24-item scrollable list to a category-first accordion
- First flyout level shows only 4 category headers: Sales, Purchasing, Inventory, Accounting
- Clicking a category expands its reports inline; only one category open at a time
- Active report category auto-expands when the flyout opens
- Keyboard focus correctly moves to the first category header on Enter/Space
- Flyout Paper widened (minWidth: 240, maxWidth: 280) with viewport-bounded height and scroll fallback as a safety net

## What is unchanged

- Expanded sidebar: full grouped report tree, all items visible
- All non-Reports flyouts (Settings, etc.): existing flat layout
- Routes and menu IA: no changes

## Implementation

`flyoutMode: 'category-first'` on the Reports `MenuItem` gates a dedicated render branch at the Popper root. A new `flyoutExpandedGroup: string | null` state tracks the single open category. The existing `flyoutExpandedIds` and `renderFlyoutItem` recursive path are untouched.

## Test plan

- [x] 8 new tests covering: initial render, expand, accordion, toggle collapse, leaf navigation, auto-expand (Sales path), keyboard focus, Settings flyout non-regression
- [x] All 372 frontend tests pass
- [x] `npm run lint` — passed
- [x] `npm run type-check` — passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)