### PR TITLE
feat(ui): PageHeader Phase 5 — unified header system (issue #180)

### DIFF
--- a/docs/superpowers/specs/2026-03-24-issue-173-pageheader-phase4-design.md
+++ b/docs/superpowers/specs/2026-03-24-issue-173-pageheader-phase4-design.md
@@ -84,6 +84,8 @@ These pages are not yet migrated. Do not force-fit them into `PageHeader` until 
 
 ### Permanent Exceptions
 
+**Note:** `AuditLogsPage` was reclassified in Phase 5 — its header was migrated using `variant="system"`. The multi-tab body content remains unchanged.
+
 | Page | Module | Exception Category |
 |------|--------|-------------------|
 | ChartOfAccountsPage | Accounting | Tree / hierarchy |

--- a/frontend/src/components/common/PageHeader.tsx
+++ b/frontend/src/components/common/PageHeader.tsx
@@ -13,6 +13,9 @@ type PageHeaderProps = {
   primaryAction?: PageHeaderAction
   secondaryAction?: PageHeaderAction
   showDivider?: boolean
+  variant?: 'standard' | 'report' | 'overview' | 'structure' | 'workflow' | 'system'
+  meta?: ReactNode
+  toolbar?: ReactNode
   children?: ReactNode
 }
 
@@ -22,6 +25,9 @@ export default function PageHeader({
   primaryAction,
   secondaryAction,
   showDivider = true,
+  variant: _variant,
+  meta,
+  toolbar,
   children,
 }: PageHeaderProps) {
   const theme = useTheme()
@@ -100,7 +106,23 @@ export default function PageHeader({
         )}
       </Box>
 
-      {children && <Box sx={{ mt: 1 }}>{children}</Box>}
+      {meta && (
+        <Box data-testid="page-header-meta" sx={{ mt: 1 }}>
+          {meta}
+        </Box>
+      )}
+
+      {toolbar && (
+        <Box data-testid="page-header-toolbar" sx={{ mt: 1 }}>
+          {toolbar}
+        </Box>
+      )}
+
+      {children && (
+        <Box data-testid="page-header-children" sx={{ mt: 1 }}>
+          {children}
+        </Box>
+      )}
     </Box>
   )
 }

--- a/frontend/src/components/common/__tests__/PageHeader.test.tsx
+++ b/frontend/src/components/common/__tests__/PageHeader.test.tsx
@@ -101,4 +101,65 @@ describe('PageHeader', () => {
     )
     expect(screen.getByText('extra content')).toBeInTheDocument()
   })
+
+  describe('slot rendering', () => {
+    it('renders meta when provided', () => {
+      renderWithTheme(
+        <PageHeader title="T" meta={<span data-testid="meta-content">Meta</span>} />
+      )
+      expect(screen.getByTestId('meta-content')).toBeInTheDocument()
+    })
+
+    it('does not render meta wrapper when meta is not provided', () => {
+      renderWithTheme(<PageHeader title="T" />)
+      expect(screen.queryByTestId('page-header-meta')).not.toBeInTheDocument()
+    })
+
+    it('renders toolbar when provided', () => {
+      renderWithTheme(
+        <PageHeader title="T" toolbar={<span data-testid="toolbar-content">Toolbar</span>} />
+      )
+      expect(screen.getByTestId('toolbar-content')).toBeInTheDocument()
+    })
+
+    it('does not render toolbar wrapper when toolbar is not provided', () => {
+      renderWithTheme(<PageHeader title="T" />)
+      expect(screen.queryByTestId('page-header-toolbar')).not.toBeInTheDocument()
+    })
+
+    it('does not render children wrapper when children is not provided', () => {
+      renderWithTheme(<PageHeader title="T" />)
+      expect(screen.queryByTestId('page-header-children')).not.toBeInTheDocument()
+    })
+
+    it('renders meta before toolbar in the DOM', () => {
+      renderWithTheme(
+        <PageHeader
+          title="T"
+          meta={<span data-testid="meta-content">Meta</span>}
+          toolbar={<span data-testid="toolbar-content">Toolbar</span>}
+        />
+      )
+      const meta = screen.getByTestId('meta-content')
+      const toolbar = screen.getByTestId('toolbar-content')
+      expect(meta.compareDocumentPosition(toolbar)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    })
+
+    it('renders toolbar before children in the DOM', () => {
+      renderWithTheme(
+        <PageHeader title="T" toolbar={<span data-testid="toolbar-content">Toolbar</span>}>
+          <span data-testid="children-content">Children</span>
+        </PageHeader>
+      )
+      const toolbar = screen.getByTestId('toolbar-content')
+      const children = screen.getByTestId('children-content')
+      expect(toolbar.compareDocumentPosition(children)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    })
+
+    it('accepts variant prop without error', () => {
+      expect(() =>
+        renderWithTheme(<PageHeader title="T" variant="report" />)
+      ).not.toThrow()
+    })
+  })
 })

--- a/frontend/src/config/__tests__/browserEnvCompatibility.test.ts
+++ b/frontend/src/config/__tests__/browserEnvCompatibility.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 

--- a/frontend/src/hooks/useProductSearch.test.ts
+++ b/frontend/src/hooks/useProductSearch.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 

--- a/frontend/src/pages/accounting/AccountingDashboardPage.tsx
+++ b/frontend/src/pages/accounting/AccountingDashboardPage.tsx
@@ -27,9 +27,9 @@ import {
   TrendingUp as TrendingUpIcon,
   TrendingDown as TrendingDownIcon,
   Add as AddIcon,
-  Dashboard as DashboardIcon,
   AccountBalanceWallet as AccountBalanceWalletIcon,
 } from '@mui/icons-material';
+import PageHeader from '@/components/common/PageHeader';
 import { useNavigate } from 'react-router-dom';
 import {
   useGetBalanceSheetQuery,
@@ -229,30 +229,20 @@ const AccountingDashboardPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{ mb: 3 }}>
-        <Typography
-          variant={TYPOGRAPHY_STYLES.pageHeader.variant}
-          sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2,
-          }}
-        >
-          <DashboardIcon
-            sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color,
-            }}
-          />
-          Accounting Dashboard
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          Overview of your financial position and accounting activity
-        </Typography>
-      </Box>
+      <PageHeader
+        variant="overview"
+        title="Accounting Dashboard"
+        subtitle="Overview of your financial position and accounting activity"
+        meta={
+          currentPeriod ? (
+            <Chip
+              label={`${currentPeriod.name} ${isCurrentPeriodOpen ? 'Open' : 'Closed'}`}
+              color={isCurrentPeriodOpen ? 'success' : 'error'}
+              size="small"
+            />
+          ) : undefined
+        }
+      />
 
       {/* Error Alert */}
       {hasError && (

--- a/frontend/src/pages/accounting/BankReconciliationDetailsPage.tsx
+++ b/frontend/src/pages/accounting/BankReconciliationDetailsPage.tsx
@@ -28,6 +28,7 @@ import {
   Delete as DeleteIcon,
   Save as SaveIcon,
 } from '@mui/icons-material';
+import PageHeader from '@/components/common/PageHeader';
 import { format } from 'date-fns';
 import { useNotification } from '@/hooks/useNotification';
 import {
@@ -41,7 +42,6 @@ import {
 } from '@/store/api/accountingApi';
 import { BankReconciliationStatus, ReconciledTransaction } from '@/types';
 import { formatCurrency } from '@/utils/formatters';
-import { TYPOGRAPHY_STYLES } from '@/constants/typography';
 import { getErrorMessage } from '@/utils/errorMessage';
 
 const BankReconciliationDetailsPage: React.FC = () => {
@@ -196,45 +196,47 @@ const BankReconciliationDetailsPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 3 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-          <IconButton onClick={handleBack}>
-            <ArrowBackIcon />
-          </IconButton>
-          <Box>
-            <Typography variant={TYPOGRAPHY_STYLES.pageHeader.variant} sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight }}>
-              {reconciliation.account ? `${reconciliation.account.code} - ${reconciliation.account.name}` : 'Bank Reconciliation'}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {reconciliation.fiscalPeriod?.name || reconciliation.fiscalPeriodId}
-            </Typography>
-          </Box>
-        </Box>
+      <PageHeader
+        variant="workflow"
+        title={reconciliation.account ? `${reconciliation.account.code} - ${reconciliation.account.name}` : 'Bank Reconciliation'}
+        subtitle={reconciliation.fiscalPeriod?.name || reconciliation.fiscalPeriodId}
+        meta={
+          <Chip
+            size="small"
+            label={reconciliation.status === BankReconciliationStatus.COMPLETED ? 'Completed' : 'In Progress'}
+            color={reconciliation.status === BankReconciliationStatus.COMPLETED ? 'success' : 'warning'}
+          />
+        }
+      />
 
-        <Stack direction="row" spacing={1}>
-          {reconciliation.status === BankReconciliationStatus.COMPLETED ? (
-            <Button variant="outlined" color="warning" startIcon={<ReopenIcon />} onClick={handleReopen}>
-              Reopen
+      <Stack direction="row" spacing={1} sx={{ mb: 3 }}>
+        <IconButton onClick={handleBack}>
+          <ArrowBackIcon />
+        </IconButton>
+        {reconciliation.status === BankReconciliationStatus.COMPLETED ? (
+          <Button variant="outlined" color="warning" startIcon={<ReopenIcon />} onClick={handleReopen}>
+            Reopen
+          </Button>
+        ) : (
+          <>
+            <Button
+              variant="contained"
+              color="success"
+              startIcon={<CheckCircleIcon />}
+              disabled={!reconciliation.isBalanced}
+              onClick={handleComplete}
+            >
+              Complete
             </Button>
-          ) : (
-            <>
-              <Button
-                variant="contained"
-                color="success"
-                startIcon={<CheckCircleIcon />}
-                disabled={!reconciliation.isBalanced}
-                onClick={handleComplete}
-              >
-                Complete
-              </Button>
-              <Button variant="outlined" color="error" startIcon={<DeleteIcon />} onClick={handleDelete}>
-                Delete
-              </Button>
-            </>
-          )}
-          <Button variant="outlined" onClick={handleBack}>Back to List</Button>
-        </Stack>
-      </Box>
+            <Button variant="outlined" color="error" startIcon={<DeleteIcon />} onClick={handleDelete}>
+              Delete
+            </Button>
+          </>
+        )}
+        <Button variant="outlined" onClick={handleBack}>
+          Back to List
+        </Button>
+      </Stack>
 
       <Card sx={{ mb: 3 }}>
         <CardContent>

--- a/frontend/src/pages/accounting/BankReconciliationsPage.tsx
+++ b/frontend/src/pages/accounting/BankReconciliationsPage.tsx
@@ -22,15 +22,15 @@ import {
   useMediaQuery,
 } from '@mui/material';
 import {
-  AccountBalance as AccountBalanceIcon,
   Add as AddIcon,
   Delete as DeleteIcon,
 } from '@mui/icons-material';
+import PageHeader from '@/components/common/PageHeader';
 import { format } from 'date-fns';
 import ConfirmationDialog from '@/components/common/ConfirmationDialog';
 import BankReconciliationFormDialog from '@/components/accounting/BankReconciliationFormDialog';
 import { useNotification } from '@/hooks/useNotification';
-import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography';
+import { TABLE_STYLES } from '@/constants/typography';
 import {
   useDeleteBankReconciliationMutation,
   useGetBankReconciliationsQuery,
@@ -162,38 +162,24 @@ const BankReconciliationsPage: React.FC = () => {
     return <Chip size="small" color="warning" label="In Progress" />;
   };
 
+  const selectedPeriodLabel =
+    periodFilter === 'all'
+      ? 'All periods'
+      : periods.find((period: any) => period.id === periodFilter)?.name || periodFilter;
+
   return (
     <Box sx={{ p: 3 }}>
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0,
-      }}>
-        <Box>
-          <Typography
-            variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant}
-            sx={{
-              fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-              mb: 1,
-              display: 'flex',
-              alignItems: 'center',
-              gap: 2,
-            }}
-          >
-            <AccountBalanceIcon sx={{ fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize, color: TYPOGRAPHY_STYLES.pageHeader.icon.color }} />
-            Bank Reconciliations
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Reconcile bank and cash accounts ({pagination?.total || 0} total)
-          </Typography>
-        </Box>
-        <Button variant="contained" startIcon={<AddIcon />} onClick={handleOpenCreate}>
-          New Reconciliation
-        </Button>
-      </Box>
+      <PageHeader
+        variant="workflow"
+        title="Bank Reconciliations"
+        subtitle="Reconcile bank and cash accounts"
+        meta={<Chip size="small" label={selectedPeriodLabel} />}
+        toolbar={
+          <Button variant="contained" startIcon={<AddIcon />} onClick={handleOpenCreate}>
+            New Reconciliation
+          </Button>
+        }
+      />
 
       <Paper sx={{ p: 2, mb: 3 }}>
         <Box sx={{ display: 'flex', gap: 2, flexDirection: isMobile ? 'column' : 'row' }}>

--- a/frontend/src/pages/accounting/ChartOfAccountsPage.tsx
+++ b/frontend/src/pages/accounting/ChartOfAccountsPage.tsx
@@ -25,15 +25,13 @@ import {
   Grid,
 } from '@mui/material'
 import {
-  Add as AddIcon,
   Edit as EditIcon,
   Delete as DeleteIcon,
   Search as SearchIcon,
-  AccountBalance as AccountIcon,
   CloudUpload as SeedIcon,
-  Restore as RestoreIcon,
   Info as InfoIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { useNotification } from '@/hooks/useNotification'
 import { useSearchAndFilter, useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
 import ConfirmationDialog from '@/components/common/ConfirmationDialog'
@@ -205,86 +203,154 @@ const ChartOfAccountsPage: React.FC = () => {
       {/* Account Mapping Warning */}
       <AccountMappingWarning context="system" />
 
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <AccountIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Chart of Accounts
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Manage your accounting structure and account hierarchy ({pagination?.total || 0} total)
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          {accounts.length === 0 && !loading && (
-            <Button
-              variant="outlined"
-              startIcon={!isMobile ? <SeedIcon /> : undefined}
-              onClick={handleSeedAccounts}
-              size="medium"
-              fullWidth={isMobile}
+      <PageHeader
+        variant="structure"
+        title="Chart of Accounts"
+        subtitle={`Manage your accounting structure and account hierarchy (${pagination?.total || 0} total)`}
+        primaryAction={{
+          label: isMobile ? 'Add New Account' : 'Add Account',
+          onClick: handleAddAccount,
+        }}
+        secondaryAction={{
+          label: 'View Deleted',
+          onClick: () => setDeletedDialogOpen(true),
+        }}
+        toolbar={
+          <Paper sx={{ p: 2 }}>
+            <Box
               sx={{
-                color: 'info.main',
-                borderColor: 'info.main',
-                '&:hover': {
-                  borderColor: 'info.dark',
-                  backgroundColor: 'info.light'
-                }
+                display: 'flex',
+                flexDirection: isMobile ? 'column' : 'row',
+                gap: isMobile ? 2 : 1,
+                alignItems: isMobile ? 'stretch' : 'center',
+                '& > *': {
+                  alignSelf: isMobile ? 'stretch' : 'flex-start',
+                },
               }}
             >
-              {isMobile ? "Seed Default Accounts" : "Seed Defaults"}
-            </Button>
-          )}
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RestoreIcon /> : undefined}
-            onClick={() => setDeletedDialogOpen(true)}
-            size="medium"
-            fullWidth={isMobile}
-            sx={{
-              color: 'warning.main',
-              borderColor: 'warning.main',
-              '&:hover': {
-                borderColor: 'warning.dark',
-                backgroundColor: 'warning.lighter'
-              }
-            }}
-          >
-            {isMobile ? "View Deleted" : "View Deleted"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <AddIcon /> : undefined}
-            size="medium"
-            onClick={handleAddAccount}
-            fullWidth={isMobile}
-          >
-            {isMobile ? "Add New Account" : "Add Account"}
-          </Button>
-        </Box>
-      </Box>
+              <TextField
+                placeholder="Search by code or name..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                size="medium"
+                sx={{
+                  minWidth: isMobile ? 'auto' : 250,
+                  flex: isMobile ? 'none' : 1,
+                  maxWidth: isMobile ? 'none' : 400,
+                  '& .MuiOutlinedInput-root': {
+                    height: TYPOGRAPHY_STYLES.searchField.input.height,
+                    fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                    '& input': {
+                      padding: TYPOGRAPHY_STYLES.searchField.input.padding,
+                      fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize
+                    }
+                  },
+                  '& .MuiInputAdornment-root': {
+                    '& .MuiSvgIcon-root': {
+                      fontSize: TYPOGRAPHY_STYLES.searchField.icon.fontSize,
+                      color: TYPOGRAPHY_STYLES.searchField.icon.color
+                    }
+                  }
+                }}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchIcon fontSize="small" />
+                    </InputAdornment>
+                  ),
+                }}
+              />
+
+              <FormControl
+                size="medium"
+                sx={{
+                  minWidth: isMobile ? 'auto' : 150,
+                  flex: 'none'
+                }}
+              >
+                <InputLabel
+                  sx={{
+                    fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                    '&.MuiInputLabel-shrunk': {
+                      fontSize: TYPOGRAPHY_STYLES.tableCell.caption.fontSize
+                    }
+                  }}
+                >
+                  Account Type
+                </InputLabel>
+                <Select
+                  value={typeFilter}
+                  label="Account Type"
+                  onChange={(e) => setTypeFilter(e.target.value)}
+                  sx={{
+                    height: TYPOGRAPHY_STYLES.searchField.input.height,
+                    fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                  }}
+                >
+                  <MenuItem value="all">All Types</MenuItem>
+                  <MenuItem value="asset">Asset</MenuItem>
+                  <MenuItem value="liability">Liability</MenuItem>
+                  <MenuItem value="equity">Equity</MenuItem>
+                  <MenuItem value="revenue">Revenue</MenuItem>
+                  <MenuItem value="expense">Expense</MenuItem>
+                </Select>
+              </FormControl>
+
+              <FormControl
+                size="medium"
+                sx={{
+                  minWidth: isMobile ? 'auto' : 120,
+                  flex: 'none'
+                }}
+              >
+                <InputLabel
+                  sx={{
+                    fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                    '&.MuiInputLabel-shrunk': {
+                      fontSize: TYPOGRAPHY_STYLES.tableCell.caption.fontSize
+                    }
+                  }}
+                >
+                  Status
+                </InputLabel>
+                <Select
+                  value={activeFilter}
+                  label="Status"
+                  onChange={(e) => setActiveFilter(e.target.value)}
+                  sx={{
+                    height: TYPOGRAPHY_STYLES.searchField.input.height,
+                    fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                  }}
+                >
+                  <MenuItem value="all">All</MenuItem>
+                  <MenuItem value="active">Active</MenuItem>
+                  <MenuItem value="inactive">Inactive</MenuItem>
+                </Select>
+              </FormControl>
+
+              {accounts.length === 0 && !loading && (
+                <Button
+                  variant="outlined"
+                  startIcon={!isMobile ? <SeedIcon /> : undefined}
+                  onClick={handleSeedAccounts}
+                  size="medium"
+                  fullWidth={isMobile}
+                  sx={{
+                    color: 'info.main',
+                    borderColor: 'info.main',
+                    '&:hover': {
+                      borderColor: 'info.dark',
+                      backgroundColor: 'info.light'
+                    }
+                  }}
+                >
+                  {isMobile ? 'Seed Default Accounts' : 'Seed Defaults'}
+                </Button>
+              )}
+            </Box>
+          </Paper>
+        }
+      />
 
       {/* Code Range Guide */}
       <Paper variant="outlined" sx={{ mb: 3, borderColor: 'info.light' }}>
