### PR TITLE
fix(deps): patch flatted prototype pollution (GHSA-rf6f-7fwh-wjgh)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3622,9 +3622,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.0.tgz",
-      "integrity": "sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -74,6 +74,7 @@
   },
   "overrides": {
     "qs": "6.14.2",
-    "eslint-plugin-react-hooks": "7.1.0-canary-98ce535f-20260226"
+    "eslint-plugin-react-hooks": "7.1.0-canary-98ce535f-20260226",
+    "flatted": "3.4.2"
   }
 }


### PR DESCRIPTION
## Summary

- Adds `"flatted": "3.4.2"` to the `overrides` block in `frontend/package.json`
- Forces the patched version of `flatted` instead of the vulnerable `3.4.0` pulled in transitively by `@vitest/ui@4.1.0`
- Resolves high severity advisory [GHSA-rf6f-7fwh-wjgh](https://github.com/advisories/GHSA-rf6f-7fwh-wjgh) (CWE-1321 Prototype Pollution)

Closes #145

## Test plan

- [x] `npm audit` reports 0 vulnerabilities after fix
- [x] All 404 frontend tests pass
- [x] `flatted` resolves to `3.4.2` in `package-lock.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)