### PR TITLE
feat(ui): PageHeader Phase 4 — adoption completion & enforcement (issue #173)

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -74,6 +74,14 @@ Don't:
 - Customize layout or spacing per page
 - Force a subtitle if the title is self-explanatory
 
+### New Page Checklist
+
+- Is this a standard CRUD, list, or form page? -> Use `PageHeader`
+- Does the page have at most 2 header actions? If not, move extras to a toolbar below
+- Subtitle: stable, operational, non-dynamic - or omit it entirely
+- Do not use `TYPOGRAPHY_STYLES.pageHeader` - it is lint-blocked
+- If the page does not fit `PageHeader` without introducing exceptions, classify it as Deferred/Exception - do not customize the component
+
 ---
 
 ## PageHeader - When NOT to Use
@@ -113,7 +121,7 @@ Some pages are not yet migrated to `PageHeader`. These pages are not rejected - 
 
 > Deferred pages should not be force-fit into `PageHeader` until a suitable pattern is defined. Migration is only appropriate if the page can adopt `PageHeader` without introducing exceptions to layout, action constraints, or header composition.
 
-See `docs/superpowers/specs/2026-03-24-page-header-phase3-design.md` for the full classification table.
+See `docs/superpowers/specs/2026-03-24-issue-173-pageheader-phase4-design.md` for the full classification table.
 
 ---
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -58,4 +58,81 @@ export default tseslint.config(
   {
     files: ['**/*.ts', '**/*.tsx'],
   },
+
+  // PageHeader migration guard — progressive enforcement
+  //
+  // Standard CRUD, list, and form pages must use <PageHeader> instead of TYPOGRAPHY_STYLES.pageHeader.
+  // The files below are temporarily excluded because they are either:
+  //   - Permanent exceptions (reports, dashboards, tree pages, auth) — see docs/ui.md#exception-categories
+  //   - Deferred pages awaiting pattern validation — see docs/superpowers/specs/2026-03-24-issue-173-pageheader-phase4-design.md
+  //   - Components that reuse TYPOGRAPHY_STYLES.pageHeader for its type scale (not as a page header)
+  //
+  // This ignore list should only shrink over time. Remove an entry when the page is migrated or
+  // formally classified as a permanent exception. Promote severity to 'error' once the list is empty.
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    rules: {
+      'no-restricted-syntax': [
+        'warn',
+        {
+          selector: "MemberExpression[object.name='TYPOGRAPHY_STYLES'][property.name='pageHeader']",
+          message: "Use <PageHeader> for standard CRUD/list/form pages instead of TYPOGRAPHY_STYLES.pageHeader. See docs/ui.md for usage rules and exception categories.",
+        },
+        {
+          selector: "VariableDeclarator[init.name='TYPOGRAPHY_STYLES'] > ObjectPattern > Property[key.name='pageHeader']",
+          message: "Do not destructure TYPOGRAPHY_STYLES.pageHeader — use <PageHeader> instead. See docs/ui.md.",
+        },
+      ],
+    },
+  },
+  // Known exceptions/deferred — no-restricted-syntax disabled for these files only
+  {
+    files: [
+      // Permanent exceptions (reports, dashboards, tree/hierarchy, audit, auth)
+      'src/pages/accounting/AccountingDashboardPage.tsx',
+      'src/pages/accounting/ChartOfAccountsPage.tsx',
+      'src/pages/accounting/reports/AccountActivityPage.tsx',
+      'src/pages/accounting/reports/BalanceSheetPage.tsx',
+      'src/pages/accounting/reports/GeneralLedgerPage.tsx',
+      'src/pages/accounting/reports/ProfitAndLossPage.tsx',
+      'src/pages/accounting/reports/TrialBalancePage.tsx',
+      'src/pages/audit-logs/AuditLogsPage.tsx',
+      'src/pages/dashboard/DashboardPage.tsx',
+      'src/pages/inventory/CategoriesPage.tsx',
+      'src/pages/inventory/HistoricalInventoryReport.tsx',
+      'src/pages/inventory/InventorySummaryReport.tsx',
+      'src/pages/inventory/MovementSummaryReport.tsx',
+      'src/pages/inventory/PriceListReport.tsx',
+      'src/pages/inventory/ProductCostReport.tsx',
+      'src/pages/purchasing/PurchaseOrderDetailsReport.tsx',
+      'src/pages/purchasing/PurchaseOrderStatusReport.tsx',
+      'src/pages/purchasing/PurchaseOrderSummary.tsx',
+      'src/pages/purchasing/VendorPaymentDetailsReport.tsx',
+      'src/pages/purchasing/VendorProductListReport.tsx',
+      'src/pages/sales/CustomerOrderHistory.tsx',
+      'src/pages/sales/CustomerPaymentByOrder.tsx',
+      'src/pages/sales/CustomerPaymentDetails.tsx',
+      'src/pages/sales/CustomerPaymentSummary.tsx',
+      'src/pages/sales/ProductCustomerReport.tsx',
+      'src/pages/sales/SalesByProductDetails.tsx',
+      'src/pages/sales/SalesByProductSummary.tsx',
+      'src/pages/sales/SalesOrderProfitReport.tsx',
+      'src/pages/sales/SalesOrderSummary.tsx',
+      // Deferred pages — awaiting pattern validation
+      'src/pages/accounting/BankReconciliationDetailsPage.tsx',
+      'src/pages/accounting/BankReconciliationsPage.tsx',
+      'src/pages/accounting/JournalEntriesPage.tsx',
+      'src/pages/accounting/JournalEntryDetailsPage.tsx',
+      'src/pages/purchasing/PurchasingPage.tsx',
+      'src/pages/settings/BackupManagement.tsx',
+      'src/pages/settings/PriceListDetailsPage.tsx',
+      // Components using TYPOGRAPHY_STYLES.pageHeader for its type scale (not as a page header)
+      'src/pages/dashboard/components/DashboardStats.tsx',
+      'src/pages/inventory/InventoryPage.tsx',
+      'src/pages/sales/components/SalesStatsCards.tsx',
+    ],
+    rules: {
+      'no-restricted-syntax': 'off',
+    },
+  },
 );

