### PR TITLE
feat(search): Phase 5 — search analytics & observability

### DIFF
--- a/backend/src/config/database-config.factory.ts
+++ b/backend/src/config/database-config.factory.ts
@@ -38,6 +38,8 @@ import { ReconciledTransaction } from '../database/entities/reconciled-transacti
 import { RefreshToken } from '../database/entities/refresh-token.entity';
 import { SalesOrder } from '../database/entities/sales-order.entity';
 import { SalesOrderItem } from '../database/entities/sales-order-item.entity';
+import { SearchClick } from '../database/entities/search-click.entity';
+import { SearchQuery } from '../database/entities/search-query.entity';
 import { Settlement } from '../database/entities/settlement.entity';
 import { StockAdjustment, StockAdjustmentItem } from '../database/entities/stock-adjustment.entity';
 import { StockMovement } from '../database/entities/stock-movement.entity';
@@ -89,7 +91,7 @@ export function createDatabaseConfig(configService: ConfigService, allowDefaults
       Invoice, InvoiceItem, JournalEntry, JournalEntryLine, OwnerEquityTransaction,
       Payment, PaymentMethodEntity, PriceCostingSettings, PriceList, PriceListItem,
       PrintSettings, Product, PurchaseCostHistory, PurchaseOrder, PurchaseOrderItem,
-      ReconciledTransaction, RefreshToken, SalesOrder, SalesOrderItem, Settlement,
+      ReconciledTransaction, RefreshToken, SalesOrder, SalesOrderItem, SearchClick, SearchQuery, Settlement,
       StockAdjustment, StockAdjustmentItem, StockMovement, Supplier, User, VendorPayment,
     ],
     migrations: [__dirname + '/../database/migrations/*{.ts,.js}'],

--- a/backend/src/database/entities/index.ts
+++ b/backend/src/database/entities/index.ts
@@ -12,5 +12,7 @@ export { PurchaseOrder } from './purchase-order.entity';
 export { PurchaseOrderItem } from './purchase-order-item.entity';
 export { GoodsReceivedNote } from './goods-received-note.entity';
 export { GoodsReceivedNoteItem } from './goods-received-note-item.entity';
+export { SearchClick } from './search-click.entity';
+export { SearchQuery } from './search-query.entity';
 export { VendorPayment } from './vendor-payment.entity';
 export { PaymentMethodEntity } from './payment-method.entity';

--- a/backend/src/database/entities/search-click.entity.ts
+++ b/backend/src/database/entities/search-click.entity.ts
@@ -25,19 +25,19 @@ export class SearchClick {
   @Column({ type: 'varchar', length: 500 })
   query: string;
 
-  @Column({ type: 'varchar', length: 100 })
+  @Column({ type: 'varchar', length: 100, name: 'result_type' })
   resultType: string;
 
-  @Column({ type: 'varchar', length: 255 })
+  @Column({ type: 'varchar', length: 255, name: 'result_id' })
   resultId: string;
 
-  @Column({ type: 'varchar', length: 255, nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true, name: 'result_label' })
   resultLabel: string | null;
 
   @Column({ type: 'int' })
   position: number;
 
-  @CreateDateColumn({ type: 'timestamptz' })
+  @CreateDateColumn({ type: 'timestamptz', name: 'created_at' })
   @Index()
   createdAt: Date;
 }

--- a/backend/src/database/entities/search-click.entity.ts
+++ b/backend/src/database/entities/search-click.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { SearchQuery } from './search-query.entity';
+
+@Entity('search_clicks')
+export class SearchClick {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => SearchQuery, { nullable: true, onDelete: 'NO ACTION' })
+  @JoinColumn({ name: 'search_query_id' })
+  @Index()
+  searchQuery: SearchQuery | null;
+
+  @Column({ type: 'uuid', nullable: true, name: 'search_query_id' })
+  searchQueryId: string | null;
+
+  @Column({ type: 'varchar', length: 500 })
+  query: string;
+
+  @Column({ type: 'varchar', length: 100 })
+  resultType: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  resultId: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  resultLabel: string | null;
+
+  @Column({ type: 'int' })
+  position: number;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  @Index()
+  createdAt: Date;
+}

