### PR TITLE
feat(search): global search UX polish — priority, labels, highlight, exact match

### DIFF
--- a/backend/src/modules/accounting/services/journal-entry.service.spec.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.spec.ts
@@ -29,6 +29,7 @@ import {
   UpdateJournalEntryDto,
   QueryJournalEntriesDto,
 } from '../dto/journal-entry.dto';
+import { UserRole } from '../../../database/entities/user.entity';
 
 describe('JournalEntryService', () => {
   let service: JournalEntryService;
@@ -429,6 +430,39 @@ describe('JournalEntryService', () => {
       expect(queryBuilder.andWhere).toHaveBeenCalledWith('entry.status = :status', {
         status: JournalEntryStatus.POSTED,
       });
+    });
+  });
+
+  describe('searchGlobal', () => {
+    const adminUser = { role: UserRole.ADMIN } as any;
+
+    it('exact reference number match scores SCORE_EXACT_CODE + BOOST_JOURNAL + BOOST_EXACT_MATCH', async () => {
+      journalEntryRepository.createQueryBuilder.mockReturnValue({
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([
+          {
+            id: 'je-1',
+            referenceNumber: 'JE-001',
+            description: 'Manual adjustment',
+          },
+        ]),
+      } as any);
+
+      const results = await service.searchGlobal('JE-001', adminUser);
+
+      expect(results[0]).toMatchObject({
+        type: 'journal_entry',
+        id: 'je-1',
+        label: 'JE-001',
+        description: 'Manual adjustment',
+        route: '/accounting/journal-entries/je-1',
+      });
+      expect(results[0].score).toBe(144);
     });
   });
 

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -31,6 +31,7 @@ import {
   SCORE_CONTAINS,
   SCORE_FUZZY,
   BOOST_JOURNAL,
+  BOOST_EXACT_MATCH,
 } from '../../search/search.constants';
 import { JwtPayload } from '../../auth/strategies/jwt.strategy';
 import { UserRole } from '../../../database/entities/user.entity';
@@ -430,7 +431,10 @@ export class JournalEntryService {
       label: je.referenceNumber,
       description: je.description ?? undefined,
       route: `/accounting/journal-entries/${je.id}`,
-      score: baseScore + BOOST_JOURNAL,
+      score:
+        baseScore +
+        BOOST_JOURNAL +
+        (baseScore === SCORE_EXACT_CODE ? BOOST_EXACT_MATCH : 0),
     };
   }
 

--- a/backend/src/modules/inventory/services/product.service.spec.ts
+++ b/backend/src/modules/inventory/services/product.service.spec.ts
@@ -169,7 +169,7 @@ describe('ProductService pagination removal', () => {
       expect(results).toEqual([]);
     });
 