--- a/frontend/src/pages/accounting/ExpensesPage.tsx
+++ b/frontend/src/pages/accounting/ExpensesPage.tsx
@@ -35,9 +35,8 @@ import {
   PostAdd as PostIcon,
   Refresh as RefreshIcon,
   Search as SearchIcon,
-  ReceiptLong as ExpenseIcon,
 } from '@mui/icons-material'
-import { TYPOGRAPHY_STYLES } from '@/constants/typography'
+import PageHeader from '@/components/common/PageHeader'
 import { useNotification } from '@/hooks/useNotification'
 import {
   useBulkDeleteExpensesMutation,
@@ -270,38 +269,11 @@ const ExpensesPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 3 }}>
-        <Box>
-          <Typography
-            variant={TYPOGRAPHY_STYLES.pageHeader.variant}
-            sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight, mb: 1, display: 'flex', alignItems: 'center', gap: 2 }}
-          >
-            <ExpenseIcon sx={{ fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize, color: TYPOGRAPHY_STYLES.pageHeader.icon.color }} />
-            Expenses
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Record and manage business expense transactions
-          </Typography>
-        </Box>
-        <Stack direction="row" spacing={1}>
-          {selectedIds.size > 0 && (
-            <>
-              <Button variant="contained" startIcon={<PostIcon />} onClick={onBulkPost}>
-                Bulk Post ({selectedIds.size})
-              </Button>
-              <Button variant="outlined" color="error" startIcon={<DeleteIcon />} onClick={onBulkDelete}>
-                Bulk Delete ({selectedIds.size})
-              </Button>
-            </>
-          )}
-          <IconButton onClick={() => refetch()}>
-            <RefreshIcon />
-          </IconButton>
-          <Button variant="contained" startIcon={<AddIcon />} onClick={openCreate}>
-            New Expense
-          </Button>
-        </Stack>
-      </Box>
+      <PageHeader
+        title="Expenses"
+        subtitle="Record and manage business expense transactions"
+        primaryAction={{ label: 'New Expense', onClick: openCreate }}
+      />
 
       <Card sx={{ mb: 2 }}>
         <CardContent>