--- a/backend/src/database/entities/search-query.entity.ts
+++ b/backend/src/database/entities/search-query.entity.ts
@@ -1,0 +1,25 @@
+import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
+
+@Entity('search_queries')
+@Index(['userId'])
+@Index(['resultCount', 'createdAt'])
+export class SearchQuery {
+  @PrimaryColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 500 })
+  query: string;
+
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @Column({ type: 'int' })
+  resultCount: number;
+
+  @Column({ type: 'int' })
+  executionTimeMs: number;
+
+  @Column({ type: 'timestamptz', default: () => 'CURRENT_TIMESTAMP' })
+  @Index()
+  createdAt: Date;
+}

--- a/backend/src/database/entities/search-query.entity.ts
+++ b/backend/src/database/entities/search-query.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, Index, PrimaryColumn } from 'typeorm';
 
 @Entity('search_queries')
 @Index(['userId'])
@@ -10,16 +10,16 @@ export class SearchQuery {
   @Column({ type: 'varchar', length: 500 })
   query: string;
 
-  @Column({ type: 'uuid' })
+  @Column({ type: 'uuid', name: 'user_id' })
   userId: string;
 
-  @Column({ type: 'int' })
+  @Column({ type: 'int', name: 'result_count' })
   resultCount: number;
 
-  @Column({ type: 'int' })
+  @Column({ type: 'int', name: 'execution_time_ms' })
   executionTimeMs: number;
 
-  @Column({ type: 'timestamptz', default: () => 'CURRENT_TIMESTAMP' })
+  @CreateDateColumn({ type: 'timestamptz', name: 'created_at' })
   @Index()
   createdAt: Date;
 }

--- a/backend/src/database/migrations/1774245930223-AddSearchAnalyticsTables.ts
+++ b/backend/src/database/migrations/1774245930223-AddSearchAnalyticsTables.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddSearchAnalyticsTables1774245930223 implements MigrationInterface {
+    name = 'AddSearchAnalyticsTables1774245930223'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "search_queries" ("id" uuid NOT NULL, "query" character varying(500) NOT NULL, "user_id" uuid NOT NULL, "result_count" integer NOT NULL, "execution_time_ms" integer NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_2945172d2d9a9f6b2339dd036e7" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "IDX_4981129d48833f45cc3e70f06b" ON "search_queries" ("created_at") `);
+        await queryRunner.query(`CREATE INDEX "IDX_b3f9a7099bd43b431de8e95dca" ON "search_queries" ("result_count", "created_at") `);
+        await queryRunner.query(`CREATE INDEX "IDX_65121ce59bf1c4494a6dba198f" ON "search_queries" ("user_id") `);
+        await queryRunner.query(`CREATE TABLE "search_clicks" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "search_query_id" uuid, "query" character varying(500) NOT NULL, "result_type" character varying(100) NOT NULL, "result_id" character varying(255) NOT NULL, "result_label" character varying(255), "position" integer NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_93b47d43bd22156a7208dcc8a3b" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "IDX_2ccac1b7ddd1b101f17845a6ce" ON "search_clicks" ("search_query_id") `);
+        await queryRunner.query(`CREATE INDEX "IDX_8dc36f8afc4975f27074d0bf5c" ON "search_clicks" ("created_at") `);
+        await queryRunner.query(`ALTER TABLE "search_clicks" ADD CONSTRAINT "FK_2ccac1b7ddd1b101f17845a6ced" FOREIGN KEY ("search_query_id") REFERENCES "search_queries"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "search_clicks" DROP CONSTRAINT "FK_2ccac1b7ddd1b101f17845a6ced"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_8dc36f8afc4975f27074d0bf5c"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_2ccac1b7ddd1b101f17845a6ce"`);
+        await queryRunner.query(`DROP TABLE "search_clicks"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_65121ce59bf1c4494a6dba198f"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_b3f9a7099bd43b431de8e95dca"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_4981129d48833f45cc3e70f06b"`);
+        await queryRunner.query(`DROP TABLE "search_queries"`);
+    }
+
+}

