### PR TITLE
feat(ui): sidebar footer improvements — avatar menu, instant logout, visual polish

### DIFF
--- a/frontend/src/components/common/SidebarFooter.tsx
+++ b/frontend/src/components/common/SidebarFooter.tsx
@@ -1,184 +1,25 @@
-import React, { useState } from 'react'
-import {
-  Avatar,
-  Box,
-  IconButton,
-  ListItemButton,
-  Tooltip,
-  Typography,
-} from '@mui/material'
-import ConfirmationDialog from './ConfirmationDialog'
-import { Logout as LogoutIcon } from '@mui/icons-material'
-import { useDispatch, useSelector } from 'react-redux'
-import { useNavigate } from 'react-router-dom'
-import {
-  logout,
-  selectCurrentUser,
-  selectRefreshToken,
-} from '@/store/slices/authSlice'
-import type { AppDispatch } from '@/store'
-import { persistor } from '@/store'
-
-const COLORS = {
-  border: '#1F2937',
-  hoverBg: '#1E1E1E',
-  activeText: '#FFFFFF',
-  sectionLabel: '#6B7280',
-  icon: '#6B7280',
-  hoverText: '#CBD5E1',
-} as const
+import React from 'react'
+import { Box } from '@mui/material'
+import SidebarUserMenu from './SidebarUserMenu'
 
 interface SidebarFooterProps {
   collapsed: boolean
 }
 
 const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
-  const dispatch = useDispatch<AppDispatch>()
-  const navigate = useNavigate()
-  const user = useSelector(selectCurrentUser)
-  const refreshToken = useSelector(selectRefreshToken)
-  const [confirmOpen, setConfirmOpen] = useState(false)
-
-  if (!user) return null
-
-  const { username, firstName, lastName } = user
-  const initials = ((firstName?.[0] ?? '') + (lastName?.[0] ?? '') || username?.[0] || 'U').toUpperCase()
-  const version = __APP_VERSION__ || '0.0.0'
-
-  const handleLogoutConfirm = async () => {
-    setConfirmOpen(false)
-    if (refreshToken) {
-      await dispatch(logout(refreshToken))
-    }
-    await persistor.purge()
-    navigate('/login')
-  }
-
-  const confirmDialog = (
-    <ConfirmationDialog
-      open={confirmOpen}
-      title="Logout"
-      message="Are you sure you want to log out?"
-      confirmText="Logout"
-      cancelText="Cancel"
-      severity="warning"
-      onConfirm={handleLogoutConfirm}
-      onCancel={() => setConfirmOpen(false)}
-    />
-  )
-
-  if (collapsed) {
-    return (
-      <>
-      <Box
-        sx={{
-          borderTop: `1px solid ${COLORS.border}`,
-          py: 1,
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: 0.5,
-        }}
-      >
-        <Tooltip title={username} placement="right">
-          <Box
-            tabIndex={0}
-            role="img"
-            aria-label={username}
-            sx={{
-              height: 40,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              cursor: 'default',
-              outline: 'none',
-            }}
-          >
-            <Avatar sx={{ width: 32, height: 32, bgcolor: 'primary.main', fontSize: '0.75rem' }}>
-              {initials}
-            </Avatar>
-          </Box>
-        </Tooltip>
-        <Tooltip title="Logout" placement="right">
-          <IconButton
-            onClick={() => setConfirmOpen(true)}
-            aria-label="Logout"
-            size="small"
-            sx={{
-              width: 40,
-              height: 40,
-              borderRadius: 1,
-              color: COLORS.icon,
-              '&:hover': {
-                bgcolor: COLORS.hoverBg,
-                color: COLORS.hoverText,
-              },
-            }}
-          >
-            <LogoutIcon sx={{ fontSize: 18 }} />
-          </IconButton>
-        </Tooltip>
-      </Box>
-      {confirmDialog}
-      </>
-    )
-  }
-
   return (
-    <>
-    <Box sx={{ borderTop: `1px solid ${COLORS.border}`, mt: 1 }}>
-      <ListItemButton
-        onClick={() => setConfirmOpen(true)}
-        aria-label={`Logout ${username}`}
-        sx={{
-          px: 2,
-          py: 1.5,
-          bgcolor: 'transparent',
-          transition: 'background-color 0.15s ease',
-          '&:hover': {
-            bgcolor: COLORS.hoverBg,
-            '& svg': { color: COLORS.hoverText },
-          },
-        }}
-      >
-        <Avatar
-          sx={{
-            width: 32,
-            height: 32,
-            bgcolor: 'primary.main',
-            fontSize: '0.75rem',
-            flexShrink: 0,
-          }}
-        >
-          {initials}
-        </Avatar>
-        <Box sx={{ ml: 1.5, flex: 1, minWidth: 0 }}>
-          <Typography
-            noWrap
-            sx={{ color: COLORS.activeText, fontSize: '0.875rem', lineHeight: 1.3, overflow: 'hidden', textOverflow: 'ellipsis' }}
-          >
-            {username}
-          </Typography>
-          <Typography
-            sx={{
-              color: COLORS.sectionLabel,
-              fontSize: '0.7rem',
-              lineHeight: 1.2,
-              mt: '4px',
-            }}
-          >
-            v{version}
-          </Typography>
-        </Box>
-        <Tooltip title="Logout">
-          <Box sx={{ display: 'flex', alignItems: 'center' }}>
-            <LogoutIcon sx={{ color: COLORS.icon, fontSize: 18 }} />
-          </Box>
-        </Tooltip>
-      </ListItemButton>
+    <Box
+      sx={{
+        backgroundColor: '#141414',
+        borderTop: '1px solid #1F2937',
+        py: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: collapsed ? 'center' : 'stretch',
+      }}
+    >
+      <SidebarUserMenu collapsed={collapsed} />
     </Box>
-    {confirmDialog}
-    </>
   )
 }
 

