### PR TITLE
feat(search): Global Search Phase 3 — ranking, recent searches, and UX polish

### DIFF
--- a/backend/src/modules/inventory/services/product.service.spec.ts
+++ b/backend/src/modules/inventory/services/product.service.spec.ts
@@ -16,10 +16,12 @@ import { StockMovementService } from './stock-movement.service';
 import { BaseCostCalculatorService } from './base-cost-calculator.service';
 import { SettingsService } from '../../settings/settings.service';
 import { AuditLogService } from '../../audit-logs/services';
+import { UserRole } from '../../../database/entities/user.entity';
 
 describe('ProductService pagination removal', () => {
   let service: ProductService;
   let productRepository: jest.Mocked<Repository<Product>>;
+  const adminUser = { role: UserRole.ADMIN } as any;
 
   const createProduct = (id: string, overrides: Partial<Product> = {}): Product =>
     ({
@@ -160,6 +162,47 @@ describe('ProductService pagination removal', () => {
       } as any);
       expect(results).toEqual([]);
     });
+
+    it('exact barcode match scores SCORE_EXACT_CODE + BOOST_PRODUCT', async () => {
+      const mockProduct = { id: 'p1', name: 'Widget', barcode: 'BC-001' };
+      productRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([mockProduct]),
+      } as any);
+
+      const results = await service.searchGlobal('BC-001', adminUser);
+
+      expect(results[0].score).toBe(126);
+    });
+
+    it('exact name match scores SCORE_EXACT_NAME + BOOST_PRODUCT', async () => {
+      const mockProduct = { id: 'p1', name: 'Widget', barcode: 'BC-999' };
+      productRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([mockProduct]),
+      } as any);
+
+      const results = await service.searchGlobal('widget', adminUser);
+
+      expect(results[0].score).toBe(101);
+    });
+
+    it('barcode exact match outranks name exact match', async () => {
+      const mockProduct = { id: 'p1', name: 'widget', barcode: 'widget' };
+      productRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([mockProduct]),
+      } as any);
+
+      const results = await service.searchGlobal('widget', adminUser);
+
+      expect(results[0].score).toBe(126);
+    });
   });
 });
-import { UserRole } from '../../../database/entities/user.entity';

--- a/backend/src/modules/inventory/services/product.service.ts
+++ b/backend/src/modules/inventory/services/product.service.ts
@@ -36,6 +36,15 @@ import {
 } from '../dto/product.dto';
 import { GlobalSearchResultDto } from '../../search/dto/global-search-result.dto';
 import { canSearchProducts } from '../../search/search.permissions';
+import {
+  SEARCH_CANDIDATE_LIMIT,
+  SCORE_EXACT_CODE,
+  SCORE_STARTSWITH_CODE,
+  SCORE_EXACT_NAME,
+  SCORE_STARTSWITH_NAME,
+  SCORE_CONTAINS,
+  BOOST_PRODUCT,
+} from '../../search/search.constants';
 import { CategoryService } from './category.service';
 import { StockMovementService } from './stock-movement.service';
 import { BaseCostCalculatorService } from './base-cost-calculator.service';