--- a/backend/src/modules/search/dto/global-search-response.dto.ts
+++ b/backend/src/modules/search/dto/global-search-response.dto.ts
@@ -2,5 +2,6 @@ import { GlobalSearchResultDto } from './global-search-result.dto';
 
 export class GlobalSearchResponseDto {
   query: string;
+  searchQueryId: string;
   results: GlobalSearchResultDto[];
 }

--- a/backend/src/modules/search/dto/track-click.dto.spec.ts
+++ b/backend/src/modules/search/dto/track-click.dto.spec.ts
@@ -1,0 +1,58 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { TrackClickDto } from './track-click.dto';
+import { SearchResultType } from '../search-result-type.enum';
+
+describe('TrackClickDto', () => {
+  function make(overrides: Partial<TrackClickDto> = {}): TrackClickDto {
+    return plainToInstance(TrackClickDto, {
+      query: 'acme',
+      resultType: SearchResultType.CUSTOMER,
+      resultId: 'some-id',
+      position: 1,
+      ...overrides,
+    });
+  }
+
+  it('passes with minimal valid payload', async () => {
+    const errors = await validate(make());
+    expect(errors).toHaveLength(0);
+  });
+
+  it('passes with all optional fields', async () => {
+    const errors = await validate(
+      make({
+        searchQueryId: '550e8400-e29b-41d4-a716-446655440000',
+        resultLabel: 'Acme Corp',
+      }),
+    );
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects invalid resultType', async () => {
+    const errors = await validate(make({ resultType: 'invalid' as any }));
+    expect(errors.some((e) => e.property === 'resultType')).toBe(true);
+  });
+
+  it('rejects position < 1', async () => {
+    const errors = await validate(make({ position: 0 }));
+    expect(errors.some((e) => e.property === 'position')).toBe(true);
+  });
+
+  it('rejects position > 20', async () => {
+    const errors = await validate(make({ position: 21 }));
+    expect(errors.some((e) => e.property === 'position')).toBe(true);
+  });
+
+  it('rejects invalid UUID for searchQueryId', async () => {
+    const errors = await validate(make({ searchQueryId: 'not-a-uuid' }));
+    expect(errors.some((e) => e.property === 'searchQueryId')).toBe(true);
+  });
+
+  it('accepts missing searchQueryId', async () => {
+    const dto = make();
+    delete (dto as any).searchQueryId;
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/backend/src/modules/search/dto/track-click.dto.ts
+++ b/backend/src/modules/search/dto/track-click.dto.ts
@@ -1,0 +1,38 @@
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { SearchResultType } from '../search-result-type.enum';
+
+export class TrackClickDto {
+  @IsOptional()
+  @IsUUID()
+  searchQueryId?: string;
+
+  @IsString()
+  @MaxLength(500)
+  query: string;
+
+  @IsEnum(SearchResultType)
+  resultType: SearchResultType;
+
+  @IsString()
+  @MaxLength(255)
+  resultId: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  resultLabel?: string;
+
+  @IsInt()
+  @Min(1)
+  @Max(20)
+  position: number;
+}

--- a/backend/src/modules/search/search-analytics.service.spec.ts
+++ b/backend/src/modules/search/search-analytics.service.spec.ts
@@ -1,0 +1,104 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { SearchAnalyticsService } from './search-analytics.service';
+import { SearchQuery } from '../../database/entities/search-query.entity';
+import { SearchClick } from '../../database/entities/search-click.entity';
+
+describe('SearchAnalyticsService', () => {
+  let service: SearchAnalyticsService;
+  let queryRepo: { save: jest.Mock };
+  let clickRepo: { save: jest.Mock };
+
+  beforeEach(async () => {
+    queryRepo = { save: jest.fn().mockResolvedValue({}) };
+    clickRepo = { save: jest.fn().mockResolvedValue({}) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SearchAnalyticsService,
+        { provide: getRepositoryToken(SearchQuery), useValue: queryRepo },
+        { provide: getRepositoryToken(SearchClick), useValue: clickRepo },
+      ],
+    }).compile();
+
+    service = module.get(SearchAnalyticsService);
+  });
+
+  describe('logQuery()', () => {
+    const params = {
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      query: 'acme',
+      userId: 'user-uuid',
+      resultCount: 5,
+      executionTimeMs: 42,
+    };
+
+    it('calls queryRepo.save with correct data', async () => {
+      service.logQuery(params);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(queryRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: params.id,
+          query: params.query,
+          userId: params.userId,
+          resultCount: params.resultCount,
+          executionTimeMs: params.executionTimeMs,
+        }),
+      );
+    });
+
+    it('does not throw when repo.save rejects', async () => {
+      queryRepo.save.mockRejectedValueOnce(new Error('db error'));
+
+      expect(() => service.logQuery(params)).not.toThrow();
+      await new Promise((resolve) => setImmediate(resolve));
+    });
+  });
+
+  describe('logClick()', () => {
+    const params = {
+      searchQueryId: '550e8400-e29b-41d4-a716-446655440000',
+      query: 'acme',
+      resultType: 'customer',
+      resultId: 'cust-uuid',
+      resultLabel: 'Acme Corp',
+      position: 1,
+    };
+
+    it('calls clickRepo.save with correct data', async () => {
+      service.logClick(params);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(clickRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          searchQueryId: params.searchQueryId,
+          query: params.query,
+          resultType: params.resultType,
+          resultId: params.resultId,
+          resultLabel: params.resultLabel,
+          position: params.position,
+        }),
+      );
+    });
+
+    it('does not throw when repo.save rejects', async () => {
+      clickRepo.save.mockRejectedValueOnce(new Error('db error'));
+
+      expect(() => service.logClick(params)).not.toThrow();
+      await new Promise((resolve) => setImmediate(resolve));
+    });
+
+    it('accepts undefined searchQueryId', async () => {
+      const paramsNoId = { ...params, searchQueryId: undefined };
+
+      expect(() => service.logClick(paramsNoId)).not.toThrow();
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(clickRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          searchQueryId: null,
+        }),
+      );
+    });
+  });
+});

