### PR TITLE
feat(search): Global Search Phase 4 — fuzzy matching and expanded entity coverage

### DIFF
--- a/backend/src/database/migrations/1773400000000-AddPgTrgmAndTrigramIndexes.ts
+++ b/backend/src/database/migrations/1773400000000-AddPgTrgmAndTrigramIndexes.ts
@@ -1,0 +1,99 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPgTrgmAndTrigramIndexes1773400000000
+  implements MigrationInterface
+{
+  transaction = false;
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS pg_trgm`);
+
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_products_name_trgm
+       ON products USING gin (name gin_trgm_ops)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_products_barcode_trgm
+       ON products USING gin (barcode gin_trgm_ops)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_customers_name_trgm
+       ON customers USING gin (name gin_trgm_ops)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_customers_phone_trgm
+       ON customers USING gin (phone gin_trgm_ops)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sales_orders_ordernumber_trgm
+       ON sales_orders USING gin ("orderNumber" gin_trgm_ops)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_purchase_orders_ordernumber_trgm
+       ON purchase_orders USING gin ("orderNumber" gin_trgm_ops)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_suppliers_companyname_trgm
+       ON suppliers USING gin ("companyName" gin_trgm_ops)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_invoices_invoicenumber_trgm
+       ON invoices USING gin ("invoiceNumber" gin_trgm_ops)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_payments_paymentnumber_trgm
+       ON payments USING gin ("paymentNumber" gin_trgm_ops)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_vendor_payments_paymentnumber_trgm
+       ON vendor_payments USING gin ("paymentNumber" gin_trgm_ops)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_vendor_payments_referencenumber_trgm
+       ON vendor_payments USING gin ("referenceNumber" gin_trgm_ops)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_journal_entries_referencenumber_trgm
+       ON journal_entries USING gin ("referenceNumber" gin_trgm_ops)`,
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS idx_products_name_trgm`,
+    );
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS idx_products_barcode_trgm`,
+    );
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS idx_customers_name_trgm`,
+    );
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS idx_customers_phone_trgm`,
+    );
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS idx_sales_orders_ordernumber_trgm`,
+    );
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS idx_purchase_orders_ordernumber_trgm`,
+    );
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS idx_suppliers_companyname_trgm`,
+    );
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS idx_invoices_invoicenumber_trgm`,
+    );
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS idx_payments_paymentnumber_trgm`,
+    );
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS idx_vendor_payments_paymentnumber_trgm`,
+    );
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS idx_vendor_payments_referencenumber_trgm`,
+    );
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS idx_journal_entries_referencenumber_trgm`,
+    );
+  }
+}

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -22,6 +22,18 @@ import {
   JournalEntryListResponseDto,
   JournalEntryLineResponseDto,
 } from '../dto/journal-entry.dto';
+import { GlobalSearchResultDto } from '../../search/dto/global-search-result.dto';
+import { canSearchJournalEntries } from '../../search/search.permissions';
+import {
+  SEARCH_CANDIDATE_LIMIT,
+  SCORE_EXACT_CODE,
+  SCORE_STARTSWITH_CODE,
+  SCORE_CONTAINS,
+  SCORE_FUZZY,
+  BOOST_JOURNAL,
+} from '../../search/search.constants';
+import { JwtPayload } from '../../auth/strategies/jwt.strategy';
+import { UserRole } from '../../../database/entities/user.entity';
 import { ChartOfAccountsService } from './chart-of-accounts.service';
 import { FiscalPeriodService } from './fiscal-period.service';
 import { SettingsService } from '../../settings/settings.service';
@@ -212,6 +224,38 @@ export class JournalEntryService {
     };
   }
 
+  async searchGlobal(query: string, user: JwtPayload): Promise<GlobalSearchResultDto[]> {
+    if (!canSearchJournalEntries(user.role as UserRole)) return [];
+
+    const trimmed = query.trim();
+    const q = trimmed.toLowerCase();
+
+    const results = await this.journalEntryRepository
+      .createQueryBuilder('je')
+      .where('je.deletedAt IS NULL')
+      .andWhere('(je.referenceNumber ILIKE :q OR je.description ILIKE :q)', {
+        q: `%${trimmed}%`,
+      })
+      .take(SEARCH_CANDIDATE_LIMIT)
+      .getMany();
+
+    if (results.length > 0) {
+      return results.map((je) => this.mapJournalEntry(je, q, false));
+    }
+
+    const fuzzyResults = await this.journalEntryRepository
+      .createQueryBuilder('je')
+      .addSelect('similarity(je.referenceNumber, :q)', 'sim')
+      .where('je.deletedAt IS NULL')
+      .andWhere('similarity(je.referenceNumber, :q) > 0.3')
+      .orderBy('sim', 'DESC')
+      .setParameter('q', trimmed)
+      .take(SEARCH_CANDIDATE_LIMIT)
+      .getMany();
+
+    return fuzzyResults.map((je) => this.mapJournalEntry(je, q, true));
+  }
+
   /**
    * Find one journal entry by ID with all relations
    */
@@ -364,6 +408,30 @@ export class JournalEntryService {
     );
 
     this.logger.log(`Journal entry soft-deleted successfully: ${id}`);