@@ -301,25 +310,23 @@ export class ProductService {
       .andWhere('(product.name ILIKE :q OR product.barcode ILIKE :q)', {
         q: `%${trimmed}%`,
       })
-      .take(5)
+      .take(SEARCH_CANDIDATE_LIMIT)
       .getMany();
 
     return products.map((product) => {
       const name = product.name?.toLowerCase() ?? '';
       const barcode = product.barcode?.toLowerCase() ?? '';
       const normalized = trimmed.toLowerCase();
-      let score = 50;
-
-      if (name === normalized) {
-        score = 100;
-      } else if (barcode === normalized) {
-        score = 90;
-      } else if (
-        name.startsWith(normalized) ||
-        barcode.startsWith(normalized)
-      ) {
-        score = 80;
-      }
+      const baseScore =
+        barcode && barcode === normalized
+          ? SCORE_EXACT_CODE
+          : barcode && barcode.startsWith(normalized)
+            ? SCORE_STARTSWITH_CODE
+            : name === normalized
+              ? SCORE_EXACT_NAME
+              : name.startsWith(normalized)
+                ? SCORE_STARTSWITH_NAME
+                : SCORE_CONTAINS;
 
       return {
         type: 'product',
@@ -327,7 +334,7 @@ export class ProductService {
         label: product.name,
         description: product.barcode,
         route: `/inventory/products/${product.id}/edit`,
-        score,
+        score: baseScore + BOOST_PRODUCT,
       };
     });
   }

--- a/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
@@ -35,6 +35,7 @@ describe('PurchaseOrderService', () => {
   let stockMovementService: jest.Mocked<StockMovementService>;
   let vendorPaymentService: jest.Mocked<VendorPaymentService>;
   let grnService: jest.Mocked<GoodsReceivedNoteService>;
+  const adminUser = { role: UserRole.ADMIN } as any;
 
   const mockPurchaseOrder = {
     id: 'po-1',
@@ -110,6 +111,7 @@ describe('PurchaseOrderService', () => {
             update: jest.fn(),
             save: jest.fn(),
             remove: jest.fn(),
+            createQueryBuilder: jest.fn(),
           },
         },
         {
@@ -234,6 +236,20 @@ describe('PurchaseOrderService', () => {
   });
 
   describe('searchGlobal', () => {
+    function mockPOQuery(order: {
+      id: string;
+      orderNumber: string;
+      supplier: { companyName: string };
+    }) {
+      purchaseOrderRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([order]),
+      } as any);
+    }
+
     it('returns matching purchase orders as GlobalSearchResultDto', async () => {
       const order = {
         id: 'po-uuid-1',
@@ -261,6 +277,42 @@ describe('PurchaseOrderService', () => {
         description: 'Acme Supplies',
         route: '/purchasing/orders/po-uuid-1/edit',
       });
+    });
+
+    it('exact orderNumber match scores SCORE_EXACT_CODE + BOOST_TRANSACTION', async () => {
+      mockPOQuery({
+        id: 'po1',
+        orderNumber: 'PO-001',
+        supplier: { companyName: 'Vendor' },
+      });
+
+      const results = await service.searchGlobal('PO-001', adminUser);
+
+      expect(results[0].score).toBe(130);
+    });
+
+    it('orderNumber startsWith scores SCORE_STARTSWITH_CODE + BOOST_TRANSACTION', async () => {
+      mockPOQuery({
+        id: 'po1',
+        orderNumber: 'PO-001',
+        supplier: { companyName: 'Vendor' },
+      });
+
+      const results = await service.searchGlobal('PO-', adminUser);
+
+      expect(results[0].score).toBe(110);
+    });
+
+    it('contains match scores SCORE_CONTAINS + BOOST_TRANSACTION', async () => {
+      mockPOQuery({
+        id: 'po1',
+        orderNumber: 'PO-001',
+        supplier: { companyName: 'Global Vendor' },
+      });
+
+      const results = await service.searchGlobal('Vendor', adminUser);
+
+      expect(results[0].score).toBe(70);
     });
   });
 

--- a/backend/src/modules/purchasing/services/purchase-order.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.ts
@@ -19,6 +19,13 @@ import {
 } from '../dto';
 import { GlobalSearchResultDto } from '../../search/dto/global-search-result.dto';
 import { canSearchPurchaseOrders } from '../../search/search.permissions';
+import {
+  SEARCH_CANDIDATE_LIMIT,
+  SCORE_EXACT_CODE,
+  SCORE_STARTSWITH_CODE,
+  SCORE_CONTAINS,
+  BOOST_TRANSACTION,
+} from '../../search/search.constants';
 import { SupplierService } from './supplier.service';
 import { GoodsReceivedNoteService } from './goods-received-note.service';
 import { VendorPaymentService } from './vendor-payment.service';
@@ -344,19 +351,18 @@ export class PurchaseOrderService {
       .andWhere('(order.orderNumber ILIKE :q OR supplier.companyName ILIKE :q)', {
         q: `%${trimmed}%`,
       })
-      .take(5)
+      .take(SEARCH_CANDIDATE_LIMIT)
       .getMany();
 
     return orders.map((order) => {
       const orderNumber = order.orderNumber?.toLowerCase() ?? '';
       const normalized = trimmed.toLowerCase();
-      let score = 50;
-
-      if (orderNumber === normalized) {
-        score = 90;
-      } else if (orderNumber.startsWith(normalized)) {
-        score = 80;
-      }
+      const baseScore =
+        orderNumber === normalized
+          ? SCORE_EXACT_CODE
+          : orderNumber.startsWith(normalized)
+            ? SCORE_STARTSWITH_CODE
+            : SCORE_CONTAINS;
 
       return {
         type: 'transaction',
@@ -364,7 +370,7 @@ export class PurchaseOrderService {
         label: order.orderNumber,
         description: order.supplier?.companyName ?? '',
         route: `/purchasing/orders/${order.id}/edit`,
-        score,
+        score: baseScore + BOOST_TRANSACTION,
       };
     });
   }

--- a/backend/src/modules/sales/services/customer.service.spec.ts
+++ b/backend/src/modules/sales/services/customer.service.spec.ts
@@ -7,10 +7,12 @@ import { SalesOrder } from '../../../database/entities/sales-order.entity';
 import { Invoice } from '../../../database/entities/invoice.entity';
 import { AuditLogService } from '../../audit-logs/services';
 import { TransactionManager } from '../../../common/utils/transaction.util';
+import { UserRole } from '../../../database/entities/user.entity';
 
 describe('CustomerService', () => {
   let service: CustomerService;
   let customerRepository: jest.Mocked<Repository<Customer>>;
+  const adminUser = { role: UserRole.ADMIN } as any;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -91,6 +93,54 @@ describe('CustomerService', () => {
       } as any);
       expect(results).toEqual([]);
     });
+
+    it('exact phone match scores SCORE_EXACT_CODE + BOOST_CUSTOMER', async () => {
+      const mockCustomer = {
+        id: 'c1',
+        name: 'Acme Corp',
+        phone: '0123456789',
+      };
+
+      customerRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([mockCustomer]),
+      } as any);
+
+      const results = await service.searchGlobal('0123456789', adminUser);
+
+      expect(results[0].score).toBe(128);
+    });
+
+    it('exact name match scores SCORE_EXACT_NAME + BOOST_CUSTOMER', async () => {
+      const mockCustomer = { id: 'c1', name: 'acme corp', phone: null };
+
+      customerRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([mockCustomer]),
+      } as any);
+
+      const results = await service.searchGlobal('acme corp', adminUser);
+
+      expect(results[0].score).toBe(103);
+    });
+
+    it('phone exact match outranks name exact match', async () => {
+      const mockCustomer = { id: 'c1', name: 'acme corp', phone: 'acme corp' };
+
+      customerRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([mockCustomer]),
+      } as any);
+
+      const results = await service.searchGlobal('acme corp', adminUser);
+
+      expect(results[0].score).toBe(128);
+    });
   });
 });
-import { UserRole } from '../../../database/entities/user.entity';

--- a/backend/src/modules/sales/services/customer.service.ts
+++ b/backend/src/modules/sales/services/customer.service.ts
@@ -18,6 +18,15 @@ import {
 } from '../dto/customer.dto';
 import { GlobalSearchResultDto } from '../../search/dto/global-search-result.dto';
 import { canSearchCustomers } from '../../search/search.permissions';
+import {
+  SEARCH_CANDIDATE_LIMIT,
+  SCORE_EXACT_CODE,
+  SCORE_STARTSWITH_CODE,
+  SCORE_EXACT_NAME,
+  SCORE_STARTSWITH_NAME,
+  SCORE_CONTAINS,
+  BOOST_CUSTOMER,
+} from '../../search/search.constants';
 import { ValidationUtil, BulkOperationUtil, BulkOperationResponse } from '../../../common/utils/validation.util';
 import { TransactionManager, Transactional } from '../../../common/utils/transaction.util';
 import { AuditLogService } from '../../audit-logs/services';
@@ -140,22 +149,23 @@ export class CustomerService {
         '(customer.name ILIKE :q OR customer.phone ILIKE :q)',
         { q: `%${trimmed}%` },
       )