--- a/backend/src/modules/search/search-analytics.service.ts
+++ b/backend/src/modules/search/search-analytics.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SearchQuery } from '../../database/entities/search-query.entity';
+import { SearchClick } from '../../database/entities/search-click.entity';
+
+@Injectable()
+export class SearchAnalyticsService {
+  private readonly logger = new Logger(SearchAnalyticsService.name);
+
+  constructor(
+    @InjectRepository(SearchQuery)
+    private readonly queryRepo: Repository<SearchQuery>,
+    @InjectRepository(SearchClick)
+    private readonly clickRepo: Repository<SearchClick>,
+  ) {}
+
+  logQuery(params: {
+    id: string;
+    query: string;
+    userId: string;
+    resultCount: number;
+    executionTimeMs: number;
+  }): void {
+    this.queryRepo.save({
+      id: params.id,
+      query: params.query,
+      userId: params.userId,
+      resultCount: params.resultCount,
+      executionTimeMs: params.executionTimeMs,
+    }).catch((error: Error) => {
+      this.logger.error(
+        `Failed to log search query: ${error.message}`,
+        error.stack,
+      );
+    });
+  }
+
+  logClick(params: {
+    searchQueryId?: string;
+    query: string;
+    resultType: string;
+    resultId: string;
+    resultLabel?: string;
+    position: number;
+  }): void {
+    this.clickRepo.save({
+      searchQueryId: params.searchQueryId ?? null,
+      query: params.query,
+      resultType: params.resultType,
+      resultId: params.resultId,
+      resultLabel: params.resultLabel ?? null,
+      position: params.position,
+    }).catch((error: Error) => {
+      this.logger.error(
+        `Failed to log search click: ${error.message}`,
+        error.stack,
+      );
+    });
+  }
+}