-    it('exact barcode match scores SCORE_EXACT_CODE + BOOST_PRODUCT', async () => {
+    it('exact barcode match scores SCORE_EXACT_CODE + BOOST_PRODUCT + BOOST_EXACT_MATCH', async () => {
       const mockProduct = { id: 'p1', name: 'Widget', barcode: 'BC-001' };
       productRepository.createQueryBuilder = jest.fn().mockReturnValue({
         addSelect: jest.fn().mockReturnThis(),
@@ -183,10 +183,10 @@ describe('ProductService pagination removal', () => {
 
       const results = await service.searchGlobal('BC-001', adminUser);
 
-      expect(results[0].score).toBe(126);
+      expect(results[0].score).toBe(146);
     });
 
-    it('exact name match scores SCORE_EXACT_NAME + BOOST_PRODUCT', async () => {
+    it('exact name match scores SCORE_EXACT_NAME + BOOST_PRODUCT + BOOST_EXACT_MATCH', async () => {
       const mockProduct = { id: 'p1', name: 'Widget', barcode: 'BC-999' };
       productRepository.createQueryBuilder = jest.fn().mockReturnValue({
         addSelect: jest.fn().mockReturnThis(),
@@ -200,7 +200,7 @@ describe('ProductService pagination removal', () => {
 
       const results = await service.searchGlobal('widget', adminUser);
 
-      expect(results[0].score).toBe(101);
+      expect(results[0].score).toBe(121);
     });
 
     it('barcode exact match outranks name exact match', async () => {
@@ -214,7 +214,7 @@ describe('ProductService pagination removal', () => {
 
       const results = await service.searchGlobal('widget', adminUser);
 
-      expect(results[0].score).toBe(126);
+      expect(results[0].score).toBe(146);
     });
 
     it('falls back to fuzzy search when ILIKE returns empty', async () => {

--- a/backend/src/modules/inventory/services/product.service.ts
+++ b/backend/src/modules/inventory/services/product.service.ts
@@ -45,6 +45,7 @@ import {
   SCORE_CONTAINS,
   SCORE_FUZZY,
   BOOST_PRODUCT,
+  BOOST_EXACT_MATCH,
 } from '../../search/search.constants';
 import { CategoryService } from './category.service';
 import { StockMovementService } from './stock-movement.service';
@@ -362,7 +363,12 @@ export class ProductService {
       label: product.name,
       description: product.barcode,
       route: `/inventory/products/${product.id}/edit`,
-      score: baseScore + BOOST_PRODUCT,
+      score:
+        baseScore +
+        BOOST_PRODUCT +
+        (baseScore === SCORE_EXACT_CODE || baseScore === SCORE_EXACT_NAME
+          ? BOOST_EXACT_MATCH
+          : 0),
     };
   }
 

--- a/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
@@ -279,7 +279,7 @@ describe('PurchaseOrderService', () => {
       });
     });
 
-    it('exact orderNumber match scores SCORE_EXACT_CODE + BOOST_TRANSACTION', async () => {
+    it('exact orderNumber match scores SCORE_EXACT_CODE + BOOST_TRANSACTION + BOOST_EXACT_MATCH', async () => {
       mockPOQuery({
         id: 'po1',
         orderNumber: 'PO-001',
@@ -288,7 +288,7 @@ describe('PurchaseOrderService', () => {
 
       const results = await service.searchGlobal('PO-001', adminUser);
 
-      expect(results[0].score).toBe(130);
+      expect(results[0].score).toBe(150);
     });
 
     it('orderNumber startsWith scores SCORE_STARTSWITH_CODE + BOOST_TRANSACTION', async () => {

--- a/backend/src/modules/purchasing/services/purchase-order.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.ts
@@ -26,6 +26,7 @@ import {
   SCORE_CONTAINS,
   SCORE_FUZZY,
   BOOST_TRANSACTION,
+  BOOST_EXACT_MATCH,
 } from '../../search/search.constants';
 import { SupplierService } from './supplier.service';
 import { GoodsReceivedNoteService } from './goods-received-note.service';
@@ -394,7 +395,10 @@ export class PurchaseOrderService {
       label: order.orderNumber,
       description: order.supplier?.companyName ?? '',
       route: `/purchasing/orders/${order.id}/edit`,
-      score: baseScore + BOOST_TRANSACTION,
+      score:
+        baseScore +
+        BOOST_TRANSACTION +
+        (baseScore === SCORE_EXACT_CODE ? BOOST_EXACT_MATCH : 0),
     };
   }
 

--- a/backend/src/modules/purchasing/services/supplier.service.spec.ts
+++ b/backend/src/modules/purchasing/services/supplier.service.spec.ts
@@ -1,0 +1,64 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SupplierService } from './supplier.service';
+import { Supplier } from '../../../database/entities/supplier.entity';
+import { AuditLogService } from '../../audit-logs/services';
+import { UserRole } from '../../../database/entities/user.entity';
+
+describe('SupplierService.searchGlobal', () => {
+  let service: SupplierService;
+  let supplierRepository: jest.Mocked<Repository<Supplier>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SupplierService,
+        {
+          provide: getRepositoryToken(Supplier),
+          useValue: {
+            createQueryBuilder: jest.fn(),
+          },
+        },
+        {
+          provide: AuditLogService,
+          useValue: { log: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get(SupplierService);
+    supplierRepository = module.get(getRepositoryToken(Supplier));
+  });
+
+  it('exact supplier name match scores SCORE_EXACT_NAME + BOOST_SUPPLIER + BOOST_EXACT_MATCH', async () => {
+    supplierRepository.createQueryBuilder.mockReturnValue({
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      setParameter: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([
+        {
+          id: 'sup-1',
+          companyName: 'Acme Supplies',
+          phone: '0123456789',
+        },
+      ]),
+    } as any);
+
+    const results = await service.searchGlobal('Acme Supplies', {
+      role: UserRole.ADMIN,
+    } as any);
+
+    expect(results[0]).toMatchObject({
+      type: 'supplier',
+      id: 'sup-1',
+      label: 'Acme Supplies',
+      description: '0123456789',
+      route: '/purchasing/suppliers/sup-1',
+    });
+    expect(results[0].score).toBe(122);
+  });
+});

--- a/backend/src/modules/purchasing/services/supplier.service.ts
+++ b/backend/src/modules/purchasing/services/supplier.service.ts
@@ -22,6 +22,7 @@ import {
   SCORE_CONTAINS,
   SCORE_FUZZY,
   BOOST_SUPPLIER,
+  BOOST_EXACT_MATCH,
 } from '../../search/search.constants';
 import { JwtPayload } from '../../auth/strategies/jwt.strategy';
 import { UserRole } from '../../../database/entities/user.entity';
@@ -828,7 +829,10 @@ export class SupplierService {
       label: supplier.companyName,
       description: supplier.phone ?? undefined,
       route: `/purchasing/suppliers/${supplier.id}`,
-      score: baseScore + BOOST_SUPPLIER,
+      score:
+        baseScore +
+        BOOST_SUPPLIER +
+        (baseScore === SCORE_EXACT_NAME ? BOOST_EXACT_MATCH : 0),
     };
   }
 }

--- a/backend/src/modules/purchasing/services/vendor-payment.service.spec.ts
+++ b/backend/src/modules/purchasing/services/vendor-payment.service.spec.ts
@@ -14,6 +14,7 @@ import { AuditLogService } from '../../audit-logs/services';
 import { AccountingService } from '../../accounting/services/accounting.service';
 import { SettingsService } from '../../settings/settings.service';
 import { CreateVendorPaymentDto } from '../dto';
+import { UserRole } from '../../../database/entities/user.entity';
 
 describe('VendorPaymentService', () => {
   let service: VendorPaymentService;
@@ -355,6 +356,39 @@ describe('VendorPaymentService', () => {
 
       // Verify accounting entry was still posted
       expect(accountingService.postVendorPaymentEntry).toHaveBeenCalled();
+    });
+  });
+
+  describe('searchGlobal', () => {
+    const adminUser = { role: UserRole.ADMIN } as any;
+
+    it('exact payment number match scores SCORE_EXACT_CODE + BOOST_VENDOR_PAYMENT + BOOST_EXACT_MATCH', async () => {
+      vendorPaymentRepository.createQueryBuilder.mockReturnValue({
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([
+          {
+            id: 'vp-1',
+            paymentNumber: 'VP-001',
+            referenceNumber: 'REF-001',
+          },
+        ]),
+      } as any);
+
+      const results = await service.searchGlobal('VP-001', adminUser);
+
+      expect(results[0]).toMatchObject({
+        type: 'vendor_payment',
+        id: 'vp-1',
+        label: 'VP-001',
+        description: 'REF-001',
+        route: '/purchasing/vendor-payments/vp-1',
+      });
+      expect(results[0].score).toBe(148);
     });
   });
 

--- a/backend/src/modules/purchasing/services/vendor-payment.service.ts
+++ b/backend/src/modules/purchasing/services/vendor-payment.service.ts
@@ -25,6 +25,7 @@ import {
   SCORE_CONTAINS,
   SCORE_FUZZY,
   BOOST_VENDOR_PAYMENT,
+  BOOST_EXACT_MATCH,
 } from '../../search/search.constants';
 import { JwtPayload } from '../../auth/strategies/jwt.strategy';
 import { UserRole } from '../../../database/entities/user.entity';
@@ -272,7 +273,10 @@ export class VendorPaymentService {
       label: vp.paymentNumber,
       description: vp.referenceNumber ?? undefined,
       route: `/purchasing/vendor-payments/${vp.id}`,
-      score: baseScore + BOOST_VENDOR_PAYMENT,
+      score:
+        baseScore +
+        BOOST_VENDOR_PAYMENT +
+        (baseScore === SCORE_EXACT_CODE ? BOOST_EXACT_MATCH : 0),
     };
   }
 

--- a/backend/src/modules/sales/services/customer.service.spec.ts
+++ b/backend/src/modules/sales/services/customer.service.spec.ts
@@ -100,7 +100,7 @@ describe('CustomerService', () => {
       expect(results).toEqual([]);
     });
 
-    it('exact phone match scores SCORE_EXACT_CODE + BOOST_CUSTOMER', async () => {
+    it('exact phone match scores SCORE_EXACT_CODE + BOOST_CUSTOMER + BOOST_EXACT_MATCH', async () => {
       const mockCustomer = {
         id: 'c1',
         name: 'Acme Corp',
@@ -119,10 +119,10 @@ describe('CustomerService', () => {
 
       const results = await service.searchGlobal('0123456789', adminUser);
 
-      expect(results[0].score).toBe(128);
+      expect(results[0].score).toBe(148);
     });
 
-    it('exact name match scores SCORE_EXACT_NAME + BOOST_CUSTOMER', async () => {
+    it('exact name match scores SCORE_EXACT_NAME + BOOST_CUSTOMER + BOOST_EXACT_MATCH', async () => {
       const mockCustomer = { id: 'c1', name: 'acme corp', phone: null };
 
       customerRepository.createQueryBuilder = jest.fn().mockReturnValue({
@@ -137,7 +137,7 @@ describe('CustomerService', () => {
 
       const results = await service.searchGlobal('acme corp', adminUser);
 
-      expect(results[0].score).toBe(103);
+      expect(results[0].score).toBe(123);
     });
 
     it('phone exact match outranks name exact match', async () => {
@@ -152,7 +152,7 @@ describe('CustomerService', () => {
 
       const results = await service.searchGlobal('acme corp', adminUser);
 
-      expect(results[0].score).toBe(128);
+      expect(results[0].score).toBe(148);
     });
 
     it('falls back to fuzzy search when ILIKE returns empty', async () => {

--- a/backend/src/modules/sales/services/customer.service.ts
+++ b/backend/src/modules/sales/services/customer.service.ts
@@ -27,6 +27,7 @@ import {
   SCORE_CONTAINS,
   SCORE_FUZZY,
   BOOST_CUSTOMER,
+  BOOST_EXACT_MATCH,
 } from '../../search/search.constants';
 import { ValidationUtil, BulkOperationUtil, BulkOperationResponse } from '../../../common/utils/validation.util';
 import { TransactionManager, Transactional } from '../../../common/utils/transaction.util';
@@ -202,7 +203,12 @@ export class CustomerService {
       label: customer.name,
       description: customer.phone ?? undefined,
       route: `/sales/customers/${customer.id}`,
-      score: baseScore + BOOST_CUSTOMER,
+      score:
+        baseScore +
+        BOOST_CUSTOMER +
+        (baseScore === SCORE_EXACT_CODE || baseScore === SCORE_EXACT_NAME
+          ? BOOST_EXACT_MATCH
+          : 0),
     };
   }
 

--- a/backend/src/modules/sales/services/invoice.service.spec.ts
+++ b/backend/src/modules/sales/services/invoice.service.spec.ts
@@ -77,6 +77,23 @@ describe('InvoiceService.searchGlobal', () => {
     expect(results[0].score).toBeGreaterThan(0);
   });
 
+  it('exact invoice number match scores SCORE_EXACT_CODE + BOOST_INVOICE + BOOST_EXACT_MATCH', async () => {
+    const mockInvoice = {
+      id: 'inv-1',
+      invoiceNumber: 'INV-001',
+      customer: { name: 'ABC Corp' },
+    };
+    const qb = mockQb();
+    qb.getMany.mockResolvedValue([mockInvoice]);
+    invoiceRepository.createQueryBuilder.mockReturnValue(qb);
+
+    const results = await service.searchGlobal('INV-001', {
+      role: UserRole.SALES_STAFF,
+    } as any);
+
+    expect(results[0].score).toBe(149);
+  });
+
   it('falls back to fuzzy when ILIKE returns empty', async () => {
     const fuzzyInvoice = {
       id: 'inv-2',

--- a/backend/src/modules/sales/services/invoice.service.ts
+++ b/backend/src/modules/sales/services/invoice.service.ts
@@ -34,6 +34,7 @@ import {
   SCORE_CONTAINS,
   SCORE_FUZZY,
   BOOST_INVOICE,
+  BOOST_EXACT_MATCH,
 } from '../../search/search.constants';
 import { JwtPayload } from '../../auth/strategies/jwt.strategy';
 import { UserRole } from '../../../database/entities/user.entity';
@@ -303,7 +304,10 @@ export class InvoiceService {
       label: inv.invoiceNumber,
       description: inv.customer?.name ?? undefined,
       route: `/sales/invoices/${inv.id}`,
-      score: baseScore + BOOST_INVOICE,
+      score:
+        baseScore +
+        BOOST_INVOICE +
+        (baseScore === SCORE_EXACT_CODE ? BOOST_EXACT_MATCH : 0),
     };
   }
 

--- a/backend/src/modules/sales/services/payment.service.spec.ts
+++ b/backend/src/modules/sales/services/payment.service.spec.ts
@@ -9,6 +9,7 @@ import { PaymentMethodEntity } from '../../../database/entities/payment-method.e
 import { AuditLogService } from '../../audit-logs/services';
 import { AccountingService } from '../../accounting/services/accounting.service';
 import { NotFoundException } from '@nestjs/common';
+import { UserRole } from '../../../database/entities/user.entity';
 
 describe('PaymentService', () => {
   let service: PaymentService;
@@ -48,6 +49,7 @@ describe('PaymentService', () => {
             findOne: jest.fn(),
             save: jest.fn(),
             create: jest.fn(),
+            createQueryBuilder: jest.fn(),
           },
         },
         {
@@ -248,6 +250,37 @@ describe('PaymentService', () => {
       await expect(service.create(createDto)).rejects.toThrow(
         NotFoundException,
       );
+    });
+  });
+
+  describe('searchGlobal', () => {
+    const adminUser = { role: UserRole.ADMIN } as any;
+
+    it('exact payment number match scores SCORE_EXACT_CODE + BOOST_CUSTOMER_PAYMENT + BOOST_EXACT_MATCH', async () => {
+      const mockPayment = {
+        id: 'pay-1',
+        paymentNumber: 'PAY-001',
+      };
+
+      paymentRepository.createQueryBuilder.mockReturnValue({
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([mockPayment]),
+      } as any);
+
+      const results = await service.searchGlobal('PAY-001', adminUser);
+
+      expect(results[0]).toMatchObject({
+        type: 'customer_payment',
+        id: 'pay-1',
+        label: 'PAY-001',
+        route: '/sales/payments/pay-1',
+      });
+      expect(results[0].score).toBe(148);
     });
   });
 

--- a/backend/src/modules/sales/services/payment.service.ts
+++ b/backend/src/modules/sales/services/payment.service.ts
@@ -31,6 +31,7 @@ import {
   SCORE_CONTAINS,
   SCORE_FUZZY,
   BOOST_CUSTOMER_PAYMENT,
+  BOOST_EXACT_MATCH,
 } from '../../search/search.constants';
 import { JwtPayload } from '../../auth/strategies/jwt.strategy';
 import { UserRole } from '../../../database/entities/user.entity';
@@ -590,7 +591,10 @@ export class PaymentService {
       label: p.paymentNumber,
       description: undefined,
       route: `/sales/payments/${p.id}`,
-      score: baseScore + BOOST_CUSTOMER_PAYMENT,
+      score:
+        baseScore +
+        BOOST_CUSTOMER_PAYMENT +
+        (baseScore === SCORE_EXACT_CODE ? BOOST_EXACT_MATCH : 0),
     };
   }
 

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -222,7 +222,7 @@ describe('SalesOrderService', () => {
       });
     });
 
-    it('exact orderNumber match scores SCORE_EXACT_CODE + BOOST_TRANSACTION', async () => {
+    it('exact orderNumber match scores SCORE_EXACT_CODE + BOOST_TRANSACTION + BOOST_EXACT_MATCH', async () => {
       mockSOQuery({
         id: 'so1',
         orderNumber: 'SO-001',
@@ -231,7 +231,7 @@ describe('SalesOrderService', () => {
 
       const results = await service.searchGlobal('SO-001', adminUser);
 
-      expect(results[0].score).toBe(130);
+      expect(results[0].score).toBe(150);
     });
 
     it('orderNumber startsWith scores SCORE_STARTSWITH_CODE + BOOST_TRANSACTION', async () => {

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -30,6 +30,7 @@ import {
   SCORE_CONTAINS,
   SCORE_FUZZY,
   BOOST_TRANSACTION,
+  BOOST_EXACT_MATCH,
 } from '../../search/search.constants';
 // import { CustomerService } from './customer.service';
 import { InventoryIntegrationService } from './inventory-integration.service';
@@ -414,7 +415,10 @@ export class SalesOrderService {
       label: order.orderNumber,
       description: order.customer?.name ?? '',
       route: `/sales/orders/${order.id}/edit`,
-      score: baseScore + BOOST_TRANSACTION,
+      score:
+        baseScore +
+        BOOST_TRANSACTION +
+        (baseScore === SCORE_EXACT_CODE ? BOOST_EXACT_MATCH : 0),
     };
   }
 

--- a/backend/src/modules/search/search.constants.ts
+++ b/backend/src/modules/search/search.constants.ts
@@ -25,7 +25,11 @@ export const BOOST_VENDOR_PAYMENT = 8;
 export const BOOST_SUPPLIER = 7;
 export const BOOST_PRODUCT = 6;
 export const BOOST_JOURNAL = 4;
-export const BOOST_PAGE = 2;
+export const BOOST_PAGE = 0; // intentionally zero - pages remain in formula for consistency but contribute no score boost
+
+// Applied once after baseScore resolves, when baseScore === SCORE_EXACT_CODE or SCORE_EXACT_NAME
+// Only for non-page entities - ensures exact record matches decisively outrank all partial matches
+export const BOOST_EXACT_MATCH = 20;
 
 // Fuzzy fallback score - used only when ILIKE returns no results
 export const SCORE_FUZZY = 40;

--- a/backend/src/modules/search/search.service.spec.ts
+++ b/backend/src/modules/search/search.service.spec.ts
@@ -226,6 +226,52 @@ describe('SearchService', () => {
     });
   });
 
+  describe('page descriptions (getPageCategory)', () => {
+    it('returns "Dashboard" for /dashboard', async () => {
+      const result = await service.search('dashboard', {
+        role: UserRole.ADMIN,
+      } as any);
+      const page = result.results.find((r) => r.route === '/dashboard');
+      expect(page?.description).toBe('Dashboard');
+    });
+
+    it('returns "Sales" for /sales routes', async () => {
+      const result = await service.search('customers', {
+        role: UserRole.ADMIN,
+      } as any);
+      const page = result.results.find((r) => r.route === '/sales/customers');
+      expect(page?.description).toBe('Sales');
+    });
+
+    it('returns "Report" for /reports routes (not "Sales")', async () => {
+      const result = await service.search('product summary', {
+        role: UserRole.ADMIN,
+      } as any);
+      const page = result.results.find((r) =>
+        r.route?.startsWith('/reports/sales/'),
+      );
+      expect(page?.description).toBe('Report');
+    });
+
+    it('returns "Accounting" for /accounting routes', async () => {
+      const result = await service.search('journal', {
+        role: UserRole.ADMIN,
+      } as any);
+      const page = result.results.find((r) =>
+        r.route?.startsWith('/accounting/'),
+      );
+      expect(page?.description).toBe('Accounting');
+    });
+
+    it('returns "Audit" for /audit-logs', async () => {
+      const result = await service.search('audit', {
+        role: UserRole.ADMIN,
+      } as any);
+      const page = result.results.find((r) => r.route === '/audit-logs');
+      expect(page?.description).toBe('Audit');
+    });
+  });
+
   describe('searchPages role filtering', () => {
     it('returns Dashboard for all roles', async () => {
       for (const role of Object.values(UserRole)) {

--- a/backend/src/modules/search/search.service.spec.ts
+++ b/backend/src/modules/search/search.service.spec.ts
@@ -204,25 +204,25 @@ describe('SearchService', () => {
   });
 
   describe('searchPages scoring', () => {
-    it('scores an exact page label match as SCORE_PAGE_EXACT + BOOST_PAGE (92)', async () => {
+    it('scores an exact page label match as SCORE_PAGE_EXACT + BOOST_PAGE (90)', async () => {
       // "Dashboard" is an exact match for query "dashboard"
       const result = await service.search('dashboard', { role: UserRole.ADMIN } as any);
       const dashPage = result.results.find((r) => r.route === '/dashboard');
-      expect(dashPage?.score).toBe(92); // SCORE_PAGE_EXACT(90) + BOOST_PAGE(2)
+      expect(dashPage?.score).toBe(90); // SCORE_PAGE_EXACT(90) + BOOST_PAGE(0)
     });
 
-    it('scores a page starts-with match as SCORE_PAGE_STARTSWITH + BOOST_PAGE (77)', async () => {
+    it('scores a page starts-with match as SCORE_PAGE_STARTSWITH + BOOST_PAGE (75)', async () => {
       // "Invoices" starts with "inv"
       const result = await service.search('inv', { role: UserRole.ADMIN } as any);
       const invoicesPage = result.results.find((r) => r.route === '/sales/invoices');
-      expect(invoicesPage?.score).toBe(77); // SCORE_PAGE_STARTSWITH(75) + BOOST_PAGE(2)
+      expect(invoicesPage?.score).toBe(75); // SCORE_PAGE_STARTSWITH(75) + BOOST_PAGE(0)
     });
 
-    it('scores a keyword-only match as SCORE_PAGE_KEYWORD + BOOST_PAGE (52)', async () => {
+    it('scores a keyword-only match as SCORE_PAGE_KEYWORD + BOOST_PAGE (50)', async () => {
       // "Customers" has keyword "clients" — searching "clients" is a keyword match, not label match
       const result = await service.search('clients', { role: UserRole.ADMIN } as any);
       const customersPage = result.results.find((r) => r.route === '/sales/customers');
-      expect(customersPage?.score).toBe(52); // SCORE_PAGE_KEYWORD(50) + BOOST_PAGE(2)
+      expect(customersPage?.score).toBe(50); // SCORE_PAGE_KEYWORD(50) + BOOST_PAGE(0)
     });
   });
 

--- a/backend/src/modules/search/search.service.ts
+++ b/backend/src/modules/search/search.service.ts
@@ -29,6 +29,19 @@ import {
 } from './search.constants';
 import { SearchAnalyticsService } from './search-analytics.service';
 
+function getPageCategory(route: string): string {
+  const r = route.toLowerCase().trim();
+  if (r === '/dashboard') return 'Dashboard';
+  if (r === '/reports' || r.startsWith('/reports/')) return 'Report';
+  if (r === '/accounting' || r.startsWith('/accounting/')) return 'Accounting';
+  if (r === '/sales' || r.startsWith('/sales/')) return 'Sales';
+  if (r === '/purchasing' || r.startsWith('/purchasing/')) return 'Purchasing';
+  if (r === '/inventory' || r.startsWith('/inventory/')) return 'Inventory';
+  if (r === '/settings' || r.startsWith('/settings/')) return 'Settings';
+  if (r === '/audit-logs' || r.startsWith('/audit-logs/')) return 'Audit';
+  return 'Page';
+}
+
 const STATIC_PAGES: Array<{
   label: string;
   keywords: string[];
@@ -511,7 +524,7 @@ export class SearchService {
       .map((page) => ({
         type: 'page',
         label: page.label,
-        description: 'Navigation',
+        description: getPageCategory(page.route),
         route: page.route,
         score:
           page.label.toLowerCase() === q

--- a/frontend/src/components/common/SearchModal.tsx
+++ b/frontend/src/components/common/SearchModal.tsx
@@ -8,6 +8,7 @@ import {
   InputBase,
   Modal,
   Typography,
+  useTheme,
 } from '@mui/material'
 import { useNavigate } from 'react-router-dom'
 
@@ -31,7 +32,6 @@ interface SearchModalProps {
 }
 
 const GROUP_ORDER: GlobalSearchResultType[] = [
-  'page',
   'customer',
   'product',
   'transaction',
@@ -40,6 +40,7 @@ const GROUP_ORDER: GlobalSearchResultType[] = [
   'customer_payment',
   'vendor_payment',
   'journal_entry',
+  'page',
 ]
 
 const GROUP_LABELS: Record<GlobalSearchResultType, string> = {
@@ -89,6 +90,7 @@ function useDebounce(value: string, delay: number) {
 
 export default function SearchModal({ open, onClose }: SearchModalProps) {
   const navigate = useNavigate()
+  const theme = useTheme()
   const inputRef = useRef<HTMLInputElement>(null)
   const currentUser = useAppSelector(selectCurrentUser)
   const userId = currentUser?.id ?? ''
@@ -336,6 +338,7 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
                   onClick={() => handleSelect(item)}
                   onHover={() => setSelectedIndex(idx)}
                   query=""
+                  highlightColor={theme.palette.primary.light}
                   isRecent={true}
                 />
               ))}
@@ -398,6 +401,7 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
                     onClick={() => handleSelect(item)}
                     onHover={() => setSelectedIndex(flatIndex)}
                     query={trimmedQuery}
+                    highlightColor={theme.palette.primary.light}
                   />
                 )
               })}
@@ -415,6 +419,7 @@ interface SearchResultRowProps {
   onClick: () => void
   onHover: () => void
   query: string
+  highlightColor: string
   isRecent?: boolean
 }
 
@@ -424,6 +429,7 @@ function SearchResultRow({
   onClick,
   onHover,
   query,
+  highlightColor,
   isRecent = false,
 }: SearchResultRowProps) {
   return (
@@ -449,14 +455,14 @@ function SearchResultRow({
 
       <Box sx={{ minWidth: 0, flex: 1 }}>
         <Typography sx={{ color: '#E0E0E0', fontWeight: 600 }}>
-          {highlightText(item.label, query)}
+          {highlightText(item.label, query, 700, highlightColor)}
         </Typography>
         {item.description && (
           <Typography
             variant="caption"
             sx={{ color: '#A0A0A0', display: 'block', mt: 0.25 }}
           >
-            {highlightText(item.description, query, 600)}
+            {highlightText(item.description, query, 400, highlightColor)}
           </Typography>
         )}
       </Box>

--- a/frontend/src/components/common/__tests__/SearchModal.test.tsx
+++ b/frontend/src/components/common/__tests__/SearchModal.test.tsx
@@ -217,6 +217,45 @@ describe('SearchModal', () => {
     expect(screen.getByText('Journal Entries')).toBeInTheDocument()
   })
 
+  it('renders data result groups before page group', () => {
+    mockUseSearchGlobal.mockReturnValue({
+      data: {
+        results: [
+          {
+            type: 'page',
+            label: 'Sales',
+            description: 'Sales',
+            route: '/sales',
+            score: 90,
+          },
+          {
+            type: 'customer',
+            label: 'Alpha Industries',
+            description: '',
+            route: '/sales/customers/1',
+            score: 103,
+          },
+        ],
+      },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    })
+
+    renderModal()
+
+    act(() => {
+      fireEvent.change(screen.getByRole('textbox', { name: /search/i }), {
+        target: { value: 'al' },
+      })
+      vi.advanceTimersByTime(300)
+    })
+
+    const headers = screen.getAllByText(/^(Customers|Pages)$/i)
+    expect(headers[0].textContent).toBe('Customers')
+    expect(headers[1].textContent).toBe('Pages')
+  })
+
   it('shows no-results message when results are empty', () => {
     mockUseSearchGlobal.mockReturnValue({
       data: { query: 'zzz', results: [] },

--- a/frontend/src/utils/highlightText.test.tsx
+++ b/frontend/src/utils/highlightText.test.tsx
@@ -71,4 +71,26 @@ describe('highlightText', () => {
 
     expect(span?.style.fontWeight).toBe('600')
   })
+
+  it('applies highlightColor when provided', () => {
+    const { container } = render(<>{highlightText('abc and more', 'abc', 700, '#ff0000')}</>)
+    const span = container.querySelector('span')
+
+    expect(span?.style.color).toBe('rgb(255, 0, 0)')
+  })
+
+  it('does not set color when highlightColor is not provided', () => {
+    const { container } = render(<>{highlightText('abc and more', 'abc')}</>)
+    const span = container.querySelector('span')
+
+    expect(span?.style.color).toBe('')
+  })
+
+  it('applies both weight and color when both are provided', () => {
+    const { container } = render(<>{highlightText('abc and more', 'abc', 600, '#0000ff')}</>)
+    const span = container.querySelector('span')
+
+    expect(span?.style.fontWeight).toBe('600')
+    expect(span?.style.color).toBe('rgb(0, 0, 255)')
+  })
 })

--- a/frontend/src/utils/highlightText.tsx
+++ b/frontend/src/utils/highlightText.tsx
@@ -8,6 +8,7 @@ export function highlightText(
   text: string,
   query: string,
   highlightWeight = 700,
+  highlightColor?: string,
 ): ReactNode {
   const trimmed = query.trim()
   if (!trimmed) return text
@@ -23,7 +24,14 @@ export function highlightText(
   return (
     <>
       {text.slice(0, start)}
-      <span style={{ fontWeight: highlightWeight }}>{text.slice(start, end)}</span>
+      <span
+        style={{
+          fontWeight: highlightWeight,
+          ...(highlightColor ? { color: highlightColor } : {}),
+        }}
+      >
+        {text.slice(start, end)}
+      </span>
       {text.slice(end)}
     </>
   )


### PR DESCRIPTION
Closes #184

## Summary

- **Rebalance result priority**: Pages section moves to last in `GROUP_ORDER`; `BOOST_PAGE` lowered to 0 so record results consistently outrank page results
- **Meaningful page labels**: Replaces hardcoded `"Navigation"` descriptions with route-derived categories (`Sales`, `Accounting`, `Report`, `Inventory`, `Purchasing`, `Settings`, `Dashboard`, `Audit`) via a new `getPageCategory()` helper
- **Highlight color**: `highlightText` now accepts an optional `color` param; search results use `theme.palette.primary.light` — label gets bold + color, description gets color only (weight unchanged from surrounding text)
- **Exact match boost**: New `BOOST_EXACT_MATCH = 20` constant applied in all 9 entity service mappers when `baseScore` is `SCORE_EXACT_CODE` or `SCORE_EXACT_NAME`, pushing exact record matches decisively above all partial matches and pages

## Test plan

- [x] Backend: `cd backend && npm run test` — 49 suites, 656 tests pass
- [x] Frontend: `cd frontend && npx vitest run src/utils/highlightText.test.tsx src/components/common/__tests__/SearchModal.test.tsx` — 34 tests pass
- [x] Frontend lint + type-check pass
- [x] Manual: search `customer`, `invoice`, `sales` — data sections appear before Pages
- [x] Manual: search a page keyword (e.g. `journal`) — description shows `"Accounting"` not `"Navigation"`
- [x] Manual: search `product summary` — description shows `"Report"` not `"Sales"`
- [x] Manual: type an exact customer name — that customer appears at the top
- [x] Manual: any 2+ char query — matched text highlighted in primary blue

🤖 Generated with [Claude Code](https://claude.com/claude-code)