### PR TITLE
docs: sidebar density adjustment spec and plan (issue #132)

### DIFF
--- a/frontend/src/components/common/Sidebar.tsx
+++ b/frontend/src/components/common/Sidebar.tsx
@@ -1081,7 +1081,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             sx={{
               pl: 2 + level * 2,
               py: 0,
-              height: 44,
+              height: 40,
               borderRadius: 2,
               mx: 1,
               mb: 0.5,

--- a/frontend/src/components/common/Sidebar.tsx
+++ b/frontend/src/components/common/Sidebar.tsx
@@ -830,7 +830,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             pl: 1.5 + level * 2,
             pr: 1.5,
             py: 0,
-            height: 40,
+            height: 36,
             borderRadius: 2,
             mx: 0.5,
             mb: 0.25,


### PR DESCRIPTION
## Summary
- Adds spec: `docs/superpowers/specs/2026-03-18-sidebar-density-design.md`
- Adds plan: `docs/superpowers/plans/2026-03-18-sidebar-density.md`
- Scope: reduce expanded sidebar item heights (44px → 40px top-level, 40px → 36px flyout) for denser ERP navigation

## Changes
- `renderMenuItem` height: `44` → `40`
- `renderFlyoutItem` height: `40` → `36`
- Collapsed rail (44px), typography, icons, spacing tokens — all unchanged

## Test Plan
- [x] No test changes needed (no height assertions in sidebar test suite)
- [x] Visual check: expanded sidebar items are noticeably more compact; collapsed rail unchanged

Closes #132