@@ -391,119 +457,6 @@ const ChartOfAccountsPage: React.FC = () => {
             </Grid>
           </Box>
         </Collapse>
-      </Paper>
-
-      {/* Filters and Search */}
-      <Paper sx={{ p: 2, mb: 3 }}>
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        gap: isMobile ? 2 : 1,
-        alignItems: isMobile ? 'stretch' : 'center',
-        '& > *': {
-          alignSelf: isMobile ? 'stretch' : 'flex-start'
-        }
-      }}>
-        <TextField
-          placeholder="Search by code or name..."
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 250,
-            flex: isMobile ? 'none' : 1,
-            maxWidth: isMobile ? 'none' : 400,
-            '& .MuiOutlinedInput-root': {
-              height: TYPOGRAPHY_STYLES.searchField.input.height,
-              fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
-              '& input': {
-                padding: TYPOGRAPHY_STYLES.searchField.input.padding,
-                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize
-              }
-            },
-            '& .MuiInputAdornment-root': {
-              '& .MuiSvgIcon-root': {
-                fontSize: TYPOGRAPHY_STYLES.searchField.icon.fontSize,
-                color: TYPOGRAPHY_STYLES.searchField.icon.color
-              }
-            }
-          }}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon fontSize="small" />
-              </InputAdornment>
-            ),
-          }}
-        />
-
-        <FormControl
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 150,
-            flex: 'none'
-          }}
-        >
-          <InputLabel
-            sx={{
-              fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
-              '&.MuiInputLabel-shrunk': {
-                fontSize: TYPOGRAPHY_STYLES.tableCell.caption.fontSize
-              }
-            }}
-          >
-            Account Type
-          </InputLabel>
-          <Select
-            value={typeFilter}
-            label="Account Type"
-            onChange={(e) => setTypeFilter(e.target.value)}
-            sx={{
-              height: TYPOGRAPHY_STYLES.searchField.input.height,
-              fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
-            }}
-          >
-            <MenuItem value="all">All Types</MenuItem>
-            <MenuItem value="asset">Asset</MenuItem>
-            <MenuItem value="liability">Liability</MenuItem>
-            <MenuItem value="equity">Equity</MenuItem>
-            <MenuItem value="revenue">Revenue</MenuItem>
-            <MenuItem value="expense">Expense</MenuItem>
-          </Select>
-        </FormControl>
-
-        <FormControl
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 120,
-            flex: 'none'
-          }}
-        >
-          <InputLabel
-            sx={{
-              fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
-              '&.MuiInputLabel-shrunk': {
-                fontSize: TYPOGRAPHY_STYLES.tableCell.caption.fontSize
-              }
-            }}
-          >
-            Status
-          </InputLabel>
-          <Select
-            value={activeFilter}
-            label="Status"
-            onChange={(e) => setActiveFilter(e.target.value)}
-            sx={{
-              height: TYPOGRAPHY_STYLES.searchField.input.height,
-              fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
-            }}
-          >
-            <MenuItem value="all">All</MenuItem>
-            <MenuItem value="active">Active</MenuItem>
-            <MenuItem value="inactive">Inactive</MenuItem>
-          </Select>
-        </FormControl>
-      </Box>
       </Paper>
 
       {/* Accounts Table */}

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -34,8 +34,8 @@ import {
   Delete as DeleteIcon,
   PostAdd as PostIcon,
   Refresh as RefreshIcon,
-  Description as JournalIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { useNotification } from '@/hooks/useNotification'
 import {
   useBulkDeleteJournalEntriesMutation,
@@ -48,7 +48,7 @@ import { JournalEntry, JournalEntryStatus } from '@/types'
 import { formatCurrency, formatDate } from '@/utils/formatters'
 import ConfirmationDialog from '@/components/common/ConfirmationDialog'
 import AccountMappingWarning from '@/components/accounting/AccountMappingWarning'
-import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
+import { TABLE_STYLES } from '@/constants/typography'
 import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
 import { getErrorMessage } from '@/utils/errorMessage'
 
@@ -353,59 +353,48 @@ const JournalEntriesPage: React.FC = () => {
       {/* Account Mapping Warning */}
       <AccountMappingWarning context="system" />
 
-      {/* Header */}
-      <Box sx={{ mb: 3, display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-        <Box>
-          <Typography
-            variant={TYPOGRAPHY_STYLES.pageHeader.variant}
-            sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight, mb: 1, display: 'flex', alignItems: 'center', gap: 2 }}
-          >
-            <JournalIcon sx={{ fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize, color: TYPOGRAPHY_STYLES.pageHeader.icon.color }} />
-            Journal Entries
-          </Typography>
-          <Typography variant={TYPOGRAPHY_STYLES.pageSubtitle.variant} color={TYPOGRAPHY_STYLES.pageSubtitle.color}>
-            Manage and post accounting journal entries ({pagination?.total || 0} total)
-          </Typography>
-        </Box>
-        <Stack direction="row" spacing={2}>
-          {selectedIds.size > 0 && (
-            <>
-              <Button
-                size="small"
-                variant="contained"
-                color="primary"
-                startIcon={<PostIcon />}
-                onClick={() => setIsBulkPostConfirmOpen(true)}
-              >
-                Post Selected ({selectedIds.size})
-              </Button>
-              <Button
-                size="small"
-                variant="outlined"
-                color="error"
-                startIcon={<DeleteIcon />}
-                onClick={() => setIsBulkDeleteConfirmOpen(true)}
-              >
-                Delete Selected ({selectedIds.size})
-              </Button>
-            </>
-          )}
-          <Tooltip title="Refresh">
-            <span>
-              <IconButton onClick={handleRefresh} disabled={loading}>
-                <RefreshIcon />
-              </IconButton>
-            </span>
-          </Tooltip>
-          <Button
-            variant="contained"
-            startIcon={<AddIcon />}
-            onClick={handleCreateNew}
-          >
-            New Journal Entry
-          </Button>
-        </Stack>
-      </Box>
+      <PageHeader
+        variant="workflow"
+        title="Journal Entries"
+        subtitle={`Manage and post accounting journal entries (${pagination?.total || 0} total)`}
+        meta={<Chip size="small" label={`${pagination?.total || 0} total`} />}
+        toolbar={
+          <Stack direction="row" spacing={2}>
+            {selectedIds.size > 0 && (
+              <>
+                <Button
+                  size="small"
+                  variant="contained"
+                  color="primary"
+                  startIcon={<PostIcon />}
+                  onClick={() => setIsBulkPostConfirmOpen(true)}
+                >
+                  Post Selected ({selectedIds.size})
+                </Button>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="error"
+                  startIcon={<DeleteIcon />}
+                  onClick={() => setIsBulkDeleteConfirmOpen(true)}
+                >
+                  Delete Selected ({selectedIds.size})
+                </Button>
+              </>
+            )}
+            <Tooltip title="Refresh">
+              <span>
+                <IconButton onClick={handleRefresh} disabled={loading}>
+                  <RefreshIcon />
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Button variant="contained" startIcon={<AddIcon />} onClick={handleCreateNew}>
+              New Journal Entry
+            </Button>
+          </Stack>
+        }
+      />
 
       {/* Filters */}
       <Paper sx={{ p: 2, mb: 3 }}>

--- a/frontend/src/pages/accounting/JournalEntryDetailsPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntryDetailsPage.tsx
@@ -33,6 +33,7 @@ import {
   CheckCircle as CheckCircleIcon,
   Warning as WarningIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { useNotification } from '@/hooks/useNotification'
 import {
   useDeleteJournalEntryMutation,
@@ -42,7 +43,6 @@ import {
 } from '@/store/api/accountingApi'
 import { formatCurrency, formatDate, getCurrentDate } from '@/utils/formatters'
 import { JournalEntryStatus } from '@/types'
-import { TYPOGRAPHY_STYLES } from '@/constants/typography'
 import { getErrorMessage } from '@/utils/errorMessage'
 
 const JournalEntryDetailsPage: React.FC = () => {
@@ -186,31 +186,27 @@ const JournalEntryDetailsPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{ mb: 3, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+      <PageHeader
+        variant="workflow"
+        title={entry.referenceNumber}
+        subtitle="Journal Entry Details"
+        meta={<Chip size="small" label={`Status: ${entry.status}`} />}
+      />
+
+      <Box sx={{ mb: 3 }}>
+        <Stack direction="row" spacing={1} sx={{ mb: 2 }} alignItems="center">
           <IconButton onClick={handleBack}>
             <ArrowBackIcon />
           </IconButton>
-          <Box>
-            <Typography variant={TYPOGRAPHY_STYLES.pageHeader.variant} sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight }}>
-              {entry.referenceNumber}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Journal Entry Details
-            </Typography>
-          </Box>
-        </Box>
+          <Typography variant="body2" color="text.secondary">
+            Back to List
+          </Typography>
+        </Stack>
 
-        {/* Action Buttons */}
         <Stack direction="row" spacing={1}>
           {isDraft && (
             <>
-              <Button
-                variant="outlined"
-                startIcon={<EditIcon />}
-                onClick={handleEdit}
-              >
+              <Button variant="outlined" startIcon={<EditIcon />} onClick={handleEdit}>
                 Edit
               </Button>
               <Button

--- a/frontend/src/pages/accounting/reports/AccountActivityPage.tsx
+++ b/frontend/src/pages/accounting/reports/AccountActivityPage.tsx
@@ -29,9 +29,8 @@ import {
 import {
   Download as DownloadIcon,
   Receipt as ReceiptIcon,
-  Timeline as AccountActivityIcon,
 } from '@mui/icons-material';
-import { TYPOGRAPHY_STYLES } from '@/constants/typography';
+import PageHeader from '@/components/common/PageHeader';
 import { useNavigate } from 'react-router-dom';
 import { formatDate, formatDateTime } from '@/utils/formatters';
 import { useGetAccountActivityQuery, useGetChartOfAccountsQuery } from '@/store/api/accountingApi';
@@ -246,144 +245,136 @@ const AccountActivityPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{ mb: 3 }}>
-        <Typography
-          variant={TYPOGRAPHY_STYLES.pageHeader.variant}
-          sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight, mb: 1, display: 'flex', alignItems: 'center', gap: 2 }}
-        >
-          <AccountActivityIcon sx={{ fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize, color: TYPOGRAPHY_STYLES.pageHeader.icon.color }} />
-          Account Activity Report
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          View journal entries affecting an account with drill-down to source transactions
-        </Typography>
-      </Box>
-
-      {/* Filters Section */}
-      <Paper sx={{ p: 3, mb: 3 }}>
-        <Stack
-          direction={accountActivityToolbarLayout.containerDirection}
-          spacing={2}
-          justifyContent="space-between"
-          alignItems={accountActivityToolbarLayout.containerAlignItems}
-        >
-          <Stack
-            data-testid="account-activity-filters"
-            direction="row"
-            spacing={2}
-            alignItems="flex-start"
-            flexWrap={accountActivityToolbarLayout.filtersWrap}
-          >
-            {/* Account Selector */}
-            <Autocomplete
-              options={accounts}
-              getOptionLabel={(option) => `${option.code} - ${option.name}`}
-              value={selectedAccount}
-              onChange={(event, newValue) => {
-                setSelectedAccount(newValue);
-                setValidationError(null);
-                setSubmitted(false);
-              }}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  label="Account"
-                  placeholder="Select an account"
-                  required
-                  error={!!validationError}
-                  helperText={validationError}
-                />
-              )}
-              sx={{ minWidth: { xs: 280, md: 220 }, flexGrow: 1 }}
-              size="small"
-            />
-
+      <PageHeader
+        variant="report"
+        title="Account Activity Report"
+        subtitle="View journal entries affecting an account with drill-down to source transactions"
+        toolbar={
+          <Paper sx={{ p: 3, mb: 3 }}>
             <Stack
-              direction={accountActivityToolbarLayout.dateStatusDirection}
+              direction={accountActivityToolbarLayout.containerDirection}
               spacing={2}
-              flexWrap={accountActivityToolbarLayout.dateStatusWrap}
-              sx={{ width: { xs: '100%', sm: 'auto' } }}
+              justifyContent="space-between"
+              alignItems={accountActivityToolbarLayout.containerAlignItems}
             >
-              {/* Start Date */}
-              <TextField
-                label="Start Date"
-                type="date"
-                value={startDate}
-                onChange={(e) => {
-                  setStartDate(e.target.value);
-                  setSubmitted(false);
-                }}
-                size="small"
-                InputLabelProps={{ shrink: true }}
-                sx={{ minWidth: { xs: 140, sm: 160 } }}
-              />
-
-              {/* End Date */}
-              <TextField
-                label="End Date"
-                type="date"
-                value={endDate}
-                onChange={(e) => {
-                  setEndDate(e.target.value);
-                  setSubmitted(false);
-                }}
-                size="small"
-                InputLabelProps={{ shrink: true }}
-                sx={{ minWidth: { xs: 140, sm: 160 } }}
-              />
-
-              {/* Status Filter */}
-              <FormControl size="small" sx={{ minWidth: { xs: 110, sm: 120 } }}>
-                <InputLabel id="status-filter-label">Status</InputLabel>
-                <Select
-                  labelId="status-filter-label"
-                  label="Status"
-                  value={statusFilter}
-                  onChange={(e) => {
-                    setStatusFilter(e.target.value);
+              <Stack
+                data-testid="account-activity-filters"
+                direction="row"
+                spacing={2}
+                alignItems="flex-start"
+                flexWrap={accountActivityToolbarLayout.filtersWrap}
+              >
+                {/* Account Selector */}
+                <Autocomplete
+                  options={accounts}
+                  getOptionLabel={(option) => `${option.code} - ${option.name}`}
+                  value={selectedAccount}
+                  onChange={(event, newValue) => {
+                    setSelectedAccount(newValue);
+                    setValidationError(null);
                     setSubmitted(false);
                   }}
-                >
-                  <MenuItem value="ALL">All Statuses</MenuItem>
-                  <MenuItem value="DRAFT">Draft</MenuItem>
-                  <MenuItem value="POSTED">Posted</MenuItem>
-                  <MenuItem value="REVERSED">Reversed</MenuItem>
-                </Select>
-              </FormControl>
-            </Stack>
-          </Stack>
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      label="Account"
+                      placeholder="Select an account"
+                      required
+                      error={!!validationError}
+                      helperText={validationError}
+                    />
+                  )}
+                  sx={{ minWidth: { xs: 280, md: 220 }, flexGrow: 1 }}
+                  size="small"
+                />
 
-          <Stack
-            data-testid="account-activity-actions"
-            direction="row"
-            spacing={2}
-            justifyContent={accountActivityToolbarLayout.actionsJustify}
-            flexWrap="wrap"
-          >
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={handleGenerateReport}
-              disabled={loading}
-              aria-label="Generate Report"
-              sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
-            >
-              {loading ? <CircularProgress size={24} /> : 'Generate Report'}
-            </Button>
-            <Button
-              variant="outlined"
-              color="secondary"
-              startIcon={isDownloading ? <CircularProgress size={20} /> : <DownloadIcon />}
-              onClick={handleExportToExcel}
-              disabled={!submitted || loading || isDownloading}
-              sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
-            >
-              Export to Excel
-            </Button>
-          </Stack>
-        </Stack>
-      </Paper>
+                <Stack
+                  direction={accountActivityToolbarLayout.dateStatusDirection}
+                  spacing={2}
+                  flexWrap={accountActivityToolbarLayout.dateStatusWrap}
+                  sx={{ width: { xs: '100%', sm: 'auto' } }}
+                >
+                  {/* Start Date */}
+                  <TextField
+                    label="Start Date"
+                    type="date"
+                    value={startDate}
+                    onChange={(e) => {
+                      setStartDate(e.target.value);
+                      setSubmitted(false);
+                    }}
+                    size="small"
+                    InputLabelProps={{ shrink: true }}
+                    sx={{ minWidth: { xs: 140, sm: 160 } }}
+                  />
+
+                  {/* End Date */}
+                  <TextField
+                    label="End Date"
+                    type="date"
+                    value={endDate}
+                    onChange={(e) => {
+                      setEndDate(e.target.value);
+                      setSubmitted(false);
+                    }}
+                    size="small"
+                    InputLabelProps={{ shrink: true }}
+                    sx={{ minWidth: { xs: 140, sm: 160 } }}
+                  />
+
+                  {/* Status Filter */}
+                  <FormControl size="small" sx={{ minWidth: { xs: 110, sm: 120 } }}>
+                    <InputLabel id="status-filter-label">Status</InputLabel>
+                    <Select
+                      labelId="status-filter-label"
+                      label="Status"
+                      value={statusFilter}
+                      onChange={(e) => {
+                        setStatusFilter(e.target.value);
+                        setSubmitted(false);
+                      }}
+                    >
+                      <MenuItem value="ALL">All Statuses</MenuItem>
+                      <MenuItem value="DRAFT">Draft</MenuItem>
+                      <MenuItem value="POSTED">Posted</MenuItem>
+                      <MenuItem value="REVERSED">Reversed</MenuItem>
+                    </Select>
+                  </FormControl>
+                </Stack>
+              </Stack>
+
+              <Stack
+                data-testid="account-activity-actions"
+                direction="row"
+                spacing={2}
+                justifyContent={accountActivityToolbarLayout.actionsJustify}
+                flexWrap="wrap"
+              >
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={handleGenerateReport}
+                  disabled={loading}
+                  aria-label="Generate Report"
+                  sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
+                >
+                  {loading ? <CircularProgress size={24} /> : 'Generate Report'}
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="secondary"
+                  startIcon={isDownloading ? <CircularProgress size={20} /> : <DownloadIcon />}
+                  onClick={handleExportToExcel}
+                  disabled={!submitted || loading || isDownloading}
+                  sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
+                >
+                  Export to Excel
+                </Button>
+              </Stack>
+            </Stack>
+          </Paper>
+        }
+      />
 
       {/* Error Alert */}
       {errorMessage && (

--- a/frontend/src/pages/accounting/reports/BalanceSheetPage.tsx
+++ b/frontend/src/pages/accounting/reports/BalanceSheetPage.tsx
@@ -26,9 +26,8 @@ import {
   Download as DownloadIcon,
   CheckCircle as CheckCircleIcon,
   Cancel as CancelIcon,
-  ReceiptLong as BalanceSheetIcon,
 } from '@mui/icons-material';
-import { TYPOGRAPHY_STYLES } from '@/constants/typography';
+import PageHeader from '@/components/common/PageHeader';
 import { formatDate } from '@/utils/formatters';
 import { useGetBalanceSheetQuery } from '@/store/api/accountingApi';
 import { exportReportExcel } from '@/utils/exportReport';
@@ -330,84 +329,76 @@ const BalanceSheetPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{ mb: 3 }}>
-        <Typography
-          variant={TYPOGRAPHY_STYLES.pageHeader.variant}
-          sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight, mb: 1, display: 'flex', alignItems: 'center', gap: 2 }}
-        >
-          <BalanceSheetIcon sx={{ fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize, color: TYPOGRAPHY_STYLES.pageHeader.icon.color }} />
-          Balance Sheet
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          View your financial position showing Assets = Liabilities + Equity as of a specific date
-        </Typography>
-      </Box>
-
-      {/* Filters Section */}
-      <Paper sx={{ p: 3, mb: 3 }}>
-        <Stack
-          direction={{ xs: 'column', md: 'row' }}
-          spacing={2}
-          justifyContent="space-between"
-          alignItems={{ xs: 'stretch', md: 'center' }}
-        >
-          <Stack
-            data-testid="balance-sheet-filters"
-            direction="row"
-            spacing={2}
-            alignItems="center"
-            flexWrap="wrap"
-          >
-            <TextField
-              label="As Of Date"
-              type="date"
-              value={asOfDate}
-              onChange={(e) => handleAsOfDateChange(e.target.value)}
-              size="small"
-              InputLabelProps={{ shrink: true }}
-              sx={{ minWidth: 200 }}
-            />
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={includeInactive}
-                  onChange={(e) => handleIncludeInactiveChange(e.target.checked)}
+      <PageHeader
+        variant="report"
+        title="Balance Sheet"
+        subtitle="View your financial position showing Assets = Liabilities + Equity as of a specific date"
+        toolbar={
+          <Paper sx={{ p: 3, mb: 3 }}>
+            <Stack
+              direction={{ xs: 'column', md: 'row' }}
+              spacing={2}
+              justifyContent="space-between"
+              alignItems={{ xs: 'stretch', md: 'center' }}
+            >
+              <Stack
+                data-testid="balance-sheet-filters"
+                direction="row"
+                spacing={2}
+                alignItems="center"
+                flexWrap="wrap"
+              >
+                <TextField
+                  label="As Of Date"
+                  type="date"
+                  value={asOfDate}
+                  onChange={(e) => handleAsOfDateChange(e.target.value)}
+                  size="small"
+                  InputLabelProps={{ shrink: true }}
+                  sx={{ minWidth: 200 }}
                 />
-              }
-              label="Include Inactive Accounts"
-            />
-          </Stack>
-          <Stack
-            data-testid="balance-sheet-actions"
-            direction="row"
-            spacing={2}
-            justifyContent={{ xs: 'stretch', md: 'flex-end' }}
-            flexWrap="wrap"
-          >
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={handleGenerateReport}
-              disabled={loading}
-              aria-label="Generate Report"
-              sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
-            >
-              {loading ? <CircularProgress size={24} /> : 'Generate Report'}
-            </Button>
-            <Button
-              variant="outlined"
-              color="secondary"
-              startIcon={isDownloading ? <CircularProgress size={20} /> : <DownloadIcon />}
-              onClick={handleExportToExcel}
-              disabled={!submitted || loading || isDownloading}
-              sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
-            >
-              Export to Excel
-            </Button>
-          </Stack>
-        </Stack>
-      </Paper>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={includeInactive}
+                      onChange={(e) => handleIncludeInactiveChange(e.target.checked)}
+                    />
+                  }
+                  label="Include Inactive Accounts"
+                />
+              </Stack>
+              <Stack
+                data-testid="balance-sheet-actions"
+                direction="row"
+                spacing={2}
+                justifyContent={{ xs: 'stretch', md: 'flex-end' }}
+                flexWrap="wrap"
+              >
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={handleGenerateReport}
+                  disabled={loading}
+                  aria-label="Generate Report"
+                  sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
+                >
+                  {loading ? <CircularProgress size={24} /> : 'Generate Report'}
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="secondary"
+                  startIcon={isDownloading ? <CircularProgress size={20} /> : <DownloadIcon />}
+                  onClick={handleExportToExcel}
+                  disabled={!submitted || loading || isDownloading}
+                  sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
+                >
+                  Export to Excel
+                </Button>
+              </Stack>
+            </Stack>
+          </Paper>
+        }
+      />
 
       {/* Error Alert */}
       {errorMessage && (

--- a/frontend/src/pages/accounting/reports/GeneralLedgerPage.tsx
+++ b/frontend/src/pages/accounting/reports/GeneralLedgerPage.tsx
@@ -26,9 +26,8 @@ import { alpha, useTheme } from '@mui/material/styles';
 import {
   Download as DownloadIcon,
   Receipt as ReceiptIcon,
-  Description as GeneralLedgerIcon,
 } from '@mui/icons-material';
-import { TYPOGRAPHY_STYLES } from '@/constants/typography';
+import PageHeader from '@/components/common/PageHeader';
 import { formatDate, formatDateTime } from '@/utils/formatters';
 import { useGetChartOfAccountsQuery, useGetGeneralLedgerQuery } from '@/store/api/accountingApi';
 import type { ChartOfAccount } from '@/types';
@@ -157,118 +156,110 @@ const GeneralLedgerPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{ mb: 3 }}>
-        <Typography
-          variant={TYPOGRAPHY_STYLES.pageHeader.variant}
-          sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight, mb: 1, display: 'flex', alignItems: 'center', gap: 2 }}
-        >
-          <GeneralLedgerIcon sx={{ fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize, color: TYPOGRAPHY_STYLES.pageHeader.icon.color }} />
-          General Ledger
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          View all transactions for a specific account with running balance
-        </Typography>
-      </Box>
-
-      {/* Filters Section */}
-      <Paper sx={{ p: 3, mb: 3 }}>
-        <Stack
-          direction={{ xs: 'column', md: 'row' }}
-          spacing={2}
-          justifyContent="space-between"
-          alignItems={{ xs: 'stretch', md: 'center' }}
-        >
-          <Stack
-            data-testid="general-ledger-filters"
-            direction="row"
-            spacing={2}
-            alignItems="flex-start"
-            flexWrap="wrap"
-          >
-            {/* Account Selector */}
-            <Autocomplete
-              options={accounts}
-              getOptionLabel={(option) => `${option.code} - ${option.name}`}
-              value={selectedAccount}
-              onChange={(event, newValue) => {
-                setSelectedAccount(newValue);
-                setValidationError(null);
-                setSubmitted(false);
-              }}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  label="Account"
-                  placeholder="Select an account"
-                  required
-                  error={!!validationError}
-                  helperText={validationError}
+      <PageHeader
+        variant="report"
+        title="General Ledger"
+        subtitle="View all transactions for a specific account with running balance"
+        toolbar={
+          <Paper sx={{ p: 3, mb: 3 }}>
+            <Stack
+              direction={{ xs: 'column', md: 'row' }}
+              spacing={2}
+              justifyContent="space-between"
+              alignItems={{ xs: 'stretch', md: 'center' }}
+            >
+              <Stack
+                data-testid="general-ledger-filters"
+                direction="row"
+                spacing={2}
+                alignItems="flex-start"
+                flexWrap="wrap"
+              >
+                {/* Account Selector */}
+                <Autocomplete
+                  options={accounts}
+                  getOptionLabel={(option) => `${option.code} - ${option.name}`}
+                  value={selectedAccount}
+                  onChange={(event, newValue) => {
+                    setSelectedAccount(newValue);
+                    setValidationError(null);
+                    setSubmitted(false);
+                  }}
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      label="Account"
+                      placeholder="Select an account"
+                      required
+                      error={!!validationError}
+                      helperText={validationError}
+                    />
+                  )}
+                  sx={{ minWidth: 350, flexGrow: 1 }}
+                  size="small"
                 />
