### PR TITLE
style: top bar & header modernization polish (issue #140)

### DIFF
--- a/docs/superpowers/specs/2026-03-19-topbar-modernization-polish-design.md
+++ b/docs/superpowers/specs/2026-03-19-topbar-modernization-polish-design.md
@@ -30,16 +30,37 @@ A targeted polish pass on the existing `TopBar.tsx` and `SystemStatus.tsx` compo
 
 #### 1. Breadcrumb hierarchy
 
-Strengthen contrast between ancestor and current-page segments.
+Strengthen contrast, increase font size for visual balance, and fix vertical alignment.
 
 | Element | Property | Before | After |
 |---|---|---|---|
 | Ancestor `Link` (navigable) | `color` | `#A0A0A0` | `#8A8A8A` |
+| Ancestor `Link` (navigable) | `fontSize` | `12px` | `13px` |
+| Ancestor `Link` (navigable) | `fontWeight` | _(absent)_ | `400` |
+| Ancestor `Link` (navigable) | `display` | _(absent)_ | `'flex'` |
+| Ancestor `Link` (navigable) | `alignItems` | _(absent)_ | `'center'` |
+| Ancestor `Link` (navigable) | `lineHeight` | _(absent)_ | `1.4` |
 | Ancestor `Typography` (non-navigable) | `color` | `#A0A0A0` | `#8A8A8A` |
+| Ancestor `Typography` (non-navigable) | `fontSize` | `12px` | `13px` |
+| Ancestor `Typography` (non-navigable) | `fontWeight` | _(absent)_ | `400` |
+| Ancestor `Typography` (non-navigable) | `display` | _(absent)_ | `'flex'` |
+| Ancestor `Typography` (non-navigable) | `alignItems` | _(absent)_ | `'center'` |
+| Ancestor `Typography` (non-navigable) | `lineHeight` | _(absent)_ | `1.4` |
 | Separator `NavigateNextIcon` | `color` | `#6B7280` | `#5A5A5A` |
+| Separator `NavigateNextIcon` | `mx` | _(absent)_ | `0.5` |
 | Current page `Typography` | `color` | `#E0E0E0` | `#E0E0E0` (unchanged) |
+| Current page `Typography` | `fontSize` | `12px` | `13px` |
 | Current page `Typography` | `fontWeight` | _(absent)_ | `500` |
+| Current page `Typography` | `display` | _(absent)_ | `'flex'` |
+| Current page `Typography` | `alignItems` | _(absent)_ | `'center'` |
+| Current page `Typography` | `lineHeight` | _(absent)_ | `1.4` |
 | Ancestor `Link` hover | `color` | _(absent)_ | `#CFCFCF` (navigable `Link` items only — non-navigable `Typography` ancestors have no hover state) |
+| Ancestor `Link` hover | `transition` | _(absent)_ | `'color 0.15s ease'` |
+| `Breadcrumbs` component | `sx` | minimal | add `display: 'flex', alignItems: 'center'` |
+| `Breadcrumbs` separator spacing | `MuiBreadcrumbs-separator mx` | _(absent)_ | `0.75` |
+| Breadcrumb outer `Box` | `display` | _(absent)_ | `'flex'` |
+| Breadcrumb outer `Box` | `alignItems` | _(absent)_ | `'center'` |
+| Breadcrumb outer `Box` | `height` | _(absent)_ | `'100%'` |
 
 #### 2. Right-side action spacing
 
@@ -98,7 +119,7 @@ The dot size (8px), tooltip text, and pulse animation are already correct — no
 
 ## Vertical alignment
 
-Already correct — `Toolbar` centers content by default and the right-side `Box` has explicit `alignItems: 'center'`. No code change needed.
+The breadcrumb `Box` wrapper needs explicit flex alignment (`display: 'flex', alignItems: 'center', height: '100%'`) and the `Breadcrumbs` component needs `display: 'flex', alignItems: 'center'` in its `sx` to remove the floating-text baseline mismatch. The right-side `Box` already has explicit `alignItems: 'center'`.
 
 ---
 

--- a/frontend/src/components/common/Sidebar.tsx
+++ b/frontend/src/components/common/Sidebar.tsx
@@ -74,6 +74,7 @@ import {
   ChevronLeft,
   ChevronRight,
 } from '@mui/icons-material'
+import { TOPBAR_HEIGHT } from '@/constants/layout'
 import { useGetCompanySettingsQuery } from '@/store/api/settingsApi'
 import SidebarFooter from './SidebarFooter'
 
@@ -1167,12 +1168,12 @@ const Sidebar: React.FC<SidebarProps> = ({
       <Box
         sx={{
           px: collapsed ? 0 : 2,
-          py: 1.5,
           display: 'flex',
           alignItems: 'center',
           justifyContent: collapsed ? 'center' : 'space-between',
-          borderBottom: `1px solid ${SIDEBAR_COLORS.border}`,
-          minHeight: 56,
+          borderBottom: '1px solid #2A2A2A',
+          height: TOPBAR_HEIGHT,
+          flexShrink: 0,
         }}
       >
         <Box sx={{ display: 'flex', alignItems: 'center', gap: collapsed ? 0 : 1.5 }}>

--- a/frontend/src/components/common/Sidebar.tsx
+++ b/frontend/src/components/common/Sidebar.tsx
@@ -1171,8 +1171,10 @@ const Sidebar: React.FC<SidebarProps> = ({
           display: 'flex',
           alignItems: 'center',
           justifyContent: collapsed ? 'center' : 'space-between',
-          borderBottom: '1px solid #2A2A2A',
+          boxSizing: 'border-box',
           height: TOPBAR_HEIGHT,
+          minHeight: TOPBAR_HEIGHT,
+          borderBottom: '1px solid #2A2A2A',
           flexShrink: 0,
         }}
       >

--- a/frontend/src/components/common/SystemStatus.tsx
+++ b/frontend/src/components/common/SystemStatus.tsx
@@ -145,7 +145,12 @@ const SystemStatus: React.FC = () => {
   return (
     <>
       <Tooltip title={tooltipText}>
-        <IconButton onClick={handleClick} color="inherit" size="small">
+        <IconButton
+          onClick={handleClick}
+          color="inherit"
+          size="small"
+          sx={{ '&:hover': { bgcolor: '#2A2A2A', borderRadius: '8px' } }}
+        >
           <Box sx={{ position: 'relative', display: 'inline-flex' }}>
             <DnsRoundedIcon sx={{ fontSize: 22, color: '#A0A0A0' }} />
             <Box

--- a/frontend/src/components/common/TopBar.tsx
+++ b/frontend/src/components/common/TopBar.tsx
@@ -295,7 +295,7 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
             ) : null}
           </Box>
 
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexShrink: 0 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0 }}>
             <Box
               role="button"
               aria-label="Open global search"

--- a/frontend/src/components/common/TopBar.tsx
+++ b/frontend/src/components/common/TopBar.tsx
@@ -256,7 +256,7 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
               </Typography>
             ) : breadcrumbs.length > 0 ? (
               <Breadcrumbs
-                separator={<NavigateNextIcon sx={{ fontSize: 14, color: '#6B7280' }} />}
+                separator={<NavigateNextIcon sx={{ fontSize: 14, color: '#5A5A5A' }} />}
                 aria-label="breadcrumb"
                 sx={{ '& .MuiBreadcrumbs-ol': { flexWrap: 'nowrap' } }}
               >
@@ -265,7 +265,7 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
 
                   if (isLast) {
                     return (
-                      <Typography key={segment.path} sx={{ fontSize: '12px', color: '#E0E0E0' }}>
+                      <Typography key={segment.path} sx={{ fontSize: '12px', color: '#E0E0E0', fontWeight: 500 }}>
                         {segment.label}
                       </Typography>
                     )
@@ -278,7 +278,7 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
                         component={RouterLink}
                         to={segment.path}
                         underline="hover"
-                        sx={{ fontSize: '12px', color: '#A0A0A0' }}
+                        sx={{ fontSize: '12px', color: '#8A8A8A', '&:hover': { color: '#CFCFCF' } }}
                       >
                         {segment.label}
                       </Link>
@@ -286,7 +286,7 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
                   }
 
                   return (
-                    <Typography key={segment.path} sx={{ fontSize: '12px', color: '#A0A0A0' }}>
+                    <Typography key={segment.path} sx={{ fontSize: '12px', color: '#8A8A8A' }}>
                       {segment.label}
                     </Typography>
                   )

--- a/frontend/src/components/common/TopBar.tsx
+++ b/frontend/src/components/common/TopBar.tsx
@@ -339,7 +339,11 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
             <SystemStatus />
 
             <Tooltip title="Notifications">
-              <IconButton onClick={(event) => setNotificationAnchorEl(event.currentTarget)} color="inherit">
+              <IconButton
+                onClick={(event) => setNotificationAnchorEl(event.currentTarget)}
+                color="inherit"
+                sx={{ '&:hover': { bgcolor: '#2A2A2A', borderRadius: '8px' } }}
+              >
                 <Badge badgeContent={unreadCount} color="error">
                   <NotificationsIcon />
                 </Badge>

--- a/frontend/src/components/common/TopBar.tsx
+++ b/frontend/src/components/common/TopBar.tsx
@@ -249,23 +249,31 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
             </IconButton>
           )}
 