--- a/frontend/src/components/common/SidebarUserMenu.tsx
+++ b/frontend/src/components/common/SidebarUserMenu.tsx
@@ -1,0 +1,285 @@
+import React, { useState } from 'react'
+import {
+  Avatar,
+  Box,
+  Button,
+  Divider,
+  ListItemIcon,
+  Menu,
+  MenuItem,
+  Popover,
+  Typography,
+} from '@mui/material'
+import {
+  Logout as LogoutIcon,
+  Settings as SettingsIcon,
+} from '@mui/icons-material'
+import { useSelector } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
+import { useAppDispatch } from '@/hooks/useRedux'
+import {
+  logout,
+  selectCurrentUser,
+  selectRefreshToken,
+} from '@/store/slices/authSlice'
+import { persistor } from '@/store'
+
+// Local color constants intentionally duplicate the sidebar palette.
+// The original sidebar colors are module-private, so this keeps the scope
+// small for the sidebar footer refactor.
+const COLORS = {
+  icon: '#6B7280',
+  hoverText: '#CBD5E1',
+  text: '#9CA3AF',
+  mutedText: '#6B7280',
+  menuBg: '#1E1E1E',
+  border: '#1F2937',
+} as const
+
+interface SidebarUserMenuProps {
+  collapsed: boolean
+}
+
+const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
+  const dispatch = useAppDispatch()
+  const navigate = useNavigate()
+  const user = useSelector(selectCurrentUser)
+  const refreshToken = useSelector(selectRefreshToken)
+  const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null)
+  const [logoutAnchorEl, setLogoutAnchorEl] = useState<HTMLElement | null>(null)
+
+  if (!user) return null
+
+  const { username, firstName, lastName } = user
+  const initials = (
+    (firstName?.[0] ?? '') + (lastName?.[0] ?? '') || username?.[0] || 'U'
+  ).toUpperCase()
+  const version = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0'
+
+  const handleAvatarClick = (event: React.MouseEvent<HTMLElement>) => {
+    setMenuAnchorEl(event.currentTarget)
+  }
+
+  const handleMenuClose = () => {
+    setMenuAnchorEl(null)
+  }
+
+  const handleSettingsClick = () => {
+    handleMenuClose()
+    navigate('/settings')
+  }
+
+  const handleLogoutClick = (event: React.MouseEvent<HTMLElement>) => {
+    setLogoutAnchorEl(event.currentTarget)
+    handleMenuClose()
+  }
+
+  const handleLogoutCancel = () => {
+    setLogoutAnchorEl(null)
+  }
+
+  const handleLogoutConfirm = async () => {
+    setLogoutAnchorEl(null)
+    if (refreshToken) {
+      await dispatch(logout(refreshToken))
+    }
+    await persistor.purge()
+  }
+
+  const avatarElement = (
+    <Avatar
+      sx={{
+        width: 32,
+        height: 32,
+        bgcolor: 'primary.main',
+        fontSize: '0.75rem',
+        cursor: 'pointer',
+        '&:hover': { filter: 'brightness(1.1)' },
+      }}
+    >
+      {initials}
+    </Avatar>
+  )
+
+  const avatarButton = (
+    <Box
+      component="button"
+      type="button"
+      aria-label="Open user menu"
+      aria-haspopup="true"
+      onClick={handleAvatarClick}
+      sx={{
+        background: 'none',
+        border: 'none',
+        padding: 0,
+        cursor: 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      {avatarElement}
+    </Box>
+  )
+
+  return (
+    <>
+      {collapsed ? (
+        <Box
+          sx={{
+            width: 40,
+            height: 40,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          {avatarButton}
+        </Box>
+      ) : (
+        <Box
+          component="button"
+          type="button"
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            width: '100%',
+            height: '40px',
+            px: 2,
+            cursor: 'pointer',
+            background: 'transparent',
+            border: 'none',
+            textAlign: 'left',
+            transition: 'background-color 0.15s ease, transform 0.15s ease',
+            '&:hover': {
+              backgroundColor: '#1E1E1E',
+              transform: 'translateX(1px)',
+            },
+          }}
+          onClick={handleAvatarClick}
+          aria-label="Open user menu"
+          aria-haspopup="true"
+        >
+          {avatarElement}
+          <Box sx={{ ml: 1.5, flex: 1, minWidth: 0 }}>
+            <Typography
+              noWrap
+              sx={{
+                color: '#FFFFFF',
+                fontSize: '0.875rem',
+                lineHeight: 1.3,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {username}
+            </Typography>
+            <Typography
+              sx={{
+                color: COLORS.mutedText,
+                fontSize: '0.7rem',
+                lineHeight: 1.2,
+                mt: '4px',
+              }}
+            >
+              v{version}
+            </Typography>
+          </Box>
+        </Box>
+      )}
+
+      <Menu
+        anchorEl={menuAnchorEl}
+        open={Boolean(menuAnchorEl)}
+        onClose={handleMenuClose}
+        PaperProps={{
+          sx: {
+            minWidth: 220,
+            bgcolor: COLORS.menuBg,
+            borderRadius: 1,
+            boxShadow: '0 4px 20px rgba(0,0,0,0.4)',
+          },
+        }}
+        transformOrigin={{ horizontal: 'left', vertical: 'bottom' }}
+        anchorOrigin={{ horizontal: 'left', vertical: 'top' }}
+      >
+        <Box sx={{ px: 2, py: 1 }}>
+          <Typography sx={{ color: COLORS.text, fontSize: '0.75rem' }}>
+            {username}
+          </Typography>
+        </Box>
+
+        <Divider sx={{ borderColor: COLORS.border }} />
+
+        <MenuItem
+          onClick={handleSettingsClick}
+          sx={{
+            '& .MuiListItemIcon-root': { color: COLORS.icon },
+            '&:hover .MuiListItemIcon-root': { color: COLORS.hoverText },
+          }}
+        >
+          <ListItemIcon>
+            <SettingsIcon fontSize="small" />
+          </ListItemIcon>
+          Settings
+        </MenuItem>
+
+        <MenuItem
+          onClick={handleLogoutClick}
+          sx={{
+            '& .MuiListItemIcon-root': { color: COLORS.icon },
+            '&:hover .MuiListItemIcon-root': { color: COLORS.hoverText },
+          }}
+        >
+          <ListItemIcon>
+            <LogoutIcon fontSize="small" />
+          </ListItemIcon>
+          Logout
+        </MenuItem>
+
+        <Divider sx={{ borderColor: COLORS.border }} />
+
+        <Box sx={{ px: 2, py: 1 }}>
+          <Typography sx={{ color: COLORS.mutedText, fontSize: '0.65rem' }}>
+            v{version}
+          </Typography>
+        </Box>
+      </Menu>
+
+      <Popover
+        open={Boolean(logoutAnchorEl)}
+        anchorEl={logoutAnchorEl}
+        onClose={handleLogoutCancel}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        PaperProps={{
+          sx: {
+            bgcolor: COLORS.menuBg,
+            border: `1px solid ${COLORS.border}`,
+            p: 2,
+          },
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Typography sx={{ color: '#FFFFFF', fontSize: '0.875rem' }}>
+            Log out?
+          </Typography>
+          <Button size="small" onClick={handleLogoutCancel} aria-label="Cancel">
+            Cancel
+          </Button>
+          <Button
+            size="small"
+            variant="contained"
+            color="error"
+            onClick={handleLogoutConfirm}
+            aria-label="Logout"
+          >
+            Logout
+          </Button>
+        </Box>
+      </Popover>
+    </>
+  )
+}
+
+export default SidebarUserMenu

--- a/frontend/src/components/common/SidebarUserMenu.tsx
+++ b/frontend/src/components/common/SidebarUserMenu.tsx
@@ -85,7 +85,8 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
       await dispatch(logout(refreshToken))
     }
     await persistor.purge()
-    navigate('/login')
+    // No navigate('/login') here — ProtectedRoute detects isAuthenticated === false
+    // and handles the redirect, preserving the 'from' location state for post-login return.
   }
 
   const avatarElement = (

--- a/frontend/src/components/common/SidebarUserMenu.tsx
+++ b/frontend/src/components/common/SidebarUserMenu.tsx
@@ -73,8 +73,10 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
       await dispatch(logout(refreshToken))
     }
     await persistor.purge()
-    // No navigate('/login') here — ProtectedRoute detects isAuthenticated === false
-    // and handles the redirect, preserving the 'from' location state for post-login return.
+    // Explicit navigate after purge — ProtectedRoute's redirect is unreliable here
+    // because persistor.purge() clears localStorage async, and the accessToken in Redux
+    // can trigger ProtectedRoute's verification branch before purge completes.
+    navigate('/login')
   }
 
   const avatarElement = (

--- a/frontend/src/components/common/SidebarUserMenu.tsx
+++ b/frontend/src/components/common/SidebarUserMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
 import {
   Avatar,
   Box,
@@ -47,6 +47,7 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
   const refreshToken = useSelector(selectRefreshToken)
   const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null)
   const [logoutAnchorEl, setLogoutAnchorEl] = useState<HTMLElement | null>(null)
+  const triggerButtonRef = useRef<HTMLButtonElement | null>(null)
 
   if (!user) return null
 
@@ -69,8 +70,8 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
     navigate('/settings')
   }
 
-  const handleLogoutClick = (event: React.MouseEvent<HTMLElement>) => {
-    setLogoutAnchorEl(event.currentTarget)
+  const handleLogoutClick = () => {
+    setLogoutAnchorEl(triggerButtonRef.current)
     handleMenuClose()
   }
 
@@ -101,27 +102,6 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
     </Avatar>
   )
 
-  const avatarButton = (
-    <Box
-      component="button"
-      type="button"
-      aria-label="Open user menu"
-      aria-haspopup="true"
-      onClick={handleAvatarClick}
-      sx={{
-        background: 'none',
-        border: 'none',
-        padding: 0,
-        cursor: 'pointer',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      {avatarElement}
-    </Box>
-  )
-
   return (
     <>
       {collapsed ? (
@@ -134,11 +114,32 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
             justifyContent: 'center',
           }}
         >
-          {avatarButton}
+          <Box
+            component="button"
+            ref={triggerButtonRef}
+            type="button"
+            aria-label="Open user menu"
+            aria-haspopup="true"
+            onClick={handleAvatarClick}
+            sx={{
+              width: 40,
+              height: 40,
+              background: 'none',
+              border: 'none',
+              padding: 0,
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            {avatarElement}
+          </Box>
         </Box>
       ) : (
         <Box
           component="button"
+          ref={triggerButtonRef}
           type="button"
           sx={{
             display: 'flex',

--- a/frontend/src/components/common/SidebarUserMenu.tsx
+++ b/frontend/src/components/common/SidebarUserMenu.tsx
@@ -2,12 +2,10 @@ import React, { useRef, useState } from 'react'
 import {
   Avatar,
   Box,
-  Button,
   Divider,
   ListItemIcon,
   Menu,
   MenuItem,
-  Popover,
   Typography,
 } from '@mui/material'
 import {
@@ -46,7 +44,6 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
   const user = useSelector(selectCurrentUser)
   const refreshToken = useSelector(selectRefreshToken)
   const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null)
-  const [logoutAnchorEl, setLogoutAnchorEl] = useState<HTMLElement | null>(null)
   const triggerButtonRef = useRef<HTMLButtonElement | null>(null)
 
   if (!user) return null
@@ -70,17 +67,8 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
     navigate('/settings')
   }
 
-  const handleLogoutClick = () => {
-    setLogoutAnchorEl(triggerButtonRef.current)
+  const handleLogoutClick = async () => {
     handleMenuClose()
-  }
-
-  const handleLogoutCancel = () => {
-    setLogoutAnchorEl(null)
-  }
-
-  const handleLogoutConfirm = async () => {
-    setLogoutAnchorEl(null)
     if (refreshToken) {
       await dispatch(logout(refreshToken))
     }
@@ -97,7 +85,11 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
         bgcolor: 'primary.main',
         fontSize: '0.75rem',
         cursor: 'pointer',
-        '&:hover': { filter: 'brightness(1.1)' },
+        transition: 'transform 0.15s ease, filter 0.15s ease',
+        '&:hover': {
+          filter: 'brightness(1.1)',
+          transform: 'scale(1.02)',
+        },
       }}
     >
       {initials}
@@ -203,11 +195,11 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
             boxShadow: '0 4px 20px rgba(0,0,0,0.4)',
           },
         }}
-        transformOrigin={{ horizontal: 'left', vertical: 'bottom' }}
-        anchorOrigin={{ horizontal: 'left', vertical: 'top' }}
+        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'bottom', horizontal: 'right' }}
       >
         <Box sx={{ px: 2, py: 1, cursor: 'default', userSelect: 'none' }}>
-          <Typography sx={{ color: COLORS.text, fontSize: '0.75rem' }}>
+          <Typography sx={{ color: '#D1D5DB', fontSize: '0.8rem', fontWeight: 500 }}>
             {username}
           </Typography>
         </Box>
@@ -247,44 +239,11 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
         <Divider sx={{ borderColor: COLORS.border }} />
 
         <Box sx={{ px: 2, py: 1, mt: '4px' }}>
-          <Typography sx={{ color: COLORS.mutedText, fontSize: '0.65rem' }}>
+          <Typography sx={{ color: COLORS.mutedText, fontSize: '0.65rem', opacity: 0.7, letterSpacing: '0.02em' }}>
             v{version}
           </Typography>
         </Box>
       </Menu>
-
-      <Popover
-        open={Boolean(logoutAnchorEl)}
-        anchorEl={logoutAnchorEl}
-        onClose={handleLogoutCancel}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-        PaperProps={{
-          sx: {
-            bgcolor: COLORS.menuBg,
-            border: `1px solid ${COLORS.border}`,
-            p: 2,
-          },
-        }}
-      >
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <Typography sx={{ color: '#FFFFFF', fontSize: '0.875rem' }}>
-            Log out?
-          </Typography>
-          <Button size="small" onClick={handleLogoutCancel} aria-label="Cancel">
-            Cancel
-          </Button>
-          <Button
-            size="small"
-            variant="contained"
-            color="error"
-            onClick={handleLogoutConfirm}
-            aria-label="Logout"
-          >
-            Logout
-          </Button>
-        </Box>
-      </Popover>
     </>
   )
 }

--- a/frontend/src/components/common/SidebarUserMenu.tsx
+++ b/frontend/src/components/common/SidebarUserMenu.tsx
@@ -206,7 +206,7 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
         transformOrigin={{ horizontal: 'left', vertical: 'bottom' }}
         anchorOrigin={{ horizontal: 'left', vertical: 'top' }}
       >
-        <Box sx={{ px: 2, py: 1 }}>
+        <Box sx={{ px: 2, py: 1, cursor: 'default', userSelect: 'none' }}>
           <Typography sx={{ color: COLORS.text, fontSize: '0.75rem' }}>
             {username}
           </Typography>
@@ -217,6 +217,8 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
         <MenuItem
           onClick={handleSettingsClick}
           sx={{
+            minHeight: 40,
+            alignItems: 'center',
             '& .MuiListItemIcon-root': { color: COLORS.icon },
             '&:hover .MuiListItemIcon-root': { color: COLORS.hoverText },
           }}
@@ -230,6 +232,8 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
         <MenuItem
           onClick={handleLogoutClick}
           sx={{
+            minHeight: 40,
+            alignItems: 'center',
             '& .MuiListItemIcon-root': { color: COLORS.icon },
             '&:hover .MuiListItemIcon-root': { color: COLORS.hoverText },
           }}
@@ -242,7 +246,7 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
 
         <Divider sx={{ borderColor: COLORS.border }} />
 
-        <Box sx={{ px: 2, py: 1 }}>
+        <Box sx={{ px: 2, py: 1, mt: '4px' }}>
           <Typography sx={{ color: COLORS.mutedText, fontSize: '0.65rem' }}>
             v{version}
           </Typography>

--- a/frontend/src/components/common/SidebarUserMenu.tsx
+++ b/frontend/src/components/common/SidebarUserMenu.tsx
@@ -85,6 +85,7 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
       await dispatch(logout(refreshToken))
     }
     await persistor.purge()