-              )}
-              sx={{ minWidth: 350, flexGrow: 1 }}
-              size="small"
-            />
 
-            {/* Start Date */}
-            <TextField
-              label="Start Date"
-              type="date"
-              value={startDate}
-              onChange={(e) => {
-                setStartDate(e.target.value);
-                setSubmitted(false);
-              }}
-              size="small"
-              InputLabelProps={{ shrink: true }}
-              sx={{ minWidth: 180 }}
-            />
+                {/* Start Date */}
+                <TextField
+                  label="Start Date"
+                  type="date"
+                  value={startDate}
+                  onChange={(e) => {
+                    setStartDate(e.target.value);
+                    setSubmitted(false);
+                  }}
+                  size="small"
+                  InputLabelProps={{ shrink: true }}
+                  sx={{ minWidth: 180 }}
+                />
 
-            {/* End Date */}
-            <TextField
-              label="End Date"
-              type="date"
-              value={endDate}
-              onChange={(e) => {
-                setEndDate(e.target.value);
-                setSubmitted(false);
-              }}
-              size="small"
-              InputLabelProps={{ shrink: true }}
-              sx={{ minWidth: 180 }}
-            />
-          </Stack>
+                {/* End Date */}
+                <TextField
+                  label="End Date"
+                  type="date"
+                  value={endDate}
+                  onChange={(e) => {
+                    setEndDate(e.target.value);
+                    setSubmitted(false);
+                  }}
+                  size="small"
+                  InputLabelProps={{ shrink: true }}
+                  sx={{ minWidth: 180 }}
+                />
+              </Stack>
 