-          <Box sx={{ flexGrow: 1, overflow: 'hidden' }}>
+          <Box sx={{ flexGrow: 1, overflow: 'hidden', display: 'flex', alignItems: 'center', height: '100%' }}>
             {isMobile ? (
               <Typography noWrap sx={{ fontSize: '0.875rem', color: '#E0E0E0', fontWeight: 500 }}>
                 {leafLabel}
               </Typography>
             ) : breadcrumbs.length > 0 ? (
               <Breadcrumbs
-                separator={<NavigateNextIcon sx={{ fontSize: 14, color: '#5A5A5A' }} />}
+                separator={<NavigateNextIcon sx={{ fontSize: 14, color: '#5A5A5A', mx: 0.5 }} />}
                 aria-label="breadcrumb"
-                sx={{ '& .MuiBreadcrumbs-ol': { flexWrap: 'nowrap' } }}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  '& .MuiBreadcrumbs-ol': { flexWrap: 'nowrap' },
+                  '& .MuiBreadcrumbs-separator': { mx: 0.75 },
+                }}
               >
                 {breadcrumbs.map((segment, index) => {
                   const isLast = index === breadcrumbs.length - 1
 
                   if (isLast) {
                     return (
-                      <Typography key={segment.path} sx={{ fontSize: '12px', color: '#E0E0E0', fontWeight: 500 }}>
+                      <Typography
+                        key={segment.path}
+                        sx={{ fontSize: '13px', color: '#E0E0E0', fontWeight: 500, display: 'flex', alignItems: 'center', lineHeight: 1.4 }}
+                      >
                         {segment.label}
                       </Typography>
                     )
@@ -278,7 +286,16 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
                         component={RouterLink}
                         to={segment.path}
                         underline="hover"
-                        sx={{ fontSize: '12px', color: '#8A8A8A', '&:hover': { color: '#CFCFCF' } }}
+                        sx={{
+                          fontSize: '13px',
+                          fontWeight: 400,
+                          color: '#8A8A8A',
+                          display: 'flex',
+                          alignItems: 'center',
+                          lineHeight: 1.4,
+                          transition: 'color 0.15s ease',
+                          '&:hover': { color: '#CFCFCF' },
+                        }}
                       >
                         {segment.label}
                       </Link>
@@ -286,7 +303,10 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
                   }
 
                   return (
-                    <Typography key={segment.path} sx={{ fontSize: '12px', color: '#8A8A8A' }}>
+                    <Typography
+                      key={segment.path}
+                      sx={{ fontSize: '13px', fontWeight: 400, color: '#8A8A8A', display: 'flex', alignItems: 'center', lineHeight: 1.4 }}
+                    >
                       {segment.label}
                     </Typography>
                   )

--- a/frontend/src/components/common/TopBar.tsx
+++ b/frontend/src/components/common/TopBar.tsx
@@ -232,6 +232,9 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
           bgcolor: '#1E1E1E',
           color: 'text.primary',
           boxShadow: 'none',
+          boxSizing: 'border-box',
+          height: TOPBAR_HEIGHT,
+          minHeight: TOPBAR_HEIGHT,
           borderBottom: '1px solid #2A2A2A',
           transition: 'width 0.22s ease, margin-left 0.22s ease',
         }}

--- a/frontend/src/components/common/TopBar.tsx
+++ b/frontend/src/components/common/TopBar.tsx
@@ -20,7 +20,7 @@ import {
   Search as SearchIcon,
 } from '@mui/icons-material'
 
-import { DRAWER_WIDTH_COLLAPSED, DRAWER_WIDTH_EXPANDED } from '@/constants/layout'
+import { DRAWER_WIDTH_COLLAPSED, DRAWER_WIDTH_EXPANDED, TOPBAR_HEIGHT } from '@/constants/layout'
 import { useAppSelector } from '@/hooks/useRedux'
 import { selectUnreadCount } from '@/store/slices/notificationSlice'
 
@@ -236,7 +236,7 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
           transition: 'width 0.22s ease, margin-left 0.22s ease',
         }}
       >
