### PR TITLE
feat(search): implement global command search (Phase 1)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -43,6 +43,7 @@ import { PrintSettingsModule } from './modules/print-settings/print-settings.mod
 import { BackupModule } from './modules/backup/backup.module';
 import { PriceListsModule } from './modules/price-lists/price-lists.module';
 import { AccountingModule } from './modules/accounting/accounting.module';
+import { SearchModule } from './modules/search/search.module';
 
 // Auth Guards
 import { JwtAuthGuard } from './modules/auth/guards/jwt-auth.guard';
@@ -93,6 +94,7 @@ import { AppService } from './app.service';
     BackupModule, // Backup and restore functionality
     PriceListsModule, // Price list management (Phase 3)
     AccountingModule, // Accounting module (Phase 1)
+    SearchModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/modules/inventory/services/product.service.spec.ts
+++ b/backend/src/modules/inventory/services/product.service.spec.ts
@@ -141,7 +141,7 @@ describe('ProductService pagination removal', () => {
         id: 'prod-uuid-1',
         label: 'Widget A',
         description: 'SKU-001',
-        route: '/inventory/products/prod-uuid-1',
+        route: '/inventory/products/prod-uuid-1/edit',
       });
     });
 

--- a/backend/src/modules/inventory/services/product.service.spec.ts
+++ b/backend/src/modules/inventory/services/product.service.spec.ts
@@ -117,4 +117,44 @@ describe('ProductService pagination removal', () => {
     expect(result.meta).toEqual({ total: 1 });
     expect(result.data).toHaveLength(1);
   });
+
+  describe('searchGlobal', () => {
+    it('returns matching products as GlobalSearchResultDto', async () => {
+      const product = {
+        id: 'prod-uuid-1',
+        name: 'Widget A',
+        barcode: 'SKU-001',
+        deletedAt: null,
+      };
+      productRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([product]),
+      } as any);
+
+      const results = await service.searchGlobal('Widget', {} as any);
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        type: 'product',
+        id: 'prod-uuid-1',
+        label: 'Widget A',
+        description: 'SKU-001',
+        route: '/inventory/products/prod-uuid-1',
+      });
+    });
+
+    it('returns empty array when no matches', async () => {
+      productRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      } as any);
+
+      const results = await service.searchGlobal('zzz', {} as any);
+      expect(results).toEqual([]);
+    });
+  });
 });

--- a/backend/src/modules/inventory/services/product.service.ts
+++ b/backend/src/modules/inventory/services/product.service.ts
@@ -323,7 +323,7 @@ export class ProductService {
         id: product.id,
         label: product.name,
         description: product.barcode,
-        route: `/inventory/products/${product.id}`,
+        route: `/inventory/products/${product.id}/edit`,
         score,
       };
     });

--- a/backend/src/modules/inventory/services/product.service.ts
+++ b/backend/src/modules/inventory/services/product.service.ts
@@ -34,6 +34,7 @@ import {
   ProductImportDto,
   ProductImportResultDto,
 } from '../dto/product.dto';
+import { GlobalSearchResultDto } from '../../search/dto/global-search-result.dto';
 import { CategoryService } from './category.service';
 import { StockMovementService } from './stock-movement.service';
 import { BaseCostCalculatorService } from './base-cost-calculator.service';
@@ -287,6 +288,45 @@ export class ProductService {
       data,
       meta: { total },
     };