+    navigate('/login')
   }
 
   const avatarElement = (

--- a/frontend/src/components/common/__tests__/SidebarFooter.test.tsx
+++ b/frontend/src/components/common/__tests__/SidebarFooter.test.tsx
@@ -1,8 +1,8 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router-dom'
 import { configureStore } from '@reduxjs/toolkit'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import SidebarFooter from '../SidebarFooter'
 import authReducer from '@/store/slices/authSlice'
 
@@ -37,92 +37,36 @@ const makeStore = (authOverrides = {}) =>
     },
   })
 
-const renderFooter = (props = {}, authOverrides = {}) => {
-  const store = makeStore(authOverrides)
-  return render(
-    <Provider store={store}>
+// SidebarFooter is a layout shell - SidebarUserMenu is a Redux-connected child,
+// so Provider + MemoryRouter are still required even though SidebarFooter itself
+// has no Redux or router dependencies.
+const renderFooter = (props = {}, authOverrides = {}) =>
+  render(
+    <Provider store={makeStore(authOverrides)}>
       <MemoryRouter>
         <SidebarFooter collapsed={false} {...props} />
       </MemoryRouter>
     </Provider>
   )
-}
 
-describe('SidebarFooter', () => {
-  it('renders username in expanded mode', () => {
-    renderFooter()
-    expect(screen.getByText('jdoe')).toBeInTheDocument()
+describe('SidebarFooter (layout shell)', () => {
+  it('renders in expanded mode without crashing', () => {
+    const { container } = renderFooter()
+    expect(container.firstChild).not.toBeNull()
   })
 
-  it('renders avatar with initials JD', () => {
-    renderFooter()
-    expect(screen.getByText('JD')).toBeInTheDocument()
+  it('renders in collapsed mode without crashing', () => {
+    const { container } = renderFooter({ collapsed: true })
+    expect(container.firstChild).not.toBeNull()
   })
 
-  it('renders version string', () => {
-    renderFooter()
-    expect(screen.getByText(/^v/)).toBeInTheDocument()
+  it('passes collapsed=false to SidebarUserMenu', () => {
+    renderFooter({ collapsed: false })
+    expect(screen.getByRole('button', { name: /open user menu/i })).toBeInTheDocument()
   })
 
-  it('falls back to username initial when no first/last name', () => {
-    renderFooter({}, {
-      user: {
-        id: '2',
-        username: 'bob',
-        firstName: '',
-        lastName: '',
-        email: 'b@test.com',
-        role: 'admin',
-        isActive: true,
-        status: 'active',
-        failedLoginAttempts: 0,
-        createdAt: '2024-01-01',
-        updatedAt: '2024-01-01',
-      },
-    })
-    expect(screen.getByText('B')).toBeInTheDocument()
-  })
-
-  it('renders nothing when user is null', () => {
-    const { container } = renderFooter({}, { user: null, isAuthenticated: false })
-    expect(container.firstChild).toBeNull()
-  })
-
-  it('hides username and version in collapsed mode', () => {
+  it('passes collapsed=true to SidebarUserMenu', () => {
     renderFooter({ collapsed: true })
-    expect(screen.queryByText('jdoe')).not.toBeInTheDocument()
-    expect(screen.queryByText(/^v/)).not.toBeInTheDocument()
-  })
-
-  it('shows avatar initials in collapsed mode', () => {
-    renderFooter({ collapsed: true })
-    expect(screen.getByText('JD')).toBeInTheDocument()
-  })
-
-  it('dispatches logout after confirming dialog in expanded mode', () => {
-    const store = makeStore()
-    const dispatchSpy = vi.spyOn(store, 'dispatch')
-    render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <SidebarFooter collapsed={false} />
-        </MemoryRouter>
-      </Provider>
-    )
-    fireEvent.click(screen.getByRole('button', { name: /logout jdoe/i }))
-    fireEvent.click(screen.getByRole('button', { name: /^logout$/i }))
-    expect(dispatchSpy).toHaveBeenCalled()
-  })
-
-  it('opens confirmation dialog when logout icon is clicked in collapsed mode', () => {
-    render(
-      <Provider store={makeStore()}>
-        <MemoryRouter>
-          <SidebarFooter collapsed={true} />
-        </MemoryRouter>
-      </Provider>
-    )
-    fireEvent.click(screen.getByRole('button', { name: /^logout$/i }))
-    expect(screen.getByText('Are you sure you want to log out?')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /open user menu/i })).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/common/__tests__/SidebarUserMenu.test.tsx
+++ b/frontend/src/components/common/__tests__/SidebarUserMenu.test.tsx
@@ -133,7 +133,7 @@ describe('SidebarUserMenu', () => {
     fireEvent.click(screen.getByRole('menuitem', { name: /logout/i }))
     await screen.findByText(/log out\?/i)
     fireEvent.click(screen.getByRole('button', { name: /^logout$/i }))
-    expect(dispatchSpy).toHaveBeenCalled()
+    expect(dispatchSpy).toHaveBeenCalledWith(expect.any(Function))
   })
 
   it('menu closes on Escape key', async () => {

--- a/frontend/src/components/common/__tests__/SidebarUserMenu.test.tsx
+++ b/frontend/src/components/common/__tests__/SidebarUserMenu.test.tsx
@@ -1,0 +1,146 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { configureStore } from '@reduxjs/toolkit'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import SidebarUserMenu from '../SidebarUserMenu'
+import authReducer from '@/store/slices/authSlice'
+
+vi.mock('@/store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store')>()
+  return { ...actual, persistor: { purge: vi.fn().mockResolvedValue(undefined) } }
+})
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+const baseUser = {
+  id: '1',
+  username: 'jdoe',
+  firstName: 'Jane',
+  lastName: 'Doe',
+  email: 'j@test.com',
+  role: 'admin',
+  isActive: true,
+  status: 'active',
+  failedLoginAttempts: 0,
+  createdAt: '2024-01-01',
+  updatedAt: '2024-01-01',
+}
+
+const makeStore = (authOverrides = {}) =>
+  configureStore({
+    reducer: { auth: authReducer },
+    preloadedState: {
+      auth: {
+        user: baseUser,
+        refreshToken: 'test-refresh-token',
+        accessToken: 'test-access-token',
+        isAuthenticated: true,
+        loading: false,
+        error: null,
+        lastActivityTime: null,
+        inactivityTimeoutMinutes: 30,
+        rememberMe: false,
+        ...authOverrides,
+      },
+    },
+  })
+
+const renderMenu = (props = {}, authOverrides = {}) => {
+  const store = makeStore(authOverrides)
+  return {
+    store,
+    ...render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <SidebarUserMenu collapsed={false} {...props} />
+        </MemoryRouter>
+      </Provider>
+    ),
+  }
+}
+
+describe('SidebarUserMenu', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear()
+  })
+
+  it('renders nothing when user is null', () => {
+    const { container } = renderMenu({}, { user: null, isAuthenticated: false })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('avatar click opens dropdown menu in expanded mode', async () => {
+    renderMenu()
+    fireEvent.click(screen.getByRole('button', { name: /open user menu/i }))
+    expect(await screen.findByRole('menu')).toBeInTheDocument()
+  })
+
+  it('avatar click opens dropdown menu in collapsed mode', async () => {
+    renderMenu({ collapsed: true })
+    fireEvent.click(screen.getByRole('button', { name: /open user menu/i }))
+    expect(await screen.findByRole('menu')).toBeInTheDocument()
+  })
+
+  it('menu contains username, Settings, Logout, and version', async () => {
+    renderMenu()
+    fireEvent.click(screen.getByRole('button', { name: /open user menu/i }))
+    await screen.findByRole('menu')
+    expect(screen.getAllByText('jdoe').length).toBeGreaterThan(0)
+    expect(screen.getByRole('menuitem', { name: /settings/i })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /logout/i })).toBeInTheDocument()
+    expect(screen.getAllByText(/^v/).length).toBeGreaterThan(0)
+  })
+
+  it('Settings click navigates to /settings', async () => {
+    renderMenu()
+    fireEvent.click(screen.getByRole('button', { name: /open user menu/i }))
+    await screen.findByRole('menu')
+    fireEvent.click(screen.getByRole('menuitem', { name: /settings/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/settings')
+  })
+
+  it('Logout click closes menu and opens confirmation popover', async () => {
+    renderMenu()
+    fireEvent.click(screen.getByRole('button', { name: /open user menu/i }))
+    await screen.findByRole('menu')
+    fireEvent.click(screen.getByRole('menuitem', { name: /logout/i }))
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument())
+    expect(screen.getByText(/log out\?/i)).toBeInTheDocument()
+  })
+
+  it('Cancel closes popover without dispatching logout', async () => {
+    const { store } = renderMenu()
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+    fireEvent.click(screen.getByRole('button', { name: /open user menu/i }))
+    await screen.findByRole('menu')
+    fireEvent.click(screen.getByRole('menuitem', { name: /logout/i }))
+    await screen.findByText(/log out\?/i)
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    await waitFor(() => expect(screen.queryByText(/log out\?/i)).not.toBeInTheDocument())
+    expect(dispatchSpy).not.toHaveBeenCalled()
+  })
+
+  it('Confirm dispatches logout thunk', async () => {
+    const { store } = renderMenu()
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+    fireEvent.click(screen.getByRole('button', { name: /open user menu/i }))
+    await screen.findByRole('menu')
+    fireEvent.click(screen.getByRole('menuitem', { name: /logout/i }))
+    await screen.findByText(/log out\?/i)
+    fireEvent.click(screen.getByRole('button', { name: /^logout$/i }))
+    expect(dispatchSpy).toHaveBeenCalled()
+  })
+
+  it('menu closes on Escape key', async () => {
+    renderMenu()
+    fireEvent.click(screen.getByRole('button', { name: /open user menu/i }))
+    await screen.findByRole('menu')
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument())
+  })
+})

--- a/frontend/src/components/common/__tests__/SidebarUserMenu.test.tsx
+++ b/frontend/src/components/common/__tests__/SidebarUserMenu.test.tsx
@@ -125,7 +125,7 @@ describe('SidebarUserMenu', () => {
     expect(dispatchSpy).not.toHaveBeenCalled()
   })
 
-  it('Confirm dispatches logout thunk', async () => {
+  it('Confirm dispatches logout thunk and navigates to login', async () => {
     const { store } = renderMenu()
     const dispatchSpy = vi.spyOn(store, 'dispatch')
     fireEvent.click(screen.getByRole('button', { name: /open user menu/i }))
@@ -134,6 +134,7 @@ describe('SidebarUserMenu', () => {
     await screen.findByText(/log out\?/i)
     fireEvent.click(screen.getByRole('button', { name: /^logout$/i }))
     expect(dispatchSpy).toHaveBeenCalledWith(expect.any(Function))
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/login'))
   })
 
   it('menu closes on Escape key', async () => {

--- a/frontend/src/components/common/__tests__/SidebarUserMenu.test.tsx
+++ b/frontend/src/components/common/__tests__/SidebarUserMenu.test.tsx
@@ -104,38 +104,16 @@ describe('SidebarUserMenu', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/settings')
   })
 
-  it('Logout click closes menu and opens confirmation popover', async () => {
-    renderMenu()
+  it('Logout click closes menu and dispatches logout thunk immediately', async () => {
+    const { store } = renderMenu()
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
     fireEvent.click(screen.getByRole('button', { name: /open user menu/i }))
     await screen.findByRole('menu')
     fireEvent.click(screen.getByRole('menuitem', { name: /logout/i }))
     await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument())
-    expect(screen.getByText(/log out\?/i)).toBeInTheDocument()
-  })
-
-  it('Cancel closes popover without dispatching logout', async () => {
-    const { store } = renderMenu()
-    const dispatchSpy = vi.spyOn(store, 'dispatch')
-    fireEvent.click(screen.getByRole('button', { name: /open user menu/i }))
-    await screen.findByRole('menu')
-    fireEvent.click(screen.getByRole('menuitem', { name: /logout/i }))
-    await screen.findByText(/log out\?/i)
-    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
-    await waitFor(() => expect(screen.queryByText(/log out\?/i)).not.toBeInTheDocument())
-    expect(dispatchSpy).not.toHaveBeenCalled()
-  })
-
-  it('Confirm dispatches logout thunk', async () => {
-    const { store } = renderMenu()
-    const dispatchSpy = vi.spyOn(store, 'dispatch')
-    fireEvent.click(screen.getByRole('button', { name: /open user menu/i }))
-    await screen.findByRole('menu')
-    fireEvent.click(screen.getByRole('menuitem', { name: /logout/i }))
-    await screen.findByText(/log out\?/i)
-    fireEvent.click(screen.getByRole('button', { name: /^logout$/i }))
     expect(dispatchSpy).toHaveBeenCalledWith(expect.any(Function))
     // ProtectedRoute handles redirect to /login — no navigate('/login') in this component
-    await waitFor(() => expect(mockNavigate).not.toHaveBeenCalledWith('/login'))
+    expect(mockNavigate).not.toHaveBeenCalledWith('/login')
   })
 
   it('menu closes on Escape key', async () => {

--- a/frontend/src/components/common/__tests__/SidebarUserMenu.test.tsx
+++ b/frontend/src/components/common/__tests__/SidebarUserMenu.test.tsx
@@ -125,7 +125,7 @@ describe('SidebarUserMenu', () => {
     expect(dispatchSpy).not.toHaveBeenCalled()
   })
 
-  it('Confirm dispatches logout thunk and navigates to login', async () => {
+  it('Confirm dispatches logout thunk', async () => {
     const { store } = renderMenu()
     const dispatchSpy = vi.spyOn(store, 'dispatch')
     fireEvent.click(screen.getByRole('button', { name: /open user menu/i }))
@@ -134,7 +134,8 @@ describe('SidebarUserMenu', () => {
     await screen.findByText(/log out\?/i)
     fireEvent.click(screen.getByRole('button', { name: /^logout$/i }))
     expect(dispatchSpy).toHaveBeenCalledWith(expect.any(Function))
-    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/login'))
+    // ProtectedRoute handles redirect to /login — no navigate('/login') in this component
+    await waitFor(() => expect(mockNavigate).not.toHaveBeenCalledWith('/login'))
   })
 
   it('menu closes on Escape key', async () => {

--- a/frontend/src/components/common/__tests__/SidebarUserMenu.test.tsx
+++ b/frontend/src/components/common/__tests__/SidebarUserMenu.test.tsx
@@ -104,7 +104,7 @@ describe('SidebarUserMenu', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/settings')
   })
 
-  it('Logout click closes menu and dispatches logout thunk immediately', async () => {
+  it('Logout click closes menu, dispatches logout thunk, and navigates to login', async () => {
     const { store } = renderMenu()
     const dispatchSpy = vi.spyOn(store, 'dispatch')
     fireEvent.click(screen.getByRole('button', { name: /open user menu/i }))
@@ -112,8 +112,7 @@ describe('SidebarUserMenu', () => {
     fireEvent.click(screen.getByRole('menuitem', { name: /logout/i }))
     await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument())
     expect(dispatchSpy).toHaveBeenCalledWith(expect.any(Function))
-    // ProtectedRoute handles redirect to /login — no navigate('/login') in this component
-    expect(mockNavigate).not.toHaveBeenCalledWith('/login')
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/login'))
   })
 
   it('menu closes on Escape key', async () => {


### PR DESCRIPTION
Closes #138

## Summary

- **New `SidebarUserMenu` component** owns all interactive behavior: avatar trigger, dropdown menu (username, Settings, Logout, version), Redux auth reads, logout dispatch, and redirect
- **`SidebarFooter` refactored** into a stateless layout shell — background, border, and positioning only
- **Instant logout** — removed confirmation popover; logout is immediate on click
- **Visual polish** — menu anchored upward from avatar, stronger username identity styling, version spacing and opacity, avatar scale hover, 40px menu item height

## Architecture

`SidebarFooter` (layout shell) → renders `SidebarUserMenu` (all behavior). Clean responsibility split per spec.

## Test plan

- [x] Avatar click opens dropdown in both collapsed and expanded modes
- [x] Settings navigates to `/settings`
- [x] Logout dispatches thunk, purges store, redirects to `/login`
- [x] Collapsed mode has no separate logout icon button
- [x] All 11 tests pass: `npx vitest run src/components/common/__tests__/SidebarUserMenu.test.tsx src/components/common/__tests__/SidebarFooter.test.tsx --no-coverage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)