--- a/backend/src/modules/search/search-result-type.enum.ts
+++ b/backend/src/modules/search/search-result-type.enum.ts
@@ -1,0 +1,11 @@
+export enum SearchResultType {
+  PAGE = 'page',
+  CUSTOMER = 'customer',
+  PRODUCT = 'product',
+  TRANSACTION = 'transaction',
+  SUPPLIER = 'supplier',
+  INVOICE = 'invoice',
+  CUSTOMER_PAYMENT = 'customer_payment',
+  VENDOR_PAYMENT = 'vendor_payment',
+  JOURNAL_ENTRY = 'journal_entry',
+}

--- a/backend/src/modules/search/search.controller.spec.ts
+++ b/backend/src/modules/search/search.controller.spec.ts
@@ -1,0 +1,60 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SearchController } from './search.controller';
+import { SearchService } from './search.service';
+import { SearchAnalyticsService } from './search-analytics.service';
+import { SearchResultType } from './search-result-type.enum';
+
+describe('SearchController', () => {
+  let controller: SearchController;
+  let analyticsService: { logClick: jest.Mock };
+
+  beforeEach(async () => {
+    analyticsService = { logClick: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SearchController],
+      providers: [
+        {
+          provide: SearchService,
+          useValue: {
+            search: jest.fn().mockResolvedValue({
+              query: '',
+              searchQueryId: 'sq-id',
+              results: [],
+            }),
+          },
+        },
+        {
+          provide: SearchAnalyticsService,
+          useValue: analyticsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get(SearchController);
+  });
+
+  it('POST /search/click calls logClick and returns undefined', async () => {
+    const dto = {
+      query: 'acme',
+      resultType: SearchResultType.CUSTOMER,
+      resultId: 'cust-1',
+      resultLabel: 'Acme Corp',
+      position: 1,
+    };
+
+    const result = await controller.trackClick(dto as any, {
+      user: { userId: 'u1' },
+    } as any);
+
+    expect(analyticsService.logClick).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: 'acme',
+        resultType: SearchResultType.CUSTOMER,
+        resultId: 'cust-1',
+        position: 1,
+      }),
+    );
+    expect(result).toBeUndefined();
+  });
+});

--- a/backend/src/modules/search/search.controller.ts
+++ b/backend/src/modules/search/search.controller.ts
@@ -1,13 +1,18 @@
-import { Controller, Get, Query, Request } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Post, Query, Request } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { SearchAnalyticsService } from './search-analytics.service';
 import { SearchService } from './search.service';
 import { GlobalSearchQueryDto } from './dto/global-search-query.dto';
 import { GlobalSearchResponseDto } from './dto/global-search-response.dto';