-      .take(5)
+      .take(SEARCH_CANDIDATE_LIMIT)
       .getMany();
 
     return customers.map((customer) => {
       const name = customer.name?.toLowerCase() ?? '';
       const phone = customer.phone?.toLowerCase() ?? '';
       const normalized = trimmed.toLowerCase();
-      let score = 50;
-
-      if (name === normalized) {
-        score = 100;
-      } else if (phone === normalized) {
-        score = 90;
-      } else if (name.startsWith(normalized) || phone.startsWith(normalized)) {
-        score = 80;
-      }
+      const baseScore =
+        phone && phone === normalized
+          ? SCORE_EXACT_CODE
+          : phone && phone.startsWith(normalized)
+            ? SCORE_STARTSWITH_CODE
+            : name === normalized
+              ? SCORE_EXACT_NAME
+              : name.startsWith(normalized)
+                ? SCORE_STARTSWITH_NAME
+                : SCORE_CONTAINS;
 
       return {
         type: 'customer',
@@ -163,7 +173,7 @@ export class CustomerService {
         label: customer.name,
         description: customer.phone,
         route: `/sales/customers/${customer.id}`,
-        score,
+        score: baseScore + BOOST_CUSTOMER,
       };
     });
   }

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -33,6 +33,7 @@ describe('SalesOrderService', () => {
   let settingsService: jest.Mocked<SettingsService>;
   let auditLogService: jest.Mocked<AuditLogService>;
   let dataSource: jest.Mocked<DataSource>;
+  const adminUser = { role: UserRole.ADMIN } as any;
 
   const createMockSalesOrder = (): Partial<SalesOrder> => ({
     id: '123e4567-e89b-12d3-a456-426614174000',
@@ -178,6 +179,20 @@ describe('SalesOrderService', () => {
   });
 
   describe('searchGlobal', () => {
+    function mockSOQuery(order: {
+      id: string;
+      orderNumber: string;
+      customer: { name: string };
+    }) {
+      salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([order]),
+      } as any);
+    }
+
     it('returns matching sales orders as GlobalSearchResultDto', async () => {
       const order = {
         id: 'so-uuid-1',
@@ -205,6 +220,42 @@ describe('SalesOrderService', () => {
         description: 'ABC Trading',
         route: '/sales/orders/so-uuid-1/edit',
       });
+    });
+
+    it('exact orderNumber match scores SCORE_EXACT_CODE + BOOST_TRANSACTION', async () => {
+      mockSOQuery({
+        id: 'so1',
+        orderNumber: 'SO-001',
+        customer: { name: 'Acme' },
+      });
+
+      const results = await service.searchGlobal('SO-001', adminUser);
+
+      expect(results[0].score).toBe(130);
+    });
+
+    it('orderNumber startsWith scores SCORE_STARTSWITH_CODE + BOOST_TRANSACTION', async () => {
+      mockSOQuery({
+        id: 'so1',
+        orderNumber: 'SO-001',
+        customer: { name: 'Acme' },
+      });
+
+      const results = await service.searchGlobal('SO-', adminUser);
+
+      expect(results[0].score).toBe(110);
+    });
+
+    it('contains match scores SCORE_CONTAINS + BOOST_TRANSACTION', async () => {
+      mockSOQuery({
+        id: 'so1',
+        orderNumber: 'SO-001',
+        customer: { name: 'Acme Corp' },
+      });
+
+      const results = await service.searchGlobal('Acme', adminUser);
+
+      expect(results[0].score).toBe(70);
     });
   });
 

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -23,6 +23,13 @@ import {
 } from '../dto/sales-order.dto';
 import { GlobalSearchResultDto } from '../../search/dto/global-search-result.dto';
 import { canSearchSalesOrders } from '../../search/search.permissions';
+import {
+  SEARCH_CANDIDATE_LIMIT,
+  SCORE_EXACT_CODE,
+  SCORE_STARTSWITH_CODE,
+  SCORE_CONTAINS,
+  BOOST_TRANSACTION,
+} from '../../search/search.constants';
 // import { CustomerService } from './customer.service';
 import { InventoryIntegrationService } from './inventory-integration.service';
 import { ValidationUtil, BulkOperationUtil, BulkOperationResponse } from '../../../common/utils/validation.util';
@@ -364,19 +371,18 @@ export class SalesOrderService {
       .andWhere('(order.orderNumber ILIKE :q OR customer.name ILIKE :q)', {
         q: `%${trimmed}%`,
       })
-      .take(5)
+      .take(SEARCH_CANDIDATE_LIMIT)
       .getMany();
 
     return orders.map((order) => {
       const orderNumber = order.orderNumber?.toLowerCase() ?? '';
       const normalized = trimmed.toLowerCase();
-      let score = 50;
-
-      if (orderNumber === normalized) {
-        score = 90;
-      } else if (orderNumber.startsWith(normalized)) {
-        score = 80;
-      }
+      const baseScore =
+        orderNumber === normalized
+          ? SCORE_EXACT_CODE
+          : orderNumber.startsWith(normalized)
+            ? SCORE_STARTSWITH_CODE
+            : SCORE_CONTAINS;
 
       return {
         type: 'transaction',
@@ -384,7 +390,7 @@ export class SalesOrderService {
         label: order.orderNumber,
         description: order.customer?.name ?? '',
         route: `/sales/orders/${order.id}/edit`,
-        score,
+        score: baseScore + BOOST_TRANSACTION,
       };
     });
   }

--- a/backend/src/modules/search/search.constants.ts
+++ b/backend/src/modules/search/search.constants.ts
@@ -1,0 +1,23 @@
+/** Maximum number of candidates fetched per entity source before merge */
+export const SEARCH_CANDIDATE_LIMIT = 10;
+
+/** Maximum number of results returned in the final response */
+export const SEARCH_RESPONSE_LIMIT = 20;
+
+// Base match scores - applied before entity boost
+export const SCORE_EXACT_CODE = 120;
+export const SCORE_STARTSWITH_CODE = 100;
+export const SCORE_EXACT_NAME = 95;
+export const SCORE_STARTSWITH_NAME = 85;
+export const SCORE_CONTAINS = 60;
+
+// Page-specific scores (static, in-memory - no DB query)
+export const SCORE_PAGE_EXACT = 90;
+export const SCORE_PAGE_STARTSWITH = 75;
+export const SCORE_PAGE_KEYWORD = 50;
+
+// Entity type boosts - added after base score to break cross-entity ties
+export const BOOST_TRANSACTION = 10;
+export const BOOST_CUSTOMER = 8;
+export const BOOST_PRODUCT = 6;
+export const BOOST_PAGE = 2;

--- a/backend/src/modules/search/search.service.spec.ts
+++ b/backend/src/modules/search/search.service.spec.ts
@@ -90,6 +90,22 @@ describe('SearchService', () => {
     expect(result.results[1].score).toBe(50);
   });
 
+  it('breaks score ties with case-insensitive label ascending order', async () => {
+    (customerService.searchGlobal as jest.Mock).mockResolvedValue([
+      { type: 'customer', id: 'a', label: 'Zebra Corp', route: '/customers/a', score: 80 },
+      { type: 'customer', id: 'b', label: 'apple inc', route: '/customers/b', score: 80 },
+      { type: 'customer', id: 'c', label: 'Mango Ltd', route: '/customers/c', score: 80 },
+    ]);
+
+    const result = await service.search('corp', mockUser);
+
+    expect(result.results.map((r) => r.label)).toEqual([
+      'apple inc',
+      'Mango Ltd',
+      'Zebra Corp',
+    ]);
+  });
+
   it('treats undefined score as 0 when sorting', async () => {
     const noScore: GlobalSearchResultDto = {
       type: 'page',

--- a/backend/src/modules/search/search.service.spec.ts
+++ b/backend/src/modules/search/search.service.spec.ts
@@ -145,6 +145,29 @@ describe('SearchService', () => {
     expect(result.results[0].label).toBe('Widget');
   });
 
+  describe('searchPages scoring', () => {
+    it('scores an exact page label match as SCORE_PAGE_EXACT + BOOST_PAGE (92)', async () => {
+      // "Dashboard" is an exact match for query "dashboard"
+      const result = await service.search('dashboard', { role: UserRole.ADMIN } as any);
+      const dashPage = result.results.find((r) => r.route === '/dashboard');
+      expect(dashPage?.score).toBe(92); // SCORE_PAGE_EXACT(90) + BOOST_PAGE(2)
+    });
+
+    it('scores a page starts-with match as SCORE_PAGE_STARTSWITH + BOOST_PAGE (77)', async () => {
+      // "Invoices" starts with "inv"
+      const result = await service.search('inv', { role: UserRole.ADMIN } as any);
+      const invoicesPage = result.results.find((r) => r.route === '/sales/invoices');
+      expect(invoicesPage?.score).toBe(77); // SCORE_PAGE_STARTSWITH(75) + BOOST_PAGE(2)
+    });
+
+    it('scores a keyword-only match as SCORE_PAGE_KEYWORD + BOOST_PAGE (52)', async () => {
+      // "Customers" has keyword "clients" — searching "clients" is a keyword match, not label match
+      const result = await service.search('clients', { role: UserRole.ADMIN } as any);
+      const customersPage = result.results.find((r) => r.route === '/sales/customers');
+      expect(customersPage?.score).toBe(52); // SCORE_PAGE_KEYWORD(50) + BOOST_PAGE(2)
+    });
+  });
+
   describe('searchPages role filtering', () => {
     it('returns Dashboard for all roles', async () => {
       for (const role of Object.values(UserRole)) {

--- a/backend/src/modules/search/search.service.ts
+++ b/backend/src/modules/search/search.service.ts
@@ -14,6 +14,13 @@ import {
   FINANCE_ROLES,
   ADMIN_ONLY,
 } from './search.permissions';
+import {
+  SEARCH_RESPONSE_LIMIT,
+  SCORE_PAGE_EXACT,
+  SCORE_PAGE_STARTSWITH,
+  SCORE_PAGE_KEYWORD,
+  BOOST_PAGE,
+} from './search.constants';
 
 const STATIC_PAGES: Array<{
   label: string;
@@ -402,8 +409,15 @@ export class SearchService {
       ...salesOrders,
       ...purchaseOrders,
     ]
-      .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
-      .slice(0, 20);
+      .sort((a, b) => {
+        const scoreDiff = (b.score ?? 0) - (a.score ?? 0);
+        if (scoreDiff !== 0) return scoreDiff;
+
+        return (a.label ?? '')
+          .toLowerCase()
+          .localeCompare((b.label ?? '').toLowerCase());
+      })
+      .slice(0, SEARCH_RESPONSE_LIMIT);
 
     return { query, results };
   }
@@ -439,10 +453,10 @@ export class SearchService {
         route: page.route,
         score:
           page.label.toLowerCase() === q
-            ? 90
+            ? SCORE_PAGE_EXACT + BOOST_PAGE
             : page.label.toLowerCase().startsWith(q)
-              ? 75
-              : 50,
+              ? SCORE_PAGE_STARTSWITH + BOOST_PAGE
+              : SCORE_PAGE_KEYWORD + BOOST_PAGE,
       }));
   }
 }

--- a/frontend/src/components/common/SearchModal.tsx
+++ b/frontend/src/components/common/SearchModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import HistoryIcon from '@mui/icons-material/History'
 import SearchIcon from '@mui/icons-material/Search'
 import {
   Box,
@@ -10,11 +11,19 @@ import {
 } from '@mui/material'
 import { useNavigate } from 'react-router-dom'
 
+import { useAppSelector } from '@/hooks/useRedux'
 import { useSearchGlobalQuery } from '@/store/api/searchApi'
+import { selectCurrentUser } from '@/store/slices/authSlice'
 import type {
   GlobalSearchResultDto,
   GlobalSearchResultType,
 } from '@/types/search'
+import {
+  addRecentSearch,
+  getRecentSearches,
+  type RecentSearchItem,
+} from '@/utils/recentSearch'
+import { highlightText } from '@/utils/highlightText'
 
 interface SearchModalProps {
   open: boolean
@@ -42,6 +51,13 @@ const TYPE_BADGES: Record<GlobalSearchResultType, string> = {
   transaction: 'Transaction',
 }
 
+type NavigableItem = {
+  label: string
+  description?: string
+  route: string
+  type: GlobalSearchResultType
+}
+
 function useDebounce(value: string, delay: number) {
   const [debouncedValue, setDebouncedValue] = useState(value)
 
@@ -59,14 +75,19 @@ function useDebounce(value: string, delay: number) {
 export default function SearchModal({ open, onClose }: SearchModalProps) {
   const navigate = useNavigate()
   const inputRef = useRef<HTMLInputElement>(null)
+  const currentUser = useAppSelector(selectCurrentUser)
+  const userId = currentUser?.id ?? ''
   const [query, setQuery] = useState('')
   const [selectedIndex, setSelectedIndex] = useState(0)
+  const [recentSearches, setRecentSearches] = useState<RecentSearchItem[]>([])
   const debouncedQuery = useDebounce(query, 250)
   const trimmedQuery = debouncedQuery.trim()
+  const isEmptyQuery = trimmedQuery.length === 0
+  const isActiveQuery = trimmedQuery.length >= 2
 
   const { data, isLoading, isFetching, isError } = useSearchGlobalQuery(
     { q: trimmedQuery },
-    { skip: trimmedQuery.length < 2 },
+    { skip: !isActiveQuery },
   )
 
   useEffect(() => {
@@ -100,18 +121,32 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
   }, [open])
 
   useEffect(() => {
+    if (open && userId) {
+      setRecentSearches(getRecentSearches(userId))
+    }
+  }, [open, userId])
+
+  useEffect(() => {
     setSelectedIndex(0)
   }, [data])
 
-  const flatResults = useMemo(
-    () =>
-      data
-        ? GROUP_ORDER.flatMap((type) =>
-            data.results.filter((result) => result.type === type),
-          )
-        : [],
-    [data],
-  )
+  useEffect(() => {
+    setSelectedIndex(0)
+  }, [isEmptyQuery])
+
+  const flatResults = useMemo((): NavigableItem[] => {
+    if (isEmptyQuery) {
+      return recentSearches
+    }
+
+    if (!isActiveQuery || !data) {
+      return []
+    }
+
+    return GROUP_ORDER.flatMap((type) =>
+      data.results.filter((result) => result.type === type),
+    )
+  }, [data, isActiveQuery, isEmptyQuery, recentSearches])
 
   const groups = useMemo(() => {
     let offset = 0
@@ -135,8 +170,26 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
     onClose()
   }
 
-  const navigateTo = (route: string) => {
-    navigate(route)
+  const handleSelect = (item: NavigableItem) => {
+    if (userId) {
+      addRecentSearch(userId, {
+        label: item.label,
+        description: item.description,
+        route: item.route,
+        type: item.type,
+      })
+
+      const stored = getRecentSearches(userId)
+      if (stored.some((entry) => entry.route === item.route)) {
+        setRecentSearches(stored)
+      } else {
+        setRecentSearches((current) =>
+          [{ ...item, timestamp: Date.now() }, ...current.filter((entry) => entry.route !== item.route)].slice(0, 8),
+        )
+      }
+    }
+
+    navigate(item.route)
     handleClose()
   }
 
@@ -163,15 +216,16 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
 
     if (event.key === 'Enter' && flatResults[selectedIndex]) {
       event.preventDefault()
-      navigateTo(flatResults[selectedIndex].route)
+      handleSelect(flatResults[selectedIndex])
     }
   }
 
-  const hasActiveQuery = trimmedQuery.length >= 2
-  const showHelp = !hasActiveQuery
-  const showLoading = hasActiveQuery && (isLoading || isFetching) && !data
-  const showError = hasActiveQuery && isError && !showLoading
-  const showEmpty = hasActiveQuery && !showLoading && !showError && !!data && flatResults.length === 0
+  const showHelp = !isEmptyQuery && !isActiveQuery
+  const showRecent = isEmptyQuery
+  const showLive = isActiveQuery
+  const showLoading = showLive && (isLoading || isFetching) && !data
+  const showError = showLive && isError && !showLoading
+  const showEmpty = showLive && !showLoading && !showError && !!data && flatResults.length === 0
 
   return (
     <Modal open={open} onClose={handleClose} aria-label="Global search">
@@ -235,6 +289,44 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
             </Typography>
           )}
 
+          {showRecent && recentSearches.length === 0 && (
+            <Typography
+              variant="body2"
+              sx={{ color: '#A0A0A0', textAlign: 'center', px: 3, py: 4 }}
+            >
+              Start typing to search
+            </Typography>
+          )}
+
+          {showRecent && recentSearches.length > 0 && (
+            <Box>
+              <Typography
+                variant="caption"
+                sx={{
+                  display: 'block',
+                  px: 2,
+                  py: 1,
+                  color: '#6B7280',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.08em',
+                }}
+              >
+                Recent
+              </Typography>
+              {recentSearches.map((item, idx) => (
+                <SearchResultRow
+                  key={`recent-${item.route}`}
+                  item={item}
+                  isSelected={idx === selectedIndex}
+                  onClick={() => handleSelect(item)}
+                  onHover={() => setSelectedIndex(idx)}
+                  query=""
+                  isRecent={true}
+                />
+              ))}
+            </Box>
+          )}
+
           {showLoading && (
             <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
               <CircularProgress />
@@ -251,15 +343,20 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
           )}
 
           {showEmpty && (
-            <Typography
-              variant="body2"
-              sx={{ color: '#A0A0A0', textAlign: 'center', px: 3, py: 4 }}
-            >
-              No results for "{data?.query}"
-            </Typography>
+            <Box sx={{ textAlign: 'center', px: 3, py: 4 }}>
+              <Typography variant="body2" sx={{ color: '#A0A0A0' }}>
+                No results for "{trimmedQuery}"
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{ color: '#6B7280', mt: 0.5, display: 'block' }}
+              >
+                Try searching by name, code, SKU, or order number
+              </Typography>
+            </Box>
           )}
 
-          {hasActiveQuery && groups.map((group) => (
+          {showLive && groups.map((group) => (
             <Box key={group.type}>
               <Typography
                 variant="caption"
@@ -280,11 +377,12 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
 
                 return (
                   <SearchResultRow
-                    key={`${item.type}-${item.id ?? item.route}`}
+                    key={`${item.type}-${item.route}`}
                     item={item}
                     isSelected={isSelected}
-                    onClick={() => navigateTo(item.route)}
+                    onClick={() => handleSelect(item)}
                     onHover={() => setSelectedIndex(flatIndex)}
+                    query={trimmedQuery}
                   />
                 )
               })}
@@ -297,10 +395,12 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
 }
 
 interface SearchResultRowProps {
-  item: GlobalSearchResultDto
+  item: NavigableItem
   isSelected: boolean
   onClick: () => void
   onHover: () => void
+  query: string
+  isRecent?: boolean
 }
 
 function SearchResultRow({
@@ -308,6 +408,8 @@ function SearchResultRow({
   isSelected,
   onClick,
   onHover,
+  query,
+  isRecent = false,
 }: SearchResultRowProps) {
   return (
     <Box
@@ -316,7 +418,6 @@ function SearchResultRow({
       sx={{
         display: 'flex',
         alignItems: 'center',
-        justifyContent: 'space-between',
         gap: 2,
         px: 2,
         py: 1.25,
@@ -327,33 +428,39 @@ function SearchResultRow({
         },
       }}
     >
-      <Box sx={{ minWidth: 0 }}>
+      {isRecent && (
+        <HistoryIcon sx={{ color: '#6B7280', fontSize: 16, flexShrink: 0 }} />
+      )}
+
+      <Box sx={{ minWidth: 0, flex: 1 }}>
         <Typography sx={{ color: '#E0E0E0', fontWeight: 600 }}>
-          {item.label}
+          {highlightText(item.label, query)}
         </Typography>
         {item.description && (
           <Typography
             variant="caption"
             sx={{ color: '#A0A0A0', display: 'block', mt: 0.25 }}
           >
-            {item.description}
+            {highlightText(item.description, query, 600)}
           </Typography>
         )}
       </Box>
 
-      <Typography
-        variant="caption"
-        sx={{
-          color: '#6B7280',
-          bgcolor: 'rgba(255, 255, 255, 0.05)',
-          borderRadius: '999px',
-          px: 1,
-          py: 0.5,
-          flexShrink: 0,
-        }}
-      >
-        {TYPE_BADGES[item.type]}
-      </Typography>
+      {!isRecent && (
+        <Typography
+          variant="caption"
+          sx={{
+            color: '#6B7280',
+            bgcolor: 'rgba(255, 255, 255, 0.05)',
+            borderRadius: '999px',
+            px: 1,
+            py: 0.5,
+            flexShrink: 0,
+          }}
+        >
+          {TYPE_BADGES[item.type]}
+        </Typography>
+      )}
     </Box>
   )
 }

--- a/frontend/src/components/common/__tests__/SearchModal.test.tsx
+++ b/frontend/src/components/common/__tests__/SearchModal.test.tsx
@@ -35,6 +35,14 @@ vi.mock('react-router-dom', async (importOriginal) => {
   }
 })
 
+vi.mock('@/hooks/useRedux', () => ({
+  useAppSelector: vi.fn().mockReturnValue({ id: 'user-1' }),
+}))
+
+vi.mock('@/store/slices/authSlice', () => ({
+  selectCurrentUser: (state: unknown) => state,
+}))
+
 function renderModal(open = true) {
   const onClose = vi.fn()
   const store = makeStore()
@@ -48,6 +56,10 @@ function renderModal(open = true) {
   )
 
   return { onClose }
+}
+
+function setLocalRecents(userId: string, items: object[]) {
+  localStorage.setItem(`global_search_recent_${userId}`, JSON.stringify(items))
 }
 
 // Helper: type into input and advance debounce timer
@@ -69,6 +81,7 @@ describe('SearchModal', () => {
   })
 
   afterEach(() => {
+    localStorage.clear()
     vi.useRealTimers()
   })
 
@@ -78,8 +91,9 @@ describe('SearchModal', () => {
     expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument()
   })
 
-  it('shows help text when query is shorter than 2 characters', () => {
+  it('shows help text when query is 1 character long', () => {
     renderModal()
+    typeAndFlush('a')
 
     expect(
       screen.getByText(/type at least 2 characters/i),
@@ -154,8 +168,12 @@ describe('SearchModal', () => {
 
     expect(screen.getByText('Pages')).toBeInTheDocument()
     expect(screen.getAllByText('Customers').length).toBeGreaterThan(0)
-    expect(screen.getByText('ABC Trading')).toBeInTheDocument()
-    expect(screen.getByText('ABC Widget')).toBeInTheDocument()
+    expect(
+      screen.getByText((_, element) => element?.textContent === 'ABC Trading'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText((_, element) => element?.textContent === 'ABC Widget'),
+    ).toBeInTheDocument()
   })
 
   it('shows no-results message when results are empty', () => {
@@ -170,6 +188,60 @@ describe('SearchModal', () => {
     typeAndFlush('zzz')
 
     expect(screen.getByText(/no results/i)).toBeInTheDocument()
+  })
+
+  it('shows recent searches when query is empty and recents exist', () => {
+    setLocalRecents('user-1', [
+      {
+        label: 'ABC Trading',
+        description: '01234',
+        route: '/sales/customers/1',
+        type: 'customer',
+        timestamp: Date.now(),
+      },
+    ])
+
+    renderModal()
+
+    expect(screen.getByText('Recent')).toBeInTheDocument()
+    expect(screen.getByText('ABC Trading')).toBeInTheDocument()
+  })
+
+  it('shows start-typing hint when query is empty and no recents', () => {
+    renderModal()
+
+    expect(screen.getByText(/start typing to search/i)).toBeInTheDocument()
+  })
+
+  it('replaces recent section with live results when user types', () => {
+    setLocalRecents('user-1', [
+      {
+        label: 'Old Result',
+        route: '/old',
+        type: 'page',
+        timestamp: Date.now(),
+      },
+    ])
+    mockUseSearchGlobal.mockReturnValue({
+      data: {
+        query: 'abc',
+        results: [
+          { type: 'customer', id: '1', label: 'ABC Corp', route: '/customers/1' },
+        ],
+      },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    })
+
+    renderModal()
+    typeAndFlush('ab')
+
+    expect(screen.queryByText('Recent')).not.toBeInTheDocument()
+    expect(
+      screen.getAllByText((_, element) => element?.textContent === 'ABC Corp')
+        .length,
+    ).toBeGreaterThan(0)
   })
 
   it('navigates and closes when Enter is pressed on selected result', () => {
@@ -199,6 +271,30 @@ describe('SearchModal', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
+  it('saves to recent searches on result selection', () => {
+    mockUseSearchGlobal.mockReturnValue({
+      data: {
+        query: 'abc',
+        results: [
+          { type: 'customer', id: '1', label: 'ABC Corp', route: '/customers/1' },
+        ],
+      },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    })
+
+    renderModal()
+    typeAndFlush('abc')
+    const input = screen.getByPlaceholderText(/search/i)
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    const stored = JSON.parse(
+      localStorage.getItem('global_search_recent_user-1') ?? '[]',
+    )
+    expect(stored[0].route).toBe('/customers/1')
+  })
+
   it('shows error message when query fails', () => {
     mockUseSearchGlobal.mockReturnValue({
       data: undefined,
@@ -211,6 +307,21 @@ describe('SearchModal', () => {
     typeAndFlush('abc')
 
     expect(screen.getByText(/search unavailable/i)).toBeInTheDocument()
+  })
+
+  it('shows improved empty state with two lines', () => {
+    mockUseSearchGlobal.mockReturnValue({
+      data: { query: 'zzz', results: [] },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    })
+
+    renderModal()
+    typeAndFlush('zzz')
+
+    expect(screen.getByText(/no results for/i)).toBeInTheDocument()
+    expect(screen.getByText(/try searching by name/i)).toBeInTheDocument()
   })
 
   it('skips the query when typing fewer than 2 characters', () => {

--- a/frontend/src/utils/highlightText.test.tsx
+++ b/frontend/src/utils/highlightText.test.tsx
@@ -47,10 +47,6 @@ describe('highlightText', () => {
 
   it('handles regex special characters safely with dots', () => {
     expect(() => renderHighlight('file.txt', '.')).not.toThrow()
-    renderHighlight('file.txt', '.')
-
-    const dots = screen.queryAllByText('.')
-    expect(dots.length).toBeGreaterThanOrEqual(0)
   })
 
   it('handles regex special characters safely with brackets', () => {

--- a/frontend/src/utils/highlightText.test.tsx
+++ b/frontend/src/utils/highlightText.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { highlightText } from './highlightText'
+
+function renderHighlight(text: string, query: string) {
+  render(<>{highlightText(text, query)}</>)
+}
+
+describe('highlightText', () => {
+  it('returns the original string when query is empty', () => {
+    const result = highlightText('Hello World', '')
+
+    expect(result).toBe('Hello World')
+  })
+
+  it('returns the original string when query is whitespace only', () => {
+    const result = highlightText('Hello World', '   ')
+
+    expect(result).toBe('Hello World')
+  })
+
+  it('returns the original string when there is no match', () => {
+    const result = highlightText('Hello World', 'xyz')
+
+    expect(result).toBe('Hello World')
+  })
+
+  it('highlights first occurrence, case-insensitive', () => {
+    renderHighlight('ABC Trading Sdn Bhd', 'abc')
+
+    const bold = screen.getByText('ABC')
+    expect(bold.tagName).toBe('SPAN')
+  })
+
+  it('matches regardless of case', () => {
+    renderHighlight('hello world', 'HELLO')
+
+    expect(screen.getByText('hello')).toBeInTheDocument()
+  })
+
+  it('only highlights first occurrence', () => {
+    renderHighlight('abc and abc', 'abc')
+
+    const spans = document.querySelectorAll('span')
+    expect(spans).toHaveLength(1)
+  })
+
+  it('handles regex special characters safely with dots', () => {
+    expect(() => renderHighlight('file.txt', '.')).not.toThrow()
+    renderHighlight('file.txt', '.')
+
+    const dots = screen.queryAllByText('.')
+    expect(dots.length).toBeGreaterThanOrEqual(0)
+  })
+
+  it('handles regex special characters safely with brackets', () => {
+    expect(() => renderHighlight('Item [A]', '[A]')).not.toThrow()
+  })
+
+  it('trims query before matching', () => {
+    renderHighlight('ABC Trading', '  ABC  ')
+
+    expect(screen.getByText('ABC')).toBeInTheDocument()
+  })
+
+  it('returns string on no-match so callers can treat it as ReactNode', () => {
+    const result = highlightText('Hello', 'zzz')
+
+    expect(typeof result).toBe('string')
+  })
+
+  it('applies custom fontWeight when highlightWeight is provided', () => {
+    const { container } = render(<>{highlightText('abc and more', 'abc', 600)}</>)
+    const span = container.querySelector('span')
+
+    expect(span?.style.fontWeight).toBe('600')
+  })
+})

--- a/frontend/src/utils/highlightText.tsx
+++ b/frontend/src/utils/highlightText.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react'
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export function highlightText(
+  text: string,
+  query: string,
+  highlightWeight = 700,
+): ReactNode {
+  const trimmed = query.trim()
+  if (!trimmed) return text
+
+  const regex = new RegExp(escapeRegex(trimmed), 'i')
+  const match = regex.exec(text)
+
+  if (!match) return text
+
+  const start = match.index
+  const end = start + match[0].length
+
+  return (
+    <>
+      {text.slice(0, start)}
+      <span style={{ fontWeight: highlightWeight }}>{text.slice(start, end)}</span>
+      {text.slice(end)}
+    </>
+  )
+}

--- a/frontend/src/utils/recentSearch.test.ts
+++ b/frontend/src/utils/recentSearch.test.ts
@@ -26,7 +26,13 @@ describe('getRecentSearches', () => {
     expect(getRecentSearches(USER_ID)).toEqual([])
   })
 
-  it('returns stored items newest first', () => {
+  it('returns [] when stored value is valid JSON but not an array', () => {
+    localStorage.setItem(KEY, JSON.stringify({ label: 'oops' }))
+
+    expect(getRecentSearches(USER_ID)).toEqual([])
+  })
+
+  it('returns stored items in the order they were persisted', () => {
     const items: RecentSearchItem[] = [
       {
         label: 'A',

--- a/frontend/src/utils/recentSearch.test.ts
+++ b/frontend/src/utils/recentSearch.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  addRecentSearch,
+  clearRecentSearches,
+  getRecentSearches,
+  type RecentSearchItem,
+} from './recentSearch'
+
+const USER_ID = 'user-123'
+const KEY = `global_search_recent_${USER_ID}`
+
+function makeItem(
+  route: string,
+  label = 'Label',
+): Omit<RecentSearchItem, 'timestamp'> {
+  return { label, description: 'Desc', route, type: 'customer' }
+}
+
+afterEach(() => {
+  localStorage.clear()
+  vi.restoreAllMocks()
+})
+
+describe('getRecentSearches', () => {
+  it('returns [] when nothing stored', () => {
+    expect(getRecentSearches(USER_ID)).toEqual([])
+  })
+
+  it('returns stored items newest first', () => {
+    const items: RecentSearchItem[] = [
+      {
+        label: 'A',
+        route: '/a',
+        type: 'customer',
+        description: 'Desc A',
+        timestamp: 2000,
+      },
+      {
+        label: 'B',
+        route: '/b',
+        type: 'product',
+        description: 'Desc B',
+        timestamp: 1000,
+      },
+    ]
+    localStorage.setItem(KEY, JSON.stringify(items))
+
+    expect(getRecentSearches(USER_ID)).toEqual(items)
+  })
+
+  it('returns [] on malformed JSON', () => {
+    localStorage.setItem(KEY, 'not-json')
+
+    expect(getRecentSearches(USER_ID)).toEqual([])
+  })
+
+  it('returns [] when localStorage throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage error')
+    })
+
+    expect(getRecentSearches(USER_ID)).toEqual([])
+  })
+})
+
+describe('addRecentSearch', () => {
+  it('prepends new item', () => {
+    addRecentSearch(USER_ID, makeItem('/new'))
+
+    const result = getRecentSearches(USER_ID)
+
+    expect(result[0].route).toBe('/new')
+  })
+
+  it('deduplicates by route and moves existing item to front', () => {
+    addRecentSearch(USER_ID, makeItem('/a', 'First'))
+    addRecentSearch(USER_ID, makeItem('/b', 'Second'))
+    addRecentSearch(USER_ID, makeItem('/a', 'First Again'))
+
+    const result = getRecentSearches(USER_ID)
+
+    expect(result[0].route).toBe('/a')
+    expect(result[0].label).toBe('First Again')
+    expect(result.filter((entry) => entry.route === '/a')).toHaveLength(1)
+  })
+
+  it('caps list at 8 items', () => {
+    for (let i = 0; i < 10; i += 1) {
+      addRecentSearch(USER_ID, makeItem(`/route-${i}`))
+    }
+
+    expect(getRecentSearches(USER_ID)).toHaveLength(8)
+  })
+
+  it('does not throw when localStorage.setItem throws', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota exceeded')
+    })
+
+    expect(() => addRecentSearch(USER_ID, makeItem('/x'))).not.toThrow()
+  })
+})
+
+describe('clearRecentSearches', () => {
+  it('removes all items for the user', () => {
+    addRecentSearch(USER_ID, makeItem('/a'))
+
+    clearRecentSearches(USER_ID)
+
+    expect(getRecentSearches(USER_ID)).toEqual([])
+  })
+
+  it('only clears the correct user namespace', () => {
+    addRecentSearch('other-user', makeItem('/a'))
+
+    clearRecentSearches(USER_ID)
+
+    expect(getRecentSearches('other-user')).toHaveLength(1)
+  })
+
+  it('does not throw when localStorage.removeItem throws', () => {
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new Error('storage error')
+    })
+
+    expect(() => clearRecentSearches(USER_ID)).not.toThrow()
+  })
+})

--- a/frontend/src/utils/recentSearch.ts
+++ b/frontend/src/utils/recentSearch.ts
@@ -1,0 +1,48 @@
+const MAX_RECENT = 8
+
+export interface RecentSearchItem {
+  label: string
+  description?: string
+  route: string
+  type: 'page' | 'customer' | 'product' | 'transaction'
+  timestamp: number
+}
+
+const storageKey = (userId: string) => `global_search_recent_${userId}`
+
+export function getRecentSearches(userId: string): RecentSearchItem[] {
+  try {
+    const raw = localStorage.getItem(storageKey(userId))
+    if (!raw) return []
+
+    return JSON.parse(raw) as RecentSearchItem[]
+  } catch {
+    return []
+  }
+}
+
+export function addRecentSearch(
+  userId: string,
+  item: Omit<RecentSearchItem, 'timestamp'>,
+): void {
+  try {
+    const current = getRecentSearches(userId)
+    const deduped = current.filter((entry) => entry.route !== item.route)
+    const updated = [{ ...item, timestamp: Date.now() }, ...deduped].slice(
+      0,
+      MAX_RECENT,
+    )
+
+    localStorage.setItem(storageKey(userId), JSON.stringify(updated))
+  } catch {
+    // Swallow storage failures so the search UX still works.
+  }
+}
+
+export function clearRecentSearches(userId: string): void {
+  try {
+    localStorage.removeItem(storageKey(userId))
+  } catch {
+    // Swallow storage failures so the search UX still works.
+  }
+}

--- a/frontend/src/utils/recentSearch.ts
+++ b/frontend/src/utils/recentSearch.ts
@@ -15,7 +15,9 @@ export function getRecentSearches(userId: string): RecentSearchItem[] {
     const raw = localStorage.getItem(storageKey(userId))
     if (!raw) return []
 
-    return JSON.parse(raw) as RecentSearchItem[]
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed as RecentSearchItem[]
   } catch {
     return []
   }


### PR DESCRIPTION
## Summary
- Centralizes scoring constants and raises per-entity candidate fetch limit from 5 to 10, improving cross-entity ranking quality
- Adds per-user recent searches via localStorage (namespaced by user ID, max 8, deduplicated by route)
- Adds text highlighting in search result labels and descriptions, and improves the empty state message

## Test Plan
- [x] Backend: `cd backend && npm run test` — 620 tests pass
- [x] Frontend: `cd frontend && npm run test` — all tests pass
- [x] TypeScript: `cd frontend && npm run type-check` — no errors
- [x] Lint: `cd backend && npm run lint && cd ../frontend && npm run lint` — clean
- [x] Manual: open search modal (Ctrl+K), verify recent searches appear on empty query, live results replace them on typing, highlighted matches visible in label and description
- [x] Manual: verify exact code/order-number matches rank above name matches in results

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)