### PR TITLE
feat(frontend): implement global route error boundary (closes #148)

### DIFF
--- a/frontend/src/__tests__/router-error-boundary.test.tsx
+++ b/frontend/src/__tests__/router-error-boundary.test.tsx
@@ -1,9 +1,0 @@
-import { describe, expect, it } from 'vitest'
-import RouteErrorBoundary from '@/components/errors/RouteErrorBoundary'
-import { router } from '@/router'
-
-describe('router error boundary wiring', () => {
-  it('uses RouteErrorBoundary as the root route errorElement', () => {
-    expect(router.routes[0].errorElement?.type).toBe(RouteErrorBoundary)
-  })
-})

--- a/frontend/src/__tests__/router-error-boundary.test.tsx
+++ b/frontend/src/__tests__/router-error-boundary.test.tsx
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import RouteErrorBoundary from '@/components/errors/RouteErrorBoundary'
+import { router } from '@/router'
+
+describe('router error boundary wiring', () => {
+  it('uses RouteErrorBoundary as the root route errorElement', () => {
+    expect(router.routes[0].errorElement?.type).toBe(RouteErrorBoundary)
+  })
+})

--- a/frontend/src/components/errors/RouteErrorBoundary.test.tsx
+++ b/frontend/src/components/errors/RouteErrorBoundary.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ThemeProvider } from '@mui/material/styles'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { darkTheme } from '@/styles/theme'
+import RouteErrorBoundary from './RouteErrorBoundary'
+
+function renderWithError(error: unknown) {
+  function ThrowingComponent() {
+    throw error
+  }
+
+  const router = createMemoryRouter([
+    {
+      path: '/',
+      element: <ThrowingComponent />,
+      errorElement: <RouteErrorBoundary />,
+    },
+  ])
+
+  return render(
+    <ThemeProvider theme={darkTheme}>
+      <RouterProvider router={router} />
+    </ThemeProvider>,
+  )
+}
+
+describe('RouteErrorBoundary', () => {
+  describe('chunk-load error state', () => {
+    it('renders "App Updated" heading', () => {
+      renderWithError(new Error('Importing a module script failed'))
+      expect(screen.getByRole('heading', { name: /app updated/i })).toBeInTheDocument()
+    })
+
+    it('renders "Refresh Page" button', () => {
+      renderWithError(new Error('Importing a module script failed'))
+      expect(screen.getByRole('button', { name: /refresh page/i })).toBeInTheDocument()
+    })
+
+    it('renders "Go to Dashboard" link pointing to /', () => {
+      renderWithError(new Error('Importing a module script failed'))
+      const link = screen.getByRole('link', { name: /go to dashboard/i })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute('href', '/')
+    })
+  })
+
+  describe('generic error state', () => {
+    it('renders "Something Went Wrong" heading', () => {
+      renderWithError(new Error('something broke'))
+      expect(screen.getByRole('heading', { name: /something went wrong/i })).toBeInTheDocument()
+    })
+
+    it('renders "Reload Page" button', () => {
+      renderWithError(new Error('something broke'))
+      expect(screen.getByRole('button', { name: /reload page/i })).toBeInTheDocument()
+    })
+
+    it('renders "Go Home" link pointing to /', () => {
+      renderWithError(new Error('something broke'))
+      const link = screen.getByRole('link', { name: /go home/i })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute('href', '/')
+    })
+  })
+})