-          <Stack
-            data-testid="general-ledger-actions"
-            direction="row"
-            spacing={2}
-            justifyContent={{ xs: 'stretch', md: 'flex-end' }}
-            flexWrap="wrap"
-          >
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={handleGenerateReport}
-              disabled={loading}
-              aria-label="Generate Report"
-              sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
-            >
-              {loading ? <CircularProgress size={24} /> : 'Generate Report'}
-            </Button>
-            <Button
-              variant="outlined"
-              color="secondary"
-              startIcon={isDownloading ? <CircularProgress size={20} /> : <DownloadIcon />}
-              onClick={handleExportToExcel}
-              disabled={!submitted || loading || isDownloading}
-              sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
-            >
-              Export to Excel
-            </Button>
-          </Stack>
-        </Stack>
-      </Paper>
+              <Stack
+                data-testid="general-ledger-actions"
+                direction="row"
+                spacing={2}
+                justifyContent={{ xs: 'stretch', md: 'flex-end' }}
+                flexWrap="wrap"
+              >
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={handleGenerateReport}
+                  disabled={loading}
+                  aria-label="Generate Report"
+                  sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
+                >
+                  {loading ? <CircularProgress size={24} /> : 'Generate Report'}
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="secondary"
+                  startIcon={isDownloading ? <CircularProgress size={20} /> : <DownloadIcon />}
+                  onClick={handleExportToExcel}
+                  disabled={!submitted || loading || isDownloading}
+                  sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
+                >
+                  Export to Excel
+                </Button>
+              </Stack>
+            </Stack>
+          </Paper>
+        }
+      />
 
       {/* Error Alert */}
       {errorMessage && (

--- a/frontend/src/pages/accounting/reports/ProfitAndLossPage.tsx
+++ b/frontend/src/pages/accounting/reports/ProfitAndLossPage.tsx
@@ -25,9 +25,8 @@ import {
   Download as DownloadIcon,
   TrendingUp as TrendingUpIcon,
   TrendingDown as TrendingDownIcon,
-  ShowChart as ProfitLossIcon,
 } from '@mui/icons-material';
-import { TYPOGRAPHY_STYLES } from '@/constants/typography';
+import PageHeader from '@/components/common/PageHeader';
 import { formatDate } from '@/utils/formatters';
 import { useGetProfitAndLossQuery } from '@/store/api/accountingApi';
 import { exportReportExcel } from '@/utils/exportReport';
@@ -247,93 +246,85 @@ const ProfitAndLossPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{ mb: 3 }}>
-        <Typography
-          variant={TYPOGRAPHY_STYLES.pageHeader.variant}
-          sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight, mb: 1, display: 'flex', alignItems: 'center', gap: 2 }}
-        >
-          <ProfitLossIcon sx={{ fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize, color: TYPOGRAPHY_STYLES.pageHeader.icon.color }} />
-          Profit & Loss Statement
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          View your Income Statement showing Revenue - COGS - Expenses = Net Income for a period
-        </Typography>
-      </Box>
-
-      {/* Filters Section */}
-      <Paper sx={{ p: 3, mb: 3 }}>
-        <Stack
-          direction={{ xs: 'column', md: 'row' }}
-          spacing={2}
-          justifyContent="space-between"
-          alignItems={{ xs: 'stretch', md: 'center' }}
-        >
-          <Stack
-            data-testid="profit-loss-filters"
-            direction="row"
-            spacing={2}
-            alignItems="center"
-            flexWrap="wrap"
-          >
-            <TextField
-              label="Start Date"
-              type="date"
-              value={startDate}
-              onChange={(e) => handleStartDateChange(e.target.value)}
-              size="small"
-              InputLabelProps={{ shrink: true }}
-              sx={{ minWidth: 200 }}
-            />
-            <TextField
-              label="End Date"
-              type="date"
-              value={endDate}
-              onChange={(e) => handleEndDateChange(e.target.value)}
-              size="small"
-              InputLabelProps={{ shrink: true }}
-              sx={{ minWidth: 200 }}
-            />
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={includeInactive}
-                  onChange={(e) => handleIncludeInactiveChange(e.target.checked)}
+      <PageHeader
+        variant="report"
+        title="Profit & Loss Statement"
+        subtitle="View your Income Statement showing Revenue - COGS - Expenses = Net Income for a period"
+        toolbar={
+          <Paper sx={{ p: 3, mb: 3 }}>
+            <Stack
+              direction={{ xs: 'column', md: 'row' }}
+              spacing={2}
+              justifyContent="space-between"
+              alignItems={{ xs: 'stretch', md: 'center' }}
+            >
+              <Stack
+                data-testid="profit-loss-filters"
+                direction="row"
+                spacing={2}
+                alignItems="center"
+                flexWrap="wrap"
+              >
+                <TextField
+                  label="Start Date"
+                  type="date"
+                  value={startDate}
+                  onChange={(e) => handleStartDateChange(e.target.value)}
+                  size="small"
+                  InputLabelProps={{ shrink: true }}
+                  sx={{ minWidth: 200 }}
                 />
-              }
-              label="Include Inactive Accounts"
-            />
-          </Stack>
-          <Stack
-            data-testid="profit-loss-actions"
-            direction="row"
-            spacing={2}
-            justifyContent={{ xs: 'stretch', md: 'flex-end' }}
-            flexWrap="wrap"
-          >
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={handleGenerateReport}
-              disabled={loading}
-              aria-label="Generate Report"
-              sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
-            >
-              {loading ? <CircularProgress size={24} /> : 'Generate Report'}
-            </Button>
-            <Button
-              variant="outlined"
-              color="secondary"
-              startIcon={isDownloading ? <CircularProgress size={20} /> : <DownloadIcon />}
-              onClick={handleExportToExcel}
-              disabled={!submitted || loading || isDownloading}
-              sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
-            >
-              Export to Excel
-            </Button>
-          </Stack>
-        </Stack>
-      </Paper>
+                <TextField
+                  label="End Date"
+                  type="date"
+                  value={endDate}
+                  onChange={(e) => handleEndDateChange(e.target.value)}
+                  size="small"
+                  InputLabelProps={{ shrink: true }}
+                  sx={{ minWidth: 200 }}
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={includeInactive}
+                      onChange={(e) => handleIncludeInactiveChange(e.target.checked)}
+                    />
+                  }
+                  label="Include Inactive Accounts"
+                />
+              </Stack>
+              <Stack
+                data-testid="profit-loss-actions"
+                direction="row"
+                spacing={2}
+                justifyContent={{ xs: 'stretch', md: 'flex-end' }}
+                flexWrap="wrap"
+              >
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={handleGenerateReport}
+                  disabled={loading}
+                  aria-label="Generate Report"
+                  sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
+                >
+                  {loading ? <CircularProgress size={24} /> : 'Generate Report'}
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="secondary"
+                  startIcon={isDownloading ? <CircularProgress size={20} /> : <DownloadIcon />}
+                  onClick={handleExportToExcel}
+                  disabled={!submitted || loading || isDownloading}
+                  sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
+                >
+                  Export to Excel
+                </Button>
+              </Stack>
+            </Stack>
+          </Paper>
+        }
+      />
 
       {/* Date Validation Error */}
       {dateError && (

--- a/frontend/src/pages/accounting/reports/TrialBalancePage.tsx
+++ b/frontend/src/pages/accounting/reports/TrialBalancePage.tsx
@@ -23,9 +23,8 @@ import {
   Download as DownloadIcon,
   CheckCircle as CheckCircleIcon,
   Cancel as CancelIcon,
-  AccountBalance as TrialBalanceIcon,
 } from '@mui/icons-material';
-import { TYPOGRAPHY_STYLES } from '@/constants/typography';
+import PageHeader from '@/components/common/PageHeader';
 import { formatDate } from '@/utils/formatters';
 import { useGetTrialBalanceQuery } from '@/store/api/accountingApi';
 import { exportReportExcel } from '@/utils/exportReport';
@@ -109,84 +108,76 @@ const TrialBalancePage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{ mb: 3 }}>
-        <Typography
-          variant={TYPOGRAPHY_STYLES.pageHeader.variant}
-          sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight, mb: 1, display: 'flex', alignItems: 'center', gap: 2 }}
-        >
-          <TrialBalanceIcon sx={{ fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize, color: TYPOGRAPHY_STYLES.pageHeader.icon.color }} />
-          Trial Balance
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          View account balances and verify debits equal credits as of a specific date
-        </Typography>
-      </Box>
-
-      {/* Filters Section */}
-      <Paper sx={{ p: 3, mb: 3 }}>
-        <Stack
-          direction={{ xs: 'column', md: 'row' }}
-          spacing={2}
-          justifyContent="space-between"
-          alignItems={{ xs: 'stretch', md: 'center' }}
-        >
-          <Stack
-            data-testid="trial-balance-filters"
-            direction="row"
-            spacing={2}
-            alignItems="center"
-            flexWrap="wrap"
-          >
-            <TextField
-              label="As Of Date"
-              type="date"
-              value={asOfDate}
-              onChange={(e) => handleAsOfDateChange(e.target.value)}
-              size="small"
-              InputLabelProps={{ shrink: true }}
-              sx={{ minWidth: 200 }}
-            />
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={includeInactive}
-                  onChange={(e) => handleIncludeInactiveChange(e.target.checked)}
+      <PageHeader
+        variant="report"
+        title="Trial Balance"
+        subtitle="View account balances and verify debits equal credits as of a specific date"
+        toolbar={
+          <Paper sx={{ p: 3, mb: 3 }}>
+            <Stack
+              direction={{ xs: 'column', md: 'row' }}
+              spacing={2}
+              justifyContent="space-between"
+              alignItems={{ xs: 'stretch', md: 'center' }}
+            >
+              <Stack
+                data-testid="trial-balance-filters"
+                direction="row"
+                spacing={2}
+                alignItems="center"
+                flexWrap="wrap"
+              >
+                <TextField
+                  label="As Of Date"
+                  type="date"
+                  value={asOfDate}
+                  onChange={(e) => handleAsOfDateChange(e.target.value)}
+                  size="small"
+                  InputLabelProps={{ shrink: true }}
+                  sx={{ minWidth: 200 }}
                 />
-              }
-              label="Include Inactive Accounts"
-            />
-          </Stack>
-          <Stack
-            data-testid="trial-balance-actions"
-            direction="row"
-            spacing={2}
-            justifyContent={{ xs: 'stretch', md: 'flex-end' }}
-            flexWrap="wrap"
-          >
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={handleGenerateReport}
-              disabled={loading}
-              aria-label="Generate Report"
-              sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
-            >
-              {loading ? <CircularProgress size={24} /> : 'Generate Report'}
-            </Button>
-            <Button
-              variant="outlined"
-              color="secondary"
-              startIcon={isDownloading ? <CircularProgress size={20} /> : <DownloadIcon />}
-              onClick={handleExportToExcel}
-              disabled={!submitted || loading || isDownloading}
-              sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
-            >
-              Export to Excel
-            </Button>
-          </Stack>
-        </Stack>
-      </Paper>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={includeInactive}
+                      onChange={(e) => handleIncludeInactiveChange(e.target.checked)}
+                    />
+                  }
+                  label="Include Inactive Accounts"
+                />
+              </Stack>
+              <Stack
+                data-testid="trial-balance-actions"
+                direction="row"
+                spacing={2}
+                justifyContent={{ xs: 'stretch', md: 'flex-end' }}
+                flexWrap="wrap"
+              >
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={handleGenerateReport}
+                  disabled={loading}
+                  aria-label="Generate Report"
+                  sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
+                >
+                  {loading ? <CircularProgress size={24} /> : 'Generate Report'}
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="secondary"
+                  startIcon={isDownloading ? <CircularProgress size={20} /> : <DownloadIcon />}
+                  onClick={handleExportToExcel}
+                  disabled={!submitted || loading || isDownloading}
+                  sx={{ minWidth: 150, flex: { xs: 1, sm: 'initial' } }}
+                >
+                  Export to Excel
+                </Button>
+              </Stack>
+            </Stack>
+          </Paper>
+        }
+      />
 
       {errorMessage && (
         <Alert severity="error" sx={{ mb: 2 }}>

--- a/frontend/src/pages/audit-logs/AuditLogsPage.tsx
+++ b/frontend/src/pages/audit-logs/AuditLogsPage.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react'
 import {
-  Box, Typography, Tabs, Tab, Stack,
+  Box, Tabs, Tab,
 } from '@mui/material'
-import { History as AuditIcon } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import {
   setPage,
@@ -11,7 +11,6 @@ import {
 } from '@/store/slices/auditLogSlice'
 import { useGetAuditLogsQuery, useGetAuditLogStatisticsQuery } from '@/store/api/auditLogApi'
 import { priceListApiSlice } from '@/store/api/priceListApi'
-import { TYPOGRAPHY_STYLES } from '@/constants/typography'
 import FilterSidebar from './components/FilterSidebar'
 import LogsTab from './components/LogsTab'
 import AnalyticsTab from './components/AnalyticsTab'
@@ -139,22 +138,12 @@ const AuditLogsPage: React.FC = () => {
 
       {/* Main content */}
       <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2 }}>
-        {/* Header */}
-        <Stack direction="row" justifyContent="space-between" alignItems="center">
-          <Box>
-            <Typography
-              variant={TYPOGRAPHY_STYLES.pageHeader.variant}
-              sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight, display: 'flex', alignItems: 'center', gap: 1 }}
-            >
-              <AuditIcon sx={{ fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize, color: TYPOGRAPHY_STYLES.pageHeader.icon.color }} />
-              Audit Logs
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              View all system changes and user activities
-            </Typography>
-          </Box>
-          <ExportButton logs={auditLogs} disabled={loading} />
-        </Stack>
+        <PageHeader
+          variant="system"
+          title="Audit Logs"
+          subtitle="View all system changes and user activities"
+          toolbar={<ExportButton logs={auditLogs} disabled={loading} />}
+        />
 
         {/* Tabs */}
         <Tabs

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -11,8 +11,8 @@ import {
   PointOfSale as SalesIcon,
   Assignment as PurchasingIcon,
   People as CustomersIcon,
-  Dashboard as DashboardIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES } from '@/constants/typography'
 import { useNavigate } from 'react-router-dom'