@@ -311,7 +283,8 @@ const ExpensesPage: React.FC = () => {
       </Card>
 
       <Paper sx={{ p: 2, mb: 2 }}>
-        <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+        <Stack direction="row" alignItems="flex-start" spacing={1}>
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ flex: 1, flexWrap: 'wrap' }}>
           <TextField
             inputRef={searchRef}
             label="Search"
@@ -354,8 +327,23 @@ const ExpensesPage: React.FC = () => {
           </FormControl>
           <TextField label="Start Date" type="date" size="small" value={startDate} onChange={(e) => setStartDate(e.target.value)} InputLabelProps={{ shrink: true }} />
           <TextField label="End Date" type="date" size="small" value={endDate} onChange={(e) => setEndDate(e.target.value)} InputLabelProps={{ shrink: true }} />
+          </Stack>
+          <IconButton onClick={() => refetch()} size="small" sx={{ mt: 0.5 }}>
+            <RefreshIcon />
+          </IconButton>
         </Stack>
       </Paper>
+
+      {selectedIds.size > 0 && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2, p: 1.5, bgcolor: 'action.selected', borderRadius: 1 }}>
+          <Button variant="contained" size="small" startIcon={<PostIcon />} onClick={onBulkPost}>
+            Bulk Post ({selectedIds.size})
+          </Button>
+          <Button variant="outlined" size="small" color="error" startIcon={<DeleteIcon />} onClick={onBulkDelete}>
+            Bulk Delete ({selectedIds.size})
+          </Button>
+        </Box>
+      )}
 
       <Paper>
         <TableContainer>