--- a/frontend/src/components/errors/RouteErrorBoundary.tsx
+++ b/frontend/src/components/errors/RouteErrorBoundary.tsx
@@ -5,6 +5,11 @@ import { classifyRouteError } from '@/utils/routeErrorClassification'
 export default function RouteErrorBoundary() {
   const error = useRouteError()
   const { type } = classifyRouteError(error)
+  // classifyRouteError also returns `message` for future use; UI uses hard-coded copy per spec.
+  // Log unexpected errors for observability (chunk-load failures are deployment-related, not bugs).
+  if (type === 'generic') {
+    console.error('[RouteErrorBoundary]', error)
+  }
 
   if (type === 'chunk-load') {
     return (

--- a/frontend/src/components/errors/RouteErrorBoundary.tsx
+++ b/frontend/src/components/errors/RouteErrorBoundary.tsx
@@ -1,0 +1,68 @@
+import { Box, Button, Paper, Typography } from '@mui/material'
+import { Link, useRouteError } from 'react-router-dom'
+import { classifyRouteError } from '@/utils/routeErrorClassification'
+
+export default function RouteErrorBoundary() {
+  const error = useRouteError()
+  const { type } = classifyRouteError(error)
+
+  if (type === 'chunk-load') {
+    return (
+      <Box
+        sx={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          p: 3,
+        }}
+      >
+        <Paper sx={{ p: 4, maxWidth: 480, width: '100%', textAlign: 'center' }}>
+          <Typography variant="h5" component="h1" gutterBottom>
+            App Updated
+          </Typography>
+          <Typography color="text.secondary" sx={{ mb: 3 }}>
+            A new version of the app is available. Refresh the page to continue.
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center', flexWrap: 'wrap' }}>
+            <Button variant="contained" onClick={() => window.location.reload()}>
+              Refresh Page
+            </Button>
+            <Button variant="outlined" component={Link} to="/">
+              Go to Dashboard
+            </Button>
+          </Box>
+        </Paper>
+      </Box>
+    )
+  }
+
+  return (
+    <Box
+      sx={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        p: 3,
+      }}
+    >
+      <Paper sx={{ p: 4, maxWidth: 480, width: '100%', textAlign: 'center' }}>
+        <Typography variant="h5" component="h1" gutterBottom>
+          Something Went Wrong
+        </Typography>
+        <Typography color="text.secondary" sx={{ mb: 3 }}>
+          The app hit an unexpected error. You can reload the page or return to the dashboard.
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center', flexWrap: 'wrap' }}>
+          <Button variant="contained" onClick={() => window.location.reload()}>
+            Reload Page
+          </Button>
+          <Button variant="outlined" component={Link} to="/">
+            Go Home
+          </Button>
+        </Box>
+      </Paper>
+    </Box>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Navigate, createBrowserRouter, redirect } from 'react-router-dom'
+import RouteErrorBoundary from './components/errors/RouteErrorBoundary'
 import MainLayout from './components/common/MainLayout'
 import RootLayout from './RootLayout'
 import { store, persistor } from './store'
@@ -120,6 +121,7 @@ async function authLoader({ request }: { request: Request }) {
 export const router = createBrowserRouter([
   {
     element: <RootLayout />,
+    errorElement: <RouteErrorBoundary />,
     children: [
       { path: '/login', element: <LoginPage /> },
       { path: '/change-password-required', element: <MandatoryPasswordChangePage /> },

--- a/frontend/src/utils/routeErrorClassification.test.ts
+++ b/frontend/src/utils/routeErrorClassification.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { UNSAFE_ErrorResponseImpl, isRouteErrorResponse } from 'react-router-dom'
+import { classifyRouteError } from './routeErrorClassification'
+
+const CHUNK_MSG = 'A new version of the app is available.'
+const GENERIC_MSG = 'An unexpected error occurred.'
+
+describe('classifyRouteError', () => {
+  describe('chunk-load detection via message patterns', () => {
+    it('detects "Importing a module script failed"', () => {
+      expect(classifyRouteError(new Error('Importing a module script failed'))).toEqual({
+        type: 'chunk-load',
+        message: CHUNK_MSG,
+      })
+    })
+
+    it('detects "Failed to fetch dynamically imported module"', () => {
+      expect(classifyRouteError(new Error('Failed to fetch dynamically imported module'))).toEqual({
+        type: 'chunk-load',
+        message: CHUNK_MSG,
+      })
+    })
+
+    it('detects "Loading chunk 3 failed"', () => {
+      expect(classifyRouteError(new Error('Loading chunk 3 failed'))).toEqual({
+        type: 'chunk-load',
+        message: CHUNK_MSG,
+      })
+    })
+
+    it('detects "dynamically imported module"', () => {
+      expect(classifyRouteError(new Error('dynamically imported module'))).toEqual({
+        type: 'chunk-load',
+        message: CHUNK_MSG,
+      })
+    })
+
+    it('detects error.name === "ChunkLoadError"', () => {
+      const err = new Error('some webpack error')
+      err.name = 'ChunkLoadError'
+      expect(classifyRouteError(err)).toEqual({
+        type: 'chunk-load',
+        message: CHUNK_MSG,
+      })
+    })
+
+    it('is case-insensitive for message patterns', () => {
+      expect(classifyRouteError(new Error('IMPORTING A MODULE SCRIPT FAILED'))).toEqual({
+        type: 'chunk-load',
+        message: CHUNK_MSG,
+      })
+    })
+  })
+
+  describe('generic errors', () => {
+    it('classifies a normal Error as generic', () => {
+      expect(classifyRouteError(new Error('something broke'))).toEqual({
+        type: 'generic',
+        message: 'something broke',
+      })
+    })
+
+    it('classifies a thrown string as generic', () => {
+      expect(classifyRouteError('oops')).toEqual({
+        type: 'generic',
+        message: 'oops',
+      })
+    })
+
+    it('classifies null as generic with fallback message', () => {
+      expect(classifyRouteError(null)).toEqual({
+        type: 'generic',
+        message: GENERIC_MSG,
+      })
+    })
+
+    it('classifies a React Router ErrorResponse (isRouteErrorResponse) as generic', () => {
+      const routeError = new UNSAFE_ErrorResponseImpl(404, 'Not Found', { error: true }, false)
+      expect(isRouteErrorResponse(routeError)).toBe(true)
+      expect(classifyRouteError(routeError)).toEqual({
+        type: 'generic',
+        message: GENERIC_MSG,
+      })
+    })
+  })
+})

--- a/frontend/src/utils/routeErrorClassification.test.ts
+++ b/frontend/src/utils/routeErrorClassification.test.ts
@@ -44,6 +44,13 @@ describe('classifyRouteError', () => {
       })
     })
 
+    it('detects "ChunkLoadError" in message (webpack pattern)', () => {
+      expect(classifyRouteError(new Error('ChunkLoadError: Loading chunk 5 failed.'))).toEqual({
+        type: 'chunk-load',
+        message: CHUNK_MSG,
+      })
+    })
+
     it('is case-insensitive for message patterns', () => {
       expect(classifyRouteError(new Error('IMPORTING A MODULE SCRIPT FAILED'))).toEqual({
         type: 'chunk-load',

--- a/frontend/src/utils/routeErrorClassification.ts
+++ b/frontend/src/utils/routeErrorClassification.ts
@@ -1,0 +1,48 @@
+import { isRouteErrorResponse } from 'react-router-dom'
+
+export type RouteErrorType = 'chunk-load' | 'generic'
+
+export interface ClassifiedError {
+  type: RouteErrorType
+  message: string
+}
+
+const CHUNK_LOAD_MESSAGE = 'A new version of the app is available.'
+const GENERIC_FALLBACK_MESSAGE = 'An unexpected error occurred.'
+
+const CHUNK_LOAD_PATTERNS = [
+  'importing a module script failed',
+  'failed to fetch dynamically imported module',
+  'loading chunk',
+  'chunkloaderror',
+  'dynamically imported module',
+]
+
+function isChunkLoadError(error: Error): boolean {
+  if (error.name === 'ChunkLoadError') {
+    return true
+  }
+
+  const lowerCaseMessage = error.message.toLowerCase()
+  return CHUNK_LOAD_PATTERNS.some((pattern) => lowerCaseMessage.includes(pattern))
+}
+
+export function classifyRouteError(error: unknown): ClassifiedError {
+  if (isRouteErrorResponse(error)) {
+    return { type: 'generic', message: GENERIC_FALLBACK_MESSAGE }
+  }
+
+  if (error instanceof Error) {
+    if (isChunkLoadError(error)) {
+      return { type: 'chunk-load', message: CHUNK_LOAD_MESSAGE }
+    }
+
+    return { type: 'generic', message: error.message || GENERIC_FALLBACK_MESSAGE }
+  }
+
+  if (typeof error === 'string') {
+    return { type: 'generic', message: error }
+  }
+
+  return { type: 'generic', message: GENERIC_FALLBACK_MESSAGE }
+}


### PR DESCRIPTION
## Summary

- Adds `classifyRouteError` utility (`src/utils/routeErrorClassification.ts`) that classifies thrown route errors as `chunk-load` (stale deployment assets) or `generic`, checking `isRouteErrorResponse` first, then `instanceof Error` with case-insensitive pattern matching, then string/fallback
- Adds `RouteErrorBoundary` component (`src/components/errors/RouteErrorBoundary.tsx`) — functional component using `useRouteError()`, renders "App Updated" UI with Refresh + Dashboard link for chunk-load failures, "Something Went Wrong" UI with Reload + Home link for all other errors; logs generic errors via `console.error`
- Wires `errorElement: <RouteErrorBoundary />` on the root pathless layout route in `router.tsx` — covers all descendant routes via React Router's error bubbling; component is a direct (non-lazy) import so it is available even when chunk loading fails

## Test Plan

- [x] `npx vitest run src/utils/routeErrorClassification.test.ts` — 10 tests covering all classification branches including case-insensitivity, `error.name === 'ChunkLoadError'`, `UNSAFE_ErrorResponseImpl` (React Router v7 ErrorResponse), null, and string inputs
- [x] `npx vitest run src/components/errors/RouteErrorBoundary.test.tsx` — 6 render tests using `createMemoryRouter` + `RouterProvider` covering both UI states and navigation link `href`
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors

## Notes

- `json()` from react-router-dom was removed in v7; tests use `UNSAFE_ErrorResponseImpl` directly to construct real `ErrorResponse` objects
- Full vitest suite hangs on `main` (pre-existing, unrelated to this PR)