@@ -374,31 +374,11 @@ const DashboardPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-        <Box>
-          <Typography
-            variant={TYPOGRAPHY_STYLES.pageHeader.variant}
-            sx={{
-              fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-              mb: 1,
-              display: 'flex',
-              alignItems: 'center',
-              gap: 2,
-            }}
-          >
-            <DashboardIcon
-              sx={{
-                fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-                color: TYPOGRAPHY_STYLES.pageHeader.icon.color,
-              }}
-            />
-            Dashboard
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Monitor your business performance across sales, purchasing, and inventory
-          </Typography>
-        </Box>
-      </Box>
+      <PageHeader
+        variant="overview"
+        title="Dashboard"
+        subtitle="Monitor your business performance across sales, purchasing, and inventory"
+      />
 
       {error && <Alert severity="error" sx={{ mb: 4 }}>Failed to load dashboard data</Alert>}
 

--- a/frontend/src/pages/inventory/CategoriesPage.tsx
+++ b/frontend/src/pages/inventory/CategoriesPage.tsx
@@ -25,14 +25,12 @@ import {
   InputAdornment,
 } from '@mui/material'
 import {
-  Add as AddIcon,
   Edit as EditIcon,
   Delete as DeleteIcon,
   DragIndicator as DragIndicatorIcon,
-  RestoreFromTrash as RestoreIcon,
   Search as SearchIcon,
-  Category as CategoryIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { useForm, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
@@ -354,120 +352,67 @@ const CategoriesPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <CategoryIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Categories
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Organize your products with categories ({categories.length} {categoryFilters.search ? 'found' : 'total'})
-            {categoryFilters.search && (
-              <>
-                <br />
-                <Typography component="span" variant="body2" color="primary.main" sx={{ fontStyle: 'italic' }}>
-                  Filtered by: "{categoryFilters.search}"
-                </Typography>
-              </>
-            )}
-          </Typography>
-        </Box>
-        <Box sx={{ 
-          display: 'flex', 
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RestoreIcon /> : undefined}
-            onClick={() => setDeletedCategoriesDialogOpen(true)}
-            size="medium"
-            fullWidth={isMobile}
-            sx={{
-              color: 'warning.main',
-              borderColor: 'warning.main',
-              '&:hover': {
-                borderColor: 'warning.dark',
-                backgroundColor: 'warning.light'
-              }
-            }}
-          >
-            {isMobile ? "View Deleted" : "View Deleted"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <AddIcon /> : undefined}
-            size="medium"
-            onClick={() => handleAddCategory()}
-            fullWidth={isMobile}
-          >
-            {isMobile ? "Add New Category" : "Add Category"}
-          </Button>
-        </Box>
-      </Box>
-      {/* Filters and Search */}
-      <Paper sx={{ p: 2, mb: 3 }}>
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        gap: isMobile ? 2 : 1,
-        alignItems: isMobile ? 'stretch' : 'center',
-        '& > *': {
-          alignSelf: isMobile ? 'stretch' : 'flex-start'
+      <PageHeader
+        variant="structure"
+        title="Categories"
+        subtitle={`Organize your products with categories (${categories.length} ${categoryFilters.search ? 'found' : 'total'})`}
+        primaryAction={{
+          label: isMobile ? 'Add New Category' : 'Add Category',
+          onClick: () => handleAddCategory(),
+        }}
+        secondaryAction={{
+          label: 'View Deleted',
+          onClick: () => setDeletedCategoriesDialogOpen(true),
+        }}
+        toolbar={
+          <Paper sx={{ p: 2 }}>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: isMobile ? 'column' : 'row',
+                gap: isMobile ? 2 : 1,
+                alignItems: isMobile ? 'stretch' : 'center',
+                '& > *': {
+                  alignSelf: isMobile ? 'stretch' : 'flex-start'
+                }
+              }}
+            >
+              <TextField
+                placeholder="Search categories by name..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                size="medium"
+                sx={{
+                  minWidth: isMobile ? 'auto' : 250,
+                  flex: isMobile ? 'none' : 1,
+                  maxWidth: isMobile ? 'none' : 400,
+                  '& .MuiOutlinedInput-root': {
+                    height: TYPOGRAPHY_STYLES.searchField.input.height,
+                    fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
+                    '& input': {
+                      padding: TYPOGRAPHY_STYLES.searchField.input.padding,
+                      fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize
+                    }
+                  },
+                  '& .MuiInputAdornment-root': {
+                    '& .MuiSvgIcon-root': {
+                      fontSize: TYPOGRAPHY_STYLES.searchField.icon.fontSize,
+                      color: TYPOGRAPHY_STYLES.searchField.icon.color
+                    }
+                  }
+                }}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchIcon fontSize="small" />
+                    </InputAdornment>
+                  ),
+                }}
+              />
+            </Box>
+          </Paper>
         }