-        <Toolbar sx={{ minHeight: '64px !important', gap: 1 }}>
+        <Toolbar sx={{ minHeight: `${TOPBAR_HEIGHT}px !important`, height: TOPBAR_HEIGHT, gap: 1 }}>
           {isMobile && (
             <IconButton
               color="inherit"

--- a/frontend/src/constants/layout.ts
+++ b/frontend/src/constants/layout.ts
@@ -1,2 +1,3 @@
 export const DRAWER_WIDTH_EXPANDED = 256
 export const DRAWER_WIDTH_COLLAPSED = 64
+export const TOPBAR_HEIGHT = 64


### PR DESCRIPTION
## Summary

- **Breadcrumb hierarchy**: ancestors `#8A8A8A`, separator `#5A5A5A`, current page `fontWeight: 500`; all segments bumped from 12px → 13px with `lineHeight: 1.4` and flex alignment to fix baseline; navigable ancestors get `#CFCFCF` hover with `0.15s ease` transition
- **Right-side action spacing**: `gap: 0.5` → `gap: 2` (4px → 16px) across search, status, and notification icons
- **Unified icon hover**: `SystemStatus` and notification `IconButton` both get `bgcolor: #2A2A2A, borderRadius: 8px` on hover
- **Shared header geometry**: `TOPBAR_HEIGHT = 64` constant added to `layout.ts`; both the `AppBar` and sidebar header `Box` now explicitly declare `boxSizing: border-box`, `height: 64`, `minHeight: 64`, `borderBottom: 1px solid #2A2A2A` — replacing the sidebar's previous content-sized `py: 1.5 + minHeight: 56` and its mismatched `#1F2937` border

## Test Plan

- [x] Breadcrumb text is readable at 13px — balanced against search bar and icon sizes
- [x] Ancestor breadcrumbs are visibly dimmer than current page; hover transitions smoothly to `#CFCFCF`
- [x] Right-side icons (search / status / notifications) have clear 16px breathing room
- [x] Hovering status and notification icons shows identical dark background
- [x] Sidebar header and top bar read as one continuous 64px band — border line is unbroken across full width
- [x] Sidebar collapsed and expanded states both align correctly
- [x] 394 frontend tests passing, type-check clean

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)