### PR TITLE
feat: sidebar footer — user avatar, logout, and app version (#133)

### DIFF
--- a/frontend/src/components/common/Sidebar.tsx
+++ b/frontend/src/components/common/Sidebar.tsx
@@ -75,6 +75,7 @@ import {
   ChevronRight,
 } from '@mui/icons-material'
 import { useGetCompanySettingsQuery } from '@/store/api/settingsApi'
+import SidebarFooter from './SidebarFooter'
 
 interface SidebarProps {
   onItemClick?: () => void
@@ -1291,6 +1292,8 @@ const Sidebar: React.FC<SidebarProps> = ({
           </React.Fragment>
         ))}
       </Box>
+
+      <SidebarFooter collapsed={Boolean(collapsed)} />
 
       {/* Popper gated only on flyoutItemId (not flyoutAnchorEl) so it stays mounted
           during the 80ms exit fade. flyoutAnchorEl provides the anchor position;

--- a/frontend/src/components/common/SidebarFooter.tsx
+++ b/frontend/src/components/common/SidebarFooter.tsx
@@ -1,0 +1,150 @@
+import React from 'react'
+import {
+  Avatar,
+  Box,
+  IconButton,
+  ListItemButton,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import { Logout as LogoutIcon } from '@mui/icons-material'
+import { useDispatch, useSelector } from 'react-redux'
+import {
+  logout,
+  selectCurrentUser,
+  selectRefreshToken,
+} from '@/store/slices/authSlice'
+import type { AppDispatch } from '@/store'
+
+const COLORS = {
+  border: '#1F2937',
+  hoverBg: '#1E1E1E',
+  activeText: '#FFFFFF',
+  sectionLabel: '#6B7280',
+  icon: '#6B7280',
+  hoverText: '#CBD5E1',
+} as const
+
+interface SidebarFooterProps {
+  collapsed: boolean
+}
+
+const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
+  const dispatch = useDispatch<AppDispatch>()
+  const user = useSelector(selectCurrentUser)
+  const refreshToken = useSelector(selectRefreshToken)
+
+  if (!user) return null
+
+  const { username, firstName, lastName } = user
+  const initials = ((firstName?.[0] ?? '') + (lastName?.[0] ?? '') || username?.[0] || 'U').toUpperCase()
+  const version = __APP_VERSION__ || '0.0.0'
+
+  const handleLogout = () => {
+    if (refreshToken) {
+      dispatch(logout(refreshToken))
+    }
+  }
+
+  if (collapsed) {
+    return (
+      <Box
+        sx={{
+          borderTop: `1px solid ${COLORS.border}`,
+          py: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 0.5,
+        }}
+      >
+        <Tooltip title={username} placement="right">
+          <Box
+            sx={{
+              height: 40,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: 'default',
+            }}
+          >
+            <Avatar sx={{ width: 32, height: 32, bgcolor: 'primary.main', fontSize: '0.75rem' }}>
+              {initials}
+            </Avatar>
+          </Box>
+        </Tooltip>
+        <Tooltip title="Logout" placement="right">
+          <IconButton
+            onClick={handleLogout}
+            aria-label="Logout"
+            size="small"
+            sx={{
+              width: 40,
+              height: 40,
+              borderRadius: 1,
+              color: COLORS.icon,
+              '&:hover': {
+                bgcolor: COLORS.hoverBg,
+                color: COLORS.hoverText,
+              },
+            }}
+          >
+            <LogoutIcon sx={{ fontSize: 18 }} />
+          </IconButton>
+        </Tooltip>
+      </Box>
+    )
+  }
+
+  return (
+    <Box sx={{ borderTop: `1px solid ${COLORS.border}` }}>
+      <ListItemButton
+        onClick={handleLogout}
+        aria-label="Logout"
+        sx={{
+          px: 2,
+          py: 1.5,
+          '&:hover': {
+            bgcolor: COLORS.hoverBg,
+            '& svg': { color: COLORS.hoverText },
+          },
+        }}
+      >
+        <Avatar
+          sx={{
+            width: 32,
+            height: 32,
+            bgcolor: 'primary.main',
+            fontSize: '0.75rem',
+            flexShrink: 0,
+          }}
+        >
+          {initials}
+        </Avatar>
+        <Box sx={{ ml: 1.5, flex: 1, minWidth: 0 }}>
+          <Typography
+            noWrap
+            sx={{ color: COLORS.activeText, fontSize: '0.875rem', lineHeight: 1.3 }}
+          >
+            {username}
+          </Typography>
+          <Typography
+            sx={{
+              color: COLORS.sectionLabel,
+              fontSize: '0.7rem',
+              lineHeight: 1.2,
+              mt: '2px',
+            }}
+          >
+            v{version}
+          </Typography>
+        </Box>
+        <Tooltip title="Logout">
+          <LogoutIcon sx={{ color: COLORS.icon, fontSize: 18, flexShrink: 0 }} />
+        </Tooltip>
+      </ListItemButton>
+    </Box>
+  )
+}
+
+export default SidebarFooter

--- a/frontend/src/components/common/SidebarFooter.tsx
+++ b/frontend/src/components/common/SidebarFooter.tsx
@@ -126,13 +126,14 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
 
   return (
     <>
-    <Box sx={{ borderTop: `1px solid ${COLORS.border}` }}>
+    <Box sx={{ borderTop: `1px solid ${COLORS.border}`, mt: 1 }}>
       <ListItemButton
         onClick={() => setConfirmOpen(true)}
         aria-label={`Logout ${username}`}
         sx={{
           px: 2,
           py: 1.5,
+          bgcolor: 'transparent',
           transition: 'background-color 0.15s ease',
           '&:hover': {
             bgcolor: COLORS.hoverBg,
@@ -170,7 +171,9 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
           </Typography>
         </Box>
         <Tooltip title="Logout">
-          <LogoutIcon sx={{ color: COLORS.icon, fontSize: 18, flexShrink: 0 }} />
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <LogoutIcon sx={{ color: COLORS.icon, fontSize: 18 }} />
+          </Box>
         </Tooltip>
       </ListItemButton>
     </Box>

--- a/frontend/src/components/common/SidebarFooter.tsx
+++ b/frontend/src/components/common/SidebarFooter.tsx
@@ -133,6 +133,7 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
         sx={{
           px: 2,
           py: 1.5,
+          transition: 'background-color 0.15s ease',
           '&:hover': {
             bgcolor: COLORS.hoverBg,
             '& svg': { color: COLORS.hoverText },
@@ -153,7 +154,7 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
         <Box sx={{ ml: 1.5, flex: 1, minWidth: 0 }}>
           <Typography
             noWrap
-            sx={{ color: COLORS.activeText, fontSize: '0.875rem', lineHeight: 1.3 }}
+            sx={{ color: COLORS.activeText, fontSize: '0.875rem', lineHeight: 1.3, overflow: 'hidden', textOverflow: 'ellipsis' }}
           >
             {username}
           </Typography>
@@ -162,7 +163,7 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
               color: COLORS.sectionLabel,
               fontSize: '0.7rem',
               lineHeight: 1.2,
-              mt: '2px',
+              mt: '4px',
             }}
           >
             v{version}

--- a/frontend/src/components/common/SidebarFooter.tsx
+++ b/frontend/src/components/common/SidebarFooter.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import {
   Avatar,
   Box,
@@ -7,6 +7,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
+import ConfirmationDialog from './ConfirmationDialog'
 import { Logout as LogoutIcon } from '@mui/icons-material'
 import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
@@ -36,6 +37,7 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
   const navigate = useNavigate()
   const user = useSelector(selectCurrentUser)
   const refreshToken = useSelector(selectRefreshToken)
+  const [confirmOpen, setConfirmOpen] = useState(false)
 
   if (!user) return null
 
@@ -43,7 +45,8 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
   const initials = ((firstName?.[0] ?? '') + (lastName?.[0] ?? '') || username?.[0] || 'U').toUpperCase()
   const version = __APP_VERSION__ || '0.0.0'
 
-  const handleLogout = async () => {
+  const handleLogoutConfirm = async () => {
+    setConfirmOpen(false)
     if (refreshToken) {
       await dispatch(logout(refreshToken))
     }
@@ -51,8 +54,22 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
     navigate('/login')
   }
 
+  const confirmDialog = (
+    <ConfirmationDialog
+      open={confirmOpen}
+      title="Logout"
+      message="Are you sure you want to log out?"
+      confirmText="Logout"
+      cancelText="Cancel"
+      severity="warning"
+      onConfirm={handleLogoutConfirm}
+      onCancel={() => setConfirmOpen(false)}
+    />
+  )
+
   if (collapsed) {
     return (
+      <>
       <Box
         sx={{
           borderTop: `1px solid ${COLORS.border}`,
@@ -84,7 +101,7 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
         </Tooltip>
         <Tooltip title="Logout" placement="right">
           <IconButton
-            onClick={handleLogout}
+            onClick={() => setConfirmOpen(true)}
             aria-label="Logout"
             size="small"
             sx={{
@@ -102,13 +119,16 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
           </IconButton>
         </Tooltip>
       </Box>
+      {confirmDialog}
+      </>
     )
   }
 
   return (
+    <>
     <Box sx={{ borderTop: `1px solid ${COLORS.border}` }}>
       <ListItemButton
-        onClick={handleLogout}
+        onClick={() => setConfirmOpen(true)}
         aria-label={`Logout ${username}`}
         sx={{
           px: 2,
@@ -153,6 +173,8 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
         </Tooltip>
       </ListItemButton>
     </Box>
+    {confirmDialog}
+    </>
   )
 }
 

--- a/frontend/src/components/common/SidebarFooter.tsx
+++ b/frontend/src/components/common/SidebarFooter.tsx
@@ -9,12 +9,14 @@ import {
 } from '@mui/material'
 import { Logout as LogoutIcon } from '@mui/icons-material'
 import { useDispatch, useSelector } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
 import {
   logout,
   selectCurrentUser,
   selectRefreshToken,
 } from '@/store/slices/authSlice'
 import type { AppDispatch } from '@/store'
+import { persistor } from '@/store'
 
 const COLORS = {
   border: '#1F2937',
@@ -31,6 +33,7 @@ interface SidebarFooterProps {
 
 const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
   const dispatch = useDispatch<AppDispatch>()
+  const navigate = useNavigate()
   const user = useSelector(selectCurrentUser)
   const refreshToken = useSelector(selectRefreshToken)
 
@@ -40,10 +43,12 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
   const initials = ((firstName?.[0] ?? '') + (lastName?.[0] ?? '') || username?.[0] || 'U').toUpperCase()
   const version = __APP_VERSION__ || '0.0.0'
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
     if (refreshToken) {
-      dispatch(logout(refreshToken))
+      await dispatch(logout(refreshToken))
     }
+    await persistor.purge()
+    navigate('/login')
   }
 
   if (collapsed) {

--- a/frontend/src/components/common/SidebarFooter.tsx
+++ b/frontend/src/components/common/SidebarFooter.tsx
@@ -60,12 +60,16 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
       >
         <Tooltip title={username} placement="right">
           <Box
+            tabIndex={0}
+            role="img"
+            aria-label={username}
             sx={{
               height: 40,
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
               cursor: 'default',
+              outline: 'none',
             }}
           >
             <Avatar sx={{ width: 32, height: 32, bgcolor: 'primary.main', fontSize: '0.75rem' }}>
@@ -100,7 +104,7 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
     <Box sx={{ borderTop: `1px solid ${COLORS.border}` }}>
       <ListItemButton
         onClick={handleLogout}
-        aria-label="Logout"
+        aria-label={`Logout ${username}`}
         sx={{
           px: 2,
           py: 1.5,

--- a/frontend/src/components/common/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/common/__tests__/Sidebar.test.tsx
@@ -29,6 +29,10 @@ vi.mock('react-transition-group', async () => {
   }
 })
 
+vi.mock('../SidebarFooter', () => ({
+  default: () => null,
+}))
+
 describe('Sidebar', () => {
   beforeEach(() => {
     localStorage.clear()

--- a/frontend/src/components/common/__tests__/SidebarFooter.test.tsx
+++ b/frontend/src/components/common/__tests__/SidebarFooter.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
 import { configureStore } from '@reduxjs/toolkit'
 import { describe, expect, it, vi } from 'vitest'
 import SidebarFooter from '../SidebarFooter'
@@ -40,7 +41,9 @@ const renderFooter = (props = {}, authOverrides = {}) => {
   const store = makeStore(authOverrides)
   return render(
     <Provider store={store}>
-      <SidebarFooter collapsed={false} {...props} />
+      <MemoryRouter>
+        <SidebarFooter collapsed={false} {...props} />
+      </MemoryRouter>
     </Provider>
   )
 }
@@ -101,7 +104,9 @@ describe('SidebarFooter', () => {
     const dispatchSpy = vi.spyOn(store, 'dispatch')
     render(
       <Provider store={store}>
-        <SidebarFooter collapsed={false} />
+        <MemoryRouter>
+          <SidebarFooter collapsed={false} />
+        </MemoryRouter>
       </Provider>
     )
     fireEvent.click(screen.getByRole('button', { name: /logout jdoe/i }))
@@ -113,7 +118,9 @@ describe('SidebarFooter', () => {
     const dispatchSpy = vi.spyOn(store, 'dispatch')
     render(
       <Provider store={store}>
-        <SidebarFooter collapsed={true} />
+        <MemoryRouter>
+          <SidebarFooter collapsed={true} />
+        </MemoryRouter>
       </Provider>
     )
     fireEvent.click(screen.getByRole('button', { name: /logout/i }))

--- a/frontend/src/components/common/__tests__/SidebarFooter.test.tsx
+++ b/frontend/src/components/common/__tests__/SidebarFooter.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import { describe, expect, it, vi } from 'vitest'
+import SidebarFooter from '../SidebarFooter'
+import authReducer from '@/store/slices/authSlice'
+
+const makeStore = (authOverrides = {}) =>
+  configureStore({
+    reducer: { auth: authReducer },
+    preloadedState: {
+      auth: {
+        user: {
+          id: '1',
+          username: 'jdoe',
+          firstName: 'Jane',
+          lastName: 'Doe',
+          email: 'j@test.com',
+          role: 'admin',
+          isActive: true,
+          status: 'active',
+          failedLoginAttempts: 0,
+          createdAt: '2024-01-01',
+          updatedAt: '2024-01-01',
+        },
+        refreshToken: 'test-refresh-token',
+        accessToken: 'test-access-token',
+        isAuthenticated: true,
+        loading: false,
+        error: null,
+        lastActivityTime: null,
+        inactivityTimeoutMinutes: 30,
+        rememberMe: false,
+        ...authOverrides,
+      },
+    },
+  })
+
+const renderFooter = (props = {}, authOverrides = {}) => {
+  const store = makeStore(authOverrides)
+  return render(
+    <Provider store={store}>
+      <SidebarFooter collapsed={false} {...props} />
+    </Provider>
+  )
+}
+
+describe('SidebarFooter', () => {
+  it('renders username in expanded mode', () => {
+    renderFooter()
+    expect(screen.getByText('jdoe')).toBeInTheDocument()
+  })
+
+  it('renders avatar with initials JD', () => {
+    renderFooter()
+    expect(screen.getByText('JD')).toBeInTheDocument()
+  })
+
+  it('renders version string', () => {
+    renderFooter()
+    expect(screen.getByText(/^v/)).toBeInTheDocument()
+  })
+
+  it('falls back to username initial when no first/last name', () => {
+    renderFooter({}, {
+      user: {
+        id: '2',
+        username: 'bob',
+        firstName: '',
+        lastName: '',
+        email: 'b@test.com',
+        role: 'admin',
+        isActive: true,
+        status: 'active',
+        failedLoginAttempts: 0,
+        createdAt: '2024-01-01',
+        updatedAt: '2024-01-01',
+      },
+    })
+    expect(screen.getByText('B')).toBeInTheDocument()
+  })
+
+  it('renders nothing when user is null', () => {
+    const { container } = renderFooter({}, { user: null, isAuthenticated: false })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('hides username and version in collapsed mode', () => {
+    renderFooter({ collapsed: true })
+    expect(screen.queryByText('jdoe')).not.toBeInTheDocument()
+    expect(screen.queryByText(/^v/)).not.toBeInTheDocument()
+  })
+
+  it('shows avatar tooltip with username in collapsed mode', async () => {
+    renderFooter({ collapsed: true })
+    expect(screen.getByText('JD')).toBeInTheDocument()
+  })
+
+  it('dispatches logout when row is clicked in expanded mode', async () => {
+    const store = makeStore()
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+    render(
+      <Provider store={store}>
+        <SidebarFooter collapsed={false} />
+      </Provider>
+    )
+    fireEvent.click(screen.getByRole('button', { name: /logout/i }))
+    expect(dispatchSpy).toHaveBeenCalled()
+  })
+
+  it('dispatches logout when icon button is clicked in collapsed mode', () => {
+    const store = makeStore()
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+    render(
+      <Provider store={store}>
+        <SidebarFooter collapsed={true} />
+      </Provider>
+    )
+    fireEvent.click(screen.getByRole('button', { name: /logout/i }))
+    expect(dispatchSpy).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/common/__tests__/SidebarFooter.test.tsx
+++ b/frontend/src/components/common/__tests__/SidebarFooter.test.tsx
@@ -99,7 +99,7 @@ describe('SidebarFooter', () => {
     expect(screen.getByText('JD')).toBeInTheDocument()
   })
 
-  it('dispatches logout when row is clicked in expanded mode', () => {
+  it('dispatches logout after confirming dialog in expanded mode', () => {
     const store = makeStore()
     const dispatchSpy = vi.spyOn(store, 'dispatch')
     render(
@@ -110,20 +110,19 @@ describe('SidebarFooter', () => {
       </Provider>
     )
     fireEvent.click(screen.getByRole('button', { name: /logout jdoe/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^logout$/i }))
     expect(dispatchSpy).toHaveBeenCalled()
   })
 
-  it('dispatches logout when icon button is clicked in collapsed mode', () => {
-    const store = makeStore()
-    const dispatchSpy = vi.spyOn(store, 'dispatch')
+  it('opens confirmation dialog when logout icon is clicked in collapsed mode', () => {
     render(
-      <Provider store={store}>
+      <Provider store={makeStore()}>
         <MemoryRouter>
           <SidebarFooter collapsed={true} />
         </MemoryRouter>
       </Provider>
     )
-    fireEvent.click(screen.getByRole('button', { name: /logout/i }))
-    expect(dispatchSpy).toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: /^logout$/i }))
+    expect(screen.getByText('Are you sure you want to log out?')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/common/__tests__/SidebarFooter.test.tsx
+++ b/frontend/src/components/common/__tests__/SidebarFooter.test.tsx
@@ -91,12 +91,12 @@ describe('SidebarFooter', () => {
     expect(screen.queryByText(/^v/)).not.toBeInTheDocument()
   })
 
-  it('shows avatar tooltip with username in collapsed mode', async () => {
+  it('shows avatar initials in collapsed mode', () => {
     renderFooter({ collapsed: true })
     expect(screen.getByText('JD')).toBeInTheDocument()
   })
 
-  it('dispatches logout when row is clicked in expanded mode', async () => {
+  it('dispatches logout when row is clicked in expanded mode', () => {
     const store = makeStore()
     const dispatchSpy = vi.spyOn(store, 'dispatch')
     render(
@@ -104,7 +104,7 @@ describe('SidebarFooter', () => {
         <SidebarFooter collapsed={false} />
       </Provider>
     )
-    fireEvent.click(screen.getByRole('button', { name: /logout/i }))
+    fireEvent.click(screen.getByRole('button', { name: /logout jdoe/i }))
     expect(dispatchSpy).toHaveBeenCalled()
   })
 

--- a/frontend/src/services/authApi.ts
+++ b/frontend/src/services/authApi.ts
@@ -59,9 +59,11 @@ export const authApi = {
 
   /**
    * Logout user and invalidate refresh token
+   * Note: This requires Authorization header via the main api instance
    */
   logout: async (refreshToken: string): Promise<AxiosResponse<void>> => {
-    return await authAxios.post<void>('/auth/logout', { refreshToken });
+    const apiInstance = (await import('./api')).default;
+    return await apiInstance.post<void>('/auth/logout', { refreshToken });
   },
 
   /**

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -29,6 +29,9 @@ export default defineConfig(({ mode }) => {
   return {
     customLogger: isVitest ? vitestLogger : undefined,
     plugins: isVitest ? [] : [react()],
+    define: {
+      __APP_VERSION__: JSON.stringify(process.env.npm_package_version ?? '0.0.0'),
+    },
     resolve: {
       alias: {
         '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary

- Adds `SidebarFooter` component showing logged-in user avatar (with initials fallback), username, logout action, and app version
- Adapts layout for expanded (full row, username + version visible) and collapsed (avatar + logout icon only) sidebar states
- Version injected at build time via Vite `define` (`__APP_VERSION__`), avoiding runtime env plumbing
- Logout flow: confirmation dialog → dispatch thunk → purge redux-persist storage → navigate to `/login`

## Fixes

- `POST /auth/logout` was 401 — switched from bare `authAxios` to the authenticated `api` instance (same pattern as `getCurrentUser`)
- Logout didn't redirect — `authLoader` only runs on navigation; added explicit `navigate('/login')` + `persistor.purge()` after dispatch

## Test Plan

- [x] Log in, click logout icon in sidebar footer — confirmation dialog appears
- [x] Confirm logout — redirected to `/login`, cannot navigate back without logging in again
- [x] Refresh after logout — stays on `/login` (persist purged)
- [x] Collapse sidebar — avatar and logout icon visible, username tooltip on hover, version hidden
- [x] Long username — truncates with ellipsis, no layout break
- [x] 381/381 frontend tests pass (`npm run test`)

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)