--- a/frontend/src/pages/accounting/JournalEntryFormPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntryFormPage.tsx
@@ -35,6 +35,7 @@ import {
 import { useForm, useFieldArray, Controller, useWatch } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
+import PageHeader from '@/components/common/PageHeader'
 import { useNotification } from '@/hooks/useNotification'
 import {
   useCreateJournalEntryMutation,
@@ -46,7 +47,6 @@ import {
 import { formatCurrency, formatDate, getCurrentDate } from '@/utils/formatters'
 import { JournalEntryStatus, FiscalPeriodStatus } from '@/types'
 import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
-import { TYPOGRAPHY_STYLES } from '@/constants/typography'
 import { getErrorMessage } from '@/utils/errorMessage'
 
 interface JournalEntryLineForm {
@@ -357,14 +357,13 @@ const JournalEntryFormPage: React.FC = () => {
   return (
     <Box sx={{ p: 3 }}>
       {/* Header */}
-      <Box sx={{ mb: 3, display: 'flex', alignItems: 'center', gap: 2 }}>
-        <IconButton onClick={handleBack}>
-          <ArrowBackIcon />
-        </IconButton>
-        <Typography variant={TYPOGRAPHY_STYLES.pageHeader.variant} sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight }}>
-          {isEditMode ? 'Edit Journal Entry' : 'New Journal Entry'}
-        </Typography>
-      </Box>
+      <IconButton onClick={handleBack} sx={{ mb: 1 }}>
+        <ArrowBackIcon />
+      </IconButton>
+      <PageHeader
+        title={isEditMode ? 'Edit Journal Entry' : 'New Journal Entry'}
+        showDivider={false}
+      />
 
       {/* Error Alert */}
       {errorMessage && (

--- a/frontend/src/pages/accounting/__tests__/ExpensesPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/ExpensesPage.test.tsx
@@ -100,6 +100,19 @@ describe('ExpensesPage', () => {
     expect(screen.getByText('EXP-001')).toBeInTheDocument()
   })
 
+  it('renders Expenses title via PageHeader (h5 heading)', () => {
+    renderPage()
+
+    expect(screen.getByRole('heading', { level: 5, name: 'Expenses' })).toBeInTheDocument()
+  })
+
+  it('bulk action buttons are hidden when no rows are selected', () => {
+    renderPage()
+
+    expect(screen.queryByText(/Bulk Post/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Bulk Delete/i)).not.toBeInTheDocument()
+  })
+
   it('shows loading state', () => {
     mockedApi.useGetExpensesQuery.mockReturnValue({
       data: undefined,

--- a/frontend/src/pages/accounting/__tests__/JournalEntryFormPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/JournalEntryFormPage.test.tsx
@@ -104,6 +104,25 @@ describe('JournalEntryFormPage', () => {
     mockedApi.useUpdateJournalEntryMutation.mockReturnValue([vi.fn()])
   })
 
+  it('renders PageHeader with title "New Journal Entry" in create mode', () => {
+    renderWithProviders()
+
+    expect(screen.getByRole('heading', { name: 'New Journal Entry' })).toBeInTheDocument()
+  })
+
+  it('renders PageHeader with title "Edit Journal Entry" in edit mode', async () => {
+    mockParams.id = 'test-id'
+    mockedApi.useGetJournalEntryQuery.mockReturnValue({
+      data: mockJournalEntry,
+      isLoading: false,
+      error: undefined,
+    })
+
+    renderWithProviders()
+
+    expect(await screen.findByRole('heading', { name: 'Edit Journal Entry' })).toBeInTheDocument()
+  })
+
   it('renders create form with header and fields', () => {
     renderWithProviders()
 

--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -30,6 +30,7 @@ import { useForm, useFieldArray, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import { ApiService } from '@/services/api'
+import PageHeader from '@/components/common/PageHeader'
 import {
   useLazyGetStockAdjustmentQuery,
   useCreateStockAdjustmentMutation,
@@ -38,7 +39,6 @@ import {
 import { useProductSearch } from '@/hooks/useProductSearch'
 import { getCurrentDate } from '@/utils/formatters'
 import { useNotification } from '@/hooks/useNotification'
-import { TYPOGRAPHY_STYLES } from '@/constants/typography'
 
 interface AdjustmentItem {
   productId: string
@@ -281,14 +281,13 @@ const CreateStockAdjustmentPage: React.FC = () => {
     <Container maxWidth="xl">
       <Box sx={{ py: 3 }}>
         {/* Header */}
-        <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
-          <IconButton onClick={() => navigate('/inventory/stock-adjustments')} sx={{ mr: 2 }}>
-            <ArrowBackIcon />
-          </IconButton>
-          <Typography variant={TYPOGRAPHY_STYLES.pageHeader.variant} sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight }}>
-            {isEditMode ? 'Edit Stock Adjustment' : 'Create Stock Adjustment'}
-          </Typography>
-        </Box>
+        <IconButton onClick={() => navigate('/inventory/stock-adjustments')} sx={{ mb: 1 }}>
+          <ArrowBackIcon />
+        </IconButton>
+        <PageHeader
+          title={isEditMode ? 'Edit Stock Adjustment' : 'Create Stock Adjustment'}
+          showDivider={false}
+        />
 
         {loadingAdjustment ? (
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -88,6 +88,16 @@ describe('CreateStockAdjustmentPage product search', { timeout: 60000 }, () => {
     })
   })
 
+  it('renders PageHeader with title "Create Stock Adjustment" in create mode', () => {
+    render(
+      <BrowserRouter>
+        <CreateStockAdjustmentPage />
+      </BrowserRouter>
+    )
+
+    expect(screen.getByRole('heading', { name: 'Create Stock Adjustment' })).toBeInTheDocument()
+  })
+
   it('replaces autocomplete options with only the latest search results', async () => {
     render(
       <BrowserRouter>

--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -31,6 +31,7 @@ import { useForm, useFieldArray, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import { formatCurrency, getCurrentDate } from '@/utils/formatters'
+import PageHeader from '@/components/common/PageHeader'
 import { useNotification } from '@/hooks/useNotification'
 import { useProductSearch } from '@/hooks/useProductSearch'
 import { useAppDispatch } from '@/hooks/useRedux'
@@ -42,7 +43,6 @@ import {
   useLazyGetPurchaseOrderQuery,
 } from '@/store/api/purchasingApi'
 import { useCurrency } from '@/hooks/useCurrency'
-import { TYPOGRAPHY_STYLES } from '@/constants/typography'
 
 interface PurchaseOrderItem {
   productId: string
@@ -342,14 +342,13 @@ const CreatePurchaseOrderPage: React.FC = () => {
     <Container maxWidth="xl">
       <Box sx={{ py: 3 }}>
         {/* Header */}
-        <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
-          <IconButton onClick={() => navigate('/purchasing/orders')} sx={{ mr: 2 }}>
-            <ArrowBackIcon />
-          </IconButton>
-          <Typography variant={TYPOGRAPHY_STYLES.pageHeader.variant} sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight }}>
-            {isEditMode ? 'Edit Purchase Order' : 'Create Purchase Order'}
-          </Typography>
-        </Box>
+        <IconButton onClick={() => navigate('/purchasing/orders')} sx={{ mb: 1 }}>
+          <ArrowBackIcon />
+        </IconButton>
+        <PageHeader
+          title={isEditMode ? 'Edit Purchase Order' : 'Create Purchase Order'}
+          showDivider={false}
+        />
 
         {loadingOrder ? (
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>

--- a/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
@@ -91,6 +91,28 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
     })
   })
 
+  it('renders PageHeader with title "Create Purchase Order" in create mode', () => {
+    render(
+      <BrowserRouter>
+        <CreatePurchaseOrderPage />
+      </BrowserRouter>
+    )
+
+    expect(screen.getByRole('heading', { name: 'Create Purchase Order' })).toBeInTheDocument()
+  })
+
+  it('renders PageHeader with title "Edit Purchase Order" in edit mode', async () => {
+    mockParams.mockReturnValue({ id: 'po-test-id' })
+
+    render(
+      <BrowserRouter>
+        <CreatePurchaseOrderPage />
+      </BrowserRouter>
+    )
+
+    expect(await screen.findByRole('heading', { name: 'Edit Purchase Order' })).toBeInTheDocument()
+  })
+
   it('replaces the autocomplete options with only the latest product search results', async () => {
     render(
       <BrowserRouter>


### PR DESCRIPTION
## Summary

- **Tier 1 migrations:** `CreatePurchaseOrderPage`, `CreateStockAdjustmentPage`, `JournalEntryFormPage` — replaced legacy `TYPOGRAPHY_STYLES.pageHeader` Typography blocks with `<PageHeader showDivider={false} />`, back-arrow `IconButton` kept as sibling above header
- **Tier 2 migration:** `ExpensesPage` — `<PageHeader>` with title + subtitle + primary action; bulk-action buttons moved to an inline selection-context bar between filter row and table; refresh icon moved into the filter bar
- **Governance:** ESLint `no-restricted-syntax` rule added as a progressive warning; 39 known exception/deferred files explicitly excluded; rule fires on any new file using the legacy pattern; upgrade path to `error` documented in config comments
- **Docs:** `docs/ui.md` updated with new-page checklist and Phase 4 spec reference

## Test Plan

- [x] All 4 migrated pages have Vitest assertions covering the PageHeader title
- [x] 79 test files, 482 tests — all pass (`npm run test`)
- [x] `npm run lint` passes with 0 errors, 0 warnings
- [x] `npm run type-check` passes with no errors
- [x] `TYPOGRAPHY_STYLES.pageHeader` confirmed absent from all 4 migrated files
- [x] Deferred pages confirmed untouched (11 legacy usages remain in known files)
- [x] ESLint rule verified: warns on new files using legacy pattern, silent on migrated files and excluded files

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)