+  }
+
+  private mapJournalEntry(
+    je: JournalEntry,
+    q: string,
+    fuzzy: boolean,
+  ): GlobalSearchResultDto {
+    const ref = je.referenceNumber?.toLowerCase() ?? '';
+    const baseScore = fuzzy
+      ? SCORE_FUZZY
+      : ref === q
+        ? SCORE_EXACT_CODE
+        : ref.startsWith(q)
+          ? SCORE_STARTSWITH_CODE
+          : SCORE_CONTAINS;
+
+    return {
+      type: 'journal_entry',
+      id: je.id,
+      label: je.referenceNumber,
+      description: je.description ?? undefined,
+      route: `/accounting/journal-entries/${je.id}`,
+      score: baseScore + BOOST_JOURNAL,
+    } as unknown as GlobalSearchResultDto;
   }
 
   /**

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -431,7 +431,7 @@ export class JournalEntryService {
       description: je.description ?? undefined,
       route: `/accounting/journal-entries/${je.id}`,
       score: baseScore + BOOST_JOURNAL,
-    } as unknown as GlobalSearchResultDto;
+    };
   }
 
   /**

--- a/backend/src/modules/inventory/services/product.service.spec.ts
+++ b/backend/src/modules/inventory/services/product.service.spec.ts
@@ -129,8 +129,11 @@ describe('ProductService pagination removal', () => {
         deletedAt: null,
       };
       productRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         take: jest.fn().mockReturnThis(),
         getMany: jest.fn().mockResolvedValue([product]),
       } as any);
@@ -151,8 +154,11 @@ describe('ProductService pagination removal', () => {
 
     it('returns empty array when no matches', async () => {
       productRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         take: jest.fn().mockReturnThis(),
         getMany: jest.fn().mockResolvedValue([]),
       } as any);
@@ -166,8 +172,11 @@ describe('ProductService pagination removal', () => {
     it('exact barcode match scores SCORE_EXACT_CODE + BOOST_PRODUCT', async () => {
       const mockProduct = { id: 'p1', name: 'Widget', barcode: 'BC-001' };
       productRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         take: jest.fn().mockReturnThis(),
         getMany: jest.fn().mockResolvedValue([mockProduct]),
       } as any);
@@ -180,8 +189,11 @@ describe('ProductService pagination removal', () => {
     it('exact name match scores SCORE_EXACT_NAME + BOOST_PRODUCT', async () => {
       const mockProduct = { id: 'p1', name: 'Widget', barcode: 'BC-999' };
       productRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         take: jest.fn().mockReturnThis(),
         getMany: jest.fn().mockResolvedValue([mockProduct]),
       } as any);
@@ -203,6 +215,50 @@ describe('ProductService pagination removal', () => {
       const results = await service.searchGlobal('widget', adminUser);
 
       expect(results[0].score).toBe(126);
+    });
+
+    it('falls back to fuzzy search when ILIKE returns empty', async () => {
+      const fuzzyProduct = { id: 'p2', name: 'Widget Pro', barcode: null };
+
+      let callCount = 0;
+      productRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockImplementation(() => {
+          callCount++;
+          return Promise.resolve(callCount === 1 ? [] : [fuzzyProduct]);
+        }),
+      } as any);
+
+      const results = await service.searchGlobal('Widgt', {
+        role: UserRole.SALES_STAFF,
+      } as any);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].label).toBe('Widget Pro');
+      expect(results[0].score).toBe(46);
+    });
+
+    it('fuzzy fallback returns empty when no fuzzy matches', async () => {
+      productRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      } as any);
+
+      const results = await service.searchGlobal('zzzqqq', {
+        role: UserRole.SALES_STAFF,
+      } as any);
+
+      expect(results).toEqual([]);
     });
   });
 });

--- a/backend/src/modules/inventory/services/product.service.ts
+++ b/backend/src/modules/inventory/services/product.service.ts
@@ -43,6 +43,7 @@ import {
   SCORE_EXACT_NAME,
   SCORE_STARTSWITH_NAME,
   SCORE_CONTAINS,
+  SCORE_FUZZY,
   BOOST_PRODUCT,
 } from '../../search/search.constants';
 import { CategoryService } from './category.service';
@@ -304,6 +305,7 @@ export class ProductService {
     if (!canSearchProducts(user.role)) return [];
 
     const trimmed = query.trim();
+    const q = trimmed.toLowerCase();
     const products = await this.productRepository
       .createQueryBuilder('product')
       .where('product.deletedAt IS NULL')
@@ -313,30 +315,55 @@ export class ProductService {
       .take(SEARCH_CANDIDATE_LIMIT)
       .getMany();
 
-    return products.map((product) => {
-      const name = product.name?.toLowerCase() ?? '';
-      const barcode = product.barcode?.toLowerCase() ?? '';
-      const normalized = trimmed.toLowerCase();
-      const baseScore =
-        barcode && barcode === normalized
-          ? SCORE_EXACT_CODE
-          : barcode && barcode.startsWith(normalized)
-            ? SCORE_STARTSWITH_CODE
-            : name === normalized
-              ? SCORE_EXACT_NAME
-              : name.startsWith(normalized)
-                ? SCORE_STARTSWITH_NAME
-                : SCORE_CONTAINS;
+    if (products.length > 0) {
+      return products.map((product) => this.mapProduct(product, q, false));
+    }
 
-      return {
-        type: 'product',
-        id: product.id,
-        label: product.name,
-        description: product.barcode,
-        route: `/inventory/products/${product.id}/edit`,
-        score: baseScore + BOOST_PRODUCT,
-      };
-    });
+    const fuzzyProducts = await this.productRepository
+      .createQueryBuilder('product')
+      .addSelect(
+        'GREATEST(similarity(product.name, :q), similarity(product.barcode, :q))',
+        'sim',
+      )
+      .where('product.deletedAt IS NULL')
+      .andWhere(
+        '(similarity(product.name, :q) > 0.3 OR similarity(product.barcode, :q) > 0.3)',
+      )
+      .orderBy('sim', 'DESC')
+      .setParameter('q', trimmed)
+      .take(SEARCH_CANDIDATE_LIMIT)
+      .getMany();
+
+    return fuzzyProducts.map((product) => this.mapProduct(product, q, true));
+  }
+
+  private mapProduct(
+    product: Product,
+    q: string,
+    fuzzy: boolean,
+  ): GlobalSearchResultDto {
+    const name = product.name?.toLowerCase() ?? '';
+    const barcode = product.barcode?.toLowerCase() ?? '';
+    const baseScore = fuzzy
+      ? SCORE_FUZZY
+      : barcode && barcode === q
+        ? SCORE_EXACT_CODE
+        : barcode && barcode.startsWith(q)
+          ? SCORE_STARTSWITH_CODE
+          : name === q
+            ? SCORE_EXACT_NAME
+            : name.startsWith(q)
+              ? SCORE_STARTSWITH_NAME
+              : SCORE_CONTAINS;
+
+    return {
+      type: 'product',
+      id: product.id,
+      label: product.name,
+      description: product.barcode,
+      route: `/inventory/products/${product.id}/edit`,
+      score: baseScore + BOOST_PRODUCT,
+    };
   }
 
   /**

--- a/backend/src/modules/purchasing/services/purchase-order.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.ts
@@ -24,6 +24,7 @@ import {
   SCORE_EXACT_CODE,
   SCORE_STARTSWITH_CODE,
   SCORE_CONTAINS,
+  SCORE_FUZZY,
   BOOST_TRANSACTION,
 } from '../../search/search.constants';
 import { SupplierService } from './supplier.service';
@@ -344,6 +345,7 @@ export class PurchaseOrderService {
     if (!canSearchPurchaseOrders(user.role)) return [];
 
     const trimmed = query.trim();
+    const q = trimmed.toLowerCase();
     const orders = await this.purchaseOrderRepository
       .createQueryBuilder('order')
       .leftJoinAndSelect('order.supplier', 'supplier')
@@ -354,25 +356,46 @@ export class PurchaseOrderService {
       .take(SEARCH_CANDIDATE_LIMIT)
       .getMany();
 
-    return orders.map((order) => {
-      const orderNumber = order.orderNumber?.toLowerCase() ?? '';
-      const normalized = trimmed.toLowerCase();
-      const baseScore =
-        orderNumber === normalized
-          ? SCORE_EXACT_CODE
-          : orderNumber.startsWith(normalized)
-            ? SCORE_STARTSWITH_CODE
-            : SCORE_CONTAINS;
+    if (orders.length > 0) {
+      return orders.map((order) => this.mapPurchaseOrder(order, q, false));
+    }
 
-      return {
-        type: 'transaction',
-        id: order.id,
-        label: order.orderNumber,
-        description: order.supplier?.companyName ?? '',
-        route: `/purchasing/orders/${order.id}/edit`,
-        score: baseScore + BOOST_TRANSACTION,
-      };
-    });
+    const fuzzyOrders = await this.purchaseOrderRepository
+      .createQueryBuilder('order')
+      .addSelect('similarity(order.orderNumber, :q)', 'sim')
+      .leftJoinAndSelect('order.supplier', 'supplier')
+      .where('order.deletedAt IS NULL')
+      .andWhere('similarity(order.orderNumber, :q) > 0.3')
+      .orderBy('sim', 'DESC')
+      .setParameter('q', trimmed)
+      .take(SEARCH_CANDIDATE_LIMIT)
+      .getMany();
+
+    return fuzzyOrders.map((order) => this.mapPurchaseOrder(order, q, true));
+  }
+
+  private mapPurchaseOrder(
+    order: PurchaseOrder,
+    q: string,
+    fuzzy: boolean,
+  ): GlobalSearchResultDto {
+    const orderNumber = order.orderNumber?.toLowerCase() ?? '';
+    const baseScore = fuzzy
+      ? SCORE_FUZZY
+      : orderNumber === q
+        ? SCORE_EXACT_CODE
+        : orderNumber.startsWith(q)
+          ? SCORE_STARTSWITH_CODE
+          : SCORE_CONTAINS;
+
+    return {
+      type: 'transaction',
+      id: order.id,
+      label: order.orderNumber,
+      description: order.supplier?.companyName ?? '',
+      route: `/purchasing/orders/${order.id}/edit`,
+      score: baseScore + BOOST_TRANSACTION,
+    };
   }
 
   /**

--- a/backend/src/modules/purchasing/services/supplier.service.ts
+++ b/backend/src/modules/purchasing/services/supplier.service.ts
@@ -829,6 +829,6 @@ export class SupplierService {
       description: supplier.phone ?? undefined,
       route: `/purchasing/suppliers/${supplier.id}`,
       score: baseScore + BOOST_SUPPLIER,
-    } as unknown as GlobalSearchResultDto;
+    };
   }
 }

--- a/backend/src/modules/purchasing/services/supplier.service.ts
+++ b/backend/src/modules/purchasing/services/supplier.service.ts
@@ -13,6 +13,18 @@ import {
   SupplierListResponseDto,
 } from '../dto';
 import { AuditLogService } from '../../audit-logs/services';
+import { GlobalSearchResultDto } from '../../search/dto/global-search-result.dto';
+import { canSearchSuppliers } from '../../search/search.permissions';
+import {
+  SEARCH_CANDIDATE_LIMIT,
+  SCORE_EXACT_NAME,
+  SCORE_STARTSWITH_NAME,
+  SCORE_CONTAINS,
+  SCORE_FUZZY,
+  BOOST_SUPPLIER,
+} from '../../search/search.constants';
+import { JwtPayload } from '../../auth/strategies/jwt.strategy';
+import { UserRole } from '../../../database/entities/user.entity';
 
 @Injectable()
 export class SupplierService {
@@ -150,6 +162,36 @@ export class SupplierService {
       hasNext: false,
       hasPrev: false,
     };
+  }
+
+  async searchGlobal(query: string, user: JwtPayload): Promise<GlobalSearchResultDto[]> {
+    if (!canSearchSuppliers(user.role as UserRole)) return [];
+
+    const trimmed = query.trim();
+    const q = trimmed.toLowerCase();
+
+    const results = await this.supplierRepository
+      .createQueryBuilder('supplier')
+      .where('supplier.deletedAt IS NULL')
+      .andWhere('supplier.companyName ILIKE :q', { q: `%${trimmed}%` })
+      .take(SEARCH_CANDIDATE_LIMIT)
+      .getMany();
+
+    if (results.length > 0) {
+      return results.map((supplier) => this.mapSupplier(supplier, q, false));
+    }
+
+    const fuzzyResults = await this.supplierRepository
+      .createQueryBuilder('supplier')
+      .addSelect('similarity(supplier.companyName, :q)', 'sim')
+      .where('supplier.deletedAt IS NULL')
+      .andWhere('similarity(supplier.companyName, :q) > 0.3')
+      .orderBy('sim', 'DESC')
+      .setParameter('q', trimmed)
+      .take(SEARCH_CANDIDATE_LIMIT)
+      .getMany();
+
+    return fuzzyResults.map((supplier) => this.mapSupplier(supplier, q, true));
   }
 
   /**
@@ -764,5 +806,29 @@ export class SupplierService {
       updatedAt: supplier.updatedAt,
       deletedAt: supplier.deletedAt,
     };
+  }
+
+  private mapSupplier(
+    supplier: Supplier,
+    q: string,
+    fuzzy: boolean,
+  ): GlobalSearchResultDto {
+    const name = supplier.companyName?.toLowerCase() ?? '';
+    const baseScore = fuzzy
+      ? SCORE_FUZZY
+      : name === q
+        ? SCORE_EXACT_NAME
+        : name.startsWith(q)
+          ? SCORE_STARTSWITH_NAME
+          : SCORE_CONTAINS;
+
+    return {
+      type: 'supplier',
+      id: supplier.id,
+      label: supplier.companyName,
+      description: supplier.phone ?? undefined,
+      route: `/purchasing/suppliers/${supplier.id}`,
+      score: baseScore + BOOST_SUPPLIER,
+    } as unknown as GlobalSearchResultDto;
   }
 }

--- a/backend/src/modules/purchasing/services/vendor-payment.service.ts
+++ b/backend/src/modules/purchasing/services/vendor-payment.service.ts
@@ -16,6 +16,18 @@ import {
 import { AuditLogService } from '../../audit-logs/services';
 import { AccountingService } from '@modules/accounting/services/accounting.service';
 import { SettingsService } from '@modules/settings/settings.service';
+import { GlobalSearchResultDto } from '../../search/dto/global-search-result.dto';
+import { canSearchVendorPayments } from '../../search/search.permissions';
+import {
+  SEARCH_CANDIDATE_LIMIT,
+  SCORE_EXACT_CODE,
+  SCORE_STARTSWITH_CODE,
+  SCORE_CONTAINS,
+  SCORE_FUZZY,
+  BOOST_VENDOR_PAYMENT,
+} from '../../search/search.constants';
+import { JwtPayload } from '../../auth/strategies/jwt.strategy';
+import { UserRole } from '../../../database/entities/user.entity';
 
 @Injectable()
 export class VendorPaymentService {
@@ -199,6 +211,69 @@ export class VendorPaymentService {
       hasNext: false,
       hasPrev: false,
     };
+  }
+
+  async searchGlobal(query: string, user: JwtPayload): Promise<GlobalSearchResultDto[]> {
+    if (!canSearchVendorPayments(user.role as UserRole)) return [];
+
+    const trimmed = query.trim();
+    const q = trimmed.toLowerCase();
+
+    const results = await this.vendorPaymentRepository
+      .createQueryBuilder('vp')
+      .where('vp.deletedAt IS NULL')
+      .andWhere(
+        '(vp.paymentNumber ILIKE :q OR vp.referenceNumber ILIKE :q)',
+        { q: `%${trimmed}%` },
+      )
+      .take(SEARCH_CANDIDATE_LIMIT)
+      .getMany();
+
+    if (results.length > 0) {
+      return results.map((vp) => this.mapVendorPayment(vp, q, false));
+    }
+
+    const fuzzyResults = await this.vendorPaymentRepository
+      .createQueryBuilder('vp')
+      .addSelect(
+        'GREATEST(similarity(vp.paymentNumber, :q), similarity(vp.referenceNumber, :q))',
+        'sim',
+      )
+      .where('vp.deletedAt IS NULL')
+      .andWhere(
+        '(similarity(vp.paymentNumber, :q) > 0.3 OR similarity(vp.referenceNumber, :q) > 0.3)',
+      )
+      .orderBy('sim', 'DESC')
+      .setParameter('q', trimmed)
+      .take(SEARCH_CANDIDATE_LIMIT)
+      .getMany();
+
+    return fuzzyResults.map((vp) => this.mapVendorPayment(vp, q, true));
+  }
+
+  private mapVendorPayment(
+    vp: VendorPayment,
+    q: string,
+    fuzzy: boolean,
+  ): GlobalSearchResultDto {
+    const payNum = vp.paymentNumber?.toLowerCase() ?? '';
+    const refNum = vp.referenceNumber?.toLowerCase() ?? '';
+    const baseScore = fuzzy
+      ? SCORE_FUZZY
+      : payNum === q || refNum === q
+        ? SCORE_EXACT_CODE
+        : payNum.startsWith(q) || refNum.startsWith(q)
+          ? SCORE_STARTSWITH_CODE
+          : SCORE_CONTAINS;
+
+    return {
+      type: 'vendor_payment',
+      id: vp.id,
+      label: vp.paymentNumber,
+      description: vp.referenceNumber ?? undefined,
+      route: `/purchasing/vendor-payments/${vp.id}`,
+      score: baseScore + BOOST_VENDOR_PAYMENT,
+    } as unknown as GlobalSearchResultDto;
   }
 
   /**

--- a/backend/src/modules/purchasing/services/vendor-payment.service.ts
+++ b/backend/src/modules/purchasing/services/vendor-payment.service.ts
@@ -273,7 +273,7 @@ export class VendorPaymentService {
       description: vp.referenceNumber ?? undefined,
       route: `/purchasing/vendor-payments/${vp.id}`,
       score: baseScore + BOOST_VENDOR_PAYMENT,
-    } as unknown as GlobalSearchResultDto;
+    };
   }
 
   /**

--- a/backend/src/modules/sales/sales.module.ts
+++ b/backend/src/modules/sales/sales.module.ts
@@ -84,6 +84,7 @@ import { TransactionManager } from '../../common/utils/transaction.util';
     CustomerService,
     SalesOrderService, // Temporarily disabled due to TypeScript errors
     InvoiceService,
+    PaymentService,
   ],
 })
 export class SalesModule {}

--- a/backend/src/modules/sales/sales.module.ts
+++ b/backend/src/modules/sales/sales.module.ts
@@ -83,6 +83,7 @@ import { TransactionManager } from '../../common/utils/transaction.util';
   exports: [
     CustomerService,
     SalesOrderService, // Temporarily disabled due to TypeScript errors
+    InvoiceService,
   ],
 })
 export class SalesModule {}

--- a/backend/src/modules/sales/services/customer.service.spec.ts
+++ b/backend/src/modules/sales/services/customer.service.spec.ts
@@ -59,8 +59,11 @@ describe('CustomerService', () => {
         deletedAt: null,
       };
       customerRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         take: jest.fn().mockReturnThis(),
         getMany: jest.fn().mockResolvedValue([customer]),
       } as any);
@@ -82,8 +85,11 @@ describe('CustomerService', () => {
 
     it('returns empty array when no matches', async () => {
       customerRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         take: jest.fn().mockReturnThis(),
         getMany: jest.fn().mockResolvedValue([]),
       } as any);
@@ -102,8 +108,11 @@ describe('CustomerService', () => {
       };
 
       customerRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         take: jest.fn().mockReturnThis(),
         getMany: jest.fn().mockResolvedValue([mockCustomer]),
       } as any);
@@ -117,8 +126,11 @@ describe('CustomerService', () => {
       const mockCustomer = { id: 'c1', name: 'acme corp', phone: null };
 
       customerRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         take: jest.fn().mockReturnThis(),
         getMany: jest.fn().mockResolvedValue([mockCustomer]),
       } as any);
@@ -141,6 +153,50 @@ describe('CustomerService', () => {
       const results = await service.searchGlobal('acme corp', adminUser);
 
       expect(results[0].score).toBe(128);
+    });
+
+    it('falls back to fuzzy search when ILIKE returns empty', async () => {
+      const fuzzyCustomer = { id: 'c2', name: 'Acme Corp', phone: null };
+
+      let callCount = 0;
+      customerRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockImplementation(() => {
+          callCount++;
+          return Promise.resolve(callCount === 1 ? [] : [fuzzyCustomer]);
+        }),
+      } as any);
+
+      const results = await service.searchGlobal('Akme', {
+        role: UserRole.SALES_STAFF,
+      } as any);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].label).toBe('Acme Corp');
+      expect(results[0].score).toBe(48);
+    });
+
+    it('fuzzy fallback returns empty when no fuzzy matches', async () => {
+      customerRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      } as any);
+
+      const results = await service.searchGlobal('zzzqqq', {
+        role: UserRole.SALES_STAFF,
+      } as any);
+
+      expect(results).toEqual([]);
     });
   });
 });

--- a/backend/src/modules/sales/services/customer.service.ts
+++ b/backend/src/modules/sales/services/customer.service.ts
@@ -25,6 +25,7 @@ import {
   SCORE_EXACT_NAME,
   SCORE_STARTSWITH_NAME,
   SCORE_CONTAINS,
+  SCORE_FUZZY,
   BOOST_CUSTOMER,
 } from '../../search/search.constants';
 import { ValidationUtil, BulkOperationUtil, BulkOperationResponse } from '../../../common/utils/validation.util';
@@ -142,6 +143,8 @@ export class CustomerService {
     if (!canSearchCustomers(user.role)) return [];
 
     const trimmed = query.trim();
+    const q = trimmed.toLowerCase();
+
     const customers = await this.customerRepository
       .createQueryBuilder('customer')
       .where('customer.deletedAt IS NULL')
@@ -152,30 +155,55 @@ export class CustomerService {
       .take(SEARCH_CANDIDATE_LIMIT)
       .getMany();
 
-    return customers.map((customer) => {
-      const name = customer.name?.toLowerCase() ?? '';
-      const phone = customer.phone?.toLowerCase() ?? '';
-      const normalized = trimmed.toLowerCase();
-      const baseScore =
-        phone && phone === normalized
-          ? SCORE_EXACT_CODE
-          : phone && phone.startsWith(normalized)
-            ? SCORE_STARTSWITH_CODE
-            : name === normalized
-              ? SCORE_EXACT_NAME
-              : name.startsWith(normalized)
-                ? SCORE_STARTSWITH_NAME
-                : SCORE_CONTAINS;
+    if (customers.length > 0) {
+      return customers.map((customer) => this.mapCustomer(customer, q, false));
+    }
 
-      return {
-        type: 'customer',
-        id: customer.id,
-        label: customer.name,
-        description: customer.phone,
-        route: `/sales/customers/${customer.id}`,
-        score: baseScore + BOOST_CUSTOMER,
-      };
-    });
+    const fuzzyResults = await this.customerRepository
+      .createQueryBuilder('customer')
+      .addSelect(
+        'GREATEST(similarity(customer.name, :q), similarity(customer.phone, :q))',
+        'sim',
+      )
+      .where('customer.deletedAt IS NULL')
+      .andWhere(
+        '(similarity(customer.name, :q) > 0.3 OR similarity(customer.phone, :q) > 0.3)',
+      )
+      .orderBy('sim', 'DESC')
+      .setParameter('q', trimmed)
+      .take(SEARCH_CANDIDATE_LIMIT)
+      .getMany();
+
+    return fuzzyResults.map((customer) => this.mapCustomer(customer, q, true));
+  }
+
+  private mapCustomer(
+    customer: Customer,
+    q: string,
+    fuzzy: boolean,
+  ): GlobalSearchResultDto {
+    const name = customer.name?.toLowerCase() ?? '';
+    const phone = customer.phone?.toLowerCase() ?? '';
+    const baseScore = fuzzy
+      ? SCORE_FUZZY
+      : phone && phone === q
+        ? SCORE_EXACT_CODE
+        : phone && phone.startsWith(q)
+          ? SCORE_STARTSWITH_CODE
+          : name === q
+            ? SCORE_EXACT_NAME
+            : name.startsWith(q)
+              ? SCORE_STARTSWITH_NAME
+              : SCORE_CONTAINS;
+
+    return {
+      type: 'customer',
+      id: customer.id,
+      label: customer.name,
+      description: customer.phone ?? undefined,
+      route: `/sales/customers/${customer.id}`,
+      score: baseScore + BOOST_CUSTOMER,
+    };
   }
 
   async findDeleted(query: QueryCustomersDto) {

--- a/backend/src/modules/sales/services/invoice.service.spec.ts
+++ b/backend/src/modules/sales/services/invoice.service.spec.ts
@@ -1,0 +1,101 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { InvoiceService } from './invoice.service';
+import { Invoice } from '../../../database/entities/invoice.entity';
+import { Customer } from '../../../database/entities/customer.entity';
+import { SalesOrder } from '../../../database/entities/sales-order.entity';
+import { Payment } from '../../../database/entities/payment.entity';
+import { Product } from '../../../database/entities/product.entity';
+import { InvoiceItem } from '../../../database/entities/invoice-item.entity';
+import { AuditLogService } from '../../audit-logs/services';
+import { UserRole } from '../../../database/entities/user.entity';
+
+describe('InvoiceService.searchGlobal', () => {
+  let service: InvoiceService;
+  let invoiceRepository: { createQueryBuilder: jest.Mock };
+
+  const mockQb = () => ({
+    addSelect: jest.fn().mockReturnThis(),
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    setParameter: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getMany: jest.fn().mockResolvedValue([]),
+  });
+
+  beforeEach(async () => {
+    invoiceRepository = { createQueryBuilder: jest.fn().mockReturnValue(mockQb()) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InvoiceService,
+        { provide: getRepositoryToken(Invoice), useValue: invoiceRepository },
+        { provide: getRepositoryToken(Customer), useValue: { findOne: jest.fn() } },
+        { provide: getRepositoryToken(SalesOrder), useValue: {} },
+        { provide: getRepositoryToken(Payment), useValue: {} },
+        { provide: getRepositoryToken(Product), useValue: {} },
+        { provide: getRepositoryToken(InvoiceItem), useValue: {} },
+        { provide: AuditLogService, useValue: { log: jest.fn(), createLog: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get(InvoiceService);
+  });
+
+  it('returns empty for non-sales role', async () => {
+    const result = await service.searchGlobal('INV-001', {
+      role: UserRole.INVENTORY_STAFF,
+    } as any);
+
+    expect(result).toEqual([]);
+    expect(invoiceRepository.createQueryBuilder).not.toHaveBeenCalled();
+  });
+
+  it('returns matching invoices as GlobalSearchResultDto', async () => {
+    const mockInvoice = {
+      id: 'inv-1',
+      invoiceNumber: 'INV-001',
+      customer: { name: 'ABC Corp' },
+    };
+    const qb = mockQb();
+    qb.getMany.mockResolvedValue([mockInvoice]);
+    invoiceRepository.createQueryBuilder.mockReturnValue(qb);
+
+    const results = await service.searchGlobal('INV-001', {
+      role: UserRole.SALES_STAFF,
+    } as any);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      type: 'invoice',
+      id: 'inv-1',
+      label: 'INV-001',
+      route: '/sales/invoices/inv-1',
+    });
+    expect(results[0].score).toBeGreaterThan(0);
+  });
+
+  it('falls back to fuzzy when ILIKE returns empty', async () => {
+    const fuzzyInvoice = {
+      id: 'inv-2',
+      invoiceNumber: 'INV-002',
+      customer: { name: 'XYZ Ltd' },
+    };
+    let callCount = 0;
+    const qb = mockQb();
+    qb.getMany.mockImplementation(() => {
+      callCount++;
+      return Promise.resolve(callCount === 1 ? [] : [fuzzyInvoice]);
+    });
+    invoiceRepository.createQueryBuilder.mockReturnValue(qb);
+
+    const results = await service.searchGlobal('INV-00', {
+      role: UserRole.SALES_STAFF,
+    } as any);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].score).toBe(49);
+  });
+});

--- a/backend/src/modules/sales/services/invoice.service.ts
+++ b/backend/src/modules/sales/services/invoice.service.ts
@@ -304,7 +304,7 @@ export class InvoiceService {
       description: inv.customer?.name ?? undefined,
       route: `/sales/invoices/${inv.id}`,
       score: baseScore + BOOST_INVOICE,
-    } as unknown as GlobalSearchResultDto;
+    };
   }
 
   async getDashboardStats() {

--- a/backend/src/modules/sales/services/invoice.service.ts
+++ b/backend/src/modules/sales/services/invoice.service.ts
@@ -25,6 +25,18 @@ import {
   SendInvoiceDto,
   InvoicePaymentAllocationDto,
 } from '../dto/invoice.dto';
+import { GlobalSearchResultDto } from '../../search/dto/global-search-result.dto';
+import { canSearchInvoices } from '../../search/search.permissions';
+import {
+  SEARCH_CANDIDATE_LIMIT,
+  SCORE_EXACT_CODE,
+  SCORE_STARTSWITH_CODE,
+  SCORE_CONTAINS,
+  SCORE_FUZZY,
+  BOOST_INVOICE,
+} from '../../search/search.constants';
+import { JwtPayload } from '../../auth/strategies/jwt.strategy';
+import { UserRole } from '../../../database/entities/user.entity';
 // import { EmailService } from '../../auth/services/email.service'; // Temporarily disabled
 
 @Injectable()
@@ -241,6 +253,58 @@ export class InvoiceService {
       totalAmount: Number(invoice.totalAmount),
       balanceDue: Number(invoice.balanceDue),
     }));
+  }
+
+  async searchGlobal(query: string, user: JwtPayload): Promise<GlobalSearchResultDto[]> {
+    if (!canSearchInvoices(user.role as UserRole)) return [];
+
+    const trimmed = query.trim();
+    const q = trimmed.toLowerCase();
+
+    const results = await this.invoiceRepository
+      .createQueryBuilder('invoice')
+      .leftJoinAndSelect('invoice.customer', 'customer')
+      .where('invoice.deletedAt IS NULL')
+      .andWhere('invoice.invoiceNumber ILIKE :q', { q: `%${trimmed}%` })
+      .take(SEARCH_CANDIDATE_LIMIT)
+      .getMany();
+
+    if (results.length > 0) {
+      return results.map((inv) => this.mapInvoice(inv, q, false));
+    }
+
+    const fuzzyResults = await this.invoiceRepository
+      .createQueryBuilder('invoice')
+      .addSelect('similarity(invoice.invoiceNumber, :q)', 'sim')
+      .leftJoinAndSelect('invoice.customer', 'customer')
+      .where('invoice.deletedAt IS NULL')
+      .andWhere('similarity(invoice.invoiceNumber, :q) > 0.3')
+      .orderBy('sim', 'DESC')
+      .setParameter('q', trimmed)
+      .take(SEARCH_CANDIDATE_LIMIT)
+      .getMany();
+
+    return fuzzyResults.map((inv) => this.mapInvoice(inv, q, true));
+  }
+
+  private mapInvoice(inv: Invoice, q: string, fuzzy: boolean): GlobalSearchResultDto {
+    const num = inv.invoiceNumber?.toLowerCase() ?? '';
+    const baseScore = fuzzy
+      ? SCORE_FUZZY
+      : num === q
+        ? SCORE_EXACT_CODE
+        : num.startsWith(q)
+          ? SCORE_STARTSWITH_CODE
+          : SCORE_CONTAINS;
+
+    return {
+      type: 'invoice',
+      id: inv.id,
+      label: inv.invoiceNumber,
+      description: inv.customer?.name ?? undefined,
+      route: `/sales/invoices/${inv.id}`,
+      score: baseScore + BOOST_INVOICE,
+    } as unknown as GlobalSearchResultDto;
   }
 
   async getDashboardStats() {

--- a/backend/src/modules/sales/services/payment.service.ts
+++ b/backend/src/modules/sales/services/payment.service.ts
@@ -591,7 +591,7 @@ export class PaymentService {
       description: undefined,
       route: `/sales/payments/${p.id}`,
       score: baseScore + BOOST_CUSTOMER_PAYMENT,
-    } as unknown as GlobalSearchResultDto;
+    };
   }
 
   async findDeleted(query: QueryPaymentsDto = {}) {

--- a/backend/src/modules/sales/services/payment.service.ts
+++ b/backend/src/modules/sales/services/payment.service.ts
@@ -22,6 +22,18 @@ import {
   PaymentSummaryDto,
 } from '../dto/payment.dto';
 import { AccountingService } from '@modules/accounting/services/accounting.service';
+import { GlobalSearchResultDto } from '../../search/dto/global-search-result.dto';
+import { canSearchCustomerPayments } from '../../search/search.permissions';
+import {
+  SEARCH_CANDIDATE_LIMIT,
+  SCORE_EXACT_CODE,
+  SCORE_STARTSWITH_CODE,
+  SCORE_CONTAINS,
+  SCORE_FUZZY,
+  BOOST_CUSTOMER_PAYMENT,
+} from '../../search/search.constants';
+import { JwtPayload } from '../../auth/strategies/jwt.strategy';
+import { UserRole } from '../../../database/entities/user.entity';
 
 @Injectable()
 export class PaymentService {
@@ -530,6 +542,56 @@ export class PaymentService {
   private async updateInvoiceFromPayment(invoice: Invoice, payment: Payment): Promise<void> {
     invoice.addPayment(Number(payment.amount));
     await this.invoiceRepository.save(invoice);
+  }
+
+  async searchGlobal(query: string, user: JwtPayload): Promise<GlobalSearchResultDto[]> {
+    if (!canSearchCustomerPayments(user.role as UserRole)) return [];
+
+    const trimmed = query.trim();
+    const q = trimmed.toLowerCase();
+
+    const results = await this.paymentRepository
+      .createQueryBuilder('payment')
+      .where('payment.deletedAt IS NULL')
+      .andWhere('payment.paymentNumber ILIKE :q', { q: `%${trimmed}%` })
+      .take(SEARCH_CANDIDATE_LIMIT)
+      .getMany();
+
+    if (results.length > 0) {
+      return results.map((p) => this.mapPayment(p, q, false));
+    }
+
+    const fuzzyResults = await this.paymentRepository
+      .createQueryBuilder('payment')
+      .addSelect('similarity(payment.paymentNumber, :q)', 'sim')
+      .where('payment.deletedAt IS NULL')
+      .andWhere('similarity(payment.paymentNumber, :q) > 0.3')
+      .orderBy('sim', 'DESC')
+      .setParameter('q', trimmed)
+      .take(SEARCH_CANDIDATE_LIMIT)
+      .getMany();
+
+    return fuzzyResults.map((p) => this.mapPayment(p, q, true));
+  }
+
+  private mapPayment(p: Payment, q: string, fuzzy: boolean): GlobalSearchResultDto {
+    const num = p.paymentNumber?.toLowerCase() ?? '';
+    const baseScore = fuzzy
+      ? SCORE_FUZZY
+      : num === q
+        ? SCORE_EXACT_CODE
+        : num.startsWith(q)
+          ? SCORE_STARTSWITH_CODE
+          : SCORE_CONTAINS;
+
+    return {
+      type: 'customer_payment',
+      id: p.id,
+      label: p.paymentNumber,
+      description: undefined,
+      route: `/sales/payments/${p.id}`,
+      score: baseScore + BOOST_CUSTOMER_PAYMENT,
+    } as unknown as GlobalSearchResultDto;
   }
 
   async findDeleted(query: QueryPaymentsDto = {}) {

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -28,6 +28,7 @@ import {
   SCORE_EXACT_CODE,
   SCORE_STARTSWITH_CODE,
   SCORE_CONTAINS,
+  SCORE_FUZZY,
   BOOST_TRANSACTION,
 } from '../../search/search.constants';
 // import { CustomerService } from './customer.service';
@@ -364,6 +365,7 @@ export class SalesOrderService {
     if (!canSearchSalesOrders(user.role)) return [];
 
     const trimmed = query.trim();
+    const q = trimmed.toLowerCase();
     const orders = await this.salesOrderRepository
       .createQueryBuilder('order')
       .leftJoinAndSelect('order.customer', 'customer')
@@ -374,25 +376,46 @@ export class SalesOrderService {
       .take(SEARCH_CANDIDATE_LIMIT)
       .getMany();
 
-    return orders.map((order) => {
-      const orderNumber = order.orderNumber?.toLowerCase() ?? '';
-      const normalized = trimmed.toLowerCase();
-      const baseScore =
-        orderNumber === normalized
-          ? SCORE_EXACT_CODE
-          : orderNumber.startsWith(normalized)
-            ? SCORE_STARTSWITH_CODE
-            : SCORE_CONTAINS;
+    if (orders.length > 0) {
+      return orders.map((order) => this.mapSalesOrder(order, q, false));
+    }
 
-      return {
-        type: 'transaction',
-        id: order.id,
-        label: order.orderNumber,
-        description: order.customer?.name ?? '',
-        route: `/sales/orders/${order.id}/edit`,
-        score: baseScore + BOOST_TRANSACTION,
-      };
-    });
+    const fuzzyOrders = await this.salesOrderRepository
+      .createQueryBuilder('order')
+      .addSelect('similarity(order.orderNumber, :q)', 'sim')
+      .leftJoinAndSelect('order.customer', 'customer')
+      .where('order.deletedAt IS NULL')
+      .andWhere('similarity(order.orderNumber, :q) > 0.3')
+      .orderBy('sim', 'DESC')
+      .setParameter('q', trimmed)
+      .take(SEARCH_CANDIDATE_LIMIT)
+      .getMany();
+
+    return fuzzyOrders.map((order) => this.mapSalesOrder(order, q, true));
+  }
+
+  private mapSalesOrder(
+    order: SalesOrder,
+    q: string,
+    fuzzy: boolean,
+  ): GlobalSearchResultDto {
+    const orderNumber = order.orderNumber?.toLowerCase() ?? '';
+    const baseScore = fuzzy
+      ? SCORE_FUZZY
+      : orderNumber === q
+        ? SCORE_EXACT_CODE
+        : orderNumber.startsWith(q)
+          ? SCORE_STARTSWITH_CODE
+          : SCORE_CONTAINS;
+
+    return {
+      type: 'transaction',
+      id: order.id,
+      label: order.orderNumber,
+      description: order.customer?.name ?? '',
+      route: `/sales/orders/${order.id}/edit`,
+      score: baseScore + BOOST_TRANSACTION,
+    };
   }
 
   async testInvoiceRelations(orderNumber: string): Promise<any> {

--- a/backend/src/modules/search/dto/global-search-result.dto.ts
+++ b/backend/src/modules/search/dto/global-search-result.dto.ts
@@ -2,7 +2,12 @@ export type GlobalSearchResultType =
   | 'page'
   | 'customer'
   | 'product'
-  | 'transaction';
+  | 'transaction'
+  | 'supplier'
+  | 'invoice'
+  | 'customer_payment'
+  | 'vendor_payment'
+  | 'journal_entry';
 
 export class GlobalSearchResultDto {
   type: GlobalSearchResultType;

--- a/backend/src/modules/search/search.constants.ts
+++ b/backend/src/modules/search/search.constants.ts
@@ -19,5 +19,13 @@ export const SCORE_PAGE_KEYWORD = 50;
 // Entity type boosts - added after base score to break cross-entity ties
 export const BOOST_TRANSACTION = 10;
 export const BOOST_CUSTOMER = 8;
+export const BOOST_INVOICE = 9;
+export const BOOST_CUSTOMER_PAYMENT = 8;
+export const BOOST_VENDOR_PAYMENT = 8;
+export const BOOST_SUPPLIER = 7;
 export const BOOST_PRODUCT = 6;
+export const BOOST_JOURNAL = 4;
 export const BOOST_PAGE = 2;
+
+// Fuzzy fallback score - used only when ILIKE returns no results
+export const SCORE_FUZZY = 40;

--- a/backend/src/modules/search/search.module.ts
+++ b/backend/src/modules/search/search.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { AccountingModule } from '../accounting/accounting.module';
 import { InventoryModule } from '../inventory/inventory.module';
 import { PurchasingModule } from '../purchasing/purchasing.module';
 import { SalesModule } from '../sales/sales.module';
@@ -6,7 +7,7 @@ import { SearchController } from './search.controller';
 import { SearchService } from './search.service';
 
 @Module({
-  imports: [SalesModule, InventoryModule, PurchasingModule],
+  imports: [SalesModule, InventoryModule, PurchasingModule, AccountingModule],
   controllers: [SearchController],
   providers: [SearchService],
 })

--- a/backend/src/modules/search/search.permissions.ts
+++ b/backend/src/modules/search/search.permissions.ts
@@ -50,3 +50,23 @@ export function canSearchSalesOrders(role: UserRole): boolean {
 export function canSearchPurchaseOrders(role: UserRole): boolean {
   return PROCUREMENT_ROLES.includes(role);
 }
+
+export function canSearchSuppliers(role: UserRole): boolean {
+  return PROCUREMENT_ROLES.includes(role);
+}
+
+export function canSearchInvoices(role: UserRole): boolean {
+  return SALES_ROLES.includes(role);
+}
+
+export function canSearchCustomerPayments(role: UserRole): boolean {
+  return SALES_ROLES.includes(role);
+}
+
+export function canSearchVendorPayments(role: UserRole): boolean {
+  return PROCUREMENT_ROLES.includes(role);
+}
+
+export function canSearchJournalEntries(role: UserRole): boolean {
+  return FINANCE_ROLES.includes(role);
+}

--- a/backend/src/modules/search/search.service.spec.ts
+++ b/backend/src/modules/search/search.service.spec.ts
@@ -1,8 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { SearchService } from './search.service';
+import { JournalEntryService } from '../accounting/services/journal-entry.service';
 import { CustomerService } from '../sales/services/customer.service';
 import { ProductService } from '../inventory/services/product.service';
+import { SupplierService } from '../purchasing/services/supplier.service';
+import { VendorPaymentService } from '../purchasing/services/vendor-payment.service';
 import { SalesOrderService } from '../sales/services/sales-order.service';
+import { InvoiceService } from '../sales/services/invoice.service';
+import { PaymentService } from '../sales/services/payment.service';
 import { PurchaseOrderService } from '../purchasing/services/purchase-order.service';
 import { GlobalSearchResultDto } from './dto/global-search-result.dto';
 import { UserRole } from '../../database/entities/user.entity';
@@ -13,6 +18,15 @@ describe('SearchService', () => {
   let productService: jest.Mocked<Pick<ProductService, 'searchGlobal'>>;
   let salesOrderService: jest.Mocked<Pick<SalesOrderService, 'searchGlobal'>>;
   let purchaseOrderService: jest.Mocked<Pick<PurchaseOrderService, 'searchGlobal'>>;
+  let supplierService: jest.Mocked<Pick<SupplierService, 'searchGlobal'>>;
+  let invoiceService: jest.Mocked<Pick<InvoiceService, 'searchGlobal'>>;
+  let paymentService: jest.Mocked<Pick<PaymentService, 'searchGlobal'>>;
+  let vendorPaymentService: jest.Mocked<
+    Pick<VendorPaymentService, 'searchGlobal'>
+  >;
+  let journalEntryService: jest.Mocked<
+    Pick<JournalEntryService, 'searchGlobal'>
+  >;
 
   const mockUser = { userId: 'u1', username: 'admin' } as any;
 
@@ -44,6 +58,26 @@ describe('SearchService', () => {
           provide: PurchaseOrderService,
           useValue: { searchGlobal: jest.fn().mockResolvedValue([]) },
         },
+        {
+          provide: SupplierService,
+          useValue: { searchGlobal: jest.fn().mockResolvedValue([]) },
+        },
+        {
+          provide: InvoiceService,
+          useValue: { searchGlobal: jest.fn().mockResolvedValue([]) },
+        },
+        {
+          provide: PaymentService,
+          useValue: { searchGlobal: jest.fn().mockResolvedValue([]) },
+        },
+        {
+          provide: VendorPaymentService,
+          useValue: { searchGlobal: jest.fn().mockResolvedValue([]) },
+        },
+        {
+          provide: JournalEntryService,
+          useValue: { searchGlobal: jest.fn().mockResolvedValue([]) },
+        },
       ],
     }).compile();
 
@@ -52,15 +86,31 @@ describe('SearchService', () => {
     productService = module.get(ProductService);
     salesOrderService = module.get(SalesOrderService);
     purchaseOrderService = module.get(PurchaseOrderService);
+    supplierService = module.get(SupplierService);
+    invoiceService = module.get(InvoiceService);
+    paymentService = module.get(PaymentService);
+    vendorPaymentService = module.get(VendorPaymentService);
+    journalEntryService = module.get(JournalEntryService);
   });
 
-  it('fans out to all four sources in parallel', async () => {
+  it('fans out to all ten sources in parallel', async () => {
     await service.search('abc', mockUser);
 
     expect(customerService.searchGlobal).toHaveBeenCalledWith('abc', mockUser);
     expect(productService.searchGlobal).toHaveBeenCalledWith('abc', mockUser);
     expect(salesOrderService.searchGlobal).toHaveBeenCalledWith('abc', mockUser);
     expect(purchaseOrderService.searchGlobal).toHaveBeenCalledWith('abc', mockUser);
+    expect(supplierService.searchGlobal).toHaveBeenCalledWith('abc', mockUser);
+    expect(invoiceService.searchGlobal).toHaveBeenCalledWith('abc', mockUser);
+    expect(paymentService.searchGlobal).toHaveBeenCalledWith('abc', mockUser);
+    expect(vendorPaymentService.searchGlobal).toHaveBeenCalledWith(
+      'abc',
+      mockUser,
+    );
+    expect(journalEntryService.searchGlobal).toHaveBeenCalledWith(
+      'abc',
+      mockUser,
+    );
   });
 
   it('returns early with empty results for queries shorter than 2 characters', async () => {

--- a/backend/src/modules/search/search.service.ts
+++ b/backend/src/modules/search/search.service.ts
@@ -1,7 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ProductService } from '../inventory/services/product.service';
+import { JournalEntryService } from '../accounting/services/journal-entry.service';
 import { PurchaseOrderService } from '../purchasing/services/purchase-order.service';
+import { SupplierService } from '../purchasing/services/supplier.service';
+import { VendorPaymentService } from '../purchasing/services/vendor-payment.service';
 import { CustomerService } from '../sales/services/customer.service';
+import { InvoiceService } from '../sales/services/invoice.service';
+import { PaymentService } from '../sales/services/payment.service';
 import { SalesOrderService } from '../sales/services/sales-order.service';
 import { UserRole } from '../../database/entities/user.entity';
 import { GlobalSearchResponseDto } from './dto/global-search-response.dto';
@@ -375,6 +380,11 @@ export class SearchService {
     private readonly productService: ProductService,
     private readonly salesOrderService: SalesOrderService,
     private readonly purchaseOrderService: PurchaseOrderService,
+    private readonly supplierService: SupplierService,
+    private readonly invoiceService: InvoiceService,
+    private readonly paymentService: PaymentService,
+    private readonly vendorPaymentService: VendorPaymentService,
+    private readonly journalEntryService: JournalEntryService,
   ) {}
 
   async search(query: string, user: any): Promise<GlobalSearchResponseDto> {
@@ -383,24 +393,49 @@ export class SearchService {
       return { query, results: [] };
     }
 
-    const [pages, customers, products, salesOrders, purchaseOrders] =
-      await Promise.all([
-        this.safeSearch('pages', async () =>
-          Promise.resolve(this.searchPages(trimmed, user)),
-        ),
-        this.safeSearch('customers', () =>
-          this.customerService.searchGlobal(trimmed, user),
-        ),
-        this.safeSearch('products', () =>
-          this.productService.searchGlobal(trimmed, user),
-        ),
-        this.safeSearch('salesOrders', () =>
-          this.salesOrderService.searchGlobal(trimmed, user),
-        ),
-        this.safeSearch('purchaseOrders', () =>
-          this.purchaseOrderService.searchGlobal(trimmed, user),
-        ),
-      ]);
+    const [
+      pages,
+      customers,
+      products,
+      salesOrders,
+      purchaseOrders,
+      suppliers,
+      invoices,
+      customerPayments,
+      vendorPayments,
+      journalEntries,
+    ] = await Promise.all([
+      this.safeSearch('pages', () =>
+        Promise.resolve(this.searchPages(trimmed, user)),
+      ),
+      this.safeSearch('customers', () =>
+        this.customerService.searchGlobal(trimmed, user),
+      ),
+      this.safeSearch('products', () =>
+        this.productService.searchGlobal(trimmed, user),
+      ),
+      this.safeSearch('salesOrders', () =>
+        this.salesOrderService.searchGlobal(trimmed, user),
+      ),
+      this.safeSearch('purchaseOrders', () =>
+        this.purchaseOrderService.searchGlobal(trimmed, user),
+      ),
+      this.safeSearch('suppliers', () =>
+        this.supplierService.searchGlobal(trimmed, user),
+      ),
+      this.safeSearch('invoices', () =>
+        this.invoiceService.searchGlobal(trimmed, user),
+      ),
+      this.safeSearch('customerPayments', () =>
+        this.paymentService.searchGlobal(trimmed, user),
+      ),
+      this.safeSearch('vendorPayments', () =>
+        this.vendorPaymentService.searchGlobal(trimmed, user),
+      ),
+      this.safeSearch('journalEntries', () =>
+        this.journalEntryService.searchGlobal(trimmed, user),
+      ),
+    ]);
 
     const results = [
       ...pages,
@@ -408,6 +443,11 @@ export class SearchService {
       ...products,
       ...salesOrders,
       ...purchaseOrders,
+      ...suppliers,
+      ...invoices,
+      ...customerPayments,
+      ...vendorPayments,
+      ...journalEntries,
     ]
       .sort((a, b) => {
         const scoreDiff = (b.score ?? 0) - (a.score ?? 0);

--- a/frontend/src/components/common/SearchModal.tsx
+++ b/frontend/src/components/common/SearchModal.tsx
@@ -35,6 +35,11 @@ const GROUP_ORDER: GlobalSearchResultType[] = [
   'customer',
   'product',
   'transaction',
+  'supplier',
+  'invoice',
+  'customer_payment',
+  'vendor_payment',
+  'journal_entry',
 ]
 
 const GROUP_LABELS: Record<GlobalSearchResultType, string> = {
@@ -42,6 +47,11 @@ const GROUP_LABELS: Record<GlobalSearchResultType, string> = {
   customer: 'Customers',
   product: 'Products',
   transaction: 'Transactions',
+  supplier: 'Suppliers',
+  invoice: 'Invoices',
+  customer_payment: 'Customer Payments',
+  vendor_payment: 'Vendor Payments',
+  journal_entry: 'Journal Entries',
 }
 
 const TYPE_BADGES: Record<GlobalSearchResultType, string> = {
@@ -49,6 +59,11 @@ const TYPE_BADGES: Record<GlobalSearchResultType, string> = {
   customer: 'Customer',
   product: 'Product',
   transaction: 'Transaction',
+  supplier: 'Supplier',
+  invoice: 'Invoice',
+  customer_payment: 'Customer Payment',
+  vendor_payment: 'Vendor Payment',
+  journal_entry: 'Journal',
 }
 
 type NavigableItem = {

--- a/frontend/src/components/common/__tests__/SearchModal.test.tsx
+++ b/frontend/src/components/common/__tests__/SearchModal.test.tsx
@@ -176,6 +176,47 @@ describe('SearchModal', () => {
     ).toBeInTheDocument()
   })
 
+  it('renders new entity type groups when results include them', () => {
+    mockUseSearchGlobal.mockReturnValue({
+      data: {
+        query: 'ac',
+        results: [
+          {
+            type: 'supplier',
+            id: 's1',
+            label: 'ACME Supplies',
+            route: '/purchasing/suppliers/s1',
+            score: 77,
+          },
+          {
+            type: 'invoice',
+            id: 'i1',
+            label: 'INV-001',
+            route: '/sales/invoices/i1',
+            score: 69,
+          },
+          {
+            type: 'journal_entry',
+            id: 'j1',
+            label: 'JE-2026-001',
+            route: '/accounting/journal-entries/j1',
+            score: 44,
+          },
+        ],
+      },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    })
+
+    renderModal()
+    typeAndFlush('ac')
+
+    expect(screen.getByText('Suppliers')).toBeInTheDocument()
+    expect(screen.getByText('Invoices')).toBeInTheDocument()
+    expect(screen.getByText('Journal Entries')).toBeInTheDocument()
+  })
+
   it('shows no-results message when results are empty', () => {
     mockUseSearchGlobal.mockReturnValue({
       data: { query: 'zzz', results: [] },

--- a/frontend/src/types/search.ts
+++ b/frontend/src/types/search.ts
@@ -3,6 +3,11 @@ export type GlobalSearchResultType =
   | 'customer'
   | 'product'
   | 'transaction'
+  | 'supplier'
+  | 'invoice'
+  | 'customer_payment'
+  | 'vendor_payment'
+  | 'journal_entry'
 
 export interface GlobalSearchResultDto {
   type: GlobalSearchResultType

--- a/frontend/src/utils/recentSearch.ts
+++ b/frontend/src/utils/recentSearch.ts
@@ -4,7 +4,16 @@ export interface RecentSearchItem {
   label: string
   description?: string
   route: string
-  type: 'page' | 'customer' | 'product' | 'transaction'
+  type:
+    | 'page'
+    | 'customer'
+    | 'product'
+    | 'transaction'
+    | 'supplier'
+    | 'invoice'
+    | 'customer_payment'
+    | 'vendor_payment'
+    | 'journal_entry'
   timestamp: number
 }
 


### PR DESCRIPTION
## Summary

- Enables `pg_trgm` extension and adds 12 GIN trigram indexes across 7 tables for fuzzy search support
- Adds fuzzy fallback (similarity threshold 0.3) to all existing `searchGlobal` methods (Customer, Product, SalesOrder, PurchaseOrder) — ILIKE runs first, fuzzy only fires on zero results
- Adds `searchGlobal` to five new services: Supplier, Invoice, CustomerPayment, VendorPayment, JournalEntry — each with inline ILIKE + fuzzy fallback and role-based permission guards
- Wires all 10 sources into `SearchService.Promise.all` fan-out; extends frontend type contract and `SearchModal` grouping/badges for new result types

## Closes

Closes #156

## Test Plan

- [x] Migration applied cleanly (`migration:run --transaction none`), 12 trigram indexes confirmed via `\di *trgm*`
- [x] `customer.service.spec.ts` — red/green on fuzzy fallback tests
- [x] `product.service.spec.ts` — red/green on fuzzy fallback tests
- [x] `invoice.service.spec.ts` — passes (new spec file)
- [x] `search.service.spec.ts` — passes with 10-source fan-out
- [x] `cd backend && npm run test` — 44 suites, 627 tests passing
- [x] `cd backend && npx tsc --noEmit` — no errors
- [x] `cd backend && npm run lint` — clean
- [x] `cd frontend && npm run type-check` — no errors
- [x] `cd frontend && npm run lint` — clean
- [x] `SearchModal.test.tsx` — 19 tests passing
- [x] `cd frontend && npm run test` — 78 files, 458 tests passing
- [x] Manual browser smoke test (new entity badges, fuzzy typo recovery) — not yet performed

## Out of Scope (Phase 5)

Analytics (query logging, click tracking, zero-result analysis) deferred per spec.