+  }
+
+  async searchGlobal(query: string, user: any): Promise<GlobalSearchResultDto[]> {
+    const trimmed = query.trim();
+    const products = await this.productRepository
+      .createQueryBuilder('product')
+      .where('product.deletedAt IS NULL')
+      .andWhere('(product.name ILIKE :q OR product.barcode ILIKE :q)', {
+        q: `%${trimmed}%`,
+      })
+      .take(5)
+      .getMany();
+
+    return products.map((product) => {
+      const name = product.name?.toLowerCase() ?? '';
+      const barcode = product.barcode?.toLowerCase() ?? '';
+      const normalized = trimmed.toLowerCase();
+      let score = 50;
+
+      if (name === normalized) {
+        score = 100;
+      } else if (barcode === normalized) {
+        score = 90;
+      } else if (
+        name.startsWith(normalized) ||
+        barcode.startsWith(normalized)
+      ) {
+        score = 80;
+      }
+
+      return {
+        type: 'product',
+        id: product.id,
+        label: product.name,
+        description: product.barcode,
+        route: `/inventory/products/${product.id}`,
+        score,
+      };
+    });
   }
 
   /**

--- a/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
@@ -256,7 +256,7 @@ describe('PurchaseOrderService', () => {
         id: 'po-uuid-1',
         label: 'PO-000001',
         description: 'Acme Supplies',
-        route: '/purchasing/orders/po-uuid-1',
+        route: '/purchasing/orders/po-uuid-1/edit',
       });
     });
   });

--- a/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
@@ -232,6 +232,35 @@ describe('PurchaseOrderService', () => {
     jest.clearAllMocks();
   });
 
+  describe('searchGlobal', () => {
+    it('returns matching purchase orders as GlobalSearchResultDto', async () => {
+      const order = {
+        id: 'po-uuid-1',
+        orderNumber: 'PO-000001',
+        supplier: { companyName: 'Acme Supplies' },
+        deletedAt: null,
+      };
+      purchaseOrderRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([order]),
+      } as any);
+
+      const results = await service.searchGlobal('PO-000001', {} as any);
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        type: 'transaction',
+        id: 'po-uuid-1',
+        label: 'PO-000001',
+        description: 'Acme Supplies',
+        route: '/purchasing/orders/po-uuid-1',
+      });
+    });
+  });
+
   describe('receiveGoods', () => {
     it('posts accounting entry after receiving goods', async () => {
       grnRepository.findOne

--- a/backend/src/modules/purchasing/services/purchase-order.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.ts
@@ -360,7 +360,7 @@ export class PurchaseOrderService {
         id: order.id,
         label: order.orderNumber,
         description: order.supplier?.companyName ?? '',
-        route: `/purchasing/orders/${order.id}`,
+        route: `/purchasing/orders/${order.id}/edit`,
         score,
       };
     });

--- a/backend/src/modules/purchasing/services/purchase-order.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.ts
@@ -17,6 +17,7 @@ import {
   PurchaseOrderListResponseDto,
   PurchaseOrderSummaryDto,
 } from '../dto';
+import { GlobalSearchResultDto } from '../../search/dto/global-search-result.dto';
 import { SupplierService } from './supplier.service';
 import { GoodsReceivedNoteService } from './goods-received-note.service';
 import { VendorPaymentService } from './vendor-payment.service';
@@ -329,6 +330,40 @@ export class PurchaseOrderService {
       hasNext: limit ? page < Math.ceil(total / limit) : false,
       hasPrev: page ? page > 1 : false,
     };
+  }
+
+  async searchGlobal(query: string, user: any): Promise<GlobalSearchResultDto[]> {
+    const trimmed = query.trim();
+    const orders = await this.purchaseOrderRepository
+      .createQueryBuilder('order')
+      .leftJoinAndSelect('order.supplier', 'supplier')
+      .where('order.deletedAt IS NULL')
+      .andWhere('(order.orderNumber ILIKE :q OR supplier.companyName ILIKE :q)', {
+        q: `%${trimmed}%`,
+      })
+      .take(5)
+      .getMany();
+
+    return orders.map((order) => {
+      const orderNumber = order.orderNumber?.toLowerCase() ?? '';
+      const normalized = trimmed.toLowerCase();
+      let score = 50;
+
+      if (orderNumber === normalized) {
+        score = 90;
+      } else if (orderNumber.startsWith(normalized)) {
+        score = 80;
+      }
+
+      return {
+        type: 'transaction',
+        id: order.id,
+        label: order.orderNumber,
+        description: order.supplier?.companyName ?? '',
+        route: `/purchasing/orders/${order.id}`,
+        score,
+      };
+    });
   }
 
   /**

--- a/backend/src/modules/sales/services/customer.service.spec.ts
+++ b/backend/src/modules/sales/services/customer.service.spec.ts
@@ -71,7 +71,7 @@ describe('CustomerService', () => {
         id: 'uuid-1',
         label: 'ABC Trading',
         description: '0123456789',
-        route: '/customers/uuid-1',
+        route: '/sales/customers/uuid-1',
       });
       expect(results[0].score).toBeGreaterThan(0);
     });

--- a/backend/src/modules/sales/services/customer.service.spec.ts
+++ b/backend/src/modules/sales/services/customer.service.spec.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CustomerService } from './customer.service';
+import { Customer } from '../../../database/entities/customer.entity';
+import { SalesOrder } from '../../../database/entities/sales-order.entity';
+import { Invoice } from '../../../database/entities/invoice.entity';
+import { AuditLogService } from '../../audit-logs/services';
+import { TransactionManager } from '../../../common/utils/transaction.util';
+
+describe('CustomerService', () => {
+  let service: CustomerService;
+  let customerRepository: jest.Mocked<Repository<Customer>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CustomerService,
+        {
+          provide: getRepositoryToken(Customer),
+          useValue: {
+            findOne: jest.fn(),
+            save: jest.fn(),
+            find: jest.fn(),
+            createQueryBuilder: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(SalesOrder),
+          useValue: { createQueryBuilder: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(Invoice),
+          useValue: { createQueryBuilder: jest.fn() },
+        },
+        {
+          provide: TransactionManager,
+          useValue: { runInTransaction: jest.fn() },
+        },
+        {
+          provide: AuditLogService,
+          useValue: { log: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get<CustomerService>(CustomerService);
+    customerRepository = module.get(getRepositoryToken(Customer));
+  });
+
+  describe('searchGlobal', () => {
+    it('returns matching customers as GlobalSearchResultDto', async () => {
+      const customer = {
+        id: 'uuid-1',
+        name: 'ABC Trading',
+        phone: '0123456789',
+        deletedAt: null,
+      };
+      customerRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([customer]),
+      } as any);
+
+      const results = await service.searchGlobal('ABC', {} as any);
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        type: 'customer',
+        id: 'uuid-1',
+        label: 'ABC Trading',
+        description: '0123456789',
+        route: '/customers/uuid-1',
+      });
+      expect(results[0].score).toBeGreaterThan(0);
+    });
+
+    it('returns empty array when no matches', async () => {
+      customerRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      } as any);
+
+      const results = await service.searchGlobal('zzz', {} as any);
+      expect(results).toEqual([]);
+    });
+  });
+});

--- a/backend/src/modules/sales/services/customer.service.ts
+++ b/backend/src/modules/sales/services/customer.service.ts
@@ -159,7 +159,7 @@ export class CustomerService {
         id: customer.id,
         label: customer.name,
         description: customer.phone,
-        route: `/customers/${customer.id}`,
+        route: `/sales/customers/${customer.id}`,
         score,
       };
     });

--- a/backend/src/modules/sales/services/customer.service.ts
+++ b/backend/src/modules/sales/services/customer.service.ts
@@ -16,6 +16,7 @@ import {
   CustomerResponseDto,
   CustomerSummaryDto,
 } from '../dto/customer.dto';
+import { GlobalSearchResultDto } from '../../search/dto/global-search-result.dto';
 import { ValidationUtil, BulkOperationUtil, BulkOperationResponse } from '../../../common/utils/validation.util';
 import { TransactionManager, Transactional } from '../../../common/utils/transaction.util';
 import { AuditLogService } from '../../audit-logs/services';
@@ -125,6 +126,43 @@ export class CustomerService {
       limit,
       totalPages: Math.ceil(total / limit),
     };
+  }
+
+  async searchGlobal(query: string, user: any): Promise<GlobalSearchResultDto[]> {
+    const trimmed = query.trim();
+    const customers = await this.customerRepository
+      .createQueryBuilder('customer')
+      .where('customer.deletedAt IS NULL')
+      .andWhere(
+        '(customer.name ILIKE :q OR customer.phone ILIKE :q)',
+        { q: `%${trimmed}%` },
+      )
+      .take(5)
+      .getMany();
+
+    return customers.map((customer) => {
+      const name = customer.name?.toLowerCase() ?? '';
+      const phone = customer.phone?.toLowerCase() ?? '';
+      const normalized = trimmed.toLowerCase();
+      let score = 50;
+
+      if (name === normalized) {
+        score = 100;
+      } else if (phone === normalized) {
+        score = 90;
+      } else if (name.startsWith(normalized) || phone.startsWith(normalized)) {
+        score = 80;
+      }
+
+      return {
+        type: 'customer',
+        id: customer.id,
+        label: customer.name,
+        description: customer.phone,
+        route: `/customers/${customer.id}`,
+        score,
+      };
+    });
   }
 
   async findDeleted(query: QueryCustomersDto) {

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -201,7 +201,7 @@ describe('SalesOrderService', () => {
         id: 'so-uuid-1',
         label: 'SO-000001',
         description: 'ABC Trading',
-        route: '/sales/orders/so-uuid-1',
+        route: '/sales/orders/so-uuid-1/edit',
       });
     });
   });

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -177,6 +177,35 @@ describe('SalesOrderService', () => {
     expect(service).toBeDefined();
   });
 
+  describe('searchGlobal', () => {
+    it('returns matching sales orders as GlobalSearchResultDto', async () => {
+      const order = {
+        id: 'so-uuid-1',
+        orderNumber: 'SO-000001',
+        customer: { name: 'ABC Trading' },
+        deletedAt: null,
+      };
+      salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([order]),
+      } as any);
+
+      const results = await service.searchGlobal('SO-000001', {} as any);
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        type: 'transaction',
+        id: 'so-uuid-1',
+        label: 'SO-000001',
+        description: 'ABC Trading',
+        route: '/sales/orders/so-uuid-1',
+      });
+    });
+  });
+
   describe('fulfillOrder', () => {
     it('should post accounting entry successfully', async () => {
       // Arrange

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -21,6 +21,7 @@ import {
   QuerySalesOrdersDto,
   SalesOrderResponseDto,
 } from '../dto/sales-order.dto';
+import { GlobalSearchResultDto } from '../../search/dto/global-search-result.dto';
 // import { CustomerService } from './customer.service';
 import { InventoryIntegrationService } from './inventory-integration.service';
 import { ValidationUtil, BulkOperationUtil, BulkOperationResponse } from '../../../common/utils/validation.util';
@@ -349,6 +350,40 @@ export class SalesOrderService {
 
   async findAll(query: QuerySalesOrdersDto) {
     return this.salesOrderQueryService.findAll(query);
+  }
+
+  async searchGlobal(query: string, user: any): Promise<GlobalSearchResultDto[]> {
+    const trimmed = query.trim();
+    const orders = await this.salesOrderRepository
+      .createQueryBuilder('order')
+      .leftJoinAndSelect('order.customer', 'customer')
+      .where('order.deletedAt IS NULL')
+      .andWhere('(order.orderNumber ILIKE :q OR customer.name ILIKE :q)', {
+        q: `%${trimmed}%`,
+      })
+      .take(5)
+      .getMany();
+
+    return orders.map((order) => {
+      const orderNumber = order.orderNumber?.toLowerCase() ?? '';
+      const normalized = trimmed.toLowerCase();
+      let score = 50;
+
+      if (orderNumber === normalized) {
+        score = 90;
+      } else if (orderNumber.startsWith(normalized)) {
+        score = 80;
+      }
+
+      return {
+        type: 'transaction',
+        id: order.id,
+        label: order.orderNumber,
+        description: order.customer?.name ?? '',
+        route: `/sales/orders/${order.id}`,
+        score,
+      };
+    });
   }
 
   async testInvoiceRelations(orderNumber: string): Promise<any> {

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -380,7 +380,7 @@ export class SalesOrderService {
         id: order.id,
         label: order.orderNumber,
         description: order.customer?.name ?? '',
-        route: `/sales/orders/${order.id}`,
+        route: `/sales/orders/${order.id}/edit`,
         score,
       };
     });

--- a/backend/src/modules/search/dto/global-search-query.dto.ts
+++ b/backend/src/modules/search/dto/global-search-query.dto.ts
@@ -1,0 +1,8 @@
+import { IsString, MaxLength, MinLength } from 'class-validator';
+
+export class GlobalSearchQueryDto {
+  @IsString()
+  @MinLength(2)
+  @MaxLength(100)
+  q: string;
+}

--- a/backend/src/modules/search/dto/global-search-response.dto.ts
+++ b/backend/src/modules/search/dto/global-search-response.dto.ts
@@ -1,0 +1,6 @@
+import { GlobalSearchResultDto } from './global-search-result.dto';
+
+export class GlobalSearchResponseDto {
+  query: string;
+  results: GlobalSearchResultDto[];
+}

--- a/backend/src/modules/search/dto/global-search-result.dto.ts
+++ b/backend/src/modules/search/dto/global-search-result.dto.ts
@@ -1,0 +1,14 @@
+export type GlobalSearchResultType =
+  | 'page'
+  | 'customer'
+  | 'product'
+  | 'transaction';
+
+export class GlobalSearchResultDto {
+  type: GlobalSearchResultType;
+  id?: string;
+  label: string;
+  description?: string;
+  route: string;
+  score?: number;
+}

--- a/backend/src/modules/search/search.controller.ts
+++ b/backend/src/modules/search/search.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Query, Request } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { SearchService } from './search.service';
+import { GlobalSearchQueryDto } from './dto/global-search-query.dto';
+import { GlobalSearchResponseDto } from './dto/global-search-response.dto';
+
+@ApiTags('Search')
+@Controller('search')
+export class SearchController {
+  constructor(private readonly searchService: SearchService) {}
+
+  @Get('global')
+  @ApiOperation({
+    summary: 'Global search across pages, customers, products, and transactions',
+  })
+  async searchGlobal(
+    @Query() query: GlobalSearchQueryDto,
+    @Request() req: any,
+  ): Promise<GlobalSearchResponseDto> {
+    return this.searchService.search(query.q, req.user);
+  }
+}

--- a/backend/src/modules/search/search.module.ts
+++ b/backend/src/modules/search/search.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { InventoryModule } from '../inventory/inventory.module';
+import { PurchasingModule } from '../purchasing/purchasing.module';
+import { SalesModule } from '../sales/sales.module';
+import { SearchController } from './search.controller';
+import { SearchService } from './search.service';
+
+@Module({
+  imports: [SalesModule, InventoryModule, PurchasingModule],
+  controllers: [SearchController],
+  providers: [SearchService],
+})
+export class SearchModule {}

--- a/backend/src/modules/search/search.service.spec.ts
+++ b/backend/src/modules/search/search.service.spec.ts
@@ -1,0 +1,130 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SearchService } from './search.service';
+import { CustomerService } from '../sales/services/customer.service';
+import { ProductService } from '../inventory/services/product.service';
+import { SalesOrderService } from '../sales/services/sales-order.service';
+import { PurchaseOrderService } from '../purchasing/services/purchase-order.service';
+import { GlobalSearchResultDto } from './dto/global-search-result.dto';
+
+describe('SearchService', () => {
+  let service: SearchService;
+  let customerService: jest.Mocked<Pick<CustomerService, 'searchGlobal'>>;
+  let productService: jest.Mocked<Pick<ProductService, 'searchGlobal'>>;
+  let salesOrderService: jest.Mocked<Pick<SalesOrderService, 'searchGlobal'>>;
+  let purchaseOrderService: jest.Mocked<Pick<PurchaseOrderService, 'searchGlobal'>>;
+
+  const mockUser = { userId: 'u1', username: 'admin' } as any;
+
+  const makeResult = (label: string, score: number): GlobalSearchResultDto => ({
+    type: 'customer',
+    id: 'id-1',
+    label,
+    route: '/customers/id-1',
+    score,
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SearchService,
+        {
+          provide: CustomerService,
+          useValue: { searchGlobal: jest.fn().mockResolvedValue([]) },
+        },
+        {
+          provide: ProductService,
+          useValue: { searchGlobal: jest.fn().mockResolvedValue([]) },
+        },
+        {
+          provide: SalesOrderService,
+          useValue: { searchGlobal: jest.fn().mockResolvedValue([]) },
+        },
+        {
+          provide: PurchaseOrderService,
+          useValue: { searchGlobal: jest.fn().mockResolvedValue([]) },
+        },
+      ],
+    }).compile();
+
+    service = module.get(SearchService);
+    customerService = module.get(CustomerService);
+    productService = module.get(ProductService);
+    salesOrderService = module.get(SalesOrderService);
+    purchaseOrderService = module.get(PurchaseOrderService);
+  });
+
+  it('fans out to all four sources in parallel', async () => {
+    await service.search('abc', mockUser);
+
+    expect(customerService.searchGlobal).toHaveBeenCalledWith('abc', mockUser);
+    expect(productService.searchGlobal).toHaveBeenCalledWith('abc', mockUser);
+    expect(salesOrderService.searchGlobal).toHaveBeenCalledWith('abc', mockUser);
+    expect(purchaseOrderService.searchGlobal).toHaveBeenCalledWith('abc', mockUser);
+  });
+
+  it('returns early with empty results for queries shorter than 2 characters', async () => {
+    const result = await service.search('a', mockUser);
+
+    expect(result.results).toEqual([]);
+    expect(customerService.searchGlobal).not.toHaveBeenCalled();
+  });
+
+  it('returns early with empty results for blank query', async () => {
+    const result = await service.search('  ', mockUser);
+
+    expect(result.results).toEqual([]);
+  });
+
+  it('sorts merged results by descending score', async () => {
+    (customerService.searchGlobal as jest.Mock).mockResolvedValue([
+      makeResult('Low', 50),
+    ]);
+    (productService.searchGlobal as jest.Mock).mockResolvedValue([
+      makeResult('High', 100),
+    ]);
+
+    const result = await service.search('test', mockUser);
+
+    expect(result.results[0].score).toBe(100);
+    expect(result.results[1].score).toBe(50);
+  });
+
+  it('treats undefined score as 0 when sorting', async () => {
+    const noScore: GlobalSearchResultDto = {
+      type: 'page',
+      label: 'Dashboard',
+      route: '/dashboard',
+    };
+    const withScore = makeResult('ABC', 50);
+    (customerService.searchGlobal as jest.Mock).mockResolvedValue([noScore]);
+    (productService.searchGlobal as jest.Mock).mockResolvedValue([withScore]);
+
+    const result = await service.search('dash', mockUser);
+
+    expect(result.results[0].score).toBe(50);
+  });
+
+  it('caps results at 20', async () => {
+    const many = Array.from({ length: 15 }, (_, i) => makeResult(`item-${i}`, 50));
+    (customerService.searchGlobal as jest.Mock).mockResolvedValue(many);
+    (productService.searchGlobal as jest.Mock).mockResolvedValue(many);
+
+    const result = await service.search('item', mockUser);
+
+    expect(result.results.length).toBeLessThanOrEqual(20);
+  });
+
+  it('returns partial results if one source fails', async () => {
+    (customerService.searchGlobal as jest.Mock).mockRejectedValue(
+      new Error('DB error'),
+    );
+    (productService.searchGlobal as jest.Mock).mockResolvedValue([
+      makeResult('Widget', 80),
+    ]);
+
+    const result = await service.search('wi', mockUser);
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].label).toBe('Widget');
+  });
+});

--- a/backend/src/modules/search/search.service.ts
+++ b/backend/src/modules/search/search.service.ts
@@ -1,0 +1,156 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ProductService } from '../inventory/services/product.service';
+import { PurchaseOrderService } from '../purchasing/services/purchase-order.service';
+import { CustomerService } from '../sales/services/customer.service';
+import { SalesOrderService } from '../sales/services/sales-order.service';
+import { GlobalSearchResponseDto } from './dto/global-search-response.dto';
+import { GlobalSearchResultDto } from './dto/global-search-result.dto';
+
+const STATIC_PAGES: Array<{
+  label: string;
+  keywords: string[];
+  route: string;
+}> = [
+  { label: 'Dashboard', keywords: ['home', 'overview'], route: '/dashboard' },
+  { label: 'Customers', keywords: ['clients', 'buyers'], route: '/customers' },
+  {
+    label: 'Products',
+    keywords: ['items', 'inventory', 'catalogue'],
+    route: '/inventory/products',
+  },
+  { label: 'Sales Orders', keywords: ['orders', 'so'], route: '/sales/orders' },
+  {
+    label: 'Purchase Orders',
+    keywords: ['purchasing', 'po', 'procurement'],
+    route: '/purchasing/orders',
+  },
+  { label: 'Invoices', keywords: ['billing'], route: '/sales/invoices' },
+  { label: 'Payments', keywords: ['receipts'], route: '/sales/payments' },
+  { label: 'Suppliers', keywords: ['vendors'], route: '/purchasing/suppliers' },
+  {
+    label: 'Stock Adjustments',
+    keywords: ['adjustment', 'inventory'],
+    route: '/inventory/adjustments',
+  },
+  {
+    label: 'Categories',
+    keywords: ['product categories'],
+    route: '/inventory/categories',
+  },
+  { label: 'Price Lists', keywords: ['pricing'], route: '/price-lists' },
+  {
+    label: 'Journal Entries',
+    keywords: ['accounting', 'ledger'],
+    route: '/accounting/journal-entries',
+  },
+  {
+    label: 'Chart of Accounts',
+    keywords: ['accounts', 'coa'],
+    route: '/accounting/chart-of-accounts',
+  },
+  {
+    label: 'Fiscal Periods',
+    keywords: ['financial periods'],
+    route: '/accounting/fiscal-periods',
+  },
+  {
+    label: 'User Management',
+    keywords: ['users', 'roles'],
+    route: '/settings/users',
+  },
+  {
+    label: 'Settings',
+    keywords: ['configuration', 'preferences'],
+    route: '/settings',
+  },
+  { label: 'Audit Logs', keywords: ['activity', 'history'], route: '/audit-logs' },
+];
+
+@Injectable()
+export class SearchService {
+  private readonly logger = new Logger(SearchService.name);
+
+  constructor(
+    private readonly customerService: CustomerService,
+    private readonly productService: ProductService,
+    private readonly salesOrderService: SalesOrderService,
+    private readonly purchaseOrderService: PurchaseOrderService,
+  ) {}
+
+  async search(query: string, user: any): Promise<GlobalSearchResponseDto> {
+    const trimmed = query?.trim() ?? '';
+    if (trimmed.length < 2) {
+      return { query, results: [] };
+    }
+
+    const [pages, customers, products, salesOrders, purchaseOrders] =
+      await Promise.all([
+        this.safeSearch('pages', async () => this.searchPages(trimmed)),
+        this.safeSearch('customers', () =>
+          this.customerService.searchGlobal(trimmed, user),
+        ),
+        this.safeSearch('products', () =>
+          this.productService.searchGlobal(trimmed, user),
+        ),
+        this.safeSearch('salesOrders', () =>
+          this.salesOrderService.searchGlobal(trimmed, user),
+        ),
+        this.safeSearch('purchaseOrders', () =>
+          this.purchaseOrderService.searchGlobal(trimmed, user),
+        ),
+      ]);
+
+    const results = [
+      ...pages,
+      ...customers,
+      ...products,
+      ...salesOrders,
+      ...purchaseOrders,
+    ]
+      .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+      .slice(0, 20);
+
+    return { query, results };
+  }
+
+  private async safeSearch(
+    source: string,
+    fn: () => Promise<GlobalSearchResultDto[]>,
+  ): Promise<GlobalSearchResultDto[]> {
+    try {
+      return await fn();
+    } catch (error) {
+      this.logger.error(
+        `Search source "${source}" failed: ${(error as Error).message}`,
+      );
+      return [];
+    }
+  }
+
+  private searchPages(query: string): GlobalSearchResultDto[] {
+    const lowerQuery = query.toLowerCase();
+
+    return STATIC_PAGES.filter(
+      (page) =>
+        page.label.toLowerCase().includes(lowerQuery) ||
+        page.keywords.some((keyword) => keyword.toLowerCase().includes(lowerQuery)),
+    ).map((page) => {
+      const lowerLabel = page.label.toLowerCase();
+      let score = 30;
+
+      if (lowerLabel === lowerQuery) {
+        score = 100;
+      } else if (lowerLabel.startsWith(lowerQuery)) {
+        score = 40;
+      }
+
+      return {
+        type: 'page',
+        label: page.label,
+        description: 'Navigation',
+        route: page.route,
+        score,
+      };
+    });
+  }
+}

--- a/frontend/src/components/common/SearchModal.tsx
+++ b/frontend/src/components/common/SearchModal.tsx
@@ -1,41 +1,195 @@
-import React, { useEffect } from 'react'
-import { Box, Divider, InputBase, Modal, Typography } from '@mui/material'
-import { ManageSearch as ManageSearchIcon, Search as SearchIcon } from '@mui/icons-material'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import SearchIcon from '@mui/icons-material/Search'
+import {
+  Box,
+  CircularProgress,
+  Divider,
+  InputBase,
+  Modal,
+  Typography,
+} from '@mui/material'
+import { useNavigate } from 'react-router-dom'
+
+import { useSearchGlobalQuery } from '@/store/api/searchApi'
+import type {
+  GlobalSearchResultDto,
+  GlobalSearchResultType,
+} from '@/types/search'
 
 interface SearchModalProps {
   open: boolean
   onClose: () => void
 }
 
-const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
+const GROUP_ORDER: GlobalSearchResultType[] = [
+  'page',
+  'customer',
+  'product',
+  'transaction',
+]
+
+const GROUP_LABELS: Record<GlobalSearchResultType, string> = {
+  page: 'Pages',
+  customer: 'Customers',
+  product: 'Products',
+  transaction: 'Transactions',
+}
+
+const TYPE_BADGES: Record<GlobalSearchResultType, string> = {
+  page: 'Page',
+  customer: 'Customer',
+  product: 'Product',
+  transaction: 'Transaction',
+}
+
+function useDebounce(value: string, delay: number) {
+  const [debouncedValue, setDebouncedValue] = useState(value)
+
   useEffect(() => {
-    if (!open) return undefined
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    return () => window.clearTimeout(timeoutId)
+  }, [delay, value])
+
+  return debouncedValue
+}
+
+export default function SearchModal({ open, onClose }: SearchModalProps) {
+  const navigate = useNavigate()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [query, setQuery] = useState('')
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const debouncedQuery = useDebounce(query, 250)
+  const trimmedQuery = debouncedQuery.trim()
+
+  const { data, isLoading, isFetching, isError } = useSearchGlobalQuery(
+    { q: trimmedQuery },
+    { skip: trimmedQuery.length < 2 },
+  )
+
+  useEffect(() => {
+    if (!open) {
+      return undefined
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      inputRef.current?.focus()
+    }, 0)
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        onClose()
+        handleClose()
       }
     }
 
     document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
   }, [open, onClose])
 
+  useEffect(() => {
+    if (open) {
+      setQuery('')
+      setSelectedIndex(0)
+    }
+  }, [open])
+
+  useEffect(() => {
+    setSelectedIndex(0)
+  }, [data])
+
+  const flatResults = useMemo(
+    () =>
+      data
+        ? GROUP_ORDER.flatMap((type) =>
+            data.results.filter((result) => result.type === type),
+          )
+        : [],
+    [data],
+  )
+
+  const groups = useMemo(() => {
+    let offset = 0
+
+    return GROUP_ORDER.map((type) => {
+      const items = flatResults.filter((result) => result.type === type)
+      const group = {
+        type,
+        label: GROUP_LABELS[type],
+        items,
+        offset,
+      }
+      offset += items.length
+      return group
+    }).filter((group) => group.items.length > 0)
+  }, [flatResults])
+
+  const handleClose = () => {
+    setQuery('')
+    setSelectedIndex(0)
+    onClose()
+  }
+
+  const navigateTo = (route: string) => {
+    navigate(route)
+    handleClose()
+  }
+
+  const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setSelectedIndex((currentIndex) =>
+        flatResults.length === 0
+          ? 0
+          : (currentIndex + 1) % flatResults.length,
+      )
+      return
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setSelectedIndex((currentIndex) =>
+        flatResults.length === 0
+          ? 0
+          : (currentIndex - 1 + flatResults.length) % flatResults.length,
+      )
+      return
+    }
+
+    if (event.key === 'Enter' && flatResults[selectedIndex]) {
+      event.preventDefault()
+      navigateTo(flatResults[selectedIndex].route)
+    }
+  }
+
+  const showLoading = (isLoading || isFetching) && !data
+  const showError = isError && !showLoading
+  const showEmpty = !showLoading && !showError && !!data && flatResults.length === 0
+  const showHelp =
+    !showLoading && !showError && !data && trimmedQuery.length < 2
+
   return (
-    <Modal open={open} onClose={onClose} aria-label="Global search">
+    <Modal open={open} onClose={handleClose} aria-label="Global search">
       <Box
         sx={{
           position: 'absolute',
           top: '20%',
           left: '50%',
           transform: 'translate(-50%, 0)',
-          width: 560,
-          maxWidth: '90vw',
+          width: { xs: '92vw', sm: 560 },
+          maxHeight: '70vh',
           bgcolor: '#1E1E1E',
           border: '1px solid #2A2A2A',
           borderRadius: '12px',
           overflow: 'hidden',
           outline: 'none',
+          display: 'flex',
+          flexDirection: 'column',
         }}
       >
         <Box
@@ -50,70 +204,156 @@ const SearchModal: React.FC<SearchModalProps> = ({ open, onClose }) => {
         >
           <SearchIcon sx={{ color: '#6B7280', fontSize: 20, flexShrink: 0 }} />
           <InputBase
-            autoFocus
-            placeholder="Search across the ERP..."
+            inputRef={inputRef}
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={handleInputKeyDown}
+            placeholder="Search pages, customers, products, transactions..."
             fullWidth
             sx={{
               color: '#E0E0E0',
               fontSize: '0.9375rem',
               '& input::placeholder': { color: '#6B7280' },
             }}
+            inputProps={{ 'aria-label': 'search' }}
           />
-          <Typography
-            variant="caption"
-            sx={{ color: '#6B7280', whiteSpace: 'nowrap', flexShrink: 0 }}
-          >
-            Esc to close
-          </Typography>
+          {(isLoading || isFetching) && !showLoading && (
+            <CircularProgress size={16} />
+          )}
         </Box>
 
         <Divider sx={{ bgcolor: '#2A2A2A' }} />
 
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            gap: 1.5,
-            py: 5,
-            px: 3,
-          }}
-        >
-          <ManageSearchIcon sx={{ fontSize: 48, color: '#3A3A3A' }} />
-          <Typography variant="h6" sx={{ color: '#E0E0E0', fontWeight: 600 }}>
-            Global Search Coming Soon
-          </Typography>
-          <Typography variant="body2" sx={{ color: '#A0A0A0', textAlign: 'center' }}>
-            Will search across Pages, Customers, Products, and Transactions
-          </Typography>
-        </Box>
-
-        <Divider sx={{ bgcolor: '#2A2A2A' }} />
-
-        <Box sx={{ px: 2, py: 1.5, textAlign: 'center' }}>
-          <Typography component="div" sx={{ color: '#6B7280', fontSize: '12px' }}>
-            Tip: Press{' '}
-            <Box
-              component="kbd"
-              sx={{
-                bgcolor: '#232323',
-                border: '1px solid #3A3A3A',
-                borderRadius: '4px',
-                px: 0.75,
-                py: 0.25,
-                fontFamily: 'monospace',
-                fontSize: '11px',
-                color: '#A0A0A0',
-              }}
+        <Box sx={{ overflowY: 'auto', maxHeight: 'calc(70vh - 61px)' }}>
+          {showHelp && (
+            <Typography
+              variant="body2"
+              sx={{ color: '#A0A0A0', textAlign: 'center', px: 3, py: 4 }}
             >
-              Ctrl+K
-            </Box>{' '}
-            to open search anytime
-          </Typography>
+              Type at least 2 characters to search pages, customers, products,
+              and transactions.
+            </Typography>
+          )}
+
+          {showLoading && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+              <CircularProgress />
+            </Box>
+          )}
+
+          {showError && (
+            <Typography
+              variant="body2"
+              sx={{ color: '#F87171', textAlign: 'center', px: 3, py: 4 }}
+            >
+              Search unavailable, please try again.
+            </Typography>
+          )}
+
+          {showEmpty && (
+            <Typography
+              variant="body2"
+              sx={{ color: '#A0A0A0', textAlign: 'center', px: 3, py: 4 }}
+            >
+              No results for "{data?.query}"
+            </Typography>
+          )}
+
+          {groups.map((group) => (
+            <Box key={group.type}>
+              <Typography
+                variant="caption"
+                sx={{
+                  display: 'block',
+                  px: 2,
+                  py: 1,
+                  color: '#6B7280',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.08em',
+                }}
+              >
+                {group.label}
+              </Typography>
+              {group.items.map((item, itemIndex) => {
+                const flatIndex = group.offset + itemIndex
+                const isSelected = flatIndex === selectedIndex
+
+                return (
+                  <SearchResultRow
+                    key={`${item.type}-${item.id ?? item.route}`}
+                    item={item}
+                    isSelected={isSelected}
+                    onClick={() => navigateTo(item.route)}
+                    onHover={() => setSelectedIndex(flatIndex)}
+                  />
+                )
+              })}
+            </Box>
+          ))}
         </Box>
       </Box>
     </Modal>
   )
 }
 
-export default SearchModal
+interface SearchResultRowProps {
+  item: GlobalSearchResultDto
+  isSelected: boolean
+  onClick: () => void
+  onHover: () => void
+}
+
+function SearchResultRow({
+  item,
+  isSelected,
+  onClick,
+  onHover,
+}: SearchResultRowProps) {
+  return (
+    <Box
+      onClick={onClick}
+      onMouseEnter={onHover}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 2,
+        px: 2,
+        py: 1.25,
+        cursor: 'pointer',
+        bgcolor: isSelected ? 'rgba(255, 255, 255, 0.08)' : 'transparent',
+        '&:hover': {
+          bgcolor: 'rgba(255, 255, 255, 0.08)',
+        },
+      }}
+    >
+      <Box sx={{ minWidth: 0 }}>
+        <Typography sx={{ color: '#E0E0E0', fontWeight: 600 }}>
+          {item.label}
+        </Typography>
+        {item.description && (
+          <Typography
+            variant="caption"
+            sx={{ color: '#A0A0A0', display: 'block', mt: 0.25 }}
+          >
+            {item.description}
+          </Typography>
+        )}
+      </Box>
+
+      <Typography
+        variant="caption"
+        sx={{
+          color: '#6B7280',
+          bgcolor: 'rgba(255, 255, 255, 0.05)',
+          borderRadius: '999px',
+          px: 1,
+          py: 0.5,
+          flexShrink: 0,
+        }}
+      >
+        {TYPE_BADGES[item.type]}
+      </Typography>
+    </Box>
+  )
+}

--- a/frontend/src/components/common/SearchModal.tsx
+++ b/frontend/src/components/common/SearchModal.tsx
@@ -167,11 +167,11 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
     }
   }
 
-  const showLoading = (isLoading || isFetching) && !data
-  const showError = isError && !showLoading
-  const showEmpty = !showLoading && !showError && !!data && flatResults.length === 0
-  const showHelp =
-    !showLoading && !showError && !data && trimmedQuery.length < 2
+  const hasActiveQuery = trimmedQuery.length >= 2
+  const showHelp = !hasActiveQuery
+  const showLoading = hasActiveQuery && (isLoading || isFetching) && !data
+  const showError = hasActiveQuery && isError && !showLoading
+  const showEmpty = hasActiveQuery && !showLoading && !showError && !!data && flatResults.length === 0
 
   return (
     <Modal open={open} onClose={handleClose} aria-label="Global search">
@@ -259,7 +259,7 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
             </Typography>
           )}
 
-          {groups.map((group) => (
+          {hasActiveQuery && groups.map((group) => (
             <Box key={group.type}>
               <Typography
                 variant="caption"

--- a/frontend/src/components/common/__tests__/SearchModal.test.tsx
+++ b/frontend/src/components/common/__tests__/SearchModal.test.tsx
@@ -1,29 +1,311 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import SearchModal from '../SearchModal'
+import { searchApiSlice } from '@/store/api/searchApi'
+
+function makeStore() {
+  return configureStore({
+    reducer: {
+      [searchApiSlice.reducerPath]: searchApiSlice.reducer,
+    },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware().concat(searchApiSlice.middleware),
+  })
+}
+
+const mockUseSearchGlobal = vi.fn()
+vi.mock('@/store/api/searchApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store/api/searchApi')>()
+  return {
+    ...actual,
+    useSearchGlobalQuery: (...args: any[]) => mockUseSearchGlobal(...args),
+  }
+})
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+function renderModal(open = true) {
+  const onClose = vi.fn()
+  const store = makeStore()
+
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <SearchModal open={open} onClose={onClose} />
+      </MemoryRouter>
+    </Provider>,
+  )
+
+  return { onClose }
+}
 
 describe('SearchModal', () => {
-  it('renders nothing when closed', () => {
-    render(<SearchModal open={false} onClose={vi.fn()} />)
-
-    expect(screen.queryByPlaceholderText('Search across the ERP...')).not.toBeInTheDocument()
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseSearchGlobal.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    })
   })
 
-  it('renders search input and coming soon content when open', () => {
-    render(<SearchModal open={true} onClose={vi.fn()} />)
+  it('renders nothing when closed', () => {
+    renderModal(false)
 
-    expect(screen.getByPlaceholderText('Search across the ERP...')).toBeInTheDocument()
-    expect(screen.getByText('Global Search Coming Soon')).toBeInTheDocument()
-    expect(screen.getByText(/Ctrl\+K/i)).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument()
+  })
+
+  it('shows help text when query is shorter than 2 characters', () => {
+    renderModal()
+
+    expect(
+      screen.getByText(/type at least 2 characters/i),
+    ).toBeInTheDocument()
+  })
+
+  it('skips the query when trimmed length is less than 2', () => {
+    renderModal()
+
+    expect(mockUseSearchGlobal).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ skip: true }),
+    )
   })
 
   it('calls onClose when Escape is pressed', () => {
-    const onClose = vi.fn()
+    const { onClose } = renderModal()
 
-    render(<SearchModal open={true} onClose={onClose} />)
     fireEvent.keyDown(document, { key: 'Escape' })
 
     expect(onClose).toHaveBeenCalled()
+  })
+
+  it('shows loading state while fetching with no prior results', () => {
+    mockUseSearchGlobal.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+      isError: false,
+    })
+
+    renderModal()
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('renders grouped results by type', () => {
+    mockUseSearchGlobal.mockReturnValue({
+      data: {
+        query: 'abc',
+        results: [
+          {
+            type: 'page',
+            label: 'Customers',
+            description: 'Navigation',
+            route: '/sales/customers',
+          },
+          {
+            type: 'customer',
+            id: '1',
+            label: 'ABC Trading',
+            description: '0123456789',
+            route: '/sales/customers/1',
+          },
+          {
+            type: 'product',
+            id: '2',
+            label: 'ABC Widget',
+            description: 'SKU-001',
+            route: '/inventory/products/2/edit',
+          },
+        ],
+      },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    })
+
+    renderModal()
+
+    expect(screen.getByText('Pages')).toBeInTheDocument()
+    expect(screen.getAllByText('Customers').length).toBeGreaterThan(0)
+    expect(screen.getByText('ABC Trading')).toBeInTheDocument()
+    expect(screen.getByText('ABC Widget')).toBeInTheDocument()
+  })
+
+  it('shows no-results message when results are empty', () => {
+    mockUseSearchGlobal.mockReturnValue({
+      data: { query: 'zzz', results: [] },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    })
+
+    renderModal()
+
+    expect(screen.getByText(/no results/i)).toBeInTheDocument()
+  })
+
+  it('navigates and closes when Enter is pressed on selected result', () => {
+    mockUseSearchGlobal.mockReturnValue({
+      data: {
+        query: 'abc',
+        results: [
+          {
+            type: 'customer',
+            id: '1',
+            label: 'ABC Trading',
+            route: '/sales/customers/1',
+          },
+        ],
+      },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    })
+
+    const { onClose } = renderModal()
+    const input = screen.getByPlaceholderText(/search/i)
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(mockNavigate).toHaveBeenCalledWith('/sales/customers/1')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('shows error message when query fails', () => {
+    mockUseSearchGlobal.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: true,
+    })
+
+    renderModal()
+
+    expect(screen.getByText(/search unavailable/i)).toBeInTheDocument()
+  })
+
+  it('skips the query when typing fewer than 2 characters', () => {
+    renderModal()
+
+    const input = screen.getByPlaceholderText(/search/i)
+    fireEvent.change(input, { target: { value: 'a' } })
+
+    expect(mockUseSearchGlobal).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ skip: true }),
+    )
+  })
+
+  it('resets query when modal reopens', () => {
+    const store = makeStore()
+    const onClose = vi.fn()
+    const { rerender } = render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <SearchModal open={true} onClose={onClose} />
+        </MemoryRouter>
+      </Provider>,
+    )
+
+    const input = screen.getByPlaceholderText(/search/i)
+    fireEvent.change(input, { target: { value: 'abc' } })
+    expect(input).toHaveValue('abc')
+
+    rerender(
+      <Provider store={store}>
+        <MemoryRouter>
+          <SearchModal open={false} onClose={onClose} />
+        </MemoryRouter>
+      </Provider>,
+    )
+    rerender(
+      <Provider store={store}>
+        <MemoryRouter>
+          <SearchModal open={true} onClose={onClose} />
+        </MemoryRouter>
+      </Provider>,
+    )
+
+    expect(screen.getByPlaceholderText(/search/i)).toHaveValue('')
+  })
+
+  it('ArrowUp wraps from first result to last', () => {
+    mockUseSearchGlobal.mockReturnValue({
+      data: {
+        query: 'abc',
+        results: [
+          {
+            type: 'customer',
+            id: '1',
+            label: 'First',
+            route: '/sales/customers/1',
+          },
+          {
+            type: 'customer',
+            id: '2',
+            label: 'Second',
+            route: '/sales/customers/2',
+          },
+        ],
+      },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    })
+
+    renderModal()
+
+    const input = screen.getByPlaceholderText(/search/i)
+    fireEvent.keyDown(input, { key: 'ArrowUp' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(mockNavigate).toHaveBeenCalledWith('/sales/customers/2')
+  })
+
+  it('ArrowDown wraps from last result to first', () => {
+    mockUseSearchGlobal.mockReturnValue({
+      data: {
+        query: 'abc',
+        results: [
+          {
+            type: 'customer',
+            id: '1',
+            label: 'First',
+            route: '/sales/customers/1',
+          },
+          {
+            type: 'customer',
+            id: '2',
+            label: 'Second',
+            route: '/sales/customers/2',
+          },
+        ],
+      },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    })
+
+    renderModal()
+
+    const input = screen.getByPlaceholderText(/search/i)
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(mockNavigate).toHaveBeenCalledWith('/sales/customers/1')
   })
 })

--- a/frontend/src/components/common/__tests__/SearchModal.test.tsx
+++ b/frontend/src/components/common/__tests__/SearchModal.test.tsx
@@ -1,8 +1,8 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { configureStore } from '@reduxjs/toolkit'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router-dom'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import SearchModal from '../SearchModal'
 import { searchApiSlice } from '@/store/api/searchApi'
@@ -50,8 +50,15 @@ function renderModal(open = true) {
   return { onClose }
 }
 
+// Helper: type into input and advance debounce timer
+function typeAndFlush(value: string) {
+  fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value } })
+  act(() => { vi.advanceTimersByTime(300) })
+}
+
 describe('SearchModal', () => {
   beforeEach(() => {
+    vi.useFakeTimers()
     vi.clearAllMocks()
     mockUseSearchGlobal.mockReturnValue({
       data: undefined,
@@ -59,6 +66,10 @@ describe('SearchModal', () => {
       isFetching: false,
       isError: false,
     })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('renders nothing when closed', () => {
@@ -101,6 +112,7 @@ describe('SearchModal', () => {
     })
 
     renderModal()
+    typeAndFlush('abc')
 
     expect(screen.getByRole('progressbar')).toBeInTheDocument()
   })
@@ -138,6 +150,7 @@ describe('SearchModal', () => {
     })
 
     renderModal()
+    typeAndFlush('abc')
 
     expect(screen.getByText('Pages')).toBeInTheDocument()
     expect(screen.getAllByText('Customers').length).toBeGreaterThan(0)
@@ -154,6 +167,7 @@ describe('SearchModal', () => {
     })
 
     renderModal()
+    typeAndFlush('zzz')
 
     expect(screen.getByText(/no results/i)).toBeInTheDocument()
   })
@@ -177,6 +191,7 @@ describe('SearchModal', () => {
     })
 
     const { onClose } = renderModal()
+    typeAndFlush('abc')
     const input = screen.getByPlaceholderText(/search/i)
     fireEvent.keyDown(input, { key: 'Enter' })
 
@@ -193,6 +208,7 @@ describe('SearchModal', () => {
     })
 
     renderModal()
+    typeAndFlush('abc')
 
     expect(screen.getByText(/search unavailable/i)).toBeInTheDocument()
   })
@@ -221,7 +237,7 @@ describe('SearchModal', () => {
     )
 
     const input = screen.getByPlaceholderText(/search/i)
-    fireEvent.change(input, { target: { value: 'abc' } })
+    typeAndFlush('abc')
     expect(input).toHaveValue('abc')
 
     rerender(
@@ -267,6 +283,7 @@ describe('SearchModal', () => {
     })
 
     renderModal()
+    typeAndFlush('abc')
 
     const input = screen.getByPlaceholderText(/search/i)
     fireEvent.keyDown(input, { key: 'ArrowUp' })
@@ -300,6 +317,7 @@ describe('SearchModal', () => {
     })
 
     renderModal()
+    typeAndFlush('abc')
 
     const input = screen.getByPlaceholderText(/search/i)
     fireEvent.keyDown(input, { key: 'ArrowDown' })

--- a/frontend/src/store/api/searchApi.ts
+++ b/frontend/src/store/api/searchApi.ts
@@ -1,0 +1,21 @@
+import { createApi } from '@reduxjs/toolkit/query/react'
+import type { GlobalSearchResponse } from '@/types/search'
+
+import { axiosBaseQuery } from './baseQuery'
+
+export const searchApiSlice = createApi({
+  reducerPath: 'searchApi',
+  baseQuery: axiosBaseQuery(),
+  endpoints: (builder) => ({
+    searchGlobal: builder.query<GlobalSearchResponse, { q: string }>({
+      query: ({ q }) => ({
+        url: '/search/global',
+        params: { q },
+      }),
+      transformResponse: (response: unknown) => response as GlobalSearchResponse,
+      keepUnusedDataFor: 0,
+    }),
+  }),
+})
+
+export const { useSearchGlobalQuery } = searchApiSlice

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -27,6 +27,7 @@ import { accountingApiSlice } from './api/accountingApi'
 import { settingsApiSlice } from './api/settingsApi'
 import { paymentMethodsApiSlice } from './api/paymentMethodsApi'
 import { printSettingsApiSlice } from './api/printSettingsApi'
+import { searchApiSlice } from './api/searchApi'
 import { PERSIST_KEY } from './persistKey'
 
 const rootReducer = combineReducers({
@@ -49,6 +50,7 @@ const rootReducer = combineReducers({
   [settingsApiSlice.reducerPath]: settingsApiSlice.reducer,
   [paymentMethodsApiSlice.reducerPath]: paymentMethodsApiSlice.reducer,
   [printSettingsApiSlice.reducerPath]: printSettingsApiSlice.reducer,
+  [searchApiSlice.reducerPath]: searchApiSlice.reducer,
 })
 
 // Persist configuration
@@ -102,6 +104,7 @@ export const store = configureStore({
     settingsApiSlice.middleware as any,
     paymentMethodsApiSlice.middleware as any,
     printSettingsApiSlice.middleware as any,
+    searchApiSlice.middleware as any,
   ),
   devTools: import.meta.env.MODE !== 'production',
 })

--- a/frontend/src/types/search.ts
+++ b/frontend/src/types/search.ts
@@ -1,0 +1,19 @@
+export type GlobalSearchResultType =
+  | 'page'
+  | 'customer'
+  | 'product'
+  | 'transaction'
+
+export interface GlobalSearchResultDto {
+  type: GlobalSearchResultType
+  id?: string
+  label: string
+  description?: string
+  route: string
+  score?: number
+}
+
+export interface GlobalSearchResponse {
+  query: string
+  results: GlobalSearchResultDto[]
+}


### PR DESCRIPTION
Closes #142

## Summary
- New `SearchModule` with `GET /search/global?q=abc` endpoint — fans out in parallel to pages (static), customers, products, sales orders, and purchase orders; merges and sorts by score; caps at 20 results
- `searchGlobal()` method added to `CustomerService`, `ProductService`, `SalesOrderService`, and `PurchaseOrderService` — each uses `ILIKE` matching with exact/prefix/contains scoring and excludes soft-deleted records
- Frontend: new `searchApi` RTK Query slice + `SearchModal` replacement with 250ms debounce, grouped result rendering, keyboard navigation (↑↓ Enter Esc), and wrap-around selection

## Test Plan
- [x] Backend: `cd backend && npm run test` — all tests pass including new `SearchService`, `CustomerService`, `ProductService`, `SalesOrderService`, `PurchaseOrderService` search tests
- [x] Frontend: `cd frontend && npx vitest run` — all tests pass including new `SearchModal` tests
- [x] Type check: `cd frontend && npm run type-check`
- [x] Lint: `cd backend && npm run lint && cd frontend && npm run lint`
- [x] Manual: Press Ctrl+K, type 2+ characters — grouped results appear; arrow keys navigate; Enter opens route; Esc closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)