### PR TITLE
fix(frontend): suppress test noise and fix missing MSW handlers

### DIFF
--- a/frontend/src/components/errors/RouteErrorBoundary.test.tsx
+++ b/frontend/src/components/errors/RouteErrorBoundary.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { ThemeProvider } from '@mui/material/styles'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
@@ -26,6 +26,16 @@ function renderWithError(error: unknown) {
 }
 
 describe('RouteErrorBoundary', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
   describe('chunk-load error state', () => {
     it('renders "App Updated" heading', () => {
       renderWithError(new Error('Importing a module script failed'))

--- a/frontend/src/mocks/__tests__/setup.test.ts
+++ b/frontend/src/mocks/__tests__/setup.test.ts
@@ -13,6 +13,6 @@ describe('mocks setup', () => {
 
   it('exports handlers array', () => {
     expect(Array.isArray(handlers)).toBe(true)
-    expect(handlers).toHaveLength(0)
+    expect(handlers.length).toBeGreaterThan(0)
   })
 })

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,4 +1,11 @@
-import type { RequestHandler } from 'msw'
+import { http, HttpResponse, type RequestHandler } from 'msw'
+
+// Auth handlers
+const authHandlers: RequestHandler[] = [
+  http.post('*/api/auth/logout', () =>
+    HttpResponse.json({ message: 'Logged out' })
+  ),
+]
 
 // Handlers are added per module migration as RTK Query endpoints are introduced.
-export const handlers: RequestHandler[] = []
+export const handlers: RequestHandler[] = [...authHandlers]


### PR DESCRIPTION
Closes #169

## Summary

- Suppress expected `console.error` noise in `RouteErrorBoundary.test.tsx` by adding a local `vi.spyOn` spy scoped to the outer `describe` block — keeps the global setup clean and makes suppression explicit where it belongs
- Add `POST */api/auth/logout` handler to `handlers.ts` so the logout flow in `SidebarUserMenu` tests doesn't trigger MSW unhandled-request warnings; uses wildcard origin to match across jsdom URL resolution
- Update stale `setup.test.ts` assertion (`toHaveLength(0)` → `toBeGreaterThan(0)`) now that `handlers.ts` has real content

## Test plan

- [x] `npx vitest run src/components/errors/RouteErrorBoundary.test.tsx` — 6 tests pass, no stderr boundary noise
- [x] `npx vitest run src/components/common/__tests__/SidebarUserMenu.test.tsx` — all tests pass, no MSW warning for `/api/auth/logout`
- [x] `npm run test` (full suite) — 475/475 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)