+import { TrackClickDto } from './dto/track-click.dto';
 
 @ApiTags('Search')
 @Controller('search')
 export class SearchController {
-  constructor(private readonly searchService: SearchService) {}
+  constructor(
+    private readonly searchService: SearchService,
+    private readonly searchAnalyticsService: SearchAnalyticsService,
+  ) {}
 
   @Get('global')
   @ApiOperation({
@@ -18,5 +23,19 @@ export class SearchController {
     @Request() req: any,
   ): Promise<GlobalSearchResponseDto> {
     return this.searchService.search(query.q, req.user);
+  }
+
+  @Post('click')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Track a search result click' })
+  trackClick(@Body() dto: TrackClickDto, @Request() req: any): void {
+    this.searchAnalyticsService.logClick({
+      searchQueryId: dto.searchQueryId,
+      query: dto.query.trim(),
+      resultType: dto.resultType,
+      resultId: dto.resultId,
+      resultLabel: dto.resultLabel,
+      position: dto.position,
+    });
   }
 }

--- a/backend/src/modules/search/search.module.ts
+++ b/backend/src/modules/search/search.module.ts
@@ -1,14 +1,25 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AccountingModule } from '../accounting/accounting.module';
 import { InventoryModule } from '../inventory/inventory.module';
 import { PurchasingModule } from '../purchasing/purchasing.module';
 import { SalesModule } from '../sales/sales.module';
+import { SearchClick } from '../../database/entities/search-click.entity';
+import { SearchQuery } from '../../database/entities/search-query.entity';
+import { SearchAnalyticsService } from './search-analytics.service';
 import { SearchController } from './search.controller';
+import { SearchScheduler } from './search.scheduler';
 import { SearchService } from './search.service';
 
 @Module({
-  imports: [SalesModule, InventoryModule, PurchasingModule, AccountingModule],
+  imports: [
+    TypeOrmModule.forFeature([SearchQuery, SearchClick]),
+    SalesModule,
+    InventoryModule,
+    PurchasingModule,
+    AccountingModule,
+  ],
   controllers: [SearchController],
-  providers: [SearchService],
+  providers: [SearchService, SearchAnalyticsService, SearchScheduler],
 })
 export class SearchModule {}

--- a/backend/src/modules/search/search.scheduler.spec.ts
+++ b/backend/src/modules/search/search.scheduler.spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DataSource } from 'typeorm';
+import { SearchScheduler } from './search.scheduler';
+
+describe('SearchScheduler', () => {
+  let scheduler: SearchScheduler;
+  let mockQueryRunner: {
+    connect: jest.Mock;
+    startTransaction: jest.Mock;
+    commitTransaction: jest.Mock;
+    rollbackTransaction: jest.Mock;
+    release: jest.Mock;
+    query: jest.Mock;
+  };
+  let mockDataSource: { createQueryRunner: jest.Mock };
+
+  beforeEach(async () => {
+    mockQueryRunner = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      startTransaction: jest.fn().mockResolvedValue(undefined),
+      commitTransaction: jest.fn().mockResolvedValue(undefined),
+      rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+      release: jest.fn().mockResolvedValue(undefined),
+      query: jest.fn().mockResolvedValue([{ id: 'row-1' }, { id: 'row-2' }]),
+    };
+    mockDataSource = {
+      createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SearchScheduler,
+        { provide: DataSource, useValue: mockDataSource },
+      ],
+    }).compile();
+
+    scheduler = module.get(SearchScheduler);
+  });
+
+  it('deletes clicks before queries in one transaction', async () => {
+    await scheduler.handleRetentionCleanup();
+
+    expect(mockQueryRunner.startTransaction).toHaveBeenCalled();
+    expect(mockQueryRunner.query).toHaveBeenCalledTimes(2);
+
+    const [firstCall, secondCall] = mockQueryRunner.query.mock.calls;
+    expect(firstCall[0]).toContain('search_clicks');
+    expect(secondCall[0]).toContain('search_queries');
+
+    expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+    expect(mockQueryRunner.release).toHaveBeenCalled();
+  });
+
+  it('rolls back and does not rethrow on error', async () => {
+    mockQueryRunner.query.mockRejectedValueOnce(new Error('db error'));
+
+    await expect(scheduler.handleRetentionCleanup()).resolves.not.toThrow();
+    expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+    expect(mockQueryRunner.release).toHaveBeenCalled();
+  });
+
+  it('always releases the query runner even on rollback failure', async () => {
+    mockQueryRunner.query.mockRejectedValueOnce(new Error('db error'));
+    mockQueryRunner.rollbackTransaction.mockRejectedValueOnce(
+      new Error('rollback error'),
+    );
+
+    await expect(scheduler.handleRetentionCleanup()).resolves.not.toThrow();
+    expect(mockQueryRunner.release).toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/search/search.scheduler.ts
+++ b/backend/src/modules/search/search.scheduler.ts
@@ -1,0 +1,53 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { DataSource } from 'typeorm';
+
+const RETENTION_DAYS = 90;
+
+@Injectable()
+export class SearchScheduler {
+  private readonly logger = new Logger(SearchScheduler.name);
+
+  constructor(private readonly dataSource: DataSource) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_2AM)
+  async handleRetentionCleanup(): Promise<void> {
+    this.logger.log('Starting search analytics retention cleanup');
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      const clickResult: { id: string }[] = await queryRunner.query(
+        `DELETE FROM search_clicks WHERE created_at < NOW() - INTERVAL '${RETENTION_DAYS} days'
+         RETURNING id`,
+      );
+      const clicksDeleted = clickResult.length;
+
+      const queryResult: { id: string }[] = await queryRunner.query(
+        `DELETE FROM search_queries WHERE created_at < NOW() - INTERVAL '${RETENTION_DAYS} days'
+         RETURNING id`,
+      );
+      const queriesDeleted = queryResult.length;
+
+      await queryRunner.commitTransaction();
+      this.logger.log(
+        `Retention cleanup complete: ${clicksDeleted} clicks, ${queriesDeleted} queries deleted`,
+      );
+    } catch (error) {
+      await queryRunner.rollbackTransaction().catch((rollbackError: Error) => {
+        this.logger.error(
+          'Rollback failed during retention cleanup',
+          rollbackError.stack,
+        );
+      });
+      this.logger.error(
+        'Search analytics retention cleanup failed',
+        (error as Error).stack,
+      );
+    } finally {
+      await queryRunner.release();
+    }
+  }
+}

--- a/backend/src/modules/search/search.service.spec.ts
+++ b/backend/src/modules/search/search.service.spec.ts
@@ -9,10 +9,12 @@ import { SalesOrderService } from '../sales/services/sales-order.service';
 import { InvoiceService } from '../sales/services/invoice.service';
 import { PaymentService } from '../sales/services/payment.service';
 import { PurchaseOrderService } from '../purchasing/services/purchase-order.service';
+import { SearchAnalyticsService } from './search-analytics.service';
 import { GlobalSearchResultDto } from './dto/global-search-result.dto';
 import { UserRole } from '../../database/entities/user.entity';
 
 describe('SearchService', () => {
+  let module: TestingModule;
   let service: SearchService;
   let customerService: jest.Mocked<Pick<CustomerService, 'searchGlobal'>>;
   let productService: jest.Mocked<Pick<ProductService, 'searchGlobal'>>;
@@ -27,6 +29,7 @@ describe('SearchService', () => {
   let journalEntryService: jest.Mocked<
     Pick<JournalEntryService, 'searchGlobal'>
   >;
+  let searchAnalyticsService: jest.Mocked<Pick<SearchAnalyticsService, 'logQuery'>>;
 
   const mockUser = { userId: 'u1', username: 'admin' } as any;
 
@@ -39,7 +42,7 @@ describe('SearchService', () => {
   });
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    module = await Test.createTestingModule({
       providers: [
         SearchService,
         {
@@ -78,6 +81,10 @@ describe('SearchService', () => {
           provide: JournalEntryService,
           useValue: { searchGlobal: jest.fn().mockResolvedValue([]) },
         },
+        {
+          provide: SearchAnalyticsService,
+          useValue: { logQuery: jest.fn() },
+        },
       ],
     }).compile();
 
@@ -91,6 +98,7 @@ describe('SearchService', () => {
     paymentService = module.get(PaymentService);
     vendorPaymentService = module.get(VendorPaymentService);
     journalEntryService = module.get(JournalEntryService);
+    searchAnalyticsService = module.get(SearchAnalyticsService);
   });
 
   it('fans out to all ten sources in parallel', async () => {
@@ -297,6 +305,41 @@ describe('SearchService', () => {
           ),
         ).toBeUndefined();
       }
+    });
+  });
+
+  describe('searchQueryId', () => {
+    it('includes searchQueryId in the response', async () => {
+      const result = await service.search('test', mockUser);
+
+      expect(result.searchQueryId).toBeDefined();
+      expect(typeof result.searchQueryId).toBe('string');
+      expect(result.searchQueryId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
+    });
+
+    it('calls logQuery with correct params', async () => {
+      await service.search('acme', mockUser);
+
+      expect(searchAnalyticsService.logQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: 'acme',
+          userId: mockUser.userId,
+          resultCount: expect.any(Number),
+          executionTimeMs: expect.any(Number),
+        }),
+      );
+    });
+
+    it('returns searchQueryId even when logQuery throws', async () => {
+      searchAnalyticsService.logQuery.mockImplementation(() => {
+        throw new Error('unexpected');
+      });
+
+      const result = await service.search('test', mockUser);
+
+      expect(result.searchQueryId).toBeDefined();
     });
   });
 });

--- a/backend/src/modules/search/search.service.ts
+++ b/backend/src/modules/search/search.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
 import { ProductService } from '../inventory/services/product.service';
 import { JournalEntryService } from '../accounting/services/journal-entry.service';
 import { PurchaseOrderService } from '../purchasing/services/purchase-order.service';
@@ -26,6 +27,7 @@ import {
   SCORE_PAGE_KEYWORD,
   BOOST_PAGE,
 } from './search.constants';
+import { SearchAnalyticsService } from './search-analytics.service';
 
 const STATIC_PAGES: Array<{
   label: string;
@@ -385,13 +387,17 @@ export class SearchService {
     private readonly paymentService: PaymentService,
     private readonly vendorPaymentService: VendorPaymentService,
     private readonly journalEntryService: JournalEntryService,
+    private readonly searchAnalyticsService: SearchAnalyticsService,
   ) {}
 
   async search(query: string, user: any): Promise<GlobalSearchResponseDto> {
     const trimmed = query?.trim() ?? '';
     if (trimmed.length < 2) {
-      return { query, results: [] };
+      return { query, searchQueryId: uuidv4(), results: [] };
     }
+
+    const searchQueryId = uuidv4();
+    const startTime = Date.now();
 
     const [
       pages,
@@ -437,6 +443,8 @@ export class SearchService {
       ),
     ]);
 
+    const executionTimeMs = Date.now() - startTime;
+
     const results = [
       ...pages,
       ...customers,
@@ -459,7 +467,21 @@ export class SearchService {
       })
       .slice(0, SEARCH_RESPONSE_LIMIT);
 
-    return { query, results };
+    try {
+      this.searchAnalyticsService.logQuery({
+        id: searchQueryId,
+        query: trimmed,
+        userId: user.userId,
+        resultCount: results.length,
+        executionTimeMs,
+      });
+    } catch (error) {
+      this.logger.error(
+        `Search analytics logging failed: ${(error as Error).message}`,
+      );
+    }
+
+    return { query, searchQueryId, results };
   }
 
   private async safeSearch(

--- a/backend/test/jest-e2e-global-setup.ts
+++ b/backend/test/jest-e2e-global-setup.ts
@@ -15,7 +15,7 @@ export default async function globalSetup() {
     port: parseInt(DB_PORT || '5432', 10),
     user: DB_USERNAME || 'erp_user',
     password: DB_PASSWORD,
-    database: 'erp_db', // connect to existing DB to issue CREATE DATABASE
+    database: 'postgres', // connect to maintenance DB — cannot drop the DB you're connected to
   });
 
   await client.connect();


### PR DESCRIPTION
## Summary

- Adds `search_queries` and `search_clicks` tables to capture search usage data (query text, user, result count, execution time, clicked result, position)
- Extends `GET /search/global` response with `searchQueryId` for query-to-click correlation; adds `POST /search/click` for click tracking
- Adds daily retention scheduler that hard-deletes analytics rows older than 90 days in a single transaction (clicks first, then queries)
- Analytics failures are fully isolated — a DB write error never affects search response or UX
- Fixes a pre-existing e2e test harness bug where global setup connected to `erp_db` then tried to drop it (PostgreSQL rejects dropping the currently open database)

## Test Plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test` — 646 passed (48 suites), including unit tests for `SearchAnalyticsService`, `SearchScheduler`, `TrackClickDto`, updated `SearchService` and `SearchController`
- [x] `npm run test:e2e` — 94 passed (5 suites)
- [x] Manual smoke test: `GET /search/global?q=acme` returns `searchQueryId`; `POST /search/click` returns 201; rows confirmed in `search_queries` and `search_clicks`
- [x] Migration verified: `npm run migration:run` reports no pending migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)