### PR TITLE
refactor(accounting): PageHeader Phase 3 — Accounting CRUD + subtitle spot-check + docs/ui.md

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -1,6 +1,8 @@
 # UI Design System Reference
 
-This document defines UI standards for the ERP frontend. It is a living reference - rules live here, implementation history lives in `docs/superpowers/specs/`.
+This document defines UI standards for the ERP frontend. It is a living reference — rules live here, implementation history lives in `docs/superpowers/specs/`.
+
+> **Note:** Prior to 2026-03-24 this file contained a dark theme color palette reference. That content has been superseded by the live theme implementation in `frontend/src/styles/theme.ts`.
 
 ---
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -1,159 +1,125 @@
-# 🎨 Dark Theme Palette (Base: #121212)
+# UI Design System Reference
+
+This document defines UI standards for the ERP frontend. It is a living reference - rules live here, implementation history lives in `docs/superpowers/specs/`.
 
 ---
 
-## 🧱 1. Core Background Layers
+## PageHeader
 
-| Usage | Color |
-|------|------|
-| App Background | #121212 |
-| Surface (cards, tables) | #1E1E1E |
-| Surface 2 (sections) | #232323 |
-| Hover / Active | #2C2C2C |
-| Sidebar | #0D0D0D |
-| Top Bar | #181818 |
-| Overlay | #000000 |
+### Purpose
 
----
+`PageHeader` is the standard page-level header component for all CRUD, list, and form pages. It provides a consistent title, optional subtitle, and up to two action buttons across all standard pages.
 
-## ✍️ 2. Text Colors
+### Anatomy
 
-| Usage | Color |
-|------|------|
-| Primary Text | #E0E0E0 |
-| Secondary Text | #A0A0A0 |
-| Muted / Disabled | #6B7280 |
-| Inverse Text | #111827 |
+```text
+Title
+Subtitle (optional)
+                    [Secondary Action]  [Primary Action]
+---------------------------------------------------------
+```
 
----
+### Props
 
-## 🎯 3. Primary / Accent
+| Prop | Type | Required | Default | Notes |
+|------|------|----------|---------|-------|
+| `title` | `string` | yes | - | Plain text only. No icons, counts, or dynamic values. |
+| `subtitle` | `string` | no | - | Optional. See subtitle policy below. |
+| `primaryAction` | `{ label, onClick, disabled? }` | no | - | Rendered as a contained button. |
+| `secondaryAction` | `{ label, onClick, disabled? }` | no | - | Rendered as an outlined button. |
+| `showDivider` | `boolean` | no | `true` | Set to `false` on form/create pages. |
+| `children` | `ReactNode` | no | - | Escape hatch for complex cases only. |
 
-| Usage | Color |
-|------|------|
-| Primary | #3B82F6 |
-| Primary Hover | #2563EB |
-| Primary Active | #1D4ED8 |
-| Primary Soft BG | #172554 |
+### Action Rules
 
----
+- Maximum 2 actions in the header: one primary, one secondary.
+- If a page has more than 2 actions, the primary CTA goes in `primaryAction`, secondary in `secondaryAction`, and any remaining actions move to a toolbar or inline controls below the header.
+- Do not add more actions by customizing `PageHeader`. If a page cannot fit within 2 actions without harming usability, defer it rather than extending the component.
+- Permission-gated actions: pass `primaryAction={canDoThing ? { label: '...', onClick: ... } : undefined}` - do not render a disabled primary action for permission checks.
 
-## ⚠️ 4. Semantic Colors
+### Subtitle Policy
 
-### Success
-| Usage | Color |
-|------|------|
-| Text / Icon | #22C55E |
-| Background | #052E16 |
+Subtitles are optional. Only add a subtitle where it adds clarity.
 
-### Warning
-| Usage | Color |
-|------|------|
-| Text / Icon | #F59E0B |
-| Background | #451A03 |
+Required when: Page purpose is not immediately obvious from the title alone; user benefits from operational context.
 
-### Error
-| Usage | Color |
-|------|------|
-| Text / Icon | #EF4444 |
-| Background | #450A0A |
+Forbidden content:
+- Dynamic values: counts, filter state, statuses, dates (for example `"14 pending orders"`, `"(filtered)"`)
+- Redundant text that restates the title (for example Title: "Suppliers" / Subtitle: "Manage suppliers")
+- Filler phrases: "This page allows you to...", "Here you can..."
 
