### PR TITLE
chore(deps): update ESLint to 10.1.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erp-backend",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-backend",
-      "version": "1.17.0",
+      "version": "1.17.1",
       "license": "MIT",
       "dependencies": {
         "@nestjs/bull": "^11.0.3",
@@ -57,7 +57,7 @@
         "@typescript-eslint/eslint-plugin": "^8.46.0",
         "@typescript-eslint/parser": "^8.46.0",
         "dotenv": "^17.3.1",
-        "eslint": "10.0.3",
+        "eslint": "10.1.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.0.0",
         "jest": "^30.2.0",
@@ -5879,16 +5879,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
-      "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
+      "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.3",
-        "@eslint/config-helpers": "^0.5.2",
+        "@eslint/config-helpers": "^0.5.3",
         "@eslint/core": "^1.1.1",
         "@eslint/plugin-kit": "^0.6.1",
         "@humanfs/node": "^0.16.6",
@@ -5901,7 +5901,7 @@
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^9.1.2",
         "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.1.1",
+        "espree": "^11.2.0",
         "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -74,7 +74,7 @@
     "@typescript-eslint/eslint-plugin": "^8.46.0",
     "@typescript-eslint/parser": "^8.46.0",
     "dotenv": "^17.3.1",
-    "eslint": "10.0.3",
+    "eslint": "10.1.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.0.0",
     "jest": "^30.2.0",

--- a/docs/superpowers/plans/2026-03-22-eslint-update.md
+++ b/docs/superpowers/plans/2026-03-22-eslint-update.md
@@ -65,9 +65,9 @@ git commit -m "chore(deps): update eslint to 10.1.0 in backend"
 
 - [ ] **Step 1: Edit frontend/package.json**
 
-Make two changes in the `devDependencies` section:
-- `"eslint": "10.0.3"` → `"eslint": "10.1.0"`
-- `"@eslint/js": "10.0.1"` → `"@eslint/js": "10.1.0"`
+Change `"eslint": "10.0.3"` to `"eslint": "10.1.0"` in the `devDependencies` section.
+
+Note: `@eslint/js@10.1.0` was not published as of 2026-03-22 — leave `@eslint/js` at `10.0.1`.
 
 - [ ] **Step 2: Run npm install in frontend**
 

--- a/docs/superpowers/specs/2026-03-22-eslint-update-design.md
+++ b/docs/superpowers/specs/2026-03-22-eslint-update-design.md
@@ -13,7 +13,7 @@ Bump ESLint from `10.0.3` to `10.1.0` in both backend and frontend. Also align `
 |------|---------|------|----|
 | `backend/package.json` | `eslint` | `10.0.3` | `10.1.0` |
 | `frontend/package.json` | `eslint` | `10.0.3` | `10.1.0` |
-| `frontend/package.json` | `@eslint/js` | `10.0.1` | `10.1.0` |
+| `frontend/package.json` | `@eslint/js` | `10.0.1` | `10.0.1` (unchanged — 10.1.0 not yet published) |
 
 ## Approach
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erp-frontend",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-frontend",
-      "version": "1.17.0",
+      "version": "1.17.1",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -48,7 +48,7 @@
         "@vitejs/plugin-react": "^6.0.0",
         "@vitest/coverage-v8": "^4.0.18",
         "@vitest/ui": "^4.0.18",
-        "eslint": "10.0.3",
+        "eslint": "10.1.0",
         "eslint-plugin-react-hooks": "7.1.0-canary-98ce535f-20260226",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.3.0",
@@ -3314,16 +3314,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
-      "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
+      "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.3",
-        "@eslint/config-helpers": "^0.5.2",
+        "@eslint/config-helpers": "^0.5.3",
         "@eslint/core": "^1.1.1",
         "@eslint/plugin-kit": "^0.6.1",
         "@humanfs/node": "^0.16.6",
@@ -3336,7 +3336,7 @@
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^9.1.2",
         "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.1.1",
+        "espree": "^11.2.0",
         "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,7 +56,7 @@
     "@vitejs/plugin-react": "^6.0.0",
     "@vitest/coverage-v8": "^4.0.18",
     "@vitest/ui": "^4.0.18",
-    "eslint": "10.0.3",
+    "eslint": "10.1.0",
     "eslint-plugin-react-hooks": "7.1.0-canary-98ce535f-20260226",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.3.0",


### PR DESCRIPTION
## Summary
- Bumps `eslint` from `10.0.3` to `10.1.0` in backend and frontend
- `@eslint/js` kept at `10.0.1` in frontend (`10.1.0` not yet published)

Closes #151

## Test Plan
- [x] `cd backend && npm run lint && npm run test` — 43/43 suites, 604/604 tests passed
- [x] `cd frontend && npm run lint && npm run type-check && npm run test` — 76/76 files, 429/429 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)