-      }}>
-        <TextField
-          placeholder="Search categories by name..."
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 250,
-            flex: isMobile ? 'none' : 1,
-            maxWidth: isMobile ? 'none' : 400,
-            '& .MuiOutlinedInput-root': {
-              height: TYPOGRAPHY_STYLES.searchField.input.height,
-              fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
-              '& input': {
-                padding: TYPOGRAPHY_STYLES.searchField.input.padding,
-                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize
-              }
-            },
-            '& .MuiInputAdornment-root': {
-              '& .MuiSvgIcon-root': {
-                fontSize: TYPOGRAPHY_STYLES.searchField.icon.fontSize,
-                color: TYPOGRAPHY_STYLES.searchField.icon.color
-              }
-            }
-          }}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon fontSize="small" />
-              </InputAdornment>
-            ),
-          }}
-        />
-      </Box>
-      </Paper>
+      />
       {/* Categories Content */}
       <Paper sx={{ borderRadius: 2, overflow: 'hidden' }}>
         {isCategoriesFetching ? (

--- a/frontend/src/pages/inventory/HistoricalInventoryReport.tsx
+++ b/frontend/src/pages/inventory/HistoricalInventoryReport.tsx
@@ -33,13 +33,13 @@ import {
   TableChart as ExcelIcon,
   Refresh as RefreshIcon,
   PlayArrow as GenerateIcon,
-  Timeline as HistoricalInventoryIcon,
   Close as CloseIcon,
   KeyboardArrowRight as KeyboardArrowRightIcon,
   KeyboardArrowLeft as KeyboardArrowLeftIcon,
   KeyboardDoubleArrowRight as KeyboardDoubleArrowRightIcon,
   KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
@@ -522,63 +522,42 @@ const HistoricalInventoryReport: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
+      <PageHeader
+        variant="report"
+        title="Historical Inventory"
+        subtitle={reportData.length > 0
+          ? `${reportData.length} product${reportData.length !== 1 ? 's' : ''} with historical inventory data`
+          : 'View product inventory summary based on stock movements up to a target date'}
+        toolbar={
+          <Box sx={{
             display: 'flex',
-            alignItems: 'center',
-            gap: 2
+            flexDirection: isMobile ? 'column' : 'row',
+            gap: isMobile ? 1.5 : 1,
+            alignItems: isMobile ? 'stretch' : 'center'
           }}>
-            <HistoricalInventoryIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Historical Inventory
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `${reportData.length} product${reportData.length !== 1 ? 's' : ''} with historical inventory data`
-              : 'View product inventory summary based on stock movements up to a target date'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
-          >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size={isMobile ? 'medium' : 'medium'}
+              fullWidth={isMobile}
+            >
+              {isMobile ? 'Clear Filters' : 'Clear Filters'}
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Grid container spacing={3} sx={{ alignItems: 'stretch', height: 'calc(100vh - 220px)' }}>
         {/* Left Side - Filters and Display */}
@@ -801,7 +780,6 @@ const HistoricalInventoryReport: React.FC = () => {
                     <CircularProgress />
                   ) : (
                     <>
-                      <HistoricalInventoryIcon sx={{ fontSize: 80, color: 'text.disabled', mb: 2 }} />
                       <Typography variant="h6" color="text.secondary" sx={{ mb: 1 }}>
                         No Report Generated
                       </Typography>

--- a/frontend/src/pages/inventory/InventorySummaryReport.tsx
+++ b/frontend/src/pages/inventory/InventorySummaryReport.tsx
@@ -34,13 +34,13 @@ import {
   TableChart as ExcelIcon,
   Refresh as RefreshIcon,
   PlayArrow as GenerateIcon,
-  Inventory2 as InventoryIcon,
   Close as CloseIcon,
   KeyboardArrowRight as KeyboardArrowRightIcon,
   KeyboardArrowLeft as KeyboardArrowLeftIcon,
   KeyboardDoubleArrowRight as KeyboardDoubleArrowRightIcon,
   KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
@@ -680,63 +680,42 @@ const InventorySummaryReport: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
+      <PageHeader
+        variant="report"
+        title="Inventory Summary"
+        subtitle={reportData.length > 0
+          ? `${reportData.length} products`
+          : 'View comprehensive inventory summary with values and profit potential'}
+        toolbar={
+          <Box sx={{
             display: 'flex',
-            alignItems: 'center',
-            gap: 2
+            flexDirection: isMobile ? 'column' : 'row',
+            gap: isMobile ? 1.5 : 1,
+            alignItems: isMobile ? 'stretch' : 'center'
           }}>
-            <InventoryIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Inventory Summary
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `${reportData.length} products`
-              : 'View comprehensive inventory summary with values and profit potential'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
-          >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size={isMobile ? 'medium' : 'medium'}
+              fullWidth={isMobile}
+            >
+              {isMobile ? 'Clear Filters' : 'Clear Filters'}
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Grid container spacing={3} sx={{ alignItems: 'stretch', height: 'calc(100vh - 220px)' }}>
         {/* Left Side - Filters and Display */}
@@ -965,7 +944,6 @@ const InventorySummaryReport: React.FC = () => {
                     <CircularProgress />
                   ) : (
                     <>
-                      <InventoryIcon sx={{ fontSize: 80, color: 'text.disabled', mb: 2 }} />
                       <Typography variant="h6" color="text.secondary" sx={{ mb: 1 }}>
                         No Report Generated
                       </Typography>

--- a/frontend/src/pages/inventory/MovementSummaryReport.tsx
+++ b/frontend/src/pages/inventory/MovementSummaryReport.tsx
@@ -34,13 +34,13 @@ import {
   TableChart as ExcelIcon,
   Refresh as RefreshIcon,
   PlayArrow as GenerateIcon,
-  CompareArrows as MovementIcon,
   Close as CloseIcon,
   KeyboardArrowRight as KeyboardArrowRightIcon,
   KeyboardArrowLeft as KeyboardArrowLeftIcon,
   KeyboardDoubleArrowRight as KeyboardDoubleArrowRightIcon,
   KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
@@ -516,63 +516,42 @@ const MovementSummaryReport: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
+      <PageHeader
+        variant="report"
+        title="Inventory Movement Summary"
+        subtitle={reportData.length > 0
+          ? `${reportData.length} products`
+          : 'View summary of inventory movements by product'}
+        toolbar={
+          <Box sx={{
             display: 'flex',
-            alignItems: 'center',
-            gap: 2
+            flexDirection: isMobile ? 'column' : 'row',
+            gap: isMobile ? 1.5 : 1,
+            alignItems: isMobile ? 'stretch' : 'center'
           }}>
-            <MovementIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Inventory Movement Summary
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `${reportData.length} products`
-              : 'View summary of inventory movements by product'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
-          >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size={isMobile ? 'medium' : 'medium'}
+              fullWidth={isMobile}
+            >
+              {isMobile ? 'Clear Filters' : 'Clear Filters'}
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Grid container spacing={3} sx={{ alignItems: 'stretch', height: 'calc(100vh - 220px)' }}>
         {/* Left Side - Filters and Display */}
@@ -782,7 +761,6 @@ const MovementSummaryReport: React.FC = () => {
                     <CircularProgress />
                   ) : (
                     <>
-                      <MovementIcon sx={{ fontSize: 80, color: 'text.disabled', mb: 2 }} />
                       <Typography variant="h6" color="text.secondary" sx={{ mb: 1 }}>
                         No Report Generated
                       </Typography>

--- a/frontend/src/pages/inventory/PriceListReport.tsx
+++ b/frontend/src/pages/inventory/PriceListReport.tsx
@@ -33,13 +33,13 @@ import {
   TableChart as ExcelIcon,
   Refresh as RefreshIcon,
   PlayArrow as GenerateIcon,
-  AttachMoney as PriceTagIcon,
   Close as CloseIcon,
   KeyboardArrowRight as KeyboardArrowRightIcon,
   KeyboardArrowLeft as KeyboardArrowLeftIcon,
   KeyboardDoubleArrowRight as KeyboardDoubleArrowRightIcon,
   KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
@@ -533,63 +533,42 @@ const PriceListReport: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
+      <PageHeader
+        variant="report"
+        title="Product Price List"
+        subtitle={reportData.length > 0
+          ? `${reportData.length} products`
+          : 'View product prices with discounts and costs'}
+        toolbar={
+          <Box sx={{
             display: 'flex',
-            alignItems: 'center',
-            gap: 2
+            flexDirection: isMobile ? 'column' : 'row',
+            gap: isMobile ? 1.5 : 1,
+            alignItems: isMobile ? 'stretch' : 'center'
           }}>
-            <PriceTagIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Product Price List
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `${reportData.length} products`
-              : 'View product prices with discounts and costs'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
-          >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size={isMobile ? 'medium' : 'medium'}
+              fullWidth={isMobile}
+            >
+              {isMobile ? 'Clear Filters' : 'Clear Filters'}
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Grid container spacing={3} sx={{ alignItems: 'stretch', height: 'calc(100vh - 220px)' }}>
         {/* Left Side - Filters and Display */}
@@ -829,7 +808,6 @@ const PriceListReport: React.FC = () => {
                     <CircularProgress />
                   ) : (
                     <>
-                      <PriceTagIcon sx={{ fontSize: 80, color: 'text.disabled', mb: 2 }} />
                       <Typography variant="h6" color="text.secondary" sx={{ mb: 1 }}>
                         No Report Generated
                       </Typography>

--- a/frontend/src/pages/inventory/ProductCostReport.tsx
+++ b/frontend/src/pages/inventory/ProductCostReport.tsx
@@ -33,13 +33,13 @@ import {
   TableChart as ExcelIcon,
   Refresh as RefreshIcon,
   PlayArrow as GenerateIcon,
-  TrendingDown as CostIcon,
   Close as CloseIcon,
   KeyboardArrowRight as KeyboardArrowRightIcon,
   KeyboardArrowLeft as KeyboardArrowLeftIcon,
   KeyboardDoubleArrowRight as KeyboardDoubleArrowRightIcon,
   KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
@@ -547,63 +547,42 @@ const ProductCostReport: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
+      <PageHeader
+        variant="report"
+        title="Product Cost Report"
+        subtitle={reportData.length > 0
+          ? `${reportData.length} transactions`
+          : 'Track product cost changes over time'}
+        toolbar={
+          <Box sx={{
             display: 'flex',
-            alignItems: 'center',
-            gap: 2
+            flexDirection: isMobile ? 'column' : 'row',
+            gap: isMobile ? 1.5 : 1,
+            alignItems: isMobile ? 'stretch' : 'center'
           }}>
-            <CostIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Product Cost Report
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `${reportData.length} transactions`
-              : 'Track product cost changes over time'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
-          >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size={isMobile ? 'medium' : 'medium'}
+              fullWidth={isMobile}
+            >
+              {isMobile ? 'Clear Filters' : 'Clear Filters'}
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Grid container spacing={3} sx={{ alignItems: 'stretch', height: 'calc(100vh - 220px)' }}>
         {/* Left Side - Filters and Display */}
@@ -814,7 +793,6 @@ const ProductCostReport: React.FC = () => {
                     <CircularProgress />
                   ) : (
                     <>
-                      <CostIcon sx={{ fontSize: 80, color: 'text.disabled', mb: 2 }} />
                       <Typography variant="h6" color="text.secondary" sx={{ mb: 1 }}>
                         No Report Generated
                       </Typography>

--- a/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
@@ -49,6 +49,7 @@ import {
   KeyboardDoubleArrowRight as KeyboardDoubleArrowRightIcon,
   KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import api from '@/services/api'
@@ -699,63 +700,46 @@ const PurchaseOrderDetailsReport: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <PurchaseOrderIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Purchase Order Details
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `${reportData.length} purchase order line items`
-              : 'View detailed purchase order line items'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
+      <PageHeader
+        variant="report"
+        title={reportTitle}
+        subtitle={
+          reportData.length > 0
+            ? `${reportData.length} purchase order line items`
+            : 'View detailed purchase order line items'
+        }
+        toolbar={
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: isMobile ? 'column' : 'row',
+              gap: isMobile ? 1.5 : 1,
+              alignItems: isMobile ? 'stretch' : 'center',
+            }}
           >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              Clear Filters
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Grid container spacing={3} sx={{ alignItems: 'stretch', height: 'calc(100vh - 220px)' }}>
         {/* Left Side - Filters and Display */}

--- a/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
@@ -41,6 +41,7 @@ import {
   KeyboardDoubleArrowRight as KeyboardDoubleArrowRightIcon,
   KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import api from '@/services/api'
@@ -676,63 +677,46 @@ const PurchaseOrderStatusReport: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <PurchaseOrderIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Purchase Order Status
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `${reportData.length} purchase orders`
-              : 'View purchase order status summary'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
+      <PageHeader
+        variant="report"
+        title={reportTitle}
+        subtitle={
+          reportData.length > 0
+            ? `${reportData.length} purchase orders`
+            : 'View purchase order status summary'
+        }
+        toolbar={
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: isMobile ? 'column' : 'row',
+              gap: isMobile ? 1.5 : 1,
+              alignItems: isMobile ? 'stretch' : 'center',
+            }}
           >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              Clear Filters
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Grid container spacing={3} sx={{ alignItems: 'stretch', height: 'calc(100vh - 220px)' }}>
         {/* Left Side - Filters and Display */}

--- a/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
@@ -31,6 +31,7 @@ import {
   PlayArrow as GenerateIcon,
   Summarize as PurchaseOrderIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import api from '@/services/api'
@@ -546,63 +547,46 @@ const PurchaseOrderSummary: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <PurchaseOrderIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Purchase Order Summary
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `${reportData.length} purchase order items`
-              : 'View detailed purchase order line items'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
+      <PageHeader
+        variant="report"
+        title={reportTitle}
+        subtitle={
+          reportData.length > 0
+            ? `${reportData.length} purchase order items`
+            : 'View detailed purchase order line items'
+        }
+        toolbar={
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: isMobile ? 'column' : 'row',
+              gap: isMobile ? 1.5 : 1,
+              alignItems: isMobile ? 'stretch' : 'center',
+            }}
           >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              Clear Filters
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Grid container spacing={3} sx={{ alignItems: 'stretch', height: 'calc(100vh - 220px)' }}>
         {/* Left Side - Filters and Display */}

--- a/frontend/src/pages/purchasing/PurchasingPage.tsx
+++ b/frontend/src/pages/purchasing/PurchasingPage.tsx
@@ -42,6 +42,7 @@ import { formatCurrency, formatDate } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { useNavigate } from 'react-router-dom'
 import { useGetPurchaseOrdersQuery, useGetSuppliersQuery } from '@/store/api/purchasingApi'
+import PageHeader from '@/components/common/PageHeader'
 
 ChartJS.register(
   CategoryScale,
@@ -234,27 +235,11 @@ const PurchasingPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-        <Box>
-          <Typography variant={TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <PurchasingIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Purchasing Overview
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Monitor purchasing activities and manage supplier relationships
-          </Typography>
-        </Box>
-        <Box sx={{ display: 'flex', gap: 1 }}>
+      <PageHeader
+        variant="overview"
+        title="Purchasing Overview"
+        subtitle="Monitor purchasing activities and manage supplier relationships"
+        toolbar={
           <Button
             variant="contained"
             startIcon={<AddIcon />}
@@ -262,8 +247,8 @@ const PurchasingPage: React.FC = () => {
           >
             Create Purchase Order
           </Button>
-        </Box>
-      </Box>
+        }
+      />
       {/* Stats Cards */}
       <Grid container spacing={3} sx={{ mb: 4 }}>
         {stats.map((stat, index) => (

--- a/frontend/src/pages/purchasing/VendorPaymentDetailsReport.tsx
+++ b/frontend/src/pages/purchasing/VendorPaymentDetailsReport.tsx
@@ -29,6 +29,7 @@ import {
   PlayArrow as GenerateIcon,
   MonetizationOn as PaymentIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import api from '@/services/api'
@@ -455,63 +456,46 @@ const VendorPaymentDetailsReport: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <PaymentIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Vendor Payment Details
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `Individual vendor payment transactions for ${reportData.length} payments`
-              : 'View detailed vendor payment transaction records'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
+      <PageHeader
+        variant="report"
+        title={reportTitle}
+        subtitle={
+          reportData.length > 0
+            ? `Individual vendor payment transactions for ${reportData.length} payments`
+            : 'View detailed vendor payment transaction records'
+        }
+        toolbar={
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: isMobile ? 'column' : 'row',
+              gap: isMobile ? 1.5 : 1,
+              alignItems: isMobile ? 'stretch' : 'center',
+            }}
           >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              Clear Filters
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Grid container spacing={3} sx={{ alignItems: 'stretch', height: 'calc(100vh - 220px)' }}>
         {/* Left Side - Filters and Display */}

--- a/frontend/src/pages/purchasing/VendorProductListReport.tsx
+++ b/frontend/src/pages/purchasing/VendorProductListReport.tsx
@@ -41,6 +41,7 @@ import {
   KeyboardDoubleArrowRight as KeyboardDoubleArrowRightIcon,
   KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import api from '@/services/api'
@@ -630,63 +631,46 @@ const VendorProductListReport: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <ProductIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Vendor Product List
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `${reportData.length} purchase items`
-              : 'View product-level details for vendor purchases'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
+      <PageHeader
+        variant="report"
+        title={reportTitle}
+        subtitle={
+          reportData.length > 0
+            ? `${reportData.length} purchase items`
+            : 'View product-level details for vendor purchases'
+        }
+        toolbar={
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: isMobile ? 'column' : 'row',
+              gap: isMobile ? 1.5 : 1,
+              alignItems: isMobile ? 'stretch' : 'center',
+            }}
           >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              Clear Filters
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Grid container spacing={3} sx={{ alignItems: 'stretch', height: 'calc(100vh - 220px)' }}>
         {/* Left Side - Filters and Display */}

--- a/frontend/src/pages/sales/CustomerOrderHistory.tsx
+++ b/frontend/src/pages/sales/CustomerOrderHistory.tsx
@@ -41,6 +41,7 @@ import {
   KeyboardDoubleArrowRight as KeyboardDoubleArrowRightIcon,
   KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
@@ -792,63 +793,46 @@ const CustomerOrderHistory: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <HistoryIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Customer Order History
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `Complete order history for ${reportData.length} orders`
-              : 'View detailed customer order records'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
+      <PageHeader
+        variant="report"
+        title={reportTitle}
+        subtitle={
+          reportData.length > 0
+            ? `Complete order history for ${reportData.length} orders`
+            : 'View detailed customer order records'
+        }
+        toolbar={
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: isMobile ? 'column' : 'row',
+              gap: isMobile ? 1.5 : 1,
+              alignItems: isMobile ? 'stretch' : 'center',
+            }}
           >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              Clear Filters
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Grid container spacing={3} sx={{ alignItems: 'stretch', height: 'calc(100vh - 220px)' }}>
         {/* Left Side - Filters and Display */}

--- a/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
@@ -32,6 +32,7 @@ import {
   PlayArrow as GenerateIcon,
   ReceiptLongOutlined as PaymentOrderIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
@@ -556,63 +557,46 @@ const CustomerPaymentByOrder: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <PaymentOrderIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Customer Payment by Order
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `Payment details for ${reportData.length} orders`
-              : 'View customer payments organized by sales order'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
+      <PageHeader
+        variant="report"
+        title={reportTitle}
+        subtitle={
+          reportData.length > 0
+            ? `Payment details for ${reportData.length} orders`
+            : 'View customer payments organized by sales order'
+        }
+        toolbar={
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: isMobile ? 'column' : 'row',
+              gap: isMobile ? 1.5 : 1,
+              alignItems: isMobile ? 'stretch' : 'center',
+            }}
           >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              Clear Filters
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Grid container spacing={3} sx={{ alignItems: 'stretch', height: 'calc(100vh - 220px)' }}>
         {/* Left Side - Filters and Display */}

--- a/frontend/src/pages/sales/CustomerPaymentDetails.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentDetails.tsx
@@ -29,6 +29,7 @@ import {
   PlayArrow as GenerateIcon,
   MonetizationOn as PaymentDetailIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
@@ -521,63 +522,46 @@ const CustomerPaymentDetails: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <PaymentDetailIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Customer Payment Details
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `Individual payment transactions for ${reportData.length} payments`
-              : 'View detailed payment transaction records'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
+      <PageHeader
+        variant="report"
+        title={reportTitle}
+        subtitle={
+          reportData.length > 0
+            ? `Individual payment transactions for ${reportData.length} payments`
+            : 'View detailed payment transaction records'
+        }
+        toolbar={
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: isMobile ? 'column' : 'row',
+              gap: isMobile ? 1.5 : 1,
+              alignItems: isMobile ? 'stretch' : 'center',
+            }}
           >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              Clear Filters
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Grid container spacing={3} sx={{ alignItems: 'stretch', height: 'calc(100vh - 220px)' }}>
         {/* Left Side - Filters and Display */}

--- a/frontend/src/pages/sales/CustomerPaymentSummary.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentSummary.tsx
@@ -32,6 +32,7 @@ import {
   PlayArrow as GenerateIcon,
   AccountBalanceWallet as PaymentSummaryIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import api from '@/services/api'
@@ -467,63 +468,46 @@ const CustomerPaymentSummary: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <PaymentSummaryIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Customer Payment Summary
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `Payment summary for ${reportData.length} customers`
-              : 'Analyze customer payment history and patterns'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
+      <PageHeader
+        variant="report"
+        title={reportTitle}
+        subtitle={
+          reportData.length > 0
+            ? `Payment summary for ${reportData.length} customers`
+            : 'Analyze customer payment history and patterns'
+        }
+        toolbar={
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: isMobile ? 'column' : 'row',
+              gap: isMobile ? 1.5 : 1,
+              alignItems: isMobile ? 'stretch' : 'center',
+            }}
           >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              Clear Filters
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Grid container spacing={3} sx={{ alignItems: 'stretch', height: 'calc(100vh - 220px)' }}>
         {/* Left Side - Filters and Display */}

--- a/frontend/src/pages/sales/ProductCustomerReport.tsx
+++ b/frontend/src/pages/sales/ProductCustomerReport.tsx
@@ -40,6 +40,7 @@ import {
   KeyboardDoubleArrowRight as KeyboardDoubleArrowRightIcon,
   KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
@@ -767,63 +768,46 @@ const ProductCustomerReport: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <CustomerProductIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Product Customer Report
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `Product sales to ${reportData.length} customers`
-              : 'View which customers purchased which products'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
+      <PageHeader
+        variant="report"
+        title={reportTitle}
+        subtitle={
+          reportData.length > 0
+            ? `Product sales to ${reportData.length} customers`
+            : 'View which customers purchased which products'
+        }
+        toolbar={
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: isMobile ? 'column' : 'row',
+              gap: isMobile ? 1.5 : 1,
+              alignItems: isMobile ? 'stretch' : 'center',
+            }}
           >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              Clear Filters
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Grid container spacing={3} sx={{ alignItems: 'stretch', height: 'calc(100vh - 220px)' }}>
         {/* Left Side - Filters and Display */}

--- a/frontend/src/pages/sales/SalesByProductDetails.tsx
+++ b/frontend/src/pages/sales/SalesByProductDetails.tsx
@@ -49,6 +49,7 @@ import {
   KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon,
   ViewColumn as ViewColumnIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import api from '@/services/api'
@@ -811,63 +812,46 @@ const SalesByProductDetails: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <DetailIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Sales by Product Details
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `Detailed transaction report (${reportData.length} transactions)`
-              : 'View transaction-level product details'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
+      <PageHeader
+        variant="report"
+        title={reportTitle}
+        subtitle={
+          reportData.length > 0
+            ? `Detailed transaction report (${reportData.length} transactions)`
+            : 'View transaction-level product details'
+        }
+        toolbar={
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: isMobile ? 'column' : 'row',
+              gap: isMobile ? 1.5 : 1,
+              alignItems: isMobile ? 'stretch' : 'center',
+            }}
           >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              Clear Filters
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Grid container spacing={3} sx={{ alignItems: 'stretch', height: 'calc(100vh - 220px)' }}>
         {/* Left Side - Filters and Display */}

--- a/frontend/src/pages/sales/SalesByProductSummary.tsx
+++ b/frontend/src/pages/sales/SalesByProductSummary.tsx
@@ -49,6 +49,7 @@ import {
   KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon,
   ViewColumn as ViewColumnIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
@@ -768,63 +769,46 @@ const SalesByProductSummary: React.FC = () => {
 
   return (
     <Box sx={{ p: 3, width: '100%' }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <SummaryIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Sales by Product Summary
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `Product performance report (${reportData.length} products)`
-              : 'Analyze product performance and sales metrics'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
+      <PageHeader
+        variant="report"
+        title={reportTitle}
+        subtitle={
+          reportData.length > 0
+            ? `Product performance report (${reportData.length} products)`
+            : 'Analyze product performance and sales metrics'
+        }
+        toolbar={
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: isMobile ? 'column' : 'row',
+              gap: isMobile ? 1.5 : 1,
+              alignItems: isMobile ? 'stretch' : 'center',
+            }}
           >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              Clear Filters
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Box sx={{ width: '100%', height: 'calc(100vh - 220px)' }}>
         <Grid container spacing={3} sx={{ alignItems: 'stretch', height: '100%', margin: 0, width: 'calc(100% + 24px)' }}>

--- a/frontend/src/pages/sales/SalesOrderProfitReport.tsx
+++ b/frontend/src/pages/sales/SalesOrderProfitReport.tsx
@@ -30,6 +30,7 @@ import {
   PlayArrow as GenerateIcon,
   TrendingUp as ProfitIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import api from '@/services/api'
@@ -572,63 +573,46 @@ const SalesOrderProfitReport: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <ProfitIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Sales Order Profit Report
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `Profit analysis report (${reportData.length} orders)`
-              : 'Analyze profit margins and performance for sales orders'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
+      <PageHeader
+        variant="report"
+        title={reportTitle}
+        subtitle={
+          reportData.length > 0
+            ? `Profit analysis report (${reportData.length} orders)`
+            : 'Analyze profit margins and performance for sales orders'
+        }
+        toolbar={
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: isMobile ? 'column' : 'row',
+              gap: isMobile ? 1.5 : 1,
+              alignItems: isMobile ? 'stretch' : 'center',
+            }}
           >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              Clear Filters
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Grid container spacing={3} sx={{ alignItems: 'stretch', height: 'calc(100vh - 220px)' }}>
         {/* Left Side - Filters and Display */}

--- a/frontend/src/pages/sales/SalesOrderSummary.tsx
+++ b/frontend/src/pages/sales/SalesOrderSummary.tsx
@@ -30,6 +30,7 @@ import {
   PlayArrow as GenerateIcon,
   Receipt as OrderIcon,
 } from '@mui/icons-material'
+import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import api from '@/services/api'
@@ -618,63 +619,46 @@ const SalesOrderSummary: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center',
-        mb: 3,
-        gap: isMobile ? 2 : 0
-      }}>
-        <Box sx={{ mb: isMobile ? 2 : 0 }}>
-          <Typography variant={isMobile ? TYPOGRAPHY_STYLES.pageHeader.mobileVariant : TYPOGRAPHY_STYLES.pageHeader.variant} sx={{
-            fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight,
-            mb: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2
-          }}>
-            <OrderIcon sx={{
-              fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize,
-              color: TYPOGRAPHY_STYLES.pageHeader.icon.color
-            }} />
-            Sales Order Summary
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {reportData.length > 0
-              ? `Sales order summary report (${reportData.length} orders)`
-              : 'View summary of sales orders with payment and fulfillment status'}
-          </Typography>
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          gap: isMobile ? 1.5 : 1,
-          alignItems: isMobile ? 'stretch' : 'center'
-        }}>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <RefreshIcon /> : undefined}
-            onClick={handleClearFilters}
-            disabled={loading}
-            size={isMobile ? "medium" : "medium"}
-            fullWidth={isMobile}
+      <PageHeader
+        variant="report"
+        title={reportTitle}
+        subtitle={
+          reportData.length > 0
+            ? `Sales order summary report (${reportData.length} orders)`
+            : 'View summary of sales orders with payment and fulfillment status'
+        }
+        toolbar={
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: isMobile ? 'column' : 'row',
+              gap: isMobile ? 1.5 : 1,
+              alignItems: isMobile ? 'stretch' : 'center',
+            }}
           >
-            {isMobile ? "Clear Filters" : "Clear Filters"}
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={!isMobile ? <GenerateIcon /> : undefined}
-            onClick={handleGenerateReport}
-            disabled={loading}
-            size="medium"
-            fullWidth={isMobile}
-          >
-            {loading ? 'Generating...' : 'Generate Report'}
-          </Button>
-        </Box>
-      </Box>
+            <Button
+              variant="outlined"
+              startIcon={!isMobile ? <RefreshIcon /> : undefined}
+              onClick={handleClearFilters}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              Clear Filters
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={!isMobile ? <GenerateIcon /> : undefined}
+              onClick={handleGenerateReport}
+              disabled={loading}
+              size="medium"
+              fullWidth={isMobile}
+            >
+              {loading ? 'Generating...' : 'Generate Report'}
+            </Button>
+          </Box>
+        }
+      />
       {/* Split Layout */}
       <Grid container spacing={3} sx={{ alignItems: 'stretch', height: 'calc(100vh - 220px)' }}>
         {/* Left Side - Filters and Display */}

--- a/frontend/src/pages/settings/BackupManagement.tsx
+++ b/frontend/src/pages/settings/BackupManagement.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import {
   Paper,
   Box,
-  Typography,
   Tabs,
   Tab,
   Button,
@@ -11,7 +10,7 @@ import {
   CircularProgress,
 } from '@mui/material';
 import { Add as AddIcon, Backup as BackupIcon, CloudUpload as UploadIcon } from '@mui/icons-material';
-import { TYPOGRAPHY_STYLES } from '@/constants/typography';
+import PageHeader from '@/components/common/PageHeader';
 import { useGetBackupsQuery, useGetSchedulesQuery } from '@/store/api/backupApi';
 import BackupList from '@/components/backup/BackupList';
 import BackupScheduleList from '@/components/backup/BackupScheduleList';
@@ -81,52 +80,47 @@ const BackupManagement: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Header */}
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-        <Box>
-          <Typography variant={TYPOGRAPHY_STYLES.pageHeader.variant} sx={{ fontWeight: TYPOGRAPHY_STYLES.pageHeader.fontWeight, mb: 1, display: 'flex', alignItems: 'center', gap: 2 }}>
-            <BackupIcon sx={{ fontSize: TYPOGRAPHY_STYLES.pageHeader.icon.fontSize, color: TYPOGRAPHY_STYLES.pageHeader.icon.color }} />
-            Backup & Restore Management
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Create, manage, and restore database backups
-          </Typography>
-        </Box>
-        <Box sx={{ display: 'flex', gap: 2 }}>
-          {tabValue === 0 && (
-            <>
-              <Button
-                variant="outlined"
-                color="primary"
-                startIcon={<UploadIcon />}
-                onClick={handleUploadBackup}
-                disabled={loading}
-              >
-                Upload Backup
-              </Button>
+      <PageHeader
+        variant="system"
+        title="Backup & Restore Management"
+        subtitle="Create, manage, and restore database backups"
+        toolbar={
+          <Box sx={{ display: 'flex', gap: 2 }}>
+            {tabValue === 0 && (
+              <>
+                <Button
+                  variant="outlined"
+                  color="primary"
+                  startIcon={<UploadIcon />}
+                  onClick={handleUploadBackup}
+                  disabled={loading}
+                >
+                  Upload Backup
+                </Button>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  startIcon={loading ? <CircularProgress size={20} color="inherit" /> : <BackupIcon />}
+                  onClick={handleCreateBackup}
+                  disabled={loading}
+                >
+                  {loading ? 'Processing...' : 'Create Backup'}
+                </Button>
+              </>
+            )}
+            {tabValue === 1 && (
               <Button
                 variant="contained"
                 color="primary"
-                startIcon={loading ? <CircularProgress size={20} color="inherit" /> : <BackupIcon />}
-                onClick={handleCreateBackup}
-                disabled={loading}
+                startIcon={<AddIcon />}
+                onClick={handleCreateSchedule}
               >
-                {loading ? 'Processing...' : 'Create Backup'}
+                Create Schedule
               </Button>
-            </>
-          )}
-          {tabValue === 1 && (
-            <Button
-              variant="contained"
-              color="primary"
-              startIcon={<AddIcon />}
-              onClick={handleCreateSchedule}
-            >
-              Create Schedule
-            </Button>
-          )}
-        </Box>
-      </Box>
+            )}
+          </Box>
+        }
+      />
 
       <Paper sx={{ p: 3 }}>
         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,12 +1,34 @@
 import { expect, afterAll, afterEach, beforeAll, vi } from 'vitest'
-import { cleanup } from '@testing-library/react'
-import * as matchers from '@testing-library/jest-dom/matchers'
-import ButtonBase from '@mui/material/ButtonBase'
-
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
 
 let consoleErrorSpy: ReturnType<typeof vi.spyOn> | undefined
 let consoleWarnSpy: ReturnType<typeof vi.spyOn> | undefined
+const isJsdomEnvironment =
+  typeof window !== 'undefined' &&
+  typeof document !== 'undefined' &&
+  typeof navigator !== 'undefined'
+
+if (isJsdomEnvironment) {
+  const [{ cleanup }, matchersModule, { default: ButtonBase }] = await Promise.all([
+    import('@testing-library/react'),
+    import('@testing-library/jest-dom/matchers'),
+    import('@mui/material/ButtonBase'),
+  ])
+
+  expect.extend(matchersModule)
+
+  const buttonBase = ButtonBase as any
+  buttonBase.defaultProps = {
+    ...buttonBase.defaultProps,
+    disableRipple: true,
+    disableTouchRipple: true,
+    focusRipple: false,
+  }
+
+  afterEach(() => {
+    cleanup()
+  })
+}
 
 vi.mock('@mui/material/Grow', () => ({
   default: ({ children }: any) => children,
@@ -15,8 +37,6 @@ vi.mock('@mui/material/Grow', () => ({
 vi.mock('@mui/material/Fade', () => ({
   default: ({ children }: any) => children,
 }))
-
-expect.extend(matchers)
 
 beforeAll(() => {
   const originalConsoleError = console.error
@@ -44,16 +64,4 @@ beforeAll(() => {
 afterAll(() => {
   consoleErrorSpy?.mockRestore()
   consoleWarnSpy?.mockRestore()
-})
-
-const buttonBase = ButtonBase as any
-buttonBase.defaultProps = {
-  ...buttonBase.defaultProps,
-  disableRipple: true,
-  disableTouchRipple: true,
-  focusRipple: false,
-}
-
-afterEach(() => {
-  cleanup()
 })

--- a/frontend/src/utils/clipboard.test.ts
+++ b/frontend/src/utils/clipboard.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { copyToClipboard } from './clipboard'
 

--- a/frontend/src/utils/formatters.test.ts
+++ b/frontend/src/utils/formatters.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import { describe, expect, it } from 'vitest'
 
 import { formatDate, formatDateTime, formatWholeQuantity } from './formatters'

--- a/frontend/src/utils/recentSearch.test.ts
+++ b/frontend/src/utils/recentSearch.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   addRecentSearch,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -111,6 +111,7 @@ export default defineConfig(({ mode }) => {
     test: {
       globals: true,
       environment: 'jsdom',
+      environmentMatchGlobs: [['src/**/*.test.ts', 'node']],
       setupFiles: ['./src/test/setup.ts', './src/setupTests.ts'],
       api: false,
       maxWorkers: Math.max(2, availableParallelism),


### PR DESCRIPTION
## Summary

- Extends `PageHeader` with `variant`, `meta`, and `toolbar` slot props (Phase 5A) — fully backward-compatible with all Phase 1–4 consumers
- Migrates all 24 report pages to `variant="report"` with toolbar-based filter rows (Phase 5B)
- Migrates dashboard/overview, structure, system, and workflow pages (Phases 5C–5F), completing the full ERP header unification
- Includes a Vitest environment optimization that was required to make the full test suite run reliably

## Test Plan

- [ ] All frontend tests pass: `cd frontend && npm run test`
- [ ] TypeScript clean: `cd frontend && npm run type-check`
- [ ] Lint clean: `cd frontend && npm run lint`
- [ ] Verify existing Phase 1–4 pages (e.g. SalesPage, FiscalPeriodsPage) render headers unchanged
- [ ] Verify a report page (e.g. BalanceSheetPage) shows `PageHeader` with filter toolbar
- [ ] Verify a workflow page (e.g. JournalEntriesPage) shows `PageHeader` with meta + toolbar

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)