-### Info
-| Usage | Color |
-|------|------|
-| Text / Icon | #38BDF8 |
-| Background | #082F49 |
+Style: Short, stable, operational. Present-tense verb phrase describing what the page helps the user do.
 
----
+```text
+OK  "Manage accounting periods and year boundaries"
+OK  "Configure default account assignments for transactions"
+NO  "14 Pending Orders Found"
+NO  "Manage Vendors"
+```
 
-## 🧩 5. Borders & Dividers
+### Do / Don't
 
-| Usage | Color |
-|------|------|
-| Default Border | #2A2A2A |
-| Strong Border | #3A3A3A |
-| Subtle Divider | #1A1A1A |
+Do:
+- Use `PageHeader` for all standard CRUD, list, and form pages
+- Keep titles concise, plain text, and stable
+- Use at most one primary and one secondary action
+- Write operational subtitles in plain English
+
+Don't:
+- Add icons to titles
+- Include dynamic data in titles or subtitles
+- Add more than 2 actions to the header
+- Customize layout or spacing per page
+- Force a subtitle if the title is self-explanatory
 
 ---
 
-## 🖱️ 6. Interaction States
+## PageHeader - When NOT to Use
 
-| Usage | Color |
-|------|------|
-| Hover | #2C2C2C |
-| Active Item Background | #1F2937 |
-| Focus Ring | #3B82F6 |
-| Selected Row | #172554 |
+Do not use `PageHeader` if the page requires more than one header region or custom header composition.
 
----
+### Exception Categories
 
-## 📊 7. Table Colors
+| Category | Examples | Why |
+|----------|----------|-----|
+| Tree / hierarchy | ChartOfAccountsPage, CategoriesPage | Require hierarchical navigation context, not a single title |
+| Dashboard / multi-section overview | DashboardPage, AccountingDashboardPage | Multiple header zones, no single page-level title |
+| Report / analytical | All report pages (TrialBalance, GeneralLedger, SalesOrderSummary, etc.) | Filter-heavy, parameter-driven layouts |
+| Multi-tab + sidebar filter | AuditLogsPage | Custom layout with multiple header regions |
+| Detail pages | CustomerProfilePage, JournalEntryDetailsPage, PriceListDetailsPage | Breadcrumb-led, read-only or tab-based layouts |
+| Multi-section overview | PurchasingPage | Multiple sub-headers, not a single page title |
+| Embedded section-header pattern | BackupManagement | Section headers are structural, not page-level |
+| Auth / error | LoginPage, MandatoryPasswordChangePage, NotFoundPage | No page header expected |
 
-| Usage | Color |
-|------|------|
-| Header Background | #1A1A1A |
-| Row Background | #121212 |
-| Alternate Row | #161616 |
-| Row Hover | #1F1F1F |
-| Border | #2A2A2A |
+### Decision Checklist
 
----
+Use `PageHeader` if ALL of the following are true:
 
-## 📦 8. Sidebar
+- [ ] The page has a single page-level title
+- [ ] The page has at most 2 primary actions in the header
+- [ ] No custom header widgets (date pickers, tabs, filter bars embedded in the header)
+- [ ] No multiple header zones
+- [ ] The title is stable, plain text
 
-| Usage | Color |
-|------|------|
-| Background | #0D0D0D |
-| Item | #121212 |
-| Hover | #1E1E1E |
-| Active Background | #1F2937 |
-| Active Text | #FFFFFF |
-| Text | #9CA3AF |
-| Icon | #6B7280 |
-| Active Icon | #3B82F6 |
+If any item is unchecked, do not use `PageHeader` - define an appropriate pattern first.
 
 ---
 
-## 🔝 9. Top Bar (Main Layout)
+## Deferred Pages
 
-| Usage | Color |
-|------|------|
-| Background | #181818 |
-| Border Bottom | #2A2A2A |
-| Text | #E0E0E0 |
-| Icon | #9CA3AF |
-| Hover | #2C2C2C |
-| Active | #1F2937 |
-| Search Background | #1E1E1E |
-| Search Placeholder | #6B7280 |
+Some pages are not yet migrated to `PageHeader`. These pages are not rejected - they require pattern validation before migration.
+
+> Deferred pages should not be force-fit into `PageHeader` until a suitable pattern is defined. Migration is only appropriate if the page can adopt `PageHeader` without introducing exceptions to layout, action constraints, or header composition.
+
+See `docs/superpowers/specs/2026-03-24-page-header-phase3-design.md` for the full classification table.
 
 ---
 
-## 🧠 Final Theme Object
+## Future Expansion
 
-```ts
-export const DARK_THEME = {
-  background: "#121212",
-  surface: "#1E1E1E",
-  surface2: "#232323",
-  hover: "#2C2C2C",
+This document will expand as new layout primitives are standardized. Planned additions:
 
-  sidebar: "#0D0D0D",
-  topbar: "#181818",
-
-  textPrimary: "#E0E0E0",
-  textSecondary: "#A0A0A0",
-  textMuted: "#6B7280",
-
-  primary: "#3B82F6",
-  primaryHover: "#2563EB",
-  primaryActive: "#1D4ED8",
-
-  success: "#22C55E",
-  warning: "#F59E0B",
-  error: "#EF4444",
-  info: "#38BDF8",
-
-  border: "#2A2A2A",
-  borderStrong: "#3A3A3A"
-}
+- Filter Bar
+- Table Toolbar / List Actions
+- Form Layout
+- Report & Dashboard Header Patterns

--- a/frontend/src/__tests__/integration/accounting-auto-posting.integration.test.tsx
+++ b/frontend/src/__tests__/integration/accounting-auto-posting.integration.test.tsx
@@ -151,7 +151,7 @@ describe('Accounting Auto-Posting Integration Tests', () => {
       renderWithRouter(<AccountMappingsPage />)
 
       await waitFor(() => {
-        expect(screen.getByText('Account Mappings Configuration')).toBeInTheDocument()
+        expect(screen.getByText('Account Mappings')).toBeInTheDocument()
       })
     })
 
@@ -193,7 +193,7 @@ describe('Accounting Auto-Posting Integration Tests', () => {
       renderWithRouter(<AccountMappingsPage />)
 
       await waitFor(() => {
-        expect(screen.getByText('Account Mappings Configuration')).toBeInTheDocument()
+        expect(screen.getByText('Account Mappings')).toBeInTheDocument()
       })
 
       expect(mockedApi.useGetAccountMappingsQuery).toHaveBeenCalled()

--- a/frontend/src/pages/accounting/AccountMappingsPage.test.tsx
+++ b/frontend/src/pages/accounting/AccountMappingsPage.test.tsx
@@ -122,11 +122,17 @@ describe('AccountMappingsPage', () => {
     mockedApi.useDeleteAccountMappingMutation.mockReturnValue([vi.fn()])
   })
 
-  it('renders without crashing', async () => {
+  it('renders the PageHeader title and subtitle', async () => {
     renderWithProviders(<AccountMappingsPage />)
+
     await waitFor(() => {
-      expect(screen.getByText('Account Mappings Configuration')).toBeInTheDocument()
+      expect(screen.getByText('Account Mappings')).toBeInTheDocument()
+      expect(
+        screen.getByText('Configure default account assignments for transactions'),
+      ).toBeInTheDocument()
     })
+
+    expect(screen.queryByText('Account Mappings Configuration')).not.toBeInTheDocument()
   })
 
   it('displays loading state', () => {
@@ -212,7 +218,7 @@ describe('AccountMappingsPage', () => {
     renderWithProviders(<AccountMappingsPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Account Mappings Configuration')).toBeInTheDocument()
+      expect(screen.getByText('Account Mappings')).toBeInTheDocument()
     })
 
     const configureButtons = screen.getAllByRole('button', { name: /configure/i })

--- a/frontend/src/pages/accounting/AccountMappingsPage.tsx
+++ b/frontend/src/pages/accounting/AccountMappingsPage.tsx
@@ -35,7 +35,7 @@ import type { AccountMapping } from '@/types/accountMapping'
 import AccountMappingDialog from '@/components/accounting/AccountMappingDialog'
 import PageHeader from '@/components/common/PageHeader'
 import ConfirmationDialog from '@/components/common/ConfirmationDialog'
-import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
+import { TABLE_STYLES } from '@/constants/typography'
 import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
 
 // Mapping type labels with category grouping

--- a/frontend/src/pages/accounting/AccountMappingsPage.tsx
+++ b/frontend/src/pages/accounting/AccountMappingsPage.tsx
@@ -21,7 +21,6 @@ import {
 import {
   Edit as EditIcon,
   Add as AddIcon,
-  Settings as SettingsIcon,
   Clear as ClearIcon,
 } from '@mui/icons-material'
 import { useNotification } from '@/hooks/useNotification'
@@ -34,6 +33,7 @@ import {
 import { MappingType } from '@/types/accountMapping'
 import type { AccountMapping } from '@/types/accountMapping'
 import AccountMappingDialog from '@/components/accounting/AccountMappingDialog'
+import PageHeader from '@/components/common/PageHeader'
 import ConfirmationDialog from '@/components/common/ConfirmationDialog'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
@@ -283,37 +283,10 @@ const AccountMappingsPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography
-            variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant}
-            sx={{
-              fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-              mb: 1,
-              display: 'flex',
-              alignItems: 'center',
-              gap: 2
-            }}
-          >
-            <SettingsIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Account Mappings Configuration
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Configure GL accounts for automatic journal entry posting
-          </Typography>
-        </Box>
-      </Box>
+      <PageHeader
+        title="Account Mappings"
+        subtitle="Configure default account assignments for transactions"
+      />
 
       {/* Validation Status Alert */}
       {!isValid && validationResult && validationResult.missingMappings.length > 0 && (

--- a/frontend/src/pages/accounting/FiscalPeriodsPage.tsx
+++ b/frontend/src/pages/accounting/FiscalPeriodsPage.tsx
@@ -23,11 +23,9 @@ import {
   useMediaQuery,
 } from '@mui/material'
 import {
-  Add as AddIcon,
   Edit as EditIcon,
   Delete as DeleteIcon,
   Search as SearchIcon,
-  CalendarMonth as CalendarIcon,
   LockOpen as ReopenIcon,
   Lock as CloseIcon,
   AutoAwesome as GenerateIcon,
@@ -35,6 +33,7 @@ import {
 import { format } from 'date-fns'
 import { useNotification } from '@/hooks/useNotification'
 import { useSearchAndFilter, useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
+import PageHeader from '@/components/common/PageHeader'
 import ConfirmationDialog from '@/components/common/ConfirmationDialog'
 import GeneratePeriodsDialog from '@/components/accounting/GeneratePeriodsDialog'
 import FiscalPeriodFormDialog from '@/components/accounting/FiscalPeriodFormDialog'
@@ -278,67 +277,12 @@ const FiscalPeriodsPage: React.FC = () => {
       {/* Account Mapping Warning */}
       <AccountMappingWarning context="system" />
 
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <CalendarIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Fiscal Periods
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Manage accounting periods for financial reporting ({pagination?.total || 0} total)
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGeneratePeriods}
-            size="medium"
-            fullWidth={isMobile}
-            sx={{
-              color: 'info.main',
-              borderColor: 'info.main',
-              '&:hover': {
-                borderColor: 'info.dark',
-                backgroundColor: 'info.light'
-              }
-            }}
-          >
-            {isMobile ? "Generate Periods" : "Generate"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <AddIcon /> : undefined}
-            size="medium"
-            onClick={handleAddPeriod}
-            fullWidth={isMobile}
-          >
-            {isMobile ? "Add New Period" : "Add Period"}
-          </Button>
-        </Box>
-      </Box>
+      <PageHeader
+        title="Fiscal Periods"
+        subtitle="Manage accounting periods and year boundaries"
+        secondaryAction={{ label: 'Generate Periods', onClick: handleGeneratePeriods }}
+        primaryAction={{ label: 'Add Period', onClick: handleAddPeriod }}
+      />
 
       {/* Filters and Search */}
       <Paper sx={{ p: 2, mb: 3 }}>

--- a/frontend/src/pages/accounting/FundTransfersPage.tsx
+++ b/frontend/src/pages/accounting/FundTransfersPage.tsx
@@ -17,7 +17,6 @@ import {
   DialogContent,
   DialogTitle,
   FormControl,
-  IconButton,
   InputLabel,
   MenuItem,
   Paper,
@@ -33,12 +32,9 @@ import {
   Typography,
 } from '@mui/material'
 import {
-  Add as AddIcon,
   Cancel as CancelIcon,
-  Refresh as RefreshIcon,
-  SwapHoriz as TransferIcon,
 } from '@mui/icons-material'
-import { TYPOGRAPHY_STYLES } from '@/constants/typography'
+import PageHeader from '@/components/common/PageHeader'
 import { useNotification } from '@/hooks/useNotification'
 import {
   useCancelFundTransferMutation,
@@ -210,52 +206,16 @@ const FundTransfersPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-          mb: 3,
-        }}
-      >
-        <Box>
-          <Typography
-            variant={TYPOGRAPHY_STYLES.pageHeader.variant}
-            sx={{
-              fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-              mb: 1,
-              display: 'flex',
-              alignItems: 'center',
-              gap: 2,
-            }}
-          >
-            <TransferIcon
-              sx={{
-                fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-                color: TYPOGRAPHY_STYLES.pageHeader.icon.color,
-              }}
-            />
-            Fund Transfers
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Move funds between eligible cash and bank accounts
-          </Typography>
-        </Box>
-        <Stack direction="row" spacing={1}>
-          <IconButton onClick={() => refetch()}>
-            <RefreshIcon />
-          </IconButton>
-          {canManageTransfers ? (
-            <Button
-              variant="contained"
-              startIcon={<AddIcon />}
-              onClick={() => setDialogOpen(true)}
-            >
-              New Transfer
-            </Button>
-          ) : null}
-        </Stack>
-      </Box>
+      <PageHeader
+        title="Fund Transfers"
+        subtitle="Move funds between accounts and review transfer history"
+        secondaryAction={{ label: 'Refresh', onClick: () => refetch() }}
+        primaryAction={
+          canManageTransfers
+            ? { label: 'New Transfer', onClick: () => setDialogOpen(true) }
+            : undefined
+        }
+      />
 
       <Card sx={{ mb: 2 }}>
         <CardContent>

--- a/frontend/src/pages/accounting/OwnerEquityPage.tsx
+++ b/frontend/src/pages/accounting/OwnerEquityPage.tsx
@@ -26,16 +26,13 @@ import {
   Typography,
 } from '@mui/material'
 import {
-  Add as AddIcon,
   Delete as DeleteIcon,
   Edit as EditIcon,
   PostAdd as PostIcon,
-  Refresh as RefreshIcon,
   Search as SearchIcon,
-  AccountBalanceWallet as OwnerEquityIcon,
   Undo as UndoIcon,
 } from '@mui/icons-material'
-import { TYPOGRAPHY_STYLES } from '@/constants/typography'
+import PageHeader from '@/components/common/PageHeader'
 import { useNotification } from '@/hooks/useNotification'
 import {
   useCreateOwnerEquityTransactionMutation,
@@ -224,28 +221,12 @@ const OwnerEquityPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 3 }}>
-        <Box>
-          <Typography
-            variant={TYPOGRAPHY_STYLES.pageHeader.variant}
-            sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight, mb: 1, display: 'flex', alignItems: 'center', gap: 2 }}
-          >
-            <OwnerEquityIcon sx={{ fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize, color: TYPOGRAPHY_STYLES.pageHeader.icon.color }} />
-            Owner's Equity Transactions
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Track owner capital contributions and withdrawals
-          </Typography>
-        </Box>
-        <Stack direction="row" spacing={1}>
-          <IconButton onClick={() => refetch()}>
-            <RefreshIcon />
-          </IconButton>
-          <Button variant="contained" startIcon={<AddIcon />} onClick={openCreate}>
-            New Transaction
-          </Button>
-        </Stack>
-      </Box>
+      <PageHeader
+        title="Owner Equity"
+        subtitle="Track owner contributions and equity transactions"
+        secondaryAction={{ label: 'Refresh', onClick: () => refetch() }}
+        primaryAction={{ label: 'New Transaction', onClick: openCreate }}
+      />
 
       <Paper sx={{ p: 2, mb: 2 }}>
         <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>

--- a/frontend/src/pages/accounting/SettlementsPage.tsx
+++ b/frontend/src/pages/accounting/SettlementsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import {
   Box,
   Button,
@@ -18,10 +18,9 @@ import {
   Typography,
 } from '@mui/material';
 import {
-  AccountBalanceWallet as AccountBalanceWalletIcon,
-  Add as AddIcon,
   Cancel as CancelIcon,
 } from '@mui/icons-material';
+import PageHeader from '@/components/common/PageHeader'
 import { useNotification } from '@/hooks/useNotification'
 import {
   useCancelSettlementMutation,
@@ -30,7 +29,6 @@ import {
   useGetSettlementsQuery,
 } from '@/store/api/accountingApi';
 import { formatCurrency, formatDate } from '@/utils/formatters'
-import { TYPOGRAPHY_STYLES } from '@/constants/typography';
 import type { Settlement } from '@/types';
 import CreateSettlementDialog from '@/components/accounting/CreateSettlementDialog';
 
@@ -54,8 +52,6 @@ const SettlementsPage: React.FC = () => {
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [cancelTarget, setCancelTarget] = useState<Settlement | null>(null);
-
-  const title = useMemo(() => `Settlements (${settlements.length})`, [settlements.length]);
 
   const onCreate = async (data: {
     paymentMethodId: string;
@@ -86,23 +82,11 @@ const SettlementsPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 3 }}>
-        <Box>
-          <Typography
-            variant={TYPOGRAPHY_STYLES.pageHeader.variant}
-            sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight, mb: 1, display: 'flex', alignItems: 'center', gap: 2 }}
-          >
-            <AccountBalanceWalletIcon sx={{ fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize, color: TYPOGRAPHY_STYLES.pageHeader.icon.color }} />
-            {title}
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Settle pending payments by payment method
-          </Typography>
-        </Box>
-        <Button variant="contained" startIcon={<AddIcon />} onClick={() => setDialogOpen(true)}>
-          Create Settlement
-        </Button>
-      </Box>
+      <PageHeader
+        title="Settlements"
+        subtitle="Settle pending payments by payment method"
+        primaryAction={{ label: 'Create Settlement', onClick: () => setDialogOpen(true) }}
+      />
 
       <Paper>
         <TableContainer>

--- a/frontend/src/pages/accounting/__tests__/FiscalPeriodsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/FiscalPeriodsPage.test.tsx
@@ -124,12 +124,18 @@ describe('FiscalPeriodsPage', () => {
     mockedApi.useUpdateFiscalPeriodMutation.mockReturnValue([vi.fn()])
   })
 
-  it('renders page header correctly', async () => {
+  it('renders page header with the static PageHeader copy', async () => {
     renderWithProvider()
 
     await waitFor(() => {
       expect(screen.getByText('Fiscal Periods')).toBeInTheDocument()
+      expect(
+        screen.getByText('Manage accounting periods and year boundaries')
+      ).toBeInTheDocument()
     })
+
+    expect(screen.queryByText(/financial reporting/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/\(3 total\)/i)).not.toBeInTheDocument()
   })
 
   it('renders fiscal periods list with correct data', async () => {

--- a/frontend/src/pages/accounting/__tests__/FundTransfersPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/FundTransfersPage.test.tsx
@@ -90,9 +90,17 @@ describe('FundTransfersPage', () => {
     mockedApi.useCancelFundTransferMutation.mockReturnValue([vi.fn(), { isLoading: false }])
   })
 
-  it('renders the page title', () => {
+  it('renders the PageHeader title, subtitle, and refresh action', () => {
     renderPage()
+
     expect(screen.getByText('Fund Transfers')).toBeInTheDocument()
+    expect(
+      screen.getByText('Move funds between accounts and review transfer history'),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument()
+    expect(
+      screen.queryByText('Move funds between eligible cash and bank accounts'),
+    ).not.toBeInTheDocument()
   })
 
   it('renders the transfer reference number in the table', () => {

--- a/frontend/src/pages/accounting/__tests__/OwnerEquityPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/OwnerEquityPage.test.tsx
@@ -82,9 +82,15 @@ describe('OwnerEquityPage', () => {
     mockedApi.useReverseOwnerEquityTransactionMutation.mockReturnValue([vi.fn()])
   })
 
-  it('renders the page title', () => {
+  it('renders the PageHeader title, subtitle, and refresh action', () => {
     renderPage()
-    expect(screen.getByText("Owner's Equity Transactions")).toBeInTheDocument()
+
+    expect(screen.getByText('Owner Equity')).toBeInTheDocument()
+    expect(
+      screen.getByText('Track owner contributions and equity transactions'),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument()
+    expect(screen.queryByText("Owner's Equity Transactions")).not.toBeInTheDocument()
     expect(screen.getByText('EQ-001')).toBeInTheDocument()
   })
 

--- a/frontend/src/pages/accounting/__tests__/SettlementsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/SettlementsPage.test.tsx
@@ -92,6 +92,16 @@ describe('SettlementsPage notifications', () => {
     ])
   })
 
+  it('renders a static PageHeader title and subtitle', () => {
+    render(<SettlementsPage />)
+
+    expect(screen.getByText('Settlements')).toBeInTheDocument()
+    expect(
+      screen.getByText('Settle pending payments by payment method'),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Settlements (1)')).not.toBeInTheDocument()
+  })
+
   it('shows success notification after creating settlement', async () => {
     const user = userEvent.setup()
     render(<SettlementsPage />)

--- a/frontend/src/pages/sales/CustomersPage.tsx
+++ b/frontend/src/pages/sales/CustomersPage.tsx
@@ -390,7 +390,7 @@ const CustomersPage: React.FC = () => {
     <Box sx={{ p: 3 }}>
       <PageHeader
         title="Customers"
-        subtitle={`Manage your customers and client information (${customers.length} total)`}
+        subtitle="View customer profiles and client account details"
         secondaryAction={{ label: 'View Deleted', onClick: () => setIsDeletedDialogOpen(true) }}
         primaryAction={{ label: 'New Customer', onClick: () => handleOpenForm() }}
       />

--- a/frontend/src/pages/sales/PaymentsPage.tsx
+++ b/frontend/src/pages/sales/PaymentsPage.tsx
@@ -530,7 +530,7 @@ const PaymentsPage: React.FC = () => {
       {/* Header */}
       <PageHeader
         title="Payments"
-        subtitle={`Manage customer payments and track financial transactions (${totalPayments} total)`}
+        subtitle="Review customer payments and transaction history"
         secondaryAction={{ label: 'View Deleted', onClick: () => setDeletedPaymentsDialogOpen(true) }}
       />
       {/* Filters and Search */}

--- a/frontend/src/pages/sales/components/InvoicesToolbar.tsx
+++ b/frontend/src/pages/sales/components/InvoicesToolbar.tsx
@@ -52,7 +52,7 @@ const InvoicesToolbar: React.FC<InvoicesToolbarProps> = ({
     <>
       <PageHeader
         title="Invoices"
-        subtitle={`Manage customer invoices and track payments (${total} total)`}
+        subtitle="Review customer invoices and payment status"
         secondaryAction={{ label: 'View Deleted', onClick: onOpenDeleted }}
       />
 

--- a/frontend/src/pages/sales/components/OrdersToolbar.tsx
+++ b/frontend/src/pages/sales/components/OrdersToolbar.tsx
@@ -72,7 +72,7 @@ const OrdersToolbar: React.FC<OrdersToolbarProps> = ({
     <>
       <PageHeader
         title="Sales Orders"
-        subtitle={`Manage your sales orders and track delivery status (${ordersCount} total)`}
+        subtitle="Track sales orders and delivery status"
         secondaryAction={{ label: 'View Deleted', onClick: onOpenDeleted }}
         primaryAction={{ label: 'Create Order', onClick: onCreateOrder }}
       />


### PR DESCRIPTION
## Summary

- Migrates 5 Accounting CRUD pages to `PageHeader`: FiscalPeriodsPage, FundTransfersPage, OwnerEquityPage, SettlementsPage, AccountMappingsPage
- Applies subtitle spot-check to previously migrated Sales pages — removes dynamic count-based subtitles
- Creates `docs/ui.md` as the living design system reference (anatomy, do/don't, exception categories, decision checklist)
- Updates stale integration test assertions for the new AccountMappingsPage header copy

Closes #166

## What changed

**Accounting pages (5):** Legacy `TYPOGRAPHY_STYLES.pageHeader` header markup replaced with `<PageHeader />`. Icons removed from titles. Responsive header logic removed (handled by component). Permission-gated actions use conditional `primaryAction` prop. Dynamic title in SettlementsPage (count-in-title) removed and replaced with static text.

**Subtitle spot-check:** Sales pages that had `${count} total`-style dynamic subtitles fixed to stable operational text.

**docs/ui.md:** New top-level design system reference. Rules live here; implementation history stays in `docs/superpowers/specs/`. Includes forwarding note for prior dark theme palette content.

## Test plan

- [x] `cd frontend && npm run type-check` — passes
- [x] `cd frontend && npm run test` — 475 tests pass across 79 files
- [x] Visual QA: verify PageHeader renders correctly on all 5 Accounting pages
- [x] Confirm no legacy header markup visible on migrated pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)