### PR TITLE
feat(ui): polish PageHeader and roll out to Inventory, Settings, Purchasing

### DIFF
--- a/frontend/src/components/common/PageHeader.tsx
+++ b/frontend/src/components/common/PageHeader.tsx
@@ -31,7 +31,7 @@ export default function PageHeader({
     <Box
       data-testid={showDivider ? 'page-header-divider' : undefined}
       sx={{
-        mb: 3,
+        mb: 4,
         pb: 2,
         ...(showDivider && {
           borderBottom: `1px solid ${theme.palette.divider}`,
@@ -53,7 +53,7 @@ export default function PageHeader({
         <Box sx={{ minWidth: 0 }}>
           <Typography
             variant="h5"
-            sx={{ fontWeight: 600, color: 'text.primary', lineHeight: 1.2 }}
+            sx={{ fontWeight: 700, color: 'text.primary', lineHeight: 1.2 }}
           >
             {title}
           </Typography>

--- a/frontend/src/pages/inventory/CreateProductPage.tsx
+++ b/frontend/src/pages/inventory/CreateProductPage.tsx
@@ -24,11 +24,11 @@ import { useGetPriceListsQuery, useBulkUpdatePricesMutation, priceListApiSlice }
 import { useCreateProductMutation, useLazyGetProductQuery, useUpdateProductMutation } from '@/store/api/inventoryApi'
 import { useDispatch } from 'react-redux'
 import { useNotification } from '@/hooks/useNotification'
+import PageHeader from '@/components/common/PageHeader'
 import CategorySelector from '@/components/inventory/CategorySelector'
 import { Category, PriceList } from '@/types'
 import { useDuplicateCheck } from '@/hooks/useDuplicateCheck'
 import { useCurrency } from '@/hooks/useCurrency'
-import { TYPOGRAPHY_STYLES } from '@/constants/typography'
 
 // Price field component for price list items
 const PriceListPriceField: React.FC<{
@@ -389,26 +389,25 @@ const CreateProductPage: React.FC = () => {
     <Container maxWidth="xl">
       <Box sx={{ py: 3 }}>
         {/* Header */}
-        <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
-          <IconButton
-            onClick={() => {
-              // When going back in edit mode, navigate back with the product ID to keep it selected
-              if (isEditMode && id) {
-                navigate('/inventory/products', {
-                  state: { selectedProductId: id }
-                })
-              } else {
-                navigate('/inventory/products')
-              }
-            }}
-            sx={{ mr: 2 }}
-          >
-            <ArrowBackIcon />
-          </IconButton>
-          <Typography variant={TYPOGRAPHY_STYLES.pageHeader.variant} sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight }}>
-            {isEditMode ? 'Edit Product' : 'Create Product'}
-          </Typography>
-        </Box>
+        <IconButton
+          onClick={() => {
+            // When going back in edit mode, navigate back with the product ID to keep it selected
+            if (isEditMode && id) {
+              navigate('/inventory/products', {
+                state: { selectedProductId: id }
+              })
+            } else {
+              navigate('/inventory/products')
+            }
+          }}
+          sx={{ mr: 2, mb: 1 }}
+        >
+          <ArrowBackIcon />
+        </IconButton>
+        <PageHeader
+          title={isEditMode ? 'Edit Product' : 'Create Product'}
+          showDivider={false}
+        />
 
         {isFetchingProduct ? (
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>

--- a/frontend/src/pages/inventory/InventoryPage.tsx
+++ b/frontend/src/pages/inventory/InventoryPage.tsx
@@ -43,6 +43,7 @@ import {
 } from 'chart.js'
 import { Bar, Doughnut } from 'react-chartjs-2'
 import { format } from 'date-fns'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { useNavigate } from 'react-router-dom'
@@ -238,38 +239,12 @@ const InventoryPage: React.FC = () => {
   return (
     <Box sx={{ p: 3 }}>
       {/* Header */}
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-        <Box>
-          <Typography variant={TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <InventoryIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Inventory Overview
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Monitor stock levels, track movements, and manage inventory health
-          </Typography>
-        </Box>
-        <Box sx={{ display: 'flex', gap: 1 }}>
-          <Button variant="outlined" onClick={() => navigate('/inventory/categories')}>
-            Manage Categories
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={<AddIcon />}
-            onClick={() => navigate('/inventory/products')}
-          >
-            Add Product
-          </Button>
-        </Box>
-      </Box>
+      <PageHeader
+        title="Inventory Overview"
+        subtitle="Monitor stock levels, track movements, and manage inventory health"
+        secondaryAction={{ label: 'Manage Categories', onClick: () => navigate('/inventory/categories') }}
+        primaryAction={{ label: 'Add Product', onClick: () => navigate('/inventory/products') }}
+      />
       {/* Error Alert */}
       {error && (
         <Alert severity="error" sx={{ mb: 4 }}>

--- a/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
@@ -30,7 +30,6 @@ import {
 import {
   Add as AddIcon,
   Search as SearchIcon,
-  SwapVert as StockAdjustmentIcon,
   Sort as SortIcon,
   ArrowUpward as ArrowUpIcon,
   ArrowDownward as ArrowDownIcon,
@@ -38,6 +37,7 @@ import {
   Edit as EditIcon,
   RestoreFromTrash as RestoreIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import DeletedStockAdjustmentsDialog from '@/components/inventory/DeletedStockAdjustmentsDialog'
 import ConfirmationDialog from '@/components/common/ConfirmationDialog'
 import { useLazyGetJournalEntriesQuery } from '@/store/api/accountingApi'
@@ -463,66 +463,12 @@ const StockAdjustmentsPage: React.FC = () => {
   return (
     <Box sx={{ p: 3 }}>
       {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <StockAdjustmentIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Stock Adjustments
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            View and manage stock adjustment history ({pagination?.total || 0} total)
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RestoreIcon /> : undefined}
-            onClick={() => setShowDeletedDialog(true)}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
-            sx={{
-              color: 'warning.main',
-              borderColor: 'warning.main',
-              '&:hover': {
-                borderColor: 'warning.dark',
-                backgroundColor: 'warning.light'
-              }
-            }}
-          >
-            {isMobile ? "View Deleted" : "View Deleted"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <AddIcon /> : undefined}
-            size="medium"
-            onClick={() => navigate('/inventory/stock-adjustments/create')}
-            fullWidth={isMobile}
-          >
-            {isMobile ? "New Adjustment" : "New Adjustment"}
-          </Button>
-        </Box>
-      </Box>
+      <PageHeader
+        title="Stock Adjustments"
+        subtitle="View and manage stock adjustment history"
+        secondaryAction={{ label: 'View Deleted', onClick: () => setShowDeletedDialog(true) }}
+        primaryAction={{ label: 'New Adjustment', onClick: () => navigate('/inventory/stock-adjustments/create') }}
+      />
       {/* Filters and Search */}
       <Paper sx={{ p: 2, mb: 3 }}>
       <Box sx={{

--- a/frontend/src/pages/inventory/components/ProductsToolbar.tsx
+++ b/frontend/src/pages/inventory/components/ProductsToolbar.tsx
@@ -19,9 +19,9 @@ import {
   GetApp as ExportIcon,
   RestoreFromTrash as RestoreIcon,
   Search as SearchIcon,
-  ShoppingCart as ProductIcon,
 } from '@mui/icons-material'
 
+import PageHeader from '@/components/common/PageHeader'
 import { TYPOGRAPHY_STYLES } from '@/constants/typography'
 
 interface ProductsToolbarProps {
@@ -45,7 +45,6 @@ interface ProductsToolbarProps {
 
 const ProductsToolbar: React.FC<ProductsToolbarProps> = ({
   isMobile,
-  productCount,
   searchTerm,
   selectedCategory,
   categories,
@@ -65,74 +64,17 @@ const ProductsToolbar: React.FC<ProductsToolbarProps> = ({
     <>
       <Box
         sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          justifyContent: 'space-between',
-          alignItems: isMobile ? 'stretch' : 'center',
           mb: 3,
-          gap: isMobile ? 2 : 0,
           transition: 'margin-right 0.3s ease-in-out',
           marginRight,
         }}
       >
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography
-            variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant}
-            sx={{
-              fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-              mb: 1,
-              display: 'flex',
-              alignItems: 'center',
-              gap: 2,
-            }}
-          >
-            <ProductIcon
-              sx={{
-                fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-                color: TYPOGRAPHY_STYLES.pageHeader.icon.color,
-              }}
-            />
-            Products
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Manage your product catalog and inventory ({productCount} total)
-          </Typography>
-        </Box>
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: isMobile ? 'column' : 'row',
-            gap: isMobile ? 1.5 : 1,
-            alignItems: isMobile ? 'stretch' : 'center',
-          }}
-        >
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RestoreIcon /> : undefined}
-            onClick={onOpenDeleted}
-            size="medium"
-            fullWidth={isMobile}
-            sx={{
-              color: 'warning.main',
-              borderColor: 'warning.main',
-              '&:hover': {
-                borderColor: 'warning.dark',
-                backgroundColor: 'warning.light',
-              },
-            }}
-          >
-            View Deleted
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <AddIcon /> : undefined}
-            size="medium"
-            onClick={onAddProduct}
-            fullWidth={isMobile}
-          >
-            {isMobile ? 'Add New Product' : 'Add Product'}
-          </Button>
-        </Box>
+        <PageHeader
+          title="Products"
+          subtitle="Manage your product catalog and inventory"
+          secondaryAction={{ label: 'View Deleted', onClick: onOpenDeleted }}
+          primaryAction={{ label: 'Add Product', onClick: onAddProduct }}
+        />
       </Box>
 
       <Paper sx={{ p: 2, mb: 3 }}>

--- a/frontend/src/pages/purchasing/GoodsReceivedPage.tsx
+++ b/frontend/src/pages/purchasing/GoodsReceivedPage.tsx
@@ -28,13 +28,13 @@ import {
 } from '@mui/material'
 import {
   Search as SearchIcon,
-  LocalShipping as GRNIcon,
   RestoreFromTrash as RestoreIcon,
   Sort as SortIcon,
   ArrowUpward as ArrowUpIcon,
   ArrowDownward as ArrowDownIcon,
   Print as PrintIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatDate } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
@@ -344,57 +344,11 @@ const GoodsReceivedPage: React.FC = () => {
   return (
     <Box sx={{ p: 3 }}>
       {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <GRNIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Goods Received Notes
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Track and manage incoming goods from suppliers ({filteredGRNs.length} total)
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RestoreIcon /> : undefined}
-            onClick={() => setDeletedGRNsDialogOpen(true)}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
-            sx={{
-              color: 'warning.main',
-              borderColor: 'warning.main',
-              '&:hover': {
-                borderColor: 'warning.dark',
-                backgroundColor: 'warning.light'
-              }
-            }}
-          >
-            {isMobile ? "View Deleted" : "View Deleted"}
-          </Button>
-        </Box>
-      </Box>
+      <PageHeader
+        title="Goods Received Notes"
+        subtitle="Track and manage incoming goods from suppliers"
+        secondaryAction={{ label: 'View Deleted', onClick: () => setDeletedGRNsDialogOpen(true) }}
+      />
       {/* Filters and Search */}
       <Paper sx={{ p: 2, mb: 3 }}>
       <Box sx={{

--- a/frontend/src/pages/purchasing/SuppliersPage.tsx
+++ b/frontend/src/pages/purchasing/SuppliersPage.tsx
@@ -37,13 +37,13 @@ import {
   Delete as DeleteIcon,
   Visibility as ViewIcon,
   RestoreFromTrash as RestoreIcon,
-  Business as BusinessIcon,
   Phone as PhoneIcon,
   LocationOn as LocationIcon,
 } from '@mui/icons-material'
 import { useForm, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
+import PageHeader from '@/components/common/PageHeader'
 import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import { useNotification } from '@/hooks/useNotification'
 import { useSearchAndFilter, useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
@@ -339,66 +339,12 @@ const SuppliersPage: React.FC = () => {
   return (
     <Box sx={{ p: 3 }}>
       {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <BusinessIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Suppliers
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Manage your suppliers and vendor relationships ({suppliers.length} total)
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RestoreIcon /> : undefined}
-            onClick={() => setIsDeletedDialogOpen(true)}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
-            sx={{
-              color: 'warning.main',
-              borderColor: 'warning.main',
-              '&:hover': {
-                borderColor: 'warning.dark',
-                backgroundColor: 'warning.light'
-              }
-            }}
-          >
-            {isMobile ? "View Deleted" : "View Deleted"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <AddIcon /> : undefined}
-            size="medium"
-            onClick={() => handleOpenForm()}
-            fullWidth={isMobile}
-          >
-            {isMobile ? "Add New Supplier" : "Add Supplier"}
-          </Button>
-        </Box>
-      </Box>
+      <PageHeader
+        title="Suppliers"
+        subtitle="Manage your suppliers and vendor relationships"
+        secondaryAction={{ label: 'View Deleted', onClick: () => setIsDeletedDialogOpen(true) }}
+        primaryAction={{ label: 'Add Supplier', onClick: () => handleOpenForm() }}
+      />
       {/* Filters and Search */}
       <Paper sx={{ p: 2, mb: 3 }}>
       <Box sx={{

--- a/frontend/src/pages/purchasing/VendorPaymentsPage.tsx
+++ b/frontend/src/pages/purchasing/VendorPaymentsPage.tsx
@@ -28,13 +28,13 @@ import {
 } from '@mui/material'
 import {
   Search as SearchIcon,
-  AccountBalance as PaymentIcon,
   RestoreFromTrash as RestoreIcon,
   Sort as SortIcon,
   ArrowUpward as ArrowUpIcon,
   ArrowDownward as ArrowDownIcon,
   Print as PrintIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatDate, formatCurrency, formatWholeQuantity } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
@@ -340,57 +340,11 @@ const VendorPaymentsPage: React.FC = () => {
   return (
     <Box sx={{ p: 3 }}>
       {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <PaymentIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Vendor Payments
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Track and manage payments to suppliers ({vendorPayments.length} total)
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RestoreIcon /> : undefined}
-            onClick={() => setDeletedPaymentsDialogOpen(true)}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
-            sx={{
-              color: 'warning.main',
-              borderColor: 'warning.main',
-              '&:hover': {
-                borderColor: 'warning.dark',
-                backgroundColor: 'warning.light'
-              }
-            }}
-          >
-            {isMobile ? "View Deleted" : "View Deleted"}
-          </Button>
-        </Box>
-      </Box>
+      <PageHeader
+        title="Vendor Payments"
+        subtitle="Track and manage payments to suppliers"
+        secondaryAction={{ label: 'View Deleted', onClick: () => setDeletedPaymentsDialogOpen(true) }}
+      />
       {/* Filters and Search */}
       <Paper sx={{ p: 2, mb: 3 }}>
       <Box sx={{

--- a/frontend/src/pages/purchasing/components/PurchaseOrdersToolbar.tsx
+++ b/frontend/src/pages/purchasing/components/PurchaseOrdersToolbar.tsx
@@ -3,7 +3,6 @@ import {
   Add as AddIcon,
   ArrowDownward as ArrowDownIcon,
   ArrowUpward as ArrowUpIcon,
-  Description as OrderIcon,
   RestoreFromTrash as RestoreIcon,
   Search as SearchIcon,
   Sort as SortIcon,
@@ -22,6 +21,7 @@ import {
   Typography,
 } from '@mui/material'
 
+import PageHeader from '@/components/common/PageHeader'
 import { TYPOGRAPHY_STYLES } from '@/constants/typography'
 import type { PurchaseOrdersPageState } from '../hooks/usePurchaseOrdersPageState'
 
@@ -40,7 +40,6 @@ interface PurchaseOrdersToolbarProps {
 
 const PurchaseOrdersToolbar: React.FC<PurchaseOrdersToolbarProps> = ({
   isMobile,
-  ordersCount,
   filters,
   suppliers,
   searchInputRef,
@@ -54,25 +53,12 @@ const PurchaseOrdersToolbar: React.FC<PurchaseOrdersToolbarProps> = ({
 
   return (
     <>
-      <Box sx={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', justifyContent: 'space-between', alignItems: isMobile ? 'stretch' : 'center', mb: 3, gap: isMobile ? 2 : 0 }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight, mb: 1, display: 'flex', alignItems: 'center', gap: 2 }}>
-            <OrderIcon sx={{ fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize, color: TYPOGRAPHY_STYLES.pageHeader.icon.color }} />
-            Purchase Orders
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Manage supplier purchase orders and procurement ({ordersCount} total)
-          </Typography>
-        </Box>
-        <Box sx={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: isMobile ? 1.5 : 1, alignItems: isMobile ? 'stretch' : 'center' }}>
-          <Button variant="outlined" startIcon={!isMobile ? <RestoreIcon /> : undefined} onClick={onOpenDeleted} fullWidth={isMobile} sx={{ color: 'warning.main', borderColor: 'warning.main' }}>
-            View Deleted
-          </Button>
-          <Button variant="contained" startIcon={!isMobile ? <AddIcon /> : undefined} onClick={onCreateOrder} fullWidth={isMobile}>
-            {isMobile ? 'Create New Order' : 'Create Order'}
-          </Button>
-        </Box>
-      </Box>
+      <PageHeader
+        title="Purchase Orders"
+        subtitle="Manage supplier purchase orders and procurement"
+        secondaryAction={{ label: 'View Deleted', onClick: onOpenDeleted }}
+        primaryAction={{ label: 'Create Order', onClick: onCreateOrder }}
+      />
 
       <Paper sx={{ p: 2, mb: 3 }}>
         <Box sx={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: isMobile ? 2 : 1, alignItems: isMobile ? 'stretch' : 'center', '& > *': { alignSelf: isMobile ? 'stretch' : 'flex-start' } }}>

--- a/frontend/src/pages/settings/CompanySettingsPage.tsx
+++ b/frontend/src/pages/settings/CompanySettingsPage.tsx
@@ -27,7 +27,7 @@ import {
   useUploadLogoMutation,
   useDeleteLogoMutation,
 } from '@/store/api/settingsApi'
-import { TYPOGRAPHY_STYLES } from '@/constants/typography'
+import PageHeader from '@/components/common/PageHeader'
 
 interface CompanyFormData {
   name: string
@@ -197,12 +197,7 @@ const CompanySettingsPage: React.FC = () => {
   return (
     <Box sx={{ p: 3 }}>
       {/* Page Header */}
-      <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
-        <CompanyIcon sx={{ fontSize: 40, mr: 2, color: 'primary.main' }} />
-        <Typography variant={TYPOGRAPHY_STYLES.pageHeader.variant} sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight }}>
-          Company Settings
-        </Typography>
-      </Box>
+      <PageHeader title="Company Settings" />
       {/* Error Alert */}
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>

--- a/frontend/src/pages/settings/DocumentNumbersPage.tsx
+++ b/frontend/src/pages/settings/DocumentNumbersPage.tsx
@@ -15,16 +15,15 @@ import {
   TextField,
 } from '@mui/material'
 import {
-  FormatListNumbered as DocumentNumberIcon,
   Save as SaveIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { useNotification } from '@/hooks/useNotification'
 import {
   useGetDocumentNumberSettingsQuery,
   useUpdateDocumentNumberSettingsMutation,
   type DocumentNumberConfig,
 } from '@/store/api/settingsApi'
-import { TYPOGRAPHY_STYLES } from '@/constants/typography'
 
 const MODULE_GROUPS: Record<string, string[]> = {
   Sales: ['Sales Orders', 'Invoices', 'Payments'],
@@ -113,12 +112,7 @@ const DocumentNumbersPage: React.FC = () => {
   return (
     <Box sx={{ p: 3 }}>
       {/* Page Header */}
-      <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
-        <DocumentNumberIcon sx={{ fontSize: 40, mr: 2, color: 'primary.main' }} />
-        <Typography variant={TYPOGRAPHY_STYLES.pageHeader.variant} sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight }}>
-          Document Numbers Settings
-        </Typography>
-      </Box>
+      <PageHeader title="Document Numbers Settings" />
       {/* Error Alert */}
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>

--- a/frontend/src/pages/settings/PaymentMethodsPage.tsx
+++ b/frontend/src/pages/settings/PaymentMethodsPage.tsx
@@ -1,10 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import {
-  Add as AddIcon,
   Delete as DeleteIcon,
   Edit as EditIcon,
-  Payment as PaymentIcon,
-  RestoreFromTrash as RestoreFromTrashIcon,
 } from '@mui/icons-material';
 import {
   Box,
@@ -27,7 +24,7 @@ import {
 
 import PaymentMethodFormDialog from '@/components/settings/PaymentMethodFormDialog';
 import DeletedPaymentMethodsDialog from '@/components/settings/DeletedPaymentMethodsDialog';
-import { TYPOGRAPHY_STYLES } from '@/constants/typography';
+import PageHeader from '@/components/common/PageHeader';
 import { useNotification } from '@/hooks/useNotification';
 import {
   useCreatePaymentMethodMutation,
@@ -94,51 +91,18 @@ const PaymentMethodsPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-        <Box>
-          <Typography
-            variant={TYPOGRAPHY_STYLES.pageHeader.variant}
-            sx={{
-              fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-              mb: 1,
-              display: 'flex',
-              alignItems: 'center',
-              gap: 2,
-            }}
-          >
-            <PaymentIcon
-              sx={{
-                fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-                color: TYPOGRAPHY_STYLES.pageHeader.icon.color,
-              }}
-            />
-            {title}
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Manage payment methods and configurations
-          </Typography>
-        </Box>
-        <Box sx={{ display: 'flex', gap: 1 }}>
-          <Button
-            variant="outlined"
-            color="warning"
-            startIcon={<RestoreFromTrashIcon />}
-            onClick={() => setDeletedOpen(true)}
-          >
-            View Deleted
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={<AddIcon />}
-            onClick={() => {
-              setSelected(null);
-              setFormOpen(true);
-            }}
-          >
-            Add Payment Method
-          </Button>
-        </Box>
-      </Box>
+      <PageHeader
+        title={title}
+        subtitle="Manage payment methods and configurations"
+        secondaryAction={{ label: 'View Deleted', onClick: () => setDeletedOpen(true) }}
+        primaryAction={{
+          label: 'Add Payment Method',
+          onClick: () => {
+            setSelected(null);
+            setFormOpen(true);
+          },
+        }}
+      />
 
       <Paper>
         <TableContainer>

--- a/frontend/src/pages/settings/PriceCostingPage.tsx
+++ b/frontend/src/pages/settings/PriceCostingPage.tsx
@@ -12,7 +12,6 @@ import {
   MenuItem,
 } from '@mui/material'
 import {
-  PriceChange as PriceCostingIcon,
   Calculate as CalculateIcon,
 } from '@mui/icons-material'
 import { useForm, Controller, useWatch } from 'react-hook-form'
@@ -24,7 +23,7 @@ import {
   useUpdatePriceCostingSettingsMutation,
 } from '@/store/api/settingsApi'
 import { ApiService } from '@/services/api'
-import { TYPOGRAPHY_STYLES } from '@/constants/typography'
+import PageHeader from '@/components/common/PageHeader'
 
 interface PriceCostingFormData {
   costingMethod: string
@@ -155,12 +154,7 @@ const PriceCostingPage: React.FC = () => {
   return (
     <Box sx={{ p: 3 }}>
       {/* Page Header */}
-      <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
-        <PriceCostingIcon sx={{ fontSize: 40, mr: 2, color: 'primary.main' }} />
-        <Typography variant={TYPOGRAPHY_STYLES.pageHeader.variant} sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight }}>
-          Inventory Costing Settings
-        </Typography>
-      </Box>
+      <PageHeader title="Inventory Costing Settings" />
       {/* Error Alert */}
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>

--- a/frontend/src/pages/settings/PriceListsPage.tsx
+++ b/frontend/src/pages/settings/PriceListsPage.tsx
@@ -25,7 +25,6 @@ import {
   Stack,
 } from '@mui/material'
 import {
-  Add as AddIcon,
   Search as SearchIcon,
   Edit as EditIcon,
   Delete as DeleteIcon,
@@ -33,10 +32,9 @@ import {
   Star as StarIcon,
   StarBorder as StarBorderIcon,
   Visibility as ViewIcon,
-  Refresh as RefreshIcon,
-  LocalOffer as PriceListIcon,
 } from '@mui/icons-material'
 import { useNavigate } from 'react-router-dom'
+import PageHeader from '@/components/common/PageHeader'
 import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import { useNotification } from '@/hooks/useNotification'
 import {
@@ -52,7 +50,7 @@ import type { PriceList } from '@/types'
 import PriceListFormDialog from '@/components/settings/PriceListFormDialog'
 import PriceListCopyDialog from '@/components/settings/PriceListCopyDialog'
 import ConfirmationDialog from '@/components/common/ConfirmationDialog'
-import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
+import { TABLE_STYLES } from '@/constants/typography'
 import { formatDate as formatDisplayDate } from '@/utils/formatters'
 
 const PriceListsPage: React.FC = () => {
@@ -205,46 +203,12 @@ const PriceListsPage: React.FC = () => {
   return (
     <Box sx={{ p: 3 }}>
       {/* Header */}
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          mb: 3,
-        }}
-      >
-        <Box>
-          <Typography
-            variant={TYPOGRAPHY_STYLES.pageHeader.variant}
-            sx={{
-              fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-              mb: 1,
-              display: 'flex',
-              alignItems: 'center',
-              gap: 2,
-            }}
-          >
-            <PriceListIcon
-              sx={{
-                fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-                color: TYPOGRAPHY_STYLES.pageHeader.icon.color,
-              }}
-            />
-            Price Lists
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Manage pricing structures and product prices ({total} total)
-          </Typography>
-        </Box>
-        <Box sx={{ display: 'flex', gap: 1 }}>
-          <Button variant="outlined" startIcon={<RefreshIcon />} onClick={() => refetch()}>
-            Refresh
-          </Button>
-          <Button variant="contained" startIcon={<AddIcon />} onClick={handleAddPriceList}>
-            Add Price List
-          </Button>
-        </Box>
-      </Box>
+      <PageHeader
+        title="Price Lists"
+        subtitle="Manage pricing structures and product prices"
+        secondaryAction={{ label: 'Refresh', onClick: () => refetch() }}
+        primaryAction={{ label: 'Add Price List', onClick: handleAddPriceList }}
+      />
 
       {/* Filters */}
       <Paper sx={{ p: 2, mb: 3 }}>

--- a/frontend/src/pages/settings/PrintSettingsPage.tsx
+++ b/frontend/src/pages/settings/PrintSettingsPage.tsx
@@ -9,10 +9,9 @@ import {
   Alert,
 } from '@mui/material'
 import {
-  Print as PrintIcon,
 } from '@mui/icons-material'
 import { useGetPrintSettingsQuery } from '@/store/api/printSettingsApi'
-import { TYPOGRAPHY_STYLES } from '@/constants/typography'
+import PageHeader from '@/components/common/PageHeader'
 import GeneralTab from './PrintSettings/GeneralTab'
 import TemplatesTab from './PrintSettings/TemplatesTab'
 
@@ -85,17 +84,10 @@ const PrintSettingsPage: React.FC = () => {
   return (
     <Box sx={{ p: 3 }}>
       {/* Header */}
-      <Box sx={{ mb: 3, display: 'flex', alignItems: 'center', gap: 2 }}>
-        <PrintIcon sx={{ fontSize: 32, color: 'primary.main' }} />
-        <Box>
-          <Typography variant={TYPOGRAPHY_STYLES.pageHeader.variant} sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight }}>
-            Print Settings
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Configure print templates and document footers
-          </Typography>
-        </Box>
-      </Box>
+      <PageHeader
+        title="Print Settings"
+        subtitle="Configure print templates and document footers"
+      />
 
       <Paper sx={{ borderRadius: 2 }}>
         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>

--- a/frontend/src/pages/settings/RegionalSettingsPage.tsx
+++ b/frontend/src/pages/settings/RegionalSettingsPage.tsx
@@ -11,7 +11,7 @@ import {
   Alert,
   MenuItem,
 } from '@mui/material'
-import { Language as RegionalIcon } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { useForm, Controller, useWatch } from 'react-hook-form'
 import * as yup from 'yup'
 import { yupResolver } from '@hookform/resolvers/yup'
@@ -20,7 +20,6 @@ import {
   useGetPriceCostingSettingsQuery,
   useUpdatePriceCostingSettingsMutation,
 } from '@/store/api/settingsApi'
-import { TYPOGRAPHY_STYLES } from '@/constants/typography'
 
 interface RegionalFormData {
   currency: string
@@ -181,12 +180,7 @@ const RegionalSettingsPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
-        <RegionalIcon sx={{ fontSize: 40, mr: 2, color: 'primary.main' }} />
-        <Typography variant={TYPOGRAPHY_STYLES.pageHeader.variant} sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight }}>
-          Regional Settings
-        </Typography>
-      </Box>
+      <PageHeader title="Regional Settings" />
 
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>

--- a/frontend/src/pages/settings/RoleManagementPage.tsx
+++ b/frontend/src/pages/settings/RoleManagementPage.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Box, Typography, Paper, List, ListItem, ListItemIcon, ListItemText, Chip } from '@mui/material'
 import {
-  Security as SecurityIcon,
   SupervisorAccount as AdminIcon,
   Business as ManagerIcon,
   ShoppingCart as SalesIcon,
@@ -9,7 +8,7 @@ import {
   LocalShipping as ProcurementIcon,
   Check as CheckIcon,
 } from '@mui/icons-material'
-import { TYPOGRAPHY_STYLES } from '@/constants/typography'
+import PageHeader from '@/components/common/PageHeader'
 
 interface RolePermission {
   description: string
@@ -97,17 +96,10 @@ const RoleManagementPage: React.FC = () => {
   return (
     <Box sx={{ p: 3 }}>
       {/* Header */}
-      <Box sx={{ mb: 3, display: 'flex', alignItems: 'center', gap: 2 }}>
-        <SecurityIcon sx={{ fontSize: 40, color: 'primary.main' }} />
-        <Box>
-          <Typography variant={TYPOGRAPHY_STYLES.pageHeader.variant} sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight }}>
-            Roles & Permissions
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Overview of user roles and their permissions
-          </Typography>
-        </Box>
-      </Box>
+      <PageHeader
+        title="Roles & Permissions"
+        subtitle="Overview of user roles and their permissions"
+      />
 
       {/* Information Alert */}
       <Paper sx={{ p: 2, mb: 3, bgcolor: 'info.lighter', borderLeft: 4, borderColor: 'info.main' }}>

--- a/frontend/src/pages/settings/SecuritySettingsPage.tsx
+++ b/frontend/src/pages/settings/SecuritySettingsPage.tsx
@@ -1,30 +1,22 @@
 import React from 'react'
 import { Box, Typography, Paper, Divider, Chip } from '@mui/material'
 import {
-  Lock as LockIcon,
   Password as PasswordIcon,
   Token as TokenIcon,
   Block as BlockIcon,
   Schedule as ScheduleIcon,
   Info as InfoIcon,
 } from '@mui/icons-material'
-import { TYPOGRAPHY_STYLES } from '@/constants/typography'
+import PageHeader from '@/components/common/PageHeader'
 
 const SecuritySettingsPage: React.FC = () => {
   return (
     <Box sx={{ p: 3 }}>
       {/* Header */}
-      <Box sx={{ mb: 3, display: 'flex', alignItems: 'center', gap: 2 }}>
-        <LockIcon sx={{ fontSize: 40, color: 'primary.main' }} />
-        <Box>
-          <Typography variant={TYPOGRAPHY_STYLES.pageHeader.variant} sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight }}>
-            Security Settings
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            View current security configuration and policies
-          </Typography>
-        </Box>
-      </Box>
+      <PageHeader
+        title="Security Settings"
+        subtitle="View current security configuration and policies"
+      />
 
       {/* Information Alert */}
       <Paper sx={{ p: 2, mb: 3, bgcolor: 'info.lighter', borderLeft: 4, borderColor: 'info.main' }}>

--- a/frontend/src/pages/settings/UserManagementPage.tsx
+++ b/frontend/src/pages/settings/UserManagementPage.tsx
@@ -25,14 +25,12 @@ import {
   Stack,
 } from '@mui/material'
 import {
-  Add as AddIcon,
   Search as SearchIcon,
   Edit as EditIcon,
   Delete as DeleteIcon,
   LockOpen as UnlockIcon,
-  People as PeopleIcon,
-  Refresh as RefreshIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { useAppSelector } from '@/hooks/useRedux'
 import { useNotification } from '@/hooks/useNotification'
 import {
@@ -235,50 +233,18 @@ const UserManagementPage: React.FC = () => {
   return (
     <Box sx={{ p: 3 }}>
       {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        mb: 3
-      }}>
-        <Box>
-          <Typography variant={TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <PeopleIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            User Management
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Manage system users and access control ({totalCount} total)
-          </Typography>
-        </Box>
-        <Box sx={{ display: 'flex', gap: 1 }}>
-          <Button
-            variant="outlined"
-            startIcon={<RefreshIcon />}
-            onClick={() => {
-              refetchUsers()
-              refetchStatistics()
-            }}
-          >
-            Refresh
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={<AddIcon />}
-            onClick={handleAddUser}
-          >
-            Add User
-          </Button>
-        </Box>
-      </Box>
+      <PageHeader
+        title="User Management"
+        subtitle="Manage system users and access control"
+        secondaryAction={{
+          label: 'Refresh',
+          onClick: () => {
+            refetchUsers()
+            refetchStatistics()
+          },
+        }}
+        primaryAction={{ label: 'Add User', onClick: handleAddUser }}
+      />
 
       {/* Statistics Cards */}
       {statistics && (


### PR DESCRIPTION
## Summary

- Polish `PageHeader` component: title `fontWeight` bumped to 700, bottom margin increased to `mb: 4` (32px) for better breathing room between header and filter bar
- Replaced legacy `TYPOGRAPHY_STYLES.pageHeader` inline blocks with `<PageHeader>` across 18 files in Inventory, Settings, and Purchasing modules
- Dropped decorative title icons (text-only is the new standard)
- Stripped dynamic counts from subtitles (e.g. `(24 total)`) — subtitles are now static descriptive text only
- `TYPOGRAPHY_STYLES` is preserved — still used for table headers, chips, and search fields

**Excluded from this PR (deferred to follow-on):** Dashboard, Purchasing Overview, Categories, all Accounting pages, all Report pages, Backup Management, Audit Logs

## Test Plan

- [x] `PageHeader.test.tsx` — 16/16 passed
- [x] `npx vitest run src/pages/inventory` — 13/13 passed
- [x] `npx vitest run src/pages/settings` — 1/1 passed
- [x] `npx vitest run src/pages/purchasing` — 4/4 passed
- [x] `npm run test` — 79 files, 474 tests passed
- [x] `npm run type-check` — clean
- [x] Manual visual QA (browser spot-check of title weight, subtitle cleanliness, action alignment, dark mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)