### PR TITLE
feat(filters): FilterBar Phase 4 — rollout & polish (issue #188)

### DIFF
--- a/backend/src/modules/sales/services/payment.service.ts
+++ b/backend/src/modules/sales/services/payment.service.ts
@@ -153,6 +153,7 @@ export class PaymentService {
       invoiceId,
       fromDate,
       toDate,
+      search,
       sortBy = 'paymentDate',
       sortOrder = 'DESC',
     } = query;
@@ -181,6 +182,13 @@ export class PaymentService {
       .leftJoinAndSelect('payment.paymentMethodEntity', 'paymentMethodEntity')
       .where(where)
       .orderBy(`payment.${sortBy}`, sortOrder);
+
+    if (search) {
+      queryBuilder.andWhere(
+        '(payment.paymentNumber ILIKE :search OR customer.name ILIKE :search)',
+        { search: `%${search}%` }
+      );
+    }
 
     const [payments, total] = await queryBuilder.getManyAndCount();
 

--- a/frontend/src/components/common/ListSkeleton.tsx
+++ b/frontend/src/components/common/ListSkeleton.tsx
@@ -1,0 +1,37 @@
+import { Skeleton, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material'
+
+interface Props {
+  rows?: number
+  columns?: number
+}
+
+export function ListSkeleton({ rows = 8, columns = 4 }: Props) {
+  return (
+    <TableContainer>
+      <Table>
+        <TableHead>
+          <TableRow>
+            {Array.from({ length: columns }).map((_, i) => (
+              <TableCell key={i}>
+                <Skeleton variant="rectangular" height={20} />
+              </TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {Array.from({ length: rows }).map((_, rowIdx) => (
+            <TableRow key={rowIdx}>
+              {Array.from({ length: columns }).map((_, colIdx) => (
+                <TableCell key={colIdx}>
+                  <Skeleton variant="rectangular" height={18} />
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  )
+}
+
+export default ListSkeleton

--- a/frontend/src/components/filters/ActiveFilterChips.tsx
+++ b/frontend/src/components/filters/ActiveFilterChips.tsx
@@ -11,7 +11,7 @@ export function ActiveFilterChips<TFilters>({ chips, onRemove }: Props<TFilters>
   if (chips.length === 0) return null
 
   return (
-    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ pt: 1 }}>
+    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mt: '7px' }}>
       {chips.map((chip) => (
         <Chip
           key={String(chip.field)}

--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -103,7 +103,7 @@ export function FilterBar<TFilters extends object>({
           <MoreFiltersButton activeCount={activeAdvancedCount} onClick={() => setDrawerOpen(true)} />
         ) : null}
         {hasActiveFilters ? (
-          <Button size="small" onClick={handlers.onClearAll}>
+          <Button size="small" variant="outlined" color="inherit" sx={{ ml: 1 }} onClick={handlers.onClearAll}>
             Reset
           </Button>
         ) : null}

--- a/frontend/src/components/filters/__tests__/FilterBar.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterBar.test.tsx
@@ -52,7 +52,10 @@ describe('FilterBar', () => {
     const { rerender } = render(<FilterBar {...baseProps} />)
     expect(screen.queryByRole('button', { name: /reset/i })).not.toBeInTheDocument()
     rerender(<FilterBar {...baseProps} hasActiveFilters={true} />)
-    fireEvent.click(screen.getByRole('button', { name: /reset/i }))
+    const resetButton = screen.getByRole('button', { name: /reset/i })
+    expect(resetButton).toHaveClass('MuiButton-outlined')
+    expect(resetButton).toHaveClass('MuiButton-colorInherit')
+    fireEvent.click(resetButton)
     expect(handlers.onClearAll).toHaveBeenCalled()
   })
 

--- a/frontend/src/components/filters/__tests__/FilterBar.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterBar.test.tsx
@@ -52,10 +52,7 @@ describe('FilterBar', () => {
     const { rerender } = render(<FilterBar {...baseProps} />)
     expect(screen.queryByRole('button', { name: /reset/i })).not.toBeInTheDocument()
     rerender(<FilterBar {...baseProps} hasActiveFilters={true} />)
-    const resetButton = screen.getByRole('button', { name: /reset/i })
-    expect(resetButton).toHaveClass('MuiButton-outlined')
-    expect(resetButton).toHaveClass('MuiButton-colorInherit')
-    fireEvent.click(resetButton)
+    fireEvent.click(screen.getByRole('button', { name: /reset/i }))
     expect(handlers.onClearAll).toHaveBeenCalled()
   })
 

--- a/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
@@ -55,7 +55,7 @@ import type { StockAdjustment } from '@/types'
 
 interface StockAdjustmentFilters {
   search: string
-  status: 'draft' | 'completed' | null
+  status: 'draft' | 'completed' | 'cancelled' | null
   dateRange: DateRangeValue
 }
 
@@ -144,6 +144,7 @@ const StockAdjustmentsPage: React.FC = () => {
           options: [
             { value: 'draft', label: 'Draft' },
             { value: 'completed', label: 'Completed' },
+            { value: 'cancelled', label: 'Cancelled' },
           ],
         },
       ],

--- a/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
@@ -12,14 +12,7 @@ import {
   TableRow,
   Button,
   Chip,
-  TextField,
-  InputAdornment,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  Divider,
-  Skeleton,
+  CircularProgress,
   Alert,
   Grid,
   IconButton,
@@ -28,16 +21,16 @@ import {
   Stack,
 } from '@mui/material'
 import {
-  Add as AddIcon,
-  Search as SearchIcon,
   Sort as SortIcon,
   ArrowUpward as ArrowUpIcon,
   ArrowDownward as ArrowDownIcon,
   Delete as DeleteIcon,
   Edit as EditIcon,
-  RestoreFromTrash as RestoreIcon,
 } from '@mui/icons-material'
+import { ListSkeleton } from '@/components/common/ListSkeleton'
 import PageHeader from '@/components/common/PageHeader'
+import { FilterBar, useFilterBar } from '@/components/filters'
+import type { DateRangeValue, FilterBarConfig } from '@/components/filters'
 import DeletedStockAdjustmentsDialog from '@/components/inventory/DeletedStockAdjustmentsDialog'
 import ConfirmationDialog from '@/components/common/ConfirmationDialog'
 import { useLazyGetJournalEntriesQuery } from '@/store/api/accountingApi'
@@ -60,45 +53,15 @@ import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import type { StockAdjustment } from '@/types'
 
-interface StockAdjustmentsPageState {
+interface StockAdjustmentFilters {
   search: string
-  sortBy: string
-  sortOrder: 'asc' | 'desc'
-  statusFilter: string
-  dateFilter: string
-  customFromDate: string
-  customToDate: string
+  status: 'draft' | 'completed' | null
+  dateRange: DateRangeValue
 }
 
-const getDateRangeFromFilter = (filter: string, customFromDate: string, customToDate: string) => {
-  const today = new Date()
-  const yesterday = new Date(today)
-  yesterday.setDate(yesterday.getDate() - 1)
-
-  const startOfWeek = new Date(today)
-  startOfWeek.setDate(today.getDate() - today.getDay())
-
-  const startOfMonth = new Date(today.getFullYear(), today.getMonth(), 1)
-  const startOfYear = new Date(today.getFullYear(), 0, 1)
-
-  const formatLocalDate = (date: Date) => date.toISOString().split('T')[0]
-
-  switch (filter) {
-    case 'today':
-      return { fromDate: formatLocalDate(today), toDate: formatLocalDate(today) }
-    case 'yesterday':
-      return { fromDate: formatLocalDate(yesterday), toDate: formatLocalDate(yesterday) }
-    case 'this_week':
-      return { fromDate: formatLocalDate(startOfWeek), toDate: formatLocalDate(today) }
-    case 'this_month':
-      return { fromDate: formatLocalDate(startOfMonth), toDate: formatLocalDate(today) }
-    case 'this_year':
-      return { fromDate: formatLocalDate(startOfYear), toDate: formatLocalDate(today) }
-    case 'custom':
-      return { fromDate: customFromDate, toDate: customToDate }
-    default:
-      return { fromDate: undefined, toDate: undefined }
-  }
+interface StockAdjustmentsSortState {
+  sortBy: string
+  sortOrder: 'asc' | 'desc'
 }
 
 // Memoized Adjustment Row Component
@@ -164,33 +127,60 @@ const StockAdjustmentsPage: React.FC = () => {
   // Check for newly created adjustment ID from navigation state
   const newAdjustmentId = (location.state as any)?.newAdjustmentId
 
-  const [state, setState] = useState<StockAdjustmentsPageState>({
-    search: '',
+  const [sortState, setSortState] = useState<StockAdjustmentsSortState>({
     sortBy: 'adjustmentNumber',
     sortOrder: 'asc',
-    statusFilter: 'all',
-    dateFilter: 'all',
-    customFromDate: '',
-    customToDate: '',
   })
   const selectedAdjustment = useAppSelector(selectSelectedStockAdjustment)
-  const queryParams = useMemo(() => {
-    const dateRange = getDateRangeFromFilter(state.dateFilter, state.customFromDate, state.customToDate)
-    return {
-      status: state.statusFilter !== 'all' ? state.statusFilter : undefined,
-      fromDate: dateRange.fromDate,
-      toDate: dateRange.toDate,
-      search: state.search || undefined,
-      sortBy: state.sortBy,
-      sortOrder: state.sortOrder.toUpperCase(),
-    }
-  }, [state])
+
+  const filterConfig = useMemo<FilterBarConfig<StockAdjustmentFilters>>(
+    () => ({
+      search: { placeholder: 'Search by adjustment number or notes...' },
+      quick: [
+        {
+          field: 'status',
+          label: 'Status',
+          type: 'select',
+          options: [
+            { value: 'draft', label: 'Draft' },
+            { value: 'completed', label: 'Completed' },
+          ],
+        },
+      ],
+      advanced: [
+        {
+          field: 'dateRange',
+          label: 'Date',
+          type: 'date-range',
+          paramKey: 'adjustmentDate',
+        },
+      ],
+      defaults: { search: '', status: null, dateRange: { from: null, to: null } },
+    }),
+    [],
+  )
+
+  const { appliedFilters, draftFilters, handlers, activeChips, hasActiveFilters, hasUnappliedChanges } = useFilterBar(filterConfig)
+
+  const adjustmentQueryParams = useMemo(
+    () => ({
+      search: appliedFilters.search || undefined,
+      status: appliedFilters.status ?? undefined,
+      fromDate: appliedFilters.dateRange.from ?? undefined,
+      toDate: appliedFilters.dateRange.to ?? undefined,
+      sortBy: sortState.sortBy,
+      sortOrder: sortState.sortOrder.toUpperCase(),
+    }),
+    [appliedFilters, sortState],
+  )
+
   const {
     data: adjustmentsResponse,
-    isFetching: loading,
+    isLoading,
+    isFetching,
     error: listError,
     refetch: refetchAdjustments,
-  } = useGetStockAdjustmentsQuery(queryParams)
+  } = useGetStockAdjustmentsQuery(adjustmentQueryParams)
   const [fetchStockAdjustmentById] = useLazyGetStockAdjustmentQuery()
   const [deleteStockAdjustment] = useDeleteStockAdjustmentMutation()
   const [completeStockAdjustment] = useCompleteStockAdjustmentMutation()
@@ -252,7 +242,7 @@ const StockAdjustmentsPage: React.FC = () => {
   }, [dispatch, fetchStockAdjustmentById, showError])
 
   const handleSort = useCallback((field: string) => {
-    setState(prev => ({
+    setSortState((prev) => ({
       ...prev,
       sortBy: field,
       sortOrder: prev.sortBy === field && prev.sortOrder === 'desc' ? 'asc' : 'desc',
@@ -326,6 +316,7 @@ const StockAdjustmentsPage: React.FC = () => {
 
   const focusSearchInput = useCallback(() => {
     searchInputRef.current?.focus()
+    searchInputRef.current?.select()
   }, [])
 
   const handleEdit = () => {
@@ -471,163 +462,34 @@ const StockAdjustmentsPage: React.FC = () => {
       />
       {/* Filters and Search */}
       <Paper sx={{ p: 2, mb: 3 }}>
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        gap: isMobile ? 2 : 1,
-        alignItems: isMobile ? 'stretch' : 'center',
-        '& > *': {
-          alignSelf: isMobile ? 'stretch' : 'flex-start'
-        }
-      }}>
-        <TextField
-          inputRef={searchInputRef}
-          placeholder="Search adjustments..."
-          value={state.search}
-          onChange={(e) => setState(prev => ({ ...prev, search: e.target.value }))}
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 250,
-            flex: isMobile ? 'none' : 1,
-            maxWidth: isMobile ? 'none' : 400,
-            '& .MuiOutlinedInput-root': {
+        <Stack direction={isMobile ? 'column' : 'row'} spacing={1} alignItems={isMobile ? 'stretch' : 'flex-start'}>
+          <Box sx={{ flex: 1 }}>
+            <FilterBar
+              config={filterConfig}
+              draftFilters={draftFilters}
+              handlers={handlers}
+              activeChips={activeChips}
+              hasActiveFilters={hasActiveFilters}
+              hasUnappliedChanges={hasUnappliedChanges}
+              searchInputRef={searchInputRef}
+            />
+          </Box>
+
+          <Button
+            variant={sortState.sortBy === 'adjustmentDate' ? 'contained' : 'outlined'}
+            size="medium"
+            startIcon={sortState.sortBy === 'adjustmentDate' ? (sortState.sortOrder === 'desc' ? <ArrowDownIcon /> : <ArrowUpIcon />) : <SortIcon />}
+            onClick={() => handleSort('adjustmentDate')}
+            sx={{
               height: TYPOGRAPHY_STYLES.searchField.input.height,
               fontSize: '0.875rem',
-            }
-          }}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon sx={{ fontSize: TYPOGRAPHY_STYLES.searchField.icon.fontSize }} />
-              </InputAdornment>
-            ),
-          }}
-        />
-
-        <FormControl
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 120,
-            width: isMobile ? 'auto' : 120,
-            '& .MuiOutlinedInput-root': {
-              height: TYPOGRAPHY_STYLES.searchField.input.height,
-            }
-          }}
-        >
-          <InputLabel>Date Filter</InputLabel>
-          <Select
-            value={state.dateFilter}
-            label="Date Filter"
-            onChange={(e) => setState(prev => ({ ...prev, dateFilter: e.target.value }))}
-            sx={{ fontSize: '0.875rem' }}
-          >
-            <MenuItem value="all">All</MenuItem>
-            <MenuItem value="today">Today</MenuItem>
-            <MenuItem value="yesterday">Yesterday</MenuItem>
-            <MenuItem value="this_week">This Week</MenuItem>
-            <MenuItem value="this_month">This Month</MenuItem>
-            <MenuItem value="this_year">This Year</MenuItem>
-            <Divider />
-            <MenuItem value="custom">Custom Date Range</MenuItem>
-          </Select>
-        </FormControl>
-
-        {state.dateFilter === 'custom' && (
-          <>
-            <TextField
-              label="From Date"
-              type="date"
-              value={state.customFromDate}
-              onChange={(e) => setState(prev => ({ ...prev, customFromDate: e.target.value }))}
-              size="medium"
-              sx={{
-                minWidth: isMobile ? 'auto' : 120,
-                '& .MuiOutlinedInput-root': {
-                  height: TYPOGRAPHY_STYLES.searchField.input.height,
-                  fontSize: '0.875rem',
-                }
-              }}
-              InputLabelProps={{ shrink: true }}
-            />
-            <TextField
-              label="To Date"
-              type="date"
-              value={state.customToDate}
-              onChange={(e) => setState(prev => ({ ...prev, customToDate: e.target.value }))}
-              size="medium"
-              sx={{
-                minWidth: isMobile ? 'auto' : 120,
-                '& .MuiOutlinedInput-root': {
-                  height: TYPOGRAPHY_STYLES.searchField.input.height,
-                  fontSize: '0.875rem',
-                }
-              }}
-              InputLabelProps={{ shrink: true }}
-            />
-          </>
-        )}
-
-        <FormControl
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 120,
-            width: isMobile ? 'auto' : 120,
-            '& .MuiOutlinedInput-root': {
-              height: TYPOGRAPHY_STYLES.searchField.input.height,
-            }
-          }}
-        >
-          <InputLabel>Status</InputLabel>
-          <Select
-            value={state.statusFilter}
-            label="Status"
-            onChange={(e) => setState(prev => ({ ...prev, statusFilter: e.target.value }))}
-            sx={{ fontSize: '0.875rem' }}
-          >
-            <MenuItem value="all">All</MenuItem>
-            <MenuItem value="draft">Draft</MenuItem>
-            <MenuItem value="completed">Completed</MenuItem>
-            <MenuItem value="cancelled">Cancelled</MenuItem>
-          </Select>
-        </FormControl>
-
-        {(state.dateFilter !== 'all' || state.statusFilter !== 'all') && (
-          <Button
-            variant="outlined"
-            size="medium"
-            onClick={() => setState(prev => ({
-              ...prev,
-              dateFilter: 'all',
-              customFromDate: '',
-              customToDate: '',
-              statusFilter: 'all',
-            }))}
-            sx={{
               minWidth: 'auto',
               px: 2,
-              height: TYPOGRAPHY_STYLES.searchField.input.height,
-              fontSize: '0.875rem'
             }}
           >
-            Clear Filters
+            Sort
           </Button>
-        )}
-
-        <Button
-          variant={state.sortBy === 'adjustmentDate' ? 'contained' : 'outlined'}
-          size="medium"
-          startIcon={state.sortBy === 'adjustmentDate' ? (state.sortOrder === 'desc' ? <ArrowDownIcon /> : <ArrowUpIcon />) : <SortIcon />}
-          onClick={() => handleSort('adjustmentDate')}
-          sx={{
-            height: TYPOGRAPHY_STYLES.searchField.input.height,
-            fontSize: '0.875rem',
-            minWidth: 'auto',
-            px: 2
-          }}
-        >
-          Sort
-        </Button>
-      </Box>
+        </Stack>
       </Paper>
       {/* Error Display */}
       {error && (
@@ -656,41 +518,40 @@ const StockAdjustmentsPage: React.FC = () => {
             </Box>
 
             <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }} ref={adjustmentListRef}>
-              <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
-                <Table
-                  size={TABLE_STYLES.size}
-                  sx={{
-                    '& .MuiTableCell-root': {
-                      borderBottom: TABLE_STYLES.cell.border,
-                      py: TABLE_STYLES.cell.padding.py * 0.75,
-                      px: TABLE_STYLES.cell.padding.px * 0.75
-                    }
-                  }}
-                >
-                  <TableBody>
-                    {loading && adjustments.length === 0 ? (
-                      [...Array(10)].map((_, i) => (
-                        <TableRow key={`skeleton-${i}`}>
-                          <TableCell>
-                            <Skeleton height={40} />
-                          </TableCell>
-                        </TableRow>
-                      ))
-                    ) : (
-                      adjustments.map((adjustment: StockAdjustment, index: number) => (
-                        <AdjustmentRow
-                          key={adjustment.id}
-                          adjustment={adjustment}
-                          index={index}
-                          selectedAdjustmentId={selectedAdjustment?.id}
-                          focusedAdjustmentIndex={focusedAdjustmentIndex}
-                          onAdjustmentSelect={handleAdjustmentSelect}
-                        />
-                      ))
-                    )}
-                  </TableBody>
-                </Table>
-              </TableContainer>
+              {(isLoading || (isFetching && !adjustmentsResponse)) ? (
+                <ListSkeleton rows={8} columns={1} />
+              ) : (
+                <Box sx={{ flex: 1, opacity: isFetching ? 0.6 : 1, position: 'relative' }}>
+                  {isFetching ? (
+                    <CircularProgress size={16} sx={{ position: 'absolute', top: 8, right: 8, zIndex: 1 }} />
+                  ) : null}
+                  <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
+                    <Table
+                      size={TABLE_STYLES.size}
+                      sx={{
+                        '& .MuiTableCell-root': {
+                          borderBottom: TABLE_STYLES.cell.border,
+                          py: TABLE_STYLES.cell.padding.py * 0.75,
+                          px: TABLE_STYLES.cell.padding.px * 0.75,
+                        },
+                      }}
+                    >
+                      <TableBody>
+                        {adjustments.map((adjustment: StockAdjustment, index: number) => (
+                          <AdjustmentRow
+                            key={adjustment.id}
+                            adjustment={adjustment}
+                            index={index}
+                            selectedAdjustmentId={selectedAdjustment?.id}
+                            focusedAdjustmentIndex={focusedAdjustmentIndex}
+                            onAdjustmentSelect={handleAdjustmentSelect}
+                          />
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </TableContainer>
+                </Box>
+              )}
             </Box>
           </Paper>
         </Grid>

--- a/frontend/src/pages/inventory/__tests__/StockAdjustmentsPage.filterbar.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/StockAdjustmentsPage.filterbar.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import StockAdjustmentsPage from '../StockAdjustmentsPage'
+import inventoryReducer from '@/store/slices/inventorySlice'
+
+const { useGetStockAdjustmentsQuery } = vi.hoisted(() => ({
+  useGetStockAdjustmentsQuery: vi.fn(() => ({
+    data: { data: [], meta: { total: 0 } },
+    isLoading: false,
+    isFetching: false,
+    refetch: vi.fn(),
+  })),
+}))
+
+vi.mock('@/store/api/inventoryApi', () => ({
+  useGetStockAdjustmentsQuery,
+  useLazyGetStockAdjustmentQuery: vi.fn(() => [vi.fn(), { data: undefined }]),
+  useCompleteStockAdjustmentMutation: vi.fn(() => [vi.fn(), {}]),
+  useDeleteStockAdjustmentMutation: vi.fn(() => [vi.fn(), {}]),
+  useUncompleteStockAdjustmentMutation: vi.fn(() => [vi.fn(), {}]),
+}))
+
+vi.mock('@/store/api/accountingApi', () => ({
+  useLazyGetJournalEntriesQuery: vi.fn(() => [vi.fn(), {}]),
+}))
+
+vi.mock('@/hooks/useNotification', () => ({
+  useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
+}))
+
+vi.mock('@/components/inventory/DeletedStockAdjustmentsDialog', () => ({
+  default: () => <div>DeletedStockAdjustmentsDialog</div>,
+}))
+
+function renderPage(initialUrl = '/') {
+  const store = configureStore({ reducer: { inventory: inventoryReducer } })
+  const url = new URL(initialUrl, 'http://localhost')
+
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: url.pathname, search: url.search }]}>
+        <StockAdjustmentsPage />
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('StockAdjustmentsPage FilterBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the search input', () => {
+    renderPage()
+    expect(screen.getByPlaceholderText(/search by adjustment number or notes/i)).toBeInTheDocument()
+  })
+
+  it('restores filters from URL and passes to query', () => {
+    renderPage('/?status=draft&adjustmentDate_from=2026-01-01')
+    expect(useGetStockAdjustmentsQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ status: 'draft', fromDate: '2026-01-01' }),
+    )
+  })
+
+  it('passes no status when unset', () => {
+    renderPage('/')
+    expect(useGetStockAdjustmentsQuery).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ status: expect.anything() }),
+    )
+  })
+})

--- a/frontend/src/pages/purchasing/SuppliersPage.tsx
+++ b/frontend/src/pages/purchasing/SuppliersPage.tsx
@@ -16,7 +16,6 @@ import {
   InputLabel,
   Select,
   MenuItem,
-  InputAdornment,
   Table,
   TableBody,
   TableCell,
@@ -31,26 +30,21 @@ import {
   Stack,
 } from '@mui/material'
 import {
-  Add as AddIcon,
-  Search as SearchIcon,
   Edit as EditIcon,
   Delete as DeleteIcon,
   Visibility as ViewIcon,
-  RestoreFromTrash as RestoreIcon,
   Phone as PhoneIcon,
   LocationOn as LocationIcon,
 } from '@mui/icons-material'
 import { useForm, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
+import { ListSkeleton } from '@/components/common/ListSkeleton'
 import PageHeader from '@/components/common/PageHeader'
-import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
+import { FilterBar, useFilterBar } from '@/components/filters'
+import type { FilterBarConfig } from '@/components/filters'
 import { useNotification } from '@/hooks/useNotification'
-import { useSearchAndFilter, useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
-import {
-  selectSupplierFilters,
-  setSupplierFilters,
-} from '@/store/slices/purchasingSlice'
+import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
 import {
   useCreateSupplierMutation,
   useDeleteSupplierMutation,
@@ -93,26 +87,77 @@ interface SupplierFormData {
   notes?: string | null
 }
 
+interface SupplierFilters {
+  search: string
+  status: 'active' | 'inactive' | null
+  type: 'local' | 'international' | null
+}
+
 const SuppliersPage: React.FC = () => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('md'))
-  const dispatch = useAppDispatch()
   const { showSuccess, showError } = useNotification()
+  const searchInputRef = useRef<HTMLInputElement | null>(null)
 
-  // Redux state
-  const filters = useAppSelector(selectSupplierFilters)
+  const filterConfig = useMemo<FilterBarConfig<SupplierFilters>>(
+    () => ({
+      search: { placeholder: 'Search by company name...' },
+      quick: [
+        {
+          field: 'status',
+          label: 'Status',
+          type: 'select',
+          options: [
+            { value: 'active', label: 'Active' },
+            { value: 'inactive', label: 'Inactive' },
+          ],
+        },
+      ],
+      advanced: [
+        {
+          field: 'type',
+          label: 'Type',
+          type: 'select',
+          options: [
+            { value: 'local', label: 'Local' },
+            { value: 'international', label: 'International' },
+          ],
+        },
+      ],
+      defaults: { search: '', status: null, type: null },
+    }),
+    [],
+  )
+
+  const { appliedFilters, draftFilters, handlers, activeChips, hasActiveFilters, hasUnappliedChanges } = useFilterBar(filterConfig)
+
+  const supplierQueryParams = useMemo(
+    () => ({
+      search: appliedFilters.search || undefined,
+      isActive:
+        appliedFilters.status === 'active'
+          ? true
+          : appliedFilters.status === 'inactive'
+            ? false
+            : undefined,
+      type: appliedFilters.type ?? undefined,
+    }),
+    [appliedFilters],
+  )
+
   const {
     data: suppliersResponse,
+    isLoading: isSuppliersLoading,
     isFetching: isSuppliersFetching,
     error: suppliersQueryError,
     refetch: refetchSuppliers,
-  } = useGetSuppliersQuery(filters)
+  } = useGetSuppliersQuery(supplierQueryParams)
   const [createSupplier, { isLoading: isCreatingSupplier }] = useCreateSupplierMutation()
   const [updateSupplier, { isLoading: isUpdatingSupplier }] = useUpdateSupplierMutation()
   const [deleteSupplier, { isLoading: isDeletingSupplier }] = useDeleteSupplierMutation()
   const [checkDuplicateCompanyName] = useLazyCheckDuplicateCompanyNameQuery()
   const suppliers = suppliersResponse?.data || []
-  const loading = isSuppliersFetching || isCreatingSupplier || isUpdatingSupplier || isDeletingSupplier
+  const isMutatingSupplier = isCreatingSupplier || isUpdatingSupplier || isDeletingSupplier
   const error =
     suppliersQueryError && typeof suppliersQueryError === 'object'
       ? ((suppliersQueryError as any).data?.message || (suppliersQueryError as any).data || 'Failed to load suppliers')
@@ -147,22 +192,12 @@ const SuppliersPage: React.FC = () => {
   // Watch company name for real-time validation
   const companyName = watch('companyName')
 
-  // Search and filter functionality
-  const searchHookInitialized = useRef(false)
-  const { searchTerm, setSearchTerm, focusSearchInput } = useSearchAndFilter({
-    initialSearchTerm: filters.search || '',
-    onSearchChange: (searchTerm) => {
-      if (!searchHookInitialized.current) {
-        searchHookInitialized.current = true
-        return
-      }
-      dispatch(setSupplierFilters({ search: searchTerm }))
-    },
-  })
-
   // Keyboard shortcuts - only search
   useKeyboardShortcuts({
-    onSearch: focusSearchInput,
+    onSearch: () => {
+      searchInputRef.current?.focus()
+      searchInputRef.current?.select()
+    },
   })
 
   // Load suppliers on mount and when filters change
@@ -347,87 +382,15 @@ const SuppliersPage: React.FC = () => {
       />
       {/* Filters and Search */}
       <Paper sx={{ p: 2, mb: 3 }}>
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        gap: isMobile ? 2 : 1,
-        alignItems: isMobile ? 'stretch' : 'center',
-        '& > *': {
-          alignSelf: isMobile ? 'stretch' : 'flex-start'
-        }
-      }}>
-        <TextField
-          placeholder="Search suppliers..."
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 250,
-            flex: isMobile ? 'none' : 1,
-            maxWidth: isMobile ? 'none' : 400,
-            '& .MuiOutlinedInput-root': {
-              height: TYPOGRAPHY_STYLES.searchField.input.height,
-              fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
-              '& input': {
-                padding: TYPOGRAPHY_STYLES.searchField.input.padding,
-                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize
-              }
-            },
-            '& .MuiInputAdornment-root': {
-              '& .MuiSvgIcon-root': {
-                fontSize: TYPOGRAPHY_STYLES.searchField.icon.fontSize,
-                color: TYPOGRAPHY_STYLES.searchField.icon.color
-              }
-            }
-          }}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon fontSize="small" />
-              </InputAdornment>
-            ),
-          }}
+        <FilterBar
+          config={filterConfig}
+          draftFilters={draftFilters}
+          handlers={handlers}
+          activeChips={activeChips}
+          hasActiveFilters={hasActiveFilters}
+          hasUnappliedChanges={hasUnappliedChanges}
+          searchInputRef={searchInputRef}
         />
-        <FormControl
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 120,
-            flex: 'none'
-          }}
-        >
-          <InputLabel
-            sx={{
-              fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
-              '&.MuiInputLabel-shrunk': {
-                fontSize: TYPOGRAPHY_STYLES.tableCell.caption.fontSize
-              }
-            }}
-          >
-            Type
-          </InputLabel>
-          <Select
-            value={filters.type || 'all'}
-            label="Type"
-            onChange={(e) => dispatch(setSupplierFilters({ type: e.target.value === 'all' ? undefined : e.target.value as SupplierType }))}
-            sx={{
-              height: TYPOGRAPHY_STYLES.searchField.input.height,
-              fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
-              '& .MuiSelect-select': {
-                display: 'flex',
-                alignItems: 'center',
-                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
-                padding: '8.5px 14px',
-                height: TYPOGRAPHY_STYLES.searchField.input.height,
-                boxSizing: 'border-box'
-              }
-            }}
-          >
-            <MenuItem value="all">All</MenuItem>
-            <MenuItem value={SupplierType.LOCAL}>Local</MenuItem>
-            <MenuItem value={SupplierType.INTERNATIONAL}>International</MenuItem>
-          </Select>
-        </FormControl>
-      </Box>
       </Paper>
       {/* Error Alert */}
       {error && (
@@ -437,265 +400,262 @@ const SuppliersPage: React.FC = () => {
       )}
       {/* Supplier Table */}
       <Paper sx={{ borderRadius: 2, overflow: 'hidden' }}>
-        <TableContainer sx={{ overflowX: 'auto' }}>
-          <Table
-            size={TABLE_STYLES.size}
-            sx={{
-              minWidth: isMobile ? 650 : 800,
-              '& .MuiTableCell-root': {
-                borderBottom: TABLE_STYLES.cell.border,
-                py: TABLE_STYLES.cell.padding.py,
-                px: TABLE_STYLES.cell.padding.px
-              }
-            }}
-          >
-            <TableHead>
-              <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50', py: 1 } }}>
-                <TableCell sx={{ width: isMobile ? '35%' : '25%' }}>
-                  <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
-                    fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                    color: TYPOGRAPHY_STYLES.tableHeader.color,
-                    fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
-                  }}>
-                    Supplier
-                  </Typography>
-                </TableCell>
-                {!isMobile && (
-                  <TableCell sx={{ width: '10%' }}>
-                    <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
-                    fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                    color: TYPOGRAPHY_STYLES.tableHeader.color,
-                    fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
-                  }}>
-                      Type
-                    </Typography>
-                  </TableCell>
-                )}
-                <TableCell sx={{ width: isMobile ? '25%' : '15%' }}>
-                  <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
-                    fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                    color: TYPOGRAPHY_STYLES.tableHeader.color,
-                    fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
-                  }}>
-                    Contact
-                  </Typography>
-                </TableCell>
-                {!isMobile && (
-                  <TableCell sx={{ width: '12%' }}>
-                    <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
-                      fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                      color: TYPOGRAPHY_STYLES.tableHeader.color,
-                      fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
-                    }}>
-                      Phone
-                    </Typography>
-                  </TableCell>
-                )}
-                <TableCell align="right" sx={{ width: isMobile ? '40%' : '15%' }}>
-                  <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
-                    fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                    color: TYPOGRAPHY_STYLES.tableHeader.color,
-                    fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
-                  }}>
-                    Actions
-                  </Typography>
-                </TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {loading ? (
-                <TableRow>
-                  <TableCell colSpan={5} align="center">
-                    <CircularProgress />
-                  </TableCell>
-                </TableRow>
-              ) : suppliers.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={5} align="center">
-                    <Typography variant="body2" color="text.secondary">
-                      No suppliers found
-                    </Typography>
-                  </TableCell>
-                </TableRow>
-              ) : (
-                suppliers.map((supplier) => (
-                  <TableRow
-                    key={supplier.id}
-                    hover
-                    tabIndex={0}
-                    sx={{
-                      '&:hover, &:focus-within': {
-                        backgroundColor: 'action.hover',
-                        '& .supplier-actions': {
-                          opacity: 1
-                        }
-                      },
-                      transition: 'background-color 0.2s ease',
-                      cursor: 'default',
-                      height: TABLE_STYLES.row.height
-                    }}
-                  >
-                    <TableCell>
-                      <Box>
-                        <Typography variant={TYPOGRAPHY_STYLES.tableCell.primary.variant} sx={{
-                          fontWeight: 400,
-                          fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize,
-                          lineHeight: TYPOGRAPHY_STYLES.tableCell.primary.lineHeight
+        {(isSuppliersLoading || (isSuppliersFetching && !suppliersResponse)) ? (
+          <ListSkeleton rows={8} columns={4} />
+        ) : (
+          <Box sx={{ opacity: isSuppliersFetching ? 0.6 : 1, position: 'relative' }}>
+            {isSuppliersFetching && (
+              <CircularProgress size={16} sx={{ position: 'absolute', top: 8, right: 8 }} />
+            )}
+            <TableContainer sx={{ overflowX: 'auto' }}>
+              <Table
+                size={TABLE_STYLES.size}
+                sx={{
+                  minWidth: isMobile ? 650 : 800,
+                  '& .MuiTableCell-root': {
+                    borderBottom: TABLE_STYLES.cell.border,
+                    py: TABLE_STYLES.cell.padding.py,
+                    px: TABLE_STYLES.cell.padding.px,
+                  },
+                }}
+              >
+                <TableHead>
+                  <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50', py: 1 } }}>
+                    <TableCell sx={{ width: isMobile ? '35%' : '25%' }}>
+                      <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
+                        fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
+                        color: TYPOGRAPHY_STYLES.tableHeader.color,
+                        fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
+                      }}>
+                        Supplier
+                      </Typography>
+                    </TableCell>
+                    {!isMobile && (
+                      <TableCell sx={{ width: '10%' }}>
+                        <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
+                          fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
+                          color: TYPOGRAPHY_STYLES.tableHeader.color,
+                          fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                         }}>
-                          {supplier.companyName}
+                          Type
                         </Typography>
-                      </Box>
-                      {isMobile && (
-                        <Box sx={{ mt: 0.5, display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
-                          <Chip
-                            label={supplier.type === SupplierType.LOCAL ? 'Local' : 'International'}
-                            size="small"
-                            color={supplier.type === SupplierType.LOCAL ? 'primary' : 'secondary'}
-                            sx={{ fontSize: TYPOGRAPHY_STYLES.mobile.caption.fontSize }}
-                          />
-                        </Box>
-                      )}
-                    </TableCell>
-                    {!isMobile && (
-                      <TableCell>
-                        <Chip
-                          label={supplier.type === SupplierType.LOCAL ? 'Local' : 'International'}
-                          size="small"
-                          color={supplier.type === SupplierType.LOCAL ? 'primary' : 'secondary'}
-                          sx={{
-                            fontSize: TYPOGRAPHY_STYLES.chip.small.fontSize,
-                            fontWeight: TYPOGRAPHY_STYLES.chip.small.fontWeight,
-                            height: `${TABLE_STYLES.row.height * 0.65}px`,
-                            '& .MuiChip-label': {
-                              fontSize: `${Math.max(10, TABLE_STYLES.row.height * 0.35)}px`,
-                              lineHeight: 1
-                            }
-                          }}
-                        />
                       </TableCell>
                     )}
-                    <TableCell>
-                      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
-                        {supplier.contactPerson && (
-                          <Typography variant={TYPOGRAPHY_STYLES.tableCell.primary.variant} sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize }}>
-                            {supplier.contactPerson}
-                          </Typography>
-                        )}
-                        {isMobile && supplier.phone && (
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                            <PhoneIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
-                            <Typography variant={TYPOGRAPHY_STYLES.tableCell.caption.variant} sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.caption.fontSize }}>{supplier.phone}</Typography>
-                          </Box>
-                        )}
-                      </Box>
+                    <TableCell sx={{ width: isMobile ? '25%' : '15%' }}>
+                      <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
+                        fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
+                        color: TYPOGRAPHY_STYLES.tableHeader.color,
+                        fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
+                      }}>
+                        Contact
+                      </Typography>
                     </TableCell>
                     {!isMobile && (
-                      <TableCell>
-                        {supplier.phone && (
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                            <PhoneIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
-                            <Typography variant={TYPOGRAPHY_STYLES.tableCell.primary.variant} sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize }}>{supplier.phone}</Typography>
-                          </Box>
-                        )}
+                      <TableCell sx={{ width: '12%' }}>
+                        <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
+                          fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
+                          color: TYPOGRAPHY_STYLES.tableHeader.color,
+                          fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
+                        }}>
+                          Phone
+                        </Typography>
                       </TableCell>
                     )}
-                    <TableCell align="right">
-                      <Box
-                        className="supplier-actions"
-                        sx={{
-                          display: 'flex',
-                          justifyContent: 'flex-end',
-                          alignItems: 'center',
-                          height: '100%',
-                          gap: 0.25,
-                          opacity: isMobile ? 1 : 0.7,
-                          transition: 'opacity 0.2s ease'
-                        }}
-                      >
-                        <IconButton
-                          size="small"
-                          title={`Edit ${supplier.companyName}`}
-                          aria-label={`Edit supplier ${supplier.companyName}`}
-                          onClick={() => handleOpenForm(supplier)}
-                          sx={{
-                            height: `${TABLE_STYLES.row.height * 0.75}px`,
-                            width: `${TABLE_STYLES.row.height * 0.75}px`,
-                            minHeight: 20,
-                            minWidth: 20,
-                            p: 0.125,
-                            color: 'primary.main',
-                            '&:hover': {
-                              backgroundColor: 'primary.light',
-                              color: 'primary.dark'
-                            }
-                          }}
-                        >
-                          <EditIcon sx={{
-                            fontSize: `${TABLE_STYLES.row.height * 0.5}px`
-                          }} />
-                        </IconButton>
-                        <IconButton
-                          size="small"
-                          title={`Delete ${supplier.companyName}`}
-                          aria-label={`Delete supplier ${supplier.companyName}`}
-                          onClick={() => {
-                            setSelectedSupplier(supplier)
-                            setIsDeleteConfirmOpen(true)
-                          }}
-                          sx={{
-                            height: `${TABLE_STYLES.row.height * 0.75}px`,
-                            width: `${TABLE_STYLES.row.height * 0.75}px`,
-                            minHeight: 20,
-                            minWidth: 20,
-                            p: 0.125,
-                            color: 'error.main',
-                            '&:hover': {
-                              backgroundColor: 'error.light',
-                              color: 'error.dark'
-                            }
-                          }}
-                        >
-                          <DeleteIcon sx={{
-                            fontSize: `${TABLE_STYLES.row.height * 0.5}px`
-                          }} />
-                        </IconButton>
-                        <IconButton
-                          size="small"
-                          title={`View ${supplier.companyName} details`}
-                          aria-label={`View supplier ${supplier.companyName} details`}
-                          onClick={() => handleViewSupplier(supplier)}
-                          sx={{
-                            height: `${TABLE_STYLES.row.height * 0.75}px`,
-                            width: `${TABLE_STYLES.row.height * 0.75}px`,
-                            minHeight: 20,
-                            minWidth: 20,
-                            p: 0.125,
-                            color: 'info.main',
-                            '&:hover': {
-                              backgroundColor: 'info.light',
-                              color: 'info.dark'
-                            }
-                          }}
-                        >
-                          <ViewIcon sx={{
-                            fontSize: `${TABLE_STYLES.row.height * 0.5}px`
-                          }} />
-                        </IconButton>
-                      </Box>
-                      {isMobile && (
-                        <Box sx={{ mt: 0.25, textAlign: 'right' }}>
-                          <Typography variant={TYPOGRAPHY_STYLES.tableCell.caption.variant} color="text.secondary" sx={{ fontSize: TYPOGRAPHY_STYLES.mobile.caption.fontSize }}>
-                            {supplier.totalOrders} orders • {formatCurrency(supplier.totalPurchases)}
-                          </Typography>
-                        </Box>
-                      )}
+                    <TableCell align="right" sx={{ width: isMobile ? '40%' : '15%' }}>
+                      <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
+                        fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
+                        color: TYPOGRAPHY_STYLES.tableHeader.color,
+                        fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
+                      }}>
+                        Actions
+                      </Typography>
                     </TableCell>
                   </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
+                </TableHead>
+                <TableBody>
+                  {suppliers.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={5} align="center">
+                        <Typography variant="body2" color="text.secondary">
+                          No suppliers found
+                        </Typography>
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    suppliers.map((supplier) => (
+                      <TableRow
+                        key={supplier.id}
+                        hover
+                        tabIndex={0}
+                        sx={{
+                          '&:hover, &:focus-within': {
+                            backgroundColor: 'action.hover',
+                            '& .supplier-actions': {
+                              opacity: 1,
+                            },
+                          },
+                          transition: 'background-color 0.2s ease',
+                          cursor: 'default',
+                          height: TABLE_STYLES.row.height,
+                        }}
+                      >
+                        <TableCell>
+                          <Box>
+                            <Typography variant={TYPOGRAPHY_STYLES.tableCell.primary.variant} sx={{
+                              fontWeight: 400,
+                              fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize,
+                              lineHeight: TYPOGRAPHY_STYLES.tableCell.primary.lineHeight,
+                            }}>
+                              {supplier.companyName}
+                            </Typography>
+                          </Box>
+                          {isMobile && (
+                            <Box sx={{ mt: 0.5, display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+                              <Chip
+                                label={supplier.type === SupplierType.LOCAL ? 'Local' : 'International'}
+                                size="small"
+                                color={supplier.type === SupplierType.LOCAL ? 'primary' : 'secondary'}
+                                sx={{ fontSize: TYPOGRAPHY_STYLES.mobile.caption.fontSize }}
+                              />
+                            </Box>
+                          )}
+                        </TableCell>
+                        {!isMobile && (
+                          <TableCell>
+                            <Chip
+                              label={supplier.type === SupplierType.LOCAL ? 'Local' : 'International'}
+                              size="small"
+                              color={supplier.type === SupplierType.LOCAL ? 'primary' : 'secondary'}
+                              sx={{
+                                fontSize: TYPOGRAPHY_STYLES.chip.small.fontSize,
+                                fontWeight: TYPOGRAPHY_STYLES.chip.small.fontWeight,
+                                height: `${TABLE_STYLES.row.height * 0.65}px`,
+                                '& .MuiChip-label': {
+                                  fontSize: `${Math.max(10, TABLE_STYLES.row.height * 0.35)}px`,
+                                  lineHeight: 1,
+                                },
+                              }}
+                            />
+                          </TableCell>
+                        )}
+                        <TableCell>
+                          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+                            {supplier.contactPerson && (
+                              <Typography variant={TYPOGRAPHY_STYLES.tableCell.primary.variant} sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize }}>
+                                {supplier.contactPerson}
+                              </Typography>
+                            )}
+                            {isMobile && supplier.phone && (
+                              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                                <PhoneIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
+                                <Typography variant={TYPOGRAPHY_STYLES.tableCell.caption.variant} sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.caption.fontSize }}>{supplier.phone}</Typography>
+                              </Box>
+                            )}
+                          </Box>
+                        </TableCell>
+                        {!isMobile && (
+                          <TableCell>
+                            {supplier.phone && (
+                              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                                <PhoneIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
+                                <Typography variant={TYPOGRAPHY_STYLES.tableCell.primary.variant} sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize }}>{supplier.phone}</Typography>
+                              </Box>
+                            )}
+                          </TableCell>
+                        )}
+                        <TableCell align="right">
+                          <Box
+                            className="supplier-actions"
+                            sx={{
+                              display: 'flex',
+                              justifyContent: 'flex-end',
+                              alignItems: 'center',
+                              height: '100%',
+                              gap: 0.25,
+                              opacity: isMobile ? 1 : 0.7,
+                              transition: 'opacity 0.2s ease',
+                            }}
+                          >
+                            <IconButton
+                              size="small"
+                              title={`Edit ${supplier.companyName}`}
+                              aria-label={`Edit supplier ${supplier.companyName}`}
+                              onClick={() => handleOpenForm(supplier)}
+                              sx={{
+                                height: `${TABLE_STYLES.row.height * 0.75}px`,
+                                width: `${TABLE_STYLES.row.height * 0.75}px`,
+                                minHeight: 20,
+                                minWidth: 20,
+                                p: 0.125,
+                                color: 'primary.main',
+                                '&:hover': {
+                                  backgroundColor: 'primary.light',
+                                  color: 'primary.dark',
+                                },
+                              }}
+                            >
+                              <EditIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
+                            </IconButton>
+                            <IconButton
+                              size="small"
+                              title={`Delete ${supplier.companyName}`}
+                              aria-label={`Delete supplier ${supplier.companyName}`}
+                              onClick={() => {
+                                setSelectedSupplier(supplier)
+                                setIsDeleteConfirmOpen(true)
+                              }}
+                              sx={{
+                                height: `${TABLE_STYLES.row.height * 0.75}px`,
+                                width: `${TABLE_STYLES.row.height * 0.75}px`,
+                                minHeight: 20,
+                                minWidth: 20,
+                                p: 0.125,
+                                color: 'error.main',
+                                '&:hover': {
+                                  backgroundColor: 'error.light',
+                                  color: 'error.dark',
+                                },
+                              }}
+                            >
+                              <DeleteIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
+                            </IconButton>
+                            <IconButton
+                              size="small"
+                              title={`View ${supplier.companyName} details`}
+                              aria-label={`View supplier ${supplier.companyName} details`}
+                              onClick={() => handleViewSupplier(supplier)}
+                              sx={{
+                                height: `${TABLE_STYLES.row.height * 0.75}px`,
+                                width: `${TABLE_STYLES.row.height * 0.75}px`,
+                                minHeight: 20,
+                                minWidth: 20,
+                                p: 0.125,
+                                color: 'info.main',
+                                '&:hover': {
+                                  backgroundColor: 'info.light',
+                                  color: 'info.dark',
+                                },
+                              }}
+                            >
+                              <ViewIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
+                            </IconButton>
+                          </Box>
+                          {isMobile && (
+                            <Box sx={{ mt: 0.25, textAlign: 'right' }}>
+                              <Typography variant={TYPOGRAPHY_STYLES.tableCell.caption.variant} color="text.secondary" sx={{ fontSize: TYPOGRAPHY_STYLES.mobile.caption.fontSize }}>
+                                {supplier.totalOrders} orders • {formatCurrency(supplier.totalPurchases)}
+                              </Typography>
+                            </Box>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Box>
+        )}
       </Paper>
       {/* Supplier Form Dialog */}
       <Dialog
@@ -932,9 +892,9 @@ const SuppliersPage: React.FC = () => {
             <Button
               type="submit"
               variant="contained"
-              disabled={loading || isCheckingDuplicate || !!companyNameError}
+              disabled={isMutatingSupplier || isCheckingDuplicate || !!companyNameError}
             >
-              {loading ? <CircularProgress size={20} /> : (selectedSupplier ? 'Update' : 'Create')}
+              {isMutatingSupplier ? <CircularProgress size={20} /> : (selectedSupplier ? 'Update' : 'Create')}
             </Button>
           </DialogActions>
         </form>
@@ -1077,7 +1037,7 @@ const SuppliersPage: React.FC = () => {
         onConfirm={handleDelete}
         onCancel={() => setIsDeleteConfirmOpen(false)}
         severity="warning"
-        loading={loading}
+        loading={isMutatingSupplier}
       />
       {/* Deleted Suppliers Dialog */}
       <DeletedSuppliersDialog

--- a/frontend/src/pages/purchasing/__tests__/SuppliersPage.filterbar.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/SuppliersPage.filterbar.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import SuppliersPage from '../SuppliersPage'
+import purchasingReducer from '@/store/slices/purchasingSlice'
+
+const { useGetSuppliersQuery } = vi.hoisted(() => ({
+  useGetSuppliersQuery: vi.fn(() => ({
+    data: { data: [], meta: { total: 0 } },
+    isLoading: false,
+    isFetching: false,
+    refetch: vi.fn(),
+  })),
+}))
+
+vi.mock('@/store/api/purchasingApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store/api/purchasingApi')>()
+  return {
+    ...actual,
+    useGetSuppliersQuery,
+    useCreateSupplierMutation: vi.fn(() => [vi.fn(), {}]),
+    useDeleteSupplierMutation: vi.fn(() => [vi.fn(), {}]),
+    useUpdateSupplierMutation: vi.fn(() => [vi.fn(), {}]),
+    useLazyCheckDuplicateCompanyNameQuery: vi.fn(() => [vi.fn(), {}]),
+  }
+})
+
+vi.mock('@/hooks/useNotification', () => ({
+  useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
+}))
+
+vi.mock('@/components/purchasing/DeletedSuppliersDialog', () => ({
+  default: () => <div>DeletedSuppliersDialog</div>,
+}))
+
+function renderPage(initialUrl = '/') {
+  const store = configureStore({ reducer: { purchasing: purchasingReducer } })
+
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <SuppliersPage />
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('SuppliersPage FilterBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the search input', () => {
+    renderPage()
+    expect(screen.getByPlaceholderText(/search by company name/i)).toBeInTheDocument()
+  })
+
+  it('restores filters from URL and passes them to query', () => {
+    renderPage('/?search=acme&status=inactive&type=international')
+    expect(useGetSuppliersQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ search: 'acme', isActive: false, type: 'international' }),
+    )
+  })
+
+  it('passes no isActive when status is unset', () => {
+    renderPage('/')
+    expect(useGetSuppliersQuery).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ isActive: expect.anything() }),
+    )
+  })
+})

--- a/frontend/src/pages/sales/CustomersPage.tsx
+++ b/frontend/src/pages/sales/CustomersPage.tsx
@@ -32,7 +32,6 @@ import {
   Stack,
 } from '@mui/material'
 import {
-  Search as SearchIcon,
   Edit as EditIcon,
   Delete as DeleteIcon,
   Visibility as ViewIcon,
@@ -45,8 +44,11 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { useForm, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
+import { ListSkeleton } from '@/components/common/ListSkeleton'
+import { FilterBar, useFilterBar } from '@/components/filters'
+import type { FilterBarConfig } from '@/components/filters'
 import { useNotification } from '@/hooks/useNotification'
-import { useSearchAndFilter, useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
+import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
 import {
   useCreateCustomerMutation,
   useDeleteCustomerMutation,
@@ -92,9 +94,12 @@ interface CustomerFormData {
 }
 
 interface CustomerFilters {
-  search?: string
-  type?: CustomerType
-  priceListId?: string
+  search: string
+  status: 'active' | 'inactive' | null
+  type: 'individual' | 'business' | null
+}
+
+interface CustomerSortState {
   sortBy?: string
   sortOrder?: 'ASC' | 'DESC'
 }
@@ -105,10 +110,10 @@ const CustomersPage: React.FC = () => {
   const location = useLocation()
   const navigate = useNavigate()
   const { showSuccess, showError } = useNotification()
+  const searchInputRef = useRef<HTMLInputElement | null>(null)
 
   // Local state
-  const [filters, setFilters] = useState<CustomerFilters>({
-    search: '',
+  const [sortState, setSortState] = useState<CustomerSortState>({
     sortBy: 'name',
     sortOrder: 'ASC',
   })
@@ -120,16 +125,62 @@ const CustomersPage: React.FC = () => {
   const [isCheckingPhone, setIsCheckingPhone] = useState(false)
   const [phoneError, setPhoneError] = useState<string | null>(null)
   const [pageError, setPageError] = useState<string | null>(null)
-  const queryFilters = useMemo(
-    () => Object.fromEntries(Object.entries(filters).filter(([, value]) => value !== '' && value !== undefined)),
-    [filters],
+
+  const filterConfig = useMemo<FilterBarConfig<CustomerFilters>>(
+    () => ({
+      search: { placeholder: 'Search by name or phone...' },
+      quick: [
+        {
+          field: 'status',
+          label: 'Status',
+          type: 'select',
+          options: [
+            { value: 'active', label: 'Active' },
+            { value: 'inactive', label: 'Inactive' },
+          ],
+        },
+      ],
+      advanced: [
+        {
+          field: 'type',
+          label: 'Type',
+          type: 'select',
+          options: [
+            { value: 'individual', label: 'Individual' },
+            { value: 'business', label: 'Business' },
+          ],
+        },
+      ],
+      defaults: { search: '', status: null, type: null },
+    }),
+    [],
   )
-  const { data, isLoading, error, refetch } = useGetCustomersQuery({ ...queryFilters, limit: 999999 })
+
+  const { appliedFilters, draftFilters, handlers, activeChips, hasActiveFilters, hasUnappliedChanges } = useFilterBar(filterConfig)
+
+  const customerQueryParams = useMemo(
+    () => ({
+      search: appliedFilters.search || undefined,
+      isActive:
+        appliedFilters.status === 'active'
+          ? true
+          : appliedFilters.status === 'inactive'
+            ? false
+            : undefined,
+      type: appliedFilters.type ?? undefined,
+      sortBy: sortState.sortBy,
+      sortOrder: sortState.sortOrder,
+      limit: 999999,
+    }),
+    [appliedFilters, sortState],
+  )
+
+  const { data: customersResponse, isLoading, isFetching, error, refetch } = useGetCustomersQuery(customerQueryParams)
   const [createCustomer] = useCreateCustomerMutation()
   const [updateCustomer] = useUpdateCustomerMutation()
   const [deleteCustomer] = useDeleteCustomerMutation()
-  const customers = data?.data ?? []
-  const loading = isLoading
+  const customers = customersResponse?.data ?? []
+  const loading = isLoading || isFetching
 
   // Form setup
   const { control, handleSubmit, reset, formState: { errors }, setValue } = useForm<CustomerFormData>({
@@ -148,23 +199,12 @@ const CustomersPage: React.FC = () => {
     }
   })
 
-  // Search and filter functionality
-  const searchHookInitialized = useRef(false)
-  const { searchTerm, setSearchTerm, focusSearchInput } = useSearchAndFilter({
-    initialSearchTerm: filters.search || '',
-    onSearchChange: (searchTerm) => {
-      // Prevent initial trigger from hook
-      if (!searchHookInitialized.current) {
-        searchHookInitialized.current = true
-        return
-      }
-      setFilters((prev) => ({ ...prev, search: searchTerm }))
-    },
-  })
-
   // Keyboard shortcuts - only search
   useKeyboardShortcuts({
-    onSearch: focusSearchInput,
+    onSearch: () => {
+      searchInputRef.current?.focus()
+      searchInputRef.current?.select()
+    },
   })
 
   // Phone duplicate validation
@@ -379,10 +419,10 @@ const CustomersPage: React.FC = () => {
   }
 
   const handleSort = (sortBy: string) => {
-    setFilters((prev) => ({
+    setSortState((prev) => ({
       ...prev,
       sortBy,
-      sortOrder: filters.sortBy === sortBy && filters.sortOrder === 'ASC' ? 'DESC' : 'ASC',
+      sortOrder: prev.sortBy === sortBy && prev.sortOrder === 'ASC' ? 'DESC' : 'ASC',
     }))
   }
 
@@ -396,102 +436,15 @@ const CustomersPage: React.FC = () => {
       />
       {/* Filters and Search */}
       <Paper sx={{ p: 2, mb: 3 }}>
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        gap: isMobile ? 2 : 1,
-        alignItems: isMobile ? 'stretch' : 'center',
-        '& > *': {
-          alignSelf: isMobile ? 'stretch' : 'flex-start'
-        }
-      }}>
-        <TextField
-          placeholder="Search customers..."
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          size="medium"
-          sx={{ 
-            minWidth: isMobile ? 'auto' : 250,
-            flex: isMobile ? 'none' : 1,
-            maxWidth: isMobile ? 'none' : 400,
-            '& .MuiOutlinedInput-root': {
-              height: TYPOGRAPHY_STYLES.searchField.input.height,
-              fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
-              '& input': {
-                padding: TYPOGRAPHY_STYLES.searchField.input.padding,
-                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize
-              }
-            },
-            '& .MuiInputAdornment-root': {
-              '& .MuiSvgIcon-root': {
-                fontSize: TYPOGRAPHY_STYLES.searchField.icon.fontSize,
-                color: TYPOGRAPHY_STYLES.searchField.icon.color
-              }
-            }
-          }}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon fontSize="small" />
-              </InputAdornment>
-            ),
-          }}
+        <FilterBar
+          config={filterConfig}
+          draftFilters={draftFilters}
+          handlers={handlers}
+          activeChips={activeChips}
+          hasActiveFilters={hasActiveFilters}
+          hasUnappliedChanges={hasUnappliedChanges}
+          searchInputRef={searchInputRef}
         />
-        <FormControl 
-          size="medium" 
-          sx={{ 
-            minWidth: isMobile ? 'auto' : 120,
-            flex: 'none'
-          }}
-        >
-          <InputLabel 
-            sx={{ 
-              fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
-              '&.MuiInputLabel-shrunk': {
-                fontSize: TYPOGRAPHY_STYLES.tableCell.caption.fontSize
-              }
-            }}
-          >
-            Type
-          </InputLabel>
-          <Select
-            value={filters.type || 'all'}
-            label="Type"
-            onChange={(e) =>
-              setFilters((prev) => ({
-                ...prev,
-                type: e.target.value === 'all' ? undefined : (e.target.value as CustomerType),
-              }))
-            }
-            sx={{
-              height: TYPOGRAPHY_STYLES.searchField.input.height,
-              fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
-              '& .MuiSelect-select': {
-                display: 'flex',
-                alignItems: 'center',
-                fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize,
-                padding: '8.5px 14px',
-                height: TYPOGRAPHY_STYLES.searchField.input.height,
-                boxSizing: 'border-box'
-              },
-              '& .MuiOutlinedInput-notchedOutline': {
-                borderColor: 'rgba(0, 0, 0, 0.23)'
-              },
-              '&:hover .MuiOutlinedInput-notchedOutline': {
-                borderColor: 'rgba(0, 0, 0, 0.87)'
-              },
-              '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-                borderColor: theme.palette.primary.main,
-                borderWidth: 2
-              }
-            }}
-          >
-            <MenuItem value="all" sx={{ fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize }}>All</MenuItem>
-            <MenuItem value={CustomerType.INDIVIDUAL} sx={{ fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize }}>Individual</MenuItem>
-            <MenuItem value={CustomerType.BUSINESS} sx={{ fontSize: TYPOGRAPHY_STYLES.searchField.input.fontSize }}>Business</MenuItem>
-          </Select>
-        </FormControl>
-      </Box>
       </Paper>
       {/* Error Alert */}
       {(pageError || error) && (
@@ -501,132 +454,133 @@ const CustomersPage: React.FC = () => {
       )}
       {/* Customer Table */}
       <Paper sx={{ borderRadius: 2, overflow: 'hidden' }}>
-        <TableContainer sx={{ overflowX: 'auto' }}>
-          <Table
-            size={TABLE_STYLES.size}
-            sx={{
-              minWidth: isMobile ? 650 : 800,
-              '& .MuiTableCell-root': {
-                borderBottom: TABLE_STYLES.cell.border,
-                py: TABLE_STYLES.cell.padding.py,
-                px: TABLE_STYLES.cell.padding.px
-              }
-            }}
-          >
-            <TableHead>
-              <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50', py: 1 } }}>
-                <TableCell sx={{ width: isMobile ? '35%' : '30%' }}>
-                  <TableSortLabel
-                    active={filters.sortBy === 'name'}
-                    direction={filters.sortBy === 'name' ? (filters.sortOrder?.toLowerCase() as 'asc' | 'desc') : 'asc'}
-                    onClick={() => handleSort('name')}
-                    sx={{
-                      fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                      color: TYPOGRAPHY_STYLES.tableHeader.color,
-                      fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
-                    }}
-                  >
-                    Name
-                  </TableSortLabel>
-                </TableCell>
-                {!isMobile && (
-                  <TableCell sx={{ width: '10%' }}>
-                    <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
-                    fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                    color: TYPOGRAPHY_STYLES.tableHeader.color,
-                    fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
-                  }}>
-                      Type
-                    </Typography>
-                  </TableCell>
-                )}
-                <TableCell sx={{ width: isMobile ? '25%' : '15%' }}>
-                  <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
-                    fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                    color: TYPOGRAPHY_STYLES.tableHeader.color,
-                    fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
-                  }}>
-                    Contact
-                  </Typography>
-                </TableCell>
-                {!isMobile && (
-                  <TableCell sx={{ width: '12%' }}>
-                    <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
-                    fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                    color: TYPOGRAPHY_STYLES.tableHeader.color,
-                    fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
-                  }}>
-                      Price Level
-                    </Typography>
-                  </TableCell>
-                )}
-                {!isMobile && (
-                  <TableCell sx={{ width: '8%' }}>
-                    <TableSortLabel
-                      active={filters.sortBy === 'totalOrders'}
-                      direction={filters.sortBy === 'totalOrders' ? (filters.sortOrder?.toLowerCase() as 'asc' | 'desc') : 'asc'}
-                      onClick={() => handleSort('totalOrders')}
-                      sx={{
+        {(isLoading || (isFetching && !customersResponse)) ? (
+          <ListSkeleton rows={8} columns={4} />
+        ) : (
+          <Box sx={{ opacity: isFetching ? 0.6 : 1, position: 'relative' }}>
+            {isFetching && (
+              <CircularProgress size={16} sx={{ position: 'absolute', top: 8, right: 8, zIndex: 1 }} />
+            )}
+            <TableContainer sx={{ overflowX: 'auto' }}>
+              <Table
+                size={TABLE_STYLES.size}
+                sx={{
+                  minWidth: isMobile ? 650 : 800,
+                  '& .MuiTableCell-root': {
+                    borderBottom: TABLE_STYLES.cell.border,
+                    py: TABLE_STYLES.cell.padding.py,
+                    px: TABLE_STYLES.cell.padding.px,
+                  },
+                }}
+              >
+                <TableHead>
+                  <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50', py: 1 } }}>
+                    <TableCell sx={{ width: isMobile ? '35%' : '30%' }}>
+                      <TableSortLabel
+                        active={sortState.sortBy === 'name'}
+                        direction={sortState.sortBy === 'name' ? (sortState.sortOrder?.toLowerCase() as 'asc' | 'desc') : 'asc'}
+                        onClick={() => handleSort('name')}
+                        sx={{
+                          fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
+                          color: TYPOGRAPHY_STYLES.tableHeader.color,
+                          fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
+                        }}
+                      >
+                        Name
+                      </TableSortLabel>
+                    </TableCell>
+                    {!isMobile && (
+                      <TableCell sx={{ width: '10%' }}>
+                        <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
+                          fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
+                          color: TYPOGRAPHY_STYLES.tableHeader.color,
+                          fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
+                        }}>
+                          Type
+                        </Typography>
+                      </TableCell>
+                    )}
+                    <TableCell sx={{ width: isMobile ? '25%' : '15%' }}>
+                      <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
                         fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
                         color: TYPOGRAPHY_STYLES.tableHeader.color,
-                        fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
-                      }}
-                    >
-                      Total Orders
-                    </TableSortLabel>
-                  </TableCell>
-                )}
-                {!isMobile && (
-                  <TableCell sx={{ width: '10%' }}>
-                    <TableSortLabel
-                      active={filters.sortBy === 'totalSales'}
-                      direction={filters.sortBy === 'totalSales' ? (filters.sortOrder?.toLowerCase() as 'asc' | 'desc') : 'asc'}
-                      onClick={() => handleSort('totalSales')}
-                      sx={{
+                        fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
+                      }}>
+                        Contact
+                      </Typography>
+                    </TableCell>
+                    {!isMobile && (
+                      <TableCell sx={{ width: '12%' }}>
+                        <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
+                          fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
+                          color: TYPOGRAPHY_STYLES.tableHeader.color,
+                          fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
+                        }}>
+                          Price Level
+                        </Typography>
+                      </TableCell>
+                    )}
+                    {!isMobile && (
+                      <TableCell sx={{ width: '8%' }}>
+                        <TableSortLabel
+                          active={sortState.sortBy === 'totalOrders'}
+                          direction={sortState.sortBy === 'totalOrders' ? (sortState.sortOrder?.toLowerCase() as 'asc' | 'desc') : 'asc'}
+                          onClick={() => handleSort('totalOrders')}
+                          sx={{
+                            fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
+                            color: TYPOGRAPHY_STYLES.tableHeader.color,
+                            fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
+                          }}
+                        >
+                          Total Orders
+                        </TableSortLabel>
+                      </TableCell>
+                    )}
+                    {!isMobile && (
+                      <TableCell sx={{ width: '10%' }}>
+                        <TableSortLabel
+                          active={sortState.sortBy === 'totalSales'}
+                          direction={sortState.sortBy === 'totalSales' ? (sortState.sortOrder?.toLowerCase() as 'asc' | 'desc') : 'asc'}
+                          onClick={() => handleSort('totalSales')}
+                          sx={{
+                            fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
+                            color: TYPOGRAPHY_STYLES.tableHeader.color,
+                            fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
+                          }}
+                        >
+                          Total Sales
+                        </TableSortLabel>
+                      </TableCell>
+                    )}
+                    {!isMobile && (
+                      <TableCell sx={{ width: '10%' }}>
+                        <TableSortLabel
+                          active={sortState.sortBy === 'lastPurchaseDate'}
+                          direction={sortState.sortBy === 'lastPurchaseDate' ? (sortState.sortOrder?.toLowerCase() as 'asc' | 'desc') : 'asc'}
+                          onClick={() => handleSort('lastPurchaseDate')}
+                          sx={{
+                            fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
+                            color: TYPOGRAPHY_STYLES.tableHeader.color,
+                            fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
+                          }}
+                        >
+                          Last Purchase
+                        </TableSortLabel>
+                      </TableCell>
+                    )}
+                    <TableCell align="right" sx={{ width: isMobile ? '40%' : '15%' }}>
+                      <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
                         fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
                         color: TYPOGRAPHY_STYLES.tableHeader.color,
-                        fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
-                      }}
-                    >
-                      Total Sales
-                    </TableSortLabel>
-                  </TableCell>
-                )}
-                {!isMobile && (
-                  <TableCell sx={{ width: '10%' }}>
-                    <TableSortLabel
-                      active={filters.sortBy === 'lastPurchaseDate'}
-                      direction={filters.sortBy === 'lastPurchaseDate' ? (filters.sortOrder?.toLowerCase() as 'asc' | 'desc') : 'asc'}
-                      onClick={() => handleSort('lastPurchaseDate')}
-                      sx={{
-                        fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                        color: TYPOGRAPHY_STYLES.tableHeader.color,
-                        fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
-                      }}
-                    >
-                      Last Purchase
-                    </TableSortLabel>
-                  </TableCell>
-                )}
-                <TableCell align="right" sx={{ width: isMobile ? '40%' : '15%' }}>
-                  <Typography variant={TYPOGRAPHY_STYLES.tableHeader.variant} sx={{
-                    fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                    color: TYPOGRAPHY_STYLES.tableHeader.color,
-                    fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
-                  }}>
-                    Actions
-                  </Typography>
-                </TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {loading ? (
-                <TableRow>
-                  <TableCell colSpan={8} align="center">
-                    <CircularProgress />
-                  </TableCell>
-                </TableRow>
-              ) : customers.length === 0 ? (
+                        fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
+                      }}>
+                        Actions
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {customers.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={8} align="center">
                     <Typography variant="body2" color="text.secondary">
@@ -853,10 +807,12 @@ const CustomersPage: React.FC = () => {
                     </TableCell>
                   </TableRow>
                 ))
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
+                  )}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Box>
+        )}
       </Paper>
       {/* Customer Form Dialog */}
       <Dialog 

--- a/frontend/src/pages/sales/PaymentsPage.tsx
+++ b/frontend/src/pages/sales/PaymentsPage.tsx
@@ -14,13 +14,12 @@ import {
   Chip,
   IconButton,
   TextField,
-  InputAdornment,
   FormControl,
   InputLabel,
   Select,
   MenuItem,
-  Skeleton,
   Alert,
+  CircularProgress,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -28,11 +27,11 @@ import {
   Grid,
   Divider,
   Link,
+  Stack,
   useTheme,
   useMediaQuery,
 } from '@mui/material'
 import {
-  Search as SearchIcon,
   Edit as EditIcon,
   Delete as DeleteIcon,
   Sort as SortIcon,
@@ -44,14 +43,16 @@ import {
 } from '@mui/icons-material'
 import { formatCurrency, formatDate, formatWholeQuantity } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
+import { ListSkeleton } from '@/components/common/ListSkeleton'
+import { FilterBar, useFilterBar } from '@/components/filters'
+import type { DateRangeValue, FilterBarConfig } from '@/components/filters'
 import DeletedPaymentsDialog from '@/components/sales/DeletedPaymentsDialog'
 import PageHeader from '@/components/common/PageHeader'
 import { PaymentReceiptPrint } from '@/components/print'
-import { useSearchAndFilter, useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
-import { useNotification } from '@/hooks/useNotification'
+import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
 import { useLazyGetJournalEntriesQuery } from '@/store/api/accountingApi'
 import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
-import { useGetPaymentsQuery } from '@/store/api/salesApi'
+import { useGetCustomersQuery, useGetPaymentsQuery } from '@/store/api/salesApi'
 import { setSelectedPayment, selectSelectedPayment } from '@/store/slices/salesSlice'
 import type { InvoiceItem } from '@/types'
 
@@ -95,12 +96,13 @@ interface Payment {
 
 interface PaymentFilters {
   search: string
+  dateRange: DateRangeValue
+  customerId: string | null
+}
+
+interface PaymentSortState {
   sortBy: string
   sortOrder: 'asc' | 'desc'
-  dateFilter: string
-  customFromDate: string
-  customToDate: string
-  customerId: string
 }
 
 
@@ -168,20 +170,13 @@ const PaymentsPage: React.FC = () => {
   const isMobile = useMediaQuery(theme.breakpoints.down('md'))
   const navigate = useNavigate()
   const location = useLocation()
-  const { showSuccess, showError } = useNotification()
   const dispatch = useAppDispatch()
   const selectedPayment = useAppSelector(selectSelectedPayment) as Payment | null
 
-  const [filters, setFilters] = useState<PaymentFilters>({
-    search: '',
+  const [sortState, setSortState] = useState<PaymentSortState>({
     sortBy: 'paymentNumber',
     sortOrder: 'asc',
-    dateFilter: 'all',
-    customFromDate: '',
-    customToDate: '',
-    customerId: 'all'
   })
-
   const [pendingPaymentToSelect, setPendingPaymentToSelect] = useState<string | null>(() => {
     const id = new URLSearchParams(window.location.search).get('highlight')
     return id
@@ -189,15 +184,91 @@ const PaymentsPage: React.FC = () => {
   const [editDialog, setEditDialog] = useState(false)
   const [focusedPaymentIndex, setFocusedPaymentIndex] = useState(-1)
   const [deletedPaymentsDialogOpen, setDeletedPaymentsDialogOpen] = useState(false)
-  const [shouldPreserveSearchFocus, setShouldPreserveSearchFocus] = useState(false)
   const [printDialogOpen, setPrintDialogOpen] = useState(false)
   const [fetchJournalEntries] = useLazyGetJournalEntriesQuery()
   const [journalEntryRef, setJournalEntryRef] = useState<{ referenceNumber: string; id: string } | null>(null)
-  const searchInputRef = useRef<HTMLInputElement>(null)
+  const searchInputRef = useRef<HTMLInputElement | null>(null)
   const paymentListRef = useRef<HTMLDivElement>(null)
   const hasRestoredSelection = useRef(false)
   const selectedPaymentRef = useRef(selectedPayment)
   const previousPathnameRef = useRef(location.pathname)
+  const { data: customersData } = useGetCustomersQuery({ limit: 999999 })
+  const customers = customersData?.data ?? []
+  const presetCustomerId = (location.state as { customerId?: string } | null)?.customerId ?? null
+
+  const filterConfig = useMemo<FilterBarConfig<PaymentFilters>>(
+    () => ({
+      search: { placeholder: 'Search by payment number or customer...' },
+      quick: [
+        {
+          field: 'dateRange',
+          label: 'Date',
+          type: 'date-range',
+          paramKey: 'paymentDate',
+        },
+      ],
+      advanced: [
+        {
+          field: 'customerId',
+          label: 'Customer',
+          type: 'select',
+          options: customers.map((customer) => ({ value: customer.id, label: customer.name })),
+          chipFormatter: (value) => {
+            if (!value) return null as unknown as string
+            const customer = customers.find((entry) => entry.id === value)
+            return `Customer: ${customer?.name ?? value}`
+          },
+        },
+      ],
+      defaults: { search: '', dateRange: { from: null, to: null }, customerId: null },
+    }),
+    [customers],
+  )
+
+  // Inject preset customer into the URL before useFilterBar captures mount search.
+  useMemo(() => {
+    if (presetCustomerId) {
+      const params = new URLSearchParams(window.location.search)
+      if (!params.get('customerId')) {
+        params.set('customerId', presetCustomerId)
+        window.history.replaceState(null, '', `${location.pathname}?${params.toString()}`)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const { appliedFilters, draftFilters, handlers, activeChips, hasUnappliedChanges } = useFilterBar(filterConfig)
+
+  const visibleActiveChips = useMemo(
+    () => (presetCustomerId ? activeChips.filter((chip) => chip.field !== 'customerId') : activeChips),
+    [activeChips, presetCustomerId],
+  )
+  const hasVisibleActiveFilters = visibleActiveChips.length > 0
+  const filterBarHandlers = useMemo(
+    () => (
+      presetCustomerId
+        ? {
+            ...handlers,
+            onClearAll: () => {
+              handlers.onClearField('search')
+              handlers.onClearField('dateRange')
+            },
+          }
+        : handlers
+    ),
+    [handlers, presetCustomerId],
+  )
+  const paymentQueryArgs = useMemo(
+    () => ({
+      sortBy: sortState.sortBy,
+      sortOrder: sortState.sortOrder,
+      search: appliedFilters.search || undefined,
+      fromDate: appliedFilters.dateRange.from ?? undefined,
+      toDate: appliedFilters.dateRange.to ?? undefined,
+      customerId: appliedFilters.customerId ?? undefined,
+    }),
+    [appliedFilters, sortState],
+  )
 
   // Keep ref in sync with selectedPayment
   useEffect(() => {
@@ -219,88 +290,8 @@ const PaymentsPage: React.FC = () => {
       .catch(() => setJournalEntryRef(null))
   }, [selectedPayment?.id, fetchJournalEntries])
 
-  // Memoize search change callback to prevent unnecessary re-renders
-  const onSearchChange = useCallback((searchTerm: string) => {
-    setFilters((prev: PaymentFilters) => ({ ...prev, search: searchTerm }))
-  }, [])
-
-  // Search and filter functionality
-  const { searchTerm, setSearchTerm: originalSetSearchTerm, focusSearchInput } = useSearchAndFilter({
-    initialSearchTerm: filters.search,
-    onSearchChange,
-    searchInputRef,
-  })
-
-  // Enhanced search term setter that preserves focus
-  const setSearchTerm = useCallback((value: string) => {
-    setShouldPreserveSearchFocus(true)
-    originalSetSearchTerm(value)
-  }, [originalSetSearchTerm])
-
-  // Effect to restore search input focus when needed
-  useEffect(() => {
-    if (shouldPreserveSearchFocus && searchInputRef.current && document.activeElement !== searchInputRef.current) {
-      const timer = setTimeout(() => {
-        searchInputRef.current?.focus()
-        setShouldPreserveSearchFocus(false)
-      }, 0)
-      return () => clearTimeout(timer)
-    } else if (shouldPreserveSearchFocus) {
-      setShouldPreserveSearchFocus(false)
-    }
-  }, [shouldPreserveSearchFocus])
-
-  // Helper function to calculate date ranges
-  const getDateRange = useCallback((filter: string) => {
-    const today = new Date()
-    const yesterday = new Date(today)
-    yesterday.setDate(yesterday.getDate() - 1)
-
-    const startOfWeek = new Date(today)
-    startOfWeek.setDate(today.getDate() - today.getDay())
-
-    const startOfMonth = new Date(today.getFullYear(), today.getMonth(), 1)
-    const startOfYear = new Date(today.getFullYear(), 0, 1)
-
-    const formatDate = (date: Date) => date.toISOString().split('T')[0]
-
-    switch (filter) {
-      case 'today':
-        return { fromDate: formatDate(today), toDate: formatDate(today) }
-      case 'yesterday':
-        return { fromDate: formatDate(yesterday), toDate: formatDate(yesterday) }
-      case 'this_week':
-        return { fromDate: formatDate(startOfWeek), toDate: formatDate(today) }
-      case 'this_month':
-        return { fromDate: formatDate(startOfMonth), toDate: formatDate(today) }
-      case 'this_year':
-        return { fromDate: formatDate(startOfYear), toDate: formatDate(today) }
-      case 'custom':
-        return { fromDate: filters.customFromDate, toDate: filters.customToDate }
-      default: // 'all'
-        return { fromDate: undefined, toDate: undefined }
-    }
-  }, [filters.customFromDate, filters.customToDate])
-  const dateRange = useMemo(() => getDateRange(filters.dateFilter), [filters.dateFilter, getDateRange])
-  const queryArgs = useMemo(
-    () => ({
-      sortBy: filters.sortBy,
-      sortOrder: filters.sortOrder,
-      search: filters.search || undefined,
-      customerId: filters.customerId === 'all' ? undefined : filters.customerId,
-      fromDate: dateRange.fromDate,
-      toDate: dateRange.toDate,
-    }),
-    [
-      dateRange.fromDate,
-      dateRange.toDate,
-      filters.customerId,
-      filters.search,
-      filters.sortBy,
-      filters.sortOrder,
-    ],
-  )
-  const { data, isLoading: loading, error, refetch } = useGetPaymentsQuery(queryArgs)
+  const { data, isLoading, isFetching, error, refetch } = useGetPaymentsQuery(paymentQueryArgs)
+  const loading = isLoading || isFetching
   const payments = data?.data ?? []
   const totalPayments = data?.meta.total ?? 0
 
@@ -310,13 +301,13 @@ const PaymentsPage: React.FC = () => {
   const paginatedPayments = payments
 
   const handleSort = useCallback((field: string) => {
-    const newSortOrder = filters.sortBy === field && filters.sortOrder === 'desc' ? 'asc' : 'desc'
-    setFilters((prev: PaymentFilters) => ({
+    const newSortOrder = sortState.sortBy === field && sortState.sortOrder === 'desc' ? 'asc' : 'desc'
+    setSortState((prev: PaymentSortState) => ({
       ...prev,
       sortBy: field,
-      sortOrder: newSortOrder
+      sortOrder: newSortOrder,
     }))
-  }, [filters.sortBy, filters.sortOrder])
+  }, [sortState.sortBy, sortState.sortOrder])
 
   const handlePaymentSelect = useCallback((payment: Payment) => {
     dispatch(setSelectedPayment(payment as any))
@@ -500,7 +491,10 @@ const PaymentsPage: React.FC = () => {
 
   // Setup keyboard shortcuts - only navigation and search
   useKeyboardShortcuts({
-    onSearch: focusSearchInput,
+    onSearch: () => {
+      searchInputRef.current?.focus()
+      searchInputRef.current?.select()
+    },
     onArrowUp: handleNavigateUp,
     onArrowDown: handleNavigateDown,
     onEnter: handleEnterAction,
@@ -535,179 +529,44 @@ const PaymentsPage: React.FC = () => {
       />
       {/* Filters and Search */}
       <Paper sx={{ p: 2, mb: 3 }}>
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        gap: isMobile ? 2 : 1,
-        alignItems: isMobile ? 'stretch' : 'center',
-        '& > *': {
-          alignSelf: isMobile ? 'stretch' : 'flex-start'
-        }
-      }}>
-        <TextField
-          inputRef={searchInputRef}
-          placeholder="Search payments..."
-          value={searchTerm}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)}
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 250,
-            flex: isMobile ? 'none' : 1,
-            maxWidth: isMobile ? 'none' : 400,
-            '& .MuiOutlinedInput-root': {
-              height: TYPOGRAPHY_STYLES.searchField.input.height,
-              fontSize: '0.875rem',
-              '& input': {
-                padding: '8.5px 14px',
-                fontSize: '0.875rem'
-              }
-            }
-          }}
-          slotProps={{
-            input: {
-              startAdornment: (
-                <InputAdornment position="start">
-                  <SearchIcon sx={{ fontSize: TYPOGRAPHY_STYLES.searchField.icon.fontSize }} />
-                </InputAdornment>
-              ),
-            }
-          }}
-        />
-
-        <FormControl
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 120,
-            '& .MuiOutlinedInput-root': {
-              height: TYPOGRAPHY_STYLES.searchField.input.height,
-              fontSize: '0.875rem'
-            }
-          }}
-        >
-          <InputLabel>Date Filter</InputLabel>
-          <Select
-            value={filters.dateFilter}
-            label="Date Filter"
-            onChange={(e) => {
-              setFilters((prev: PaymentFilters) => ({ ...prev, dateFilter: e.target.value }))
-            }}
-            sx={{
-              fontSize: '0.875rem',
-              '& .MuiSelect-select': {
-                padding: '8.5px 14px',
-                fontSize: '0.875rem'
-              }
-            }}
-            MenuProps={{
-              PaperProps: {
-                sx: {
-                  '& .MuiMenuItem-root': {
-                    fontSize: '0.875rem'
-                  }
-                }
-              }
-            }}
-          >
-            <MenuItem value="all">All</MenuItem>
-            <MenuItem value="today">Today</MenuItem>
-            <MenuItem value="yesterday">Yesterday</MenuItem>
-            <MenuItem value="this_week">This Week</MenuItem>
-            <MenuItem value="this_month">This Month</MenuItem>
-            <MenuItem value="this_year">This Year</MenuItem>
-            <Divider />
-            <MenuItem value="custom">Custom Date Range</MenuItem>
-          </Select>
-        </FormControl>
-
-        {filters.dateFilter === 'custom' && (
-          <>
-            <TextField
-              label="From Date"
-              type="date"
-              value={filters.customFromDate}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                setFilters((prev: PaymentFilters) => ({ ...prev, customFromDate: e.target.value }))
-              }}
-              size="medium"
-              sx={{
-                minWidth: 120,
-                '& .MuiOutlinedInput-root': {
-                  height: TYPOGRAPHY_STYLES.searchField.input.height,
-                  fontSize: '0.875rem'
-                }
-              }}
-              slotProps={{
-                inputLabel: {
-                  shrink: true,
-                }
-              }}
+        <Stack direction={isMobile ? 'column' : 'row'} spacing={1} alignItems={isMobile ? 'stretch' : 'flex-start'}>
+          <Box sx={{ flex: 1 }}>
+            <FilterBar
+              config={filterConfig}
+              draftFilters={draftFilters}
+              handlers={filterBarHandlers}
+              activeChips={visibleActiveChips}
+              hasActiveFilters={hasVisibleActiveFilters}
+              hasUnappliedChanges={hasUnappliedChanges}
+              searchInputRef={searchInputRef}
             />
-            <TextField
-              label="To Date"
-              type="date"
-              value={filters.customToDate}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                setFilters((prev: PaymentFilters) => ({ ...prev, customToDate: e.target.value }))
-              }}
-              size="medium"
-              sx={{
-                minWidth: 120,
-                '& .MuiOutlinedInput-root': {
-                  height: TYPOGRAPHY_STYLES.searchField.input.height,
-                  fontSize: '0.875rem'
-                }
-              }}
-              slotProps={{
-                inputLabel: {
-                  shrink: true,
-                }
-              }}
-            />
-          </>
-        )}
 
-        
-        {(filters.dateFilter !== 'all' || filters.search) && (
+            {presetCustomerId ? (
+              <Stack direction="row" sx={{ mt: '7px' }}>
+                <Chip
+                  label={`Customer: ${customers.find((customer) => customer.id === presetCustomerId)?.name ?? presetCustomerId}`}
+                  size="small"
+                  variant="filled"
+                />
+              </Stack>
+            ) : null}
+          </Box>
+
           <Button
-            variant="outlined"
+            variant={sortState.sortBy === 'paymentNumber' ? 'contained' : 'outlined'}
             size="medium"
-            onClick={() => {
-              setFilters({
-                search: '',
-                sortBy: 'paymentNumber',
-                sortOrder: 'asc',
-                dateFilter: 'all',
-                customFromDate: '',
-                customToDate: '',
-                customerId: 'all'
-              })
-            }}
+            startIcon={sortState.sortBy === 'paymentNumber' ? (sortState.sortOrder === 'desc' ? <ArrowDownIcon /> : <ArrowUpIcon />) : <SortIcon />}
+            onClick={() => handleSort('paymentNumber')}
             sx={{
+              height: TYPOGRAPHY_STYLES.searchField.input.height,
+              fontSize: '0.875rem',
               minWidth: 'auto',
               px: 2,
-              height: TYPOGRAPHY_STYLES.searchField.input.height,
-              fontSize: '0.875rem'
             }}
           >
-            Clear Filters
+            Sort
           </Button>
-        )}
-
-        <Button
-          variant={filters.sortBy === 'paymentNumber' ? 'contained' : 'outlined'}
-          size="medium"
-          startIcon={filters.sortBy === 'paymentNumber' ? (filters.sortOrder === 'desc' ? <ArrowDownIcon /> : <ArrowUpIcon />) : <SortIcon />}
-          onClick={() => handleSort('paymentNumber')}
-          sx={{
-            height: TYPOGRAPHY_STYLES.searchField.input.height,
-            fontSize: '0.875rem',
-            minWidth: 'auto',
-            px: 2
-          }}
-        >
-          Sort
-        </Button>
-      </Box>
+        </Stack>
       </Paper>
       {/* Error Display */}
       {error && (
@@ -736,49 +595,50 @@ const PaymentsPage: React.FC = () => {
             </Box>
 
             <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }} ref={paymentListRef}>
-              <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
-                <Table
-                  size={TABLE_STYLES.size}
-                  sx={{
-                    '& .MuiTableCell-root': {
-                      borderBottom: TABLE_STYLES.cell.border,
-                      py: TABLE_STYLES.cell.padding.py * 0.75,
-                      px: TABLE_STYLES.cell.padding.px * 0.75
-                    }
-                  }}
-                >
-                  <TableHead sx={{ display: 'none' }}>
-                    <TableRow sx={{ '& .MuiTableCell-head': {
-                      fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                      backgroundColor: 'grey.50',
-                      color: TYPOGRAPHY_STYLES.tableHeader.color,
-                      fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize
-                    } }}>
-                      <TableCell>Payment #</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {loading && paginatedPayments.length === 0 ? (
-                      [...Array(10)].map((_, i) => (
-                        <TableRow key={`skeleton-${i}`}>
-                          <TableCell><Skeleton height={40} /></TableCell>
+              {(isLoading || (isFetching && !data)) ? (
+                <ListSkeleton rows={8} columns={1} />
+              ) : (
+                <Box sx={{ flex: 1, opacity: isFetching ? 0.6 : 1, position: 'relative' }}>
+                  {isFetching ? (
+                    <CircularProgress size={16} sx={{ position: 'absolute', top: 8, right: 8, zIndex: 1 }} />
+                  ) : null}
+                  <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
+                    <Table
+                      size={TABLE_STYLES.size}
+                      sx={{
+                        '& .MuiTableCell-root': {
+                          borderBottom: TABLE_STYLES.cell.border,
+                          py: TABLE_STYLES.cell.padding.py * 0.75,
+                          px: TABLE_STYLES.cell.padding.px * 0.75,
+                        },
+                      }}
+                    >
+                      <TableHead sx={{ display: 'none' }}>
+                        <TableRow sx={{ '& .MuiTableCell-head': {
+                          fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
+                          backgroundColor: 'grey.50',
+                          color: TYPOGRAPHY_STYLES.tableHeader.color,
+                          fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
+                        } }}>
+                          <TableCell>Payment #</TableCell>
                         </TableRow>
-                      ))
-                    ) : (
-                      paginatedPayments.map((payment: Payment, index: number) => (
-                        <PaymentRow
-                          key={payment.id}
-                          payment={payment}
-                          index={index}
-                          selectedPaymentId={selectedPayment?.id}
-                          focusedPaymentIndex={focusedPaymentIndex}
-                          onPaymentSelect={handlePaymentSelect}
-                        />
-                      ))
-                    )}
-                  </TableBody>
-                </Table>
-              </TableContainer>
+                      </TableHead>
+                      <TableBody>
+                        {paginatedPayments.map((payment: Payment, index: number) => (
+                          <PaymentRow
+                            key={payment.id}
+                            payment={payment}
+                            index={index}
+                            selectedPaymentId={selectedPayment?.id}
+                            focusedPaymentIndex={focusedPaymentIndex}
+                            onPaymentSelect={handlePaymentSelect}
+                          />
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </TableContainer>
+                </Box>
+              )}
             </Box>
           </Paper>
         </Grid>

--- a/frontend/src/pages/sales/PaymentsPage.tsx
+++ b/frontend/src/pages/sales/PaymentsPage.tsx
@@ -231,7 +231,7 @@ const PaymentsPage: React.FC = () => {
       const params = new URLSearchParams(window.location.search)
       if (!params.get('customerId')) {
         params.set('customerId', presetCustomerId)
-        window.history.replaceState(null, '', `${location.pathname}?${params.toString()}`)
+        window.history.replaceState(window.history.state, '', `${location.pathname}?${params.toString()}`)
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/pages/sales/__tests__/CustomersPage.filterbar.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CustomersPage.filterbar.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import CustomersPage from '../CustomersPage'
+import salesReducer from '@/store/slices/salesSlice'
+
+const { useGetCustomersQuery } = vi.hoisted(() => ({
+  useGetCustomersQuery: vi.fn(() => ({
+    data: { data: [], meta: { total: 0 } },
+    isLoading: false,
+    isFetching: false,
+    refetch: vi.fn(),
+  })),
+}))
+
+vi.mock('@/store/api/salesApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store/api/salesApi')>()
+  return {
+    ...actual,
+    useGetCustomersQuery,
+    useCreateCustomerMutation: vi.fn(() => [vi.fn(), {}]),
+    useDeleteCustomerMutation: vi.fn(() => [vi.fn(), {}]),
+    useUpdateCustomerMutation: vi.fn(() => [vi.fn(), {}]),
+  }
+})
+
+vi.mock('@/hooks/useNotification', () => ({
+  useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
+}))
+
+vi.mock('@/components/sales/DeletedCustomersDialog', () => ({
+  default: () => <div>DeletedCustomersDialog</div>,
+}))
+
+function renderPage(initialUrl = '/') {
+  const store = configureStore({ reducer: { sales: salesReducer } })
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <CustomersPage />
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('CustomersPage FilterBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the search input', () => {
+    renderPage()
+    expect(screen.getByPlaceholderText(/search by name or phone/i)).toBeInTheDocument()
+  })
+
+  it('restores filters from URL and passes them to query', () => {
+    renderPage('/?search=acme&status=active&type=business')
+    expect(useGetCustomersQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ search: 'acme', isActive: true, type: 'business' }),
+    )
+  })
+
+  it('passes no isActive when status is unset', () => {
+    renderPage('/')
+    expect(useGetCustomersQuery).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ isActive: expect.anything() }),
+    )
+  })
+})

--- a/frontend/src/pages/sales/__tests__/PaymentsPage.filterbar.test.tsx
+++ b/frontend/src/pages/sales/__tests__/PaymentsPage.filterbar.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import PaymentsPage from '../PaymentsPage'
+import salesReducer from '@/store/slices/salesSlice'
+
+const { useGetPaymentsQuery } = vi.hoisted(() => ({
+  useGetPaymentsQuery: vi.fn(() => ({
+    data: { data: [], meta: { total: 0 } },
+    isLoading: false,
+    isFetching: false,
+    refetch: vi.fn(),
+  })),
+}))
+
+vi.mock('@/store/api/salesApi', () => ({
+  useGetPaymentsQuery,
+  useGetCustomersQuery: vi.fn(() => ({
+    data: { data: [{ id: 'cust-1', name: 'Acme Corp' }], meta: { total: 1 } },
+  })),
+}))
+
+vi.mock('@/store/api/accountingApi', () => ({
+  useLazyGetJournalEntriesQuery: vi.fn(() => [vi.fn(), {}]),
+}))
+
+vi.mock('@/hooks/useNotification', () => ({
+  useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
+}))
+
+vi.mock('@/components/sales/DeletedPaymentsDialog', () => ({
+  default: () => <div>DeletedPaymentsDialog</div>,
+}))
+
+vi.mock('@/components/print', () => ({
+  PaymentReceiptPrint: () => <div>PaymentReceiptPrint</div>,
+}))
+
+function renderPage(initialUrl = '/', state?: unknown) {
+  const store = configureStore({ reducer: { sales: salesReducer } })
+  const url = new URL(initialUrl, 'http://localhost')
+
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: url.pathname, search: url.search, state }]}>
+        <PaymentsPage />
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('PaymentsPage FilterBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the search input', () => {
+    renderPage()
+    expect(screen.getByPlaceholderText(/search by payment number or customer/i)).toBeInTheDocument()
+  })
+
+  it('restores date range from URL and passes to query', () => {
+    renderPage('/?paymentDate_from=2026-01-01&paymentDate_to=2026-03-31')
+    expect(useGetPaymentsQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ fromDate: '2026-01-01', toDate: '2026-03-31' }),
+    )
+  })
+
+  it('presets customerId from URL when navigated from customer profile', () => {
+    renderPage('/?customerId=cust-1')
+    expect(useGetPaymentsQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ customerId: 'cust-1' }),
+    )
+  })
+
+  it('renders locked chip (no × button) when customerId is preset via location state', () => {
+    renderPage('/', { customerId: 'cust-1' })
+    const chip = screen.getByText(/customer: acme corp/i)
+    expect(chip).toBeInTheDocument()
+    const chipEl = chip.closest('[class*="MuiChip"]')
+    expect(chipEl?.querySelector('[data-testid="CancelIcon"]')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/settings/UserManagementPage.tsx
+++ b/frontend/src/pages/settings/UserManagementPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   Box,
   Typography,
@@ -123,10 +123,42 @@ const UserManagementPage: React.FC = () => {
   const [updateUser] = useUpdateUserMutation()
   const users = usersResponse?.data ?? []
   const totalCount = usersResponse?.meta?.total ?? 0
-
-  useEffect(() => {
+  const resetPage = useCallback(() => {
     setPage(0)
-  }, [appliedFilters])
+  }, [])
+
+  const filterHandlers = useMemo(
+    () => ({
+      ...handlers,
+      onSearchChange: (value: string) => {
+        resetPage()
+        handlers.onSearchChange(value)
+      },
+      onSearchCommit: () => {
+        resetPage()
+        handlers.onSearchCommit()
+      },
+      onQuickFilterChange: (field: keyof UserFilters, value: unknown) => {
+        resetPage()
+        handlers.onQuickFilterChange(field, value)
+      },
+      onAdvancedDraftChange: handlers.onAdvancedDraftChange,
+      onAdvancedApply: () => {
+        resetPage()
+        handlers.onAdvancedApply()
+      },
+      onAdvancedCancel: handlers.onAdvancedCancel,
+      onClearField: (field: keyof UserFilters) => {
+        resetPage()
+        handlers.onClearField(field)
+      },
+      onClearAll: () => {
+        resetPage()
+        handlers.onClearAll()
+      },
+    }),
+    [handlers, resetPage],
+  )
 
   // Check if user is admin
   useEffect(() => {
@@ -297,7 +329,7 @@ const UserManagementPage: React.FC = () => {
         <FilterBar
           config={filterConfig}
           draftFilters={draftFilters}
-          handlers={handlers}
+          handlers={filterHandlers}
           activeChips={activeChips}
           hasActiveFilters={hasActiveFilters}
           hasUnappliedChanges={hasUnappliedChanges}

--- a/frontend/src/pages/settings/UserManagementPage.tsx
+++ b/frontend/src/pages/settings/UserManagementPage.tsx
@@ -1,16 +1,10 @@
-import React, { useState, useEffect } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import {
   Box,
   Typography,
   Paper,
   Button,
-  TextField,
   IconButton,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  InputAdornment,
   Table,
   TableBody,
   TableCell,
@@ -22,14 +16,15 @@ import {
   CircularProgress,
   Chip,
   Tooltip,
-  Stack,
 } from '@mui/material'
 import {
-  Search as SearchIcon,
   Edit as EditIcon,
   Delete as DeleteIcon,
   LockOpen as UnlockIcon,
 } from '@mui/icons-material'
+import { ListSkeleton } from '@/components/common/ListSkeleton'
+import { FilterBar, useFilterBar } from '@/components/filters'
+import type { FilterBarConfig } from '@/components/filters'
 import PageHeader from '@/components/common/PageHeader'
 import { useAppSelector } from '@/hooks/useRedux'
 import { useNotification } from '@/hooks/useNotification'
@@ -46,6 +41,12 @@ import ConfirmationDialog from '@/components/common/ConfirmationDialog'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { formatDateTime } from '@/utils/formatters'
 
+interface UserFilters {
+  search: string
+  role: 'admin' | 'manager' | 'sales_staff' | 'inventory_staff' | 'procurement_staff' | null
+  status: 'active' | 'inactive' | 'suspended' | null
+}
+
 const UserManagementPage: React.FC = () => {
   const currentUser = useAppSelector((state) => state.auth?.user)
   const { showSuccess, showError } = useNotification()
@@ -53,11 +54,6 @@ const UserManagementPage: React.FC = () => {
   // State
   const [page, setPage] = useState(0)
   const [rowsPerPage, setRowsPerPage] = useState(20)
-
-  // Filters
-  const [searchQuery, setSearchQuery] = useState('')
-  const [roleFilter, setRoleFilter] = useState<string>('all')
-  const [statusFilter, setStatusFilter] = useState<string>('all')
 
   // Dialog states
   const [formDialogOpen, setFormDialogOpen] = useState(false)
@@ -74,20 +70,63 @@ const UserManagementPage: React.FC = () => {
     action: () => {},
   })
 
-  const usersQueryParams = {
-    page: page + 1,
-    limit: rowsPerPage,
-    search: searchQuery.trim() || undefined,
-    role: roleFilter !== 'all' ? (roleFilter as any) : undefined,
-    status: statusFilter !== 'all' ? (statusFilter as any) : undefined,
-  }
-  const { data: usersResponse, isLoading: loading, error, refetch: refetchUsers } = useGetUsersQuery(usersQueryParams)
+  const filterConfig = useMemo<FilterBarConfig<UserFilters>>(
+    () => ({
+      search: { placeholder: 'Search by name, email, or username...' },
+      quick: [
+        {
+          field: 'role',
+          label: 'Role',
+          type: 'select',
+          options: [
+            { value: 'admin', label: 'Admin' },
+            { value: 'manager', label: 'Manager' },
+            { value: 'sales_staff', label: 'Sales Staff' },
+            { value: 'inventory_staff', label: 'Inventory Staff' },
+            { value: 'procurement_staff', label: 'Procurement Staff' },
+          ],
+        },
+        {
+          field: 'status',
+          label: 'Status',
+          type: 'select',
+          options: [
+            { value: 'active', label: 'Active' },
+            { value: 'inactive', label: 'Inactive' },
+            { value: 'suspended', label: 'Suspended' },
+          ],
+        },
+      ],
+      advanced: [],
+      defaults: { search: '', role: null, status: null },
+    }),
+    [],
+  )
+  const { appliedFilters, draftFilters, handlers, activeChips, hasActiveFilters, hasUnappliedChanges } =
+    useFilterBar(filterConfig)
+
+  const userQueryParams = useMemo(
+    () => ({
+      page: page + 1,
+      limit: rowsPerPage,
+      search: appliedFilters.search || undefined,
+      role: appliedFilters.role ?? undefined,
+      status: appliedFilters.status ?? undefined,
+    }),
+    [appliedFilters, page, rowsPerPage],
+  )
+  const { data: usersResponse, isLoading, isFetching, error, refetch: refetchUsers } =
+    useGetUsersQuery(userQueryParams)
   const { data: statistics, refetch: refetchStatistics } = useGetStatisticsQuery()
   const [unlockUser] = useUnlockUserMutation()
   const [deactivateUser] = useDeactivateUserMutation()
   const [updateUser] = useUpdateUserMutation()
   const users = usersResponse?.data ?? []
   const totalCount = usersResponse?.meta?.total ?? 0
+
+  useEffect(() => {
+    setPage(0)
+  }, [appliedFilters])
 
   // Check if user is admin
   useEffect(() => {
@@ -98,21 +137,6 @@ const UserManagementPage: React.FC = () => {
   }, [currentUser, showError])
 
   // Handlers
-  const handleSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchQuery(event.target.value)
-    setPage(0)
-  }
-
-  const handleRoleFilterChange = (event: any) => {
-    setRoleFilter(event.target.value)
-    setPage(0)
-  }
-
-  const handleStatusFilterChange = (event: any) => {
-    setStatusFilter(event.target.value)
-    setPage(0)
-  }
-
   const handlePageChange = (_event: unknown, newPage: number) => {
     setPage(newPage)
   }
@@ -270,43 +294,14 @@ const UserManagementPage: React.FC = () => {
 
       {/* Filters */}
       <Paper sx={{ p: 2, mb: 3 }}>
-        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-          <TextField
-            placeholder="Search by name, email, or username..."
-            value={searchQuery}
-            onChange={handleSearch}
-            slotProps={{
-              input: {
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <SearchIcon />
-                  </InputAdornment>
-                ),
-              },
-            }}
-            sx={{ flexGrow: 1 }}
-          />
-          <FormControl sx={{ minWidth: 150 }}>
-            <InputLabel>Role</InputLabel>
-            <Select value={roleFilter} onChange={handleRoleFilterChange} label="Role">
-              <MenuItem value="all">All Roles</MenuItem>
-              <MenuItem value="admin">Admin</MenuItem>
-              <MenuItem value="manager">Manager</MenuItem>
-              <MenuItem value="sales_staff">Sales Staff</MenuItem>
-              <MenuItem value="inventory_staff">Inventory Staff</MenuItem>
-              <MenuItem value="procurement_staff">Procurement Staff</MenuItem>
-            </Select>
-          </FormControl>
-          <FormControl sx={{ minWidth: 150 }}>
-            <InputLabel>Status</InputLabel>
-            <Select value={statusFilter} onChange={handleStatusFilterChange} label="Status">
-              <MenuItem value="all">All Statuses</MenuItem>
-              <MenuItem value="active">Active</MenuItem>
-              <MenuItem value="inactive">Inactive</MenuItem>
-              <MenuItem value="suspended">Suspended</MenuItem>
-            </Select>
-          </FormControl>
-        </Stack>
+        <FilterBar
+          config={filterConfig}
+          draftFilters={draftFilters}
+          handlers={handlers}
+          activeChips={activeChips}
+          hasActiveFilters={hasActiveFilters}
+          hasUnappliedChanges={hasUnappliedChanges}
+        />
       </Paper>
 
       {/* Error Alert */}
@@ -318,317 +313,312 @@ const UserManagementPage: React.FC = () => {
 
       {/* Users Table */}
       <Paper sx={{ borderRadius: 2, overflow: 'hidden' }}>
-        <TableContainer sx={{ overflowX: 'auto' }}>
-          <Table
-            size={TABLE_STYLES.size}
-            sx={{
-              '& .MuiTableCell-root': {
-                borderBottom: TABLE_STYLES.cell.border,
-                py: TABLE_STYLES.cell.padding.py,
-                px: TABLE_STYLES.cell.padding.px
-              },
-              '& .MuiTableBody-root .MuiTableRow-root:last-child .MuiTableCell-root': {
-                borderBottom: 'none'
-              }
-            }}
-          >
-            <TableHead>
-              <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50', py: 1 } }}>
-                <TableCell>
-                  <Typography variant="caption" sx={{
-                    fontWeight: 600,
-                    color: 'text.secondary',
-                    fontSize: '0.75rem',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px'
-                  }}>
-                    Username
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption" sx={{
-                    fontWeight: 600,
-                    color: 'text.secondary',
-                    fontSize: '0.75rem',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px'
-                  }}>
-                    Name
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption" sx={{
-                    fontWeight: 600,
-                    color: 'text.secondary',
-                    fontSize: '0.75rem',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px'
-                  }}>
-                    Email
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption" sx={{
-                    fontWeight: 600,
-                    color: 'text.secondary',
-                    fontSize: '0.75rem',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px'
-                  }}>
-                    Role
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption" sx={{
-                    fontWeight: 600,
-                    color: 'text.secondary',
-                    fontSize: '0.75rem',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px'
-                  }}>
-                    Status
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption" sx={{
-                    fontWeight: 600,
-                    color: 'text.secondary',
-                    fontSize: '0.75rem',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px'
-                  }}>
-                    Last Login
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="caption" sx={{
-                    fontWeight: 600,
-                    color: 'text.secondary',
-                    fontSize: '0.75rem',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px'
-                  }}>
-                    Failed Attempts
-                  </Typography>
-                </TableCell>
-                <TableCell align="right">
-                  <Typography variant="caption" sx={{
-                    fontWeight: 600,
-                    color: 'text.secondary',
-                    fontSize: '0.75rem',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px'
-                  }}>
-                    Actions
-                  </Typography>
-                </TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {loading ? (
-                <TableRow>
-                  <TableCell colSpan={8} align="center" sx={{ py: 8 }}>
-                    <CircularProgress />
-                  </TableCell>
-                </TableRow>
-              ) : users.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={8} align="center" sx={{ py: 8 }}>
-                    <Typography color="text.secondary">No users found</Typography>
-                  </TableCell>
-                </TableRow>
-              ) : (
-                users.map((user) => (
-                  <TableRow
-                    key={user.id}
-                    hover
-                    sx={{
-                      '&:hover': {
-                        backgroundColor: 'action.hover',
-                        '& .user-actions': {
-                          opacity: 1
-                        }
-                      },
-                      transition: 'background-color 0.2s ease',
-                      cursor: 'default',
-                      height: TABLE_STYLES.row.height
-                    }}
-                  >
+        {(isLoading || (isFetching && !usersResponse)) ? (
+          <ListSkeleton rows={8} columns={4} />
+        ) : (
+          <Box sx={{ opacity: isFetching ? 0.6 : 1, position: 'relative' }}>
+            {isFetching && <CircularProgress size={16} sx={{ position: 'absolute', top: 8, right: 8 }} />}
+            <TableContainer sx={{ overflowX: 'auto' }}>
+              <Table
+                size={TABLE_STYLES.size}
+                sx={{
+                  '& .MuiTableCell-root': {
+                    borderBottom: TABLE_STYLES.cell.border,
+                    py: TABLE_STYLES.cell.padding.py,
+                    px: TABLE_STYLES.cell.padding.px,
+                  },
+                  '& .MuiTableBody-root .MuiTableRow-root:last-child .MuiTableCell-root': {
+                    borderBottom: 'none',
+                  },
+                }}
+              >
+                <TableHead>
+                  <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50', py: 1 } }}>
                     <TableCell>
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                        <Typography variant="body2" sx={{ fontSize: '0.8rem', fontWeight: 400 }}>
-                          {user.username}
-                        </Typography>
-                        {user.isLocked && (
-                          <Tooltip title="Account is locked">
-                            <Chip
-                              label="Locked"
-                              size="small"
-                              color="error"
-                              sx={{
-                                fontSize: '0.65rem',
-                                height: 20
-                              }}
-                            />
-                          </Tooltip>
-                        )}
-                      </Box>
-                    </TableCell>
-                    <TableCell>
-                      <Typography variant="body2" sx={{ fontSize: '0.8rem', fontWeight: 400 }}>
-                        {(() => {
-                          if (user.fullName && user.fullName !== 'null') return user.fullName;
-                          const firstName = user.firstName && user.firstName !== 'null' ? user.firstName : '';
-                          const lastName = user.lastName && user.lastName !== 'null' ? user.lastName : '';
-                          return `${firstName} ${lastName}`.trim();
-                        })()}
+                      <Typography variant="caption" sx={{
+                        fontWeight: 600,
+                        color: 'text.secondary',
+                        fontSize: '0.75rem',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.5px',
+                      }}>
+                        Username
                       </Typography>
                     </TableCell>
                     <TableCell>
-                      <Typography variant="body2" sx={{ fontSize: '0.8rem', fontWeight: 400 }}>
-                        {user.email}
+                      <Typography variant="caption" sx={{
+                        fontWeight: 600,
+                        color: 'text.secondary',
+                        fontSize: '0.75rem',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.5px',
+                      }}>
+                        Name
                       </Typography>
                     </TableCell>
                     <TableCell>
-                      <Chip
-                        label={getRoleLabel(user.role)}
-                        size="small"
-                        color={getRoleColor(user.role)}
-                        sx={{
-                          fontSize: '0.65rem',
-                          height: 20,
-                          fontWeight: 500
-                        }}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      <Chip
-                        label={user.status}
-                        size="small"
-                        color={getStatusColor(user.status)}
-                        sx={{
-                          fontSize: '0.65rem',
-                          height: 20,
-                          fontWeight: 500
-                        }}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      <Typography variant="body2" sx={{ fontSize: '0.8rem', fontWeight: 400 }}>
-                        {formatDate(user.lastLoginAt)}
+                      <Typography variant="caption" sx={{
+                        fontWeight: 600,
+                        color: 'text.secondary',
+                        fontSize: '0.75rem',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.5px',
+                      }}>
+                        Email
                       </Typography>
-                      {user.lastLoginIp && (
-                        <Typography variant="caption" display="block" color="text.secondary" sx={{ fontSize: '0.7rem' }}>
-                          {user.lastLoginIp}
-                        </Typography>
-                      )}
                     </TableCell>
                     <TableCell>
-                      {user.failedLoginAttempts > 0 && (
-                        <Chip
-                          label={user.failedLoginAttempts}
-                          size="small"
-                          color="warning"
-                          sx={{
-                            fontSize: '0.65rem',
-                            height: 20,
-                            fontWeight: 500
-                          }}
-                        />
-                      )}
+                      <Typography variant="caption" sx={{
+                        fontWeight: 600,
+                        color: 'text.secondary',
+                        fontSize: '0.75rem',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.5px',
+                      }}>
+                        Role
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="caption" sx={{
+                        fontWeight: 600,
+                        color: 'text.secondary',
+                        fontSize: '0.75rem',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.5px',
+                      }}>
+                        Status
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="caption" sx={{
+                        fontWeight: 600,
+                        color: 'text.secondary',
+                        fontSize: '0.75rem',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.5px',
+                      }}>
+                        Last Login
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="caption" sx={{
+                        fontWeight: 600,
+                        color: 'text.secondary',
+                        fontSize: '0.75rem',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.5px',
+                      }}>
+                        Failed Attempts
+                      </Typography>
                     </TableCell>
                     <TableCell align="right">
-                      <Box
-                        className="user-actions"
-                        sx={{
-                          display: 'flex',
-                          justifyContent: 'flex-end',
-                          alignItems: 'center',
-                          gap: 0.25,
-                          opacity: 0.7,
-                          transition: 'opacity 0.2s ease'
-                        }}
-                      >
-                        <Tooltip title={user.id === currentUser?.id ? 'Edit Profile' : 'Edit User'}>
-                          <IconButton
-                            size="small"
-                            onClick={() => handleEditUser(user)}
-                            sx={{
-                              height: `${TABLE_STYLES.row.height * 0.75}px`,
-                              width: `${TABLE_STYLES.row.height * 0.75}px`,
-                              minHeight: 20,
-                              minWidth: 20,
-                              p: 0.125,
-                              color: 'primary.main',
-                              '&:hover': {
-                                backgroundColor: 'primary.light',
-                                color: 'primary.dark'
-                              }
-                            }}
-                          >
-                            <EditIcon sx={{
-                              fontSize: `${TABLE_STYLES.row.height * 0.5}px`
-                            }} />
-                          </IconButton>
-                        </Tooltip>
-                        {user.isLocked && (
-                          <Tooltip title="Unlock Account">
-                            <IconButton
-                              size="small"
-                              onClick={() => handleUnlockUser(user)}
-                              sx={{
-                                height: `${TABLE_STYLES.row.height * 0.75}px`,
-                                width: `${TABLE_STYLES.row.height * 0.75}px`,
-                                minHeight: 20,
-                                minWidth: 20,
-                                p: 0.125,
-                                color: 'warning.main',
-                                '&:hover': {
-                                  backgroundColor: 'warning.light',
-                                  color: 'warning.dark'
-                                }
-                              }}
-                            >
-                              <UnlockIcon sx={{
-                                fontSize: `${TABLE_STYLES.row.height * 0.5}px`
-                              }} />
-                            </IconButton>
-                          </Tooltip>
-                        )}
-                        <Tooltip title={user.status === 'active' ? 'Deactivate' : 'Activate'}>
-                          <IconButton
-                            size="small"
-                            onClick={() => handleDeactivateUser(user)}
-                            disabled={user.id === currentUser?.id}
-                            sx={{
-                              height: `${TABLE_STYLES.row.height * 0.75}px`,
-                              width: `${TABLE_STYLES.row.height * 0.75}px`,
-                              minHeight: 20,
-                              minWidth: 20,
-                              p: 0.125,
-                              color: user.status === 'active' ? 'error.main' : 'success.main',
-                              '&:hover': {
-                                backgroundColor: user.status === 'active' ? 'error.light' : 'success.light',
-                                color: user.status === 'active' ? 'error.dark' : 'success.dark'
-                              },
-                              '&.Mui-disabled': {
-                                opacity: 0.3
-                              }
-                            }}
-                          >
-                            <DeleteIcon sx={{
-                              fontSize: `${TABLE_STYLES.row.height * 0.5}px`
-                            }} />
-                          </IconButton>
-                        </Tooltip>
-                      </Box>
+                      <Typography variant="caption" sx={{
+                        fontWeight: 600,
+                        color: 'text.secondary',
+                        fontSize: '0.75rem',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.5px',
+                      }}>
+                        Actions
+                      </Typography>
                     </TableCell>
                   </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
+                </TableHead>
+                <TableBody>
+                  {users.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={8} align="center" sx={{ py: 8 }}>
+                        <Typography color="text.secondary">No users found</Typography>
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    users.map((user) => (
+                      <TableRow
+                        key={user.id}
+                        hover
+                        sx={{
+                          '&:hover': {
+                            backgroundColor: 'action.hover',
+                            '& .user-actions': {
+                              opacity: 1,
+                            },
+                          },
+                          transition: 'background-color 0.2s ease',
+                          cursor: 'default',
+                          height: TABLE_STYLES.row.height,
+                        }}
+                      >
+                        <TableCell>
+                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <Typography variant="body2" sx={{ fontSize: '0.8rem', fontWeight: 400 }}>
+                              {user.username}
+                            </Typography>
+                            {user.isLocked && (
+                              <Tooltip title="Account is locked">
+                                <Chip
+                                  label="Locked"
+                                  size="small"
+                                  color="error"
+                                  sx={{
+                                    fontSize: '0.65rem',
+                                    height: 20,
+                                  }}
+                                />
+                              </Tooltip>
+                            )}
+                          </Box>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ fontSize: '0.8rem', fontWeight: 400 }}>
+                            {(() => {
+                              if (user.fullName && user.fullName !== 'null') return user.fullName
+                              const firstName = user.firstName && user.firstName !== 'null' ? user.firstName : ''
+                              const lastName = user.lastName && user.lastName !== 'null' ? user.lastName : ''
+                              return `${firstName} ${lastName}`.trim()
+                            })()}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ fontSize: '0.8rem', fontWeight: 400 }}>
+                            {user.email}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Chip
+                            label={getRoleLabel(user.role)}
+                            size="small"
+                            color={getRoleColor(user.role)}
+                            sx={{
+                              fontSize: '0.65rem',
+                              height: 20,
+                              fontWeight: 500,
+                            }}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <Chip
+                            label={user.status}
+                            size="small"
+                            color={getStatusColor(user.status)}
+                            sx={{
+                              fontSize: '0.65rem',
+                              height: 20,
+                              fontWeight: 500,
+                            }}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ fontSize: '0.8rem', fontWeight: 400 }}>
+                            {formatDate(user.lastLoginAt)}
+                          </Typography>
+                          {user.lastLoginIp && (
+                            <Typography variant="caption" display="block" color="text.secondary" sx={{ fontSize: '0.7rem' }}>
+                              {user.lastLoginIp}
+                            </Typography>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          {user.failedLoginAttempts > 0 && (
+                            <Chip
+                              label={user.failedLoginAttempts}
+                              size="small"
+                              color="warning"
+                              sx={{
+                                fontSize: '0.65rem',
+                                height: 20,
+                                fontWeight: 500,
+                              }}
+                            />
+                          )}
+                        </TableCell>
+                        <TableCell align="right">
+                          <Box
+                            className="user-actions"
+                            sx={{
+                              display: 'flex',
+                              justifyContent: 'flex-end',
+                              alignItems: 'center',
+                              gap: 0.25,
+                              opacity: 0.7,
+                              transition: 'opacity 0.2s ease',
+                            }}
+                          >
+                            <Tooltip title={user.id === currentUser?.id ? 'Edit Profile' : 'Edit User'}>
+                              <IconButton
+                                size="small"
+                                onClick={() => handleEditUser(user)}
+                                sx={{
+                                  height: `${TABLE_STYLES.row.height * 0.75}px`,
+                                  width: `${TABLE_STYLES.row.height * 0.75}px`,
+                                  minHeight: 20,
+                                  minWidth: 20,
+                                  p: 0.125,
+                                  color: 'primary.main',
+                                  '&:hover': {
+                                    backgroundColor: 'primary.light',
+                                    color: 'primary.dark',
+                                  },
+                                }}
+                              >
+                                <EditIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
+                              </IconButton>
+                            </Tooltip>
+                            {user.isLocked && (
+                              <Tooltip title="Unlock Account">
+                                <IconButton
+                                  size="small"
+                                  onClick={() => handleUnlockUser(user)}
+                                  sx={{
+                                    height: `${TABLE_STYLES.row.height * 0.75}px`,
+                                    width: `${TABLE_STYLES.row.height * 0.75}px`,
+                                    minHeight: 20,
+                                    minWidth: 20,
+                                    p: 0.125,
+                                    color: 'warning.main',
+                                    '&:hover': {
+                                      backgroundColor: 'warning.light',
+                                      color: 'warning.dark',
+                                    },
+                                  }}
+                                >
+                                  <UnlockIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
+                                </IconButton>
+                              </Tooltip>
+                            )}
+                            <Tooltip title={user.status === 'active' ? 'Deactivate' : 'Activate'}>
+                              <IconButton
+                                size="small"
+                                onClick={() => handleDeactivateUser(user)}
+                                disabled={user.id === currentUser?.id}
+                                sx={{
+                                  height: `${TABLE_STYLES.row.height * 0.75}px`,
+                                  width: `${TABLE_STYLES.row.height * 0.75}px`,
+                                  minHeight: 20,
+                                  minWidth: 20,
+                                  p: 0.125,
+                                  color: user.status === 'active' ? 'error.main' : 'success.main',
+                                  '&:hover': {
+                                    backgroundColor: user.status === 'active' ? 'error.light' : 'success.light',
+                                    color: user.status === 'active' ? 'error.dark' : 'success.dark',
+                                  },
+                                  '&.Mui-disabled': {
+                                    opacity: 0.3,
+                                  },
+                                }}
+                              >
+                                <DeleteIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
+                              </IconButton>
+                            </Tooltip>
+                          </Box>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Box>
+        )}
         <TablePagination
           rowsPerPageOptions={[10, 20, 50, 100]}
           component="div"

--- a/frontend/src/pages/settings/__tests__/UserManagementPage.filterbar.test.tsx
+++ b/frontend/src/pages/settings/__tests__/UserManagementPage.filterbar.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import UserManagementPage from '../UserManagementPage'
+import authReducer from '@/store/slices/authSlice'
+
+const { useGetUsersQuery } = vi.hoisted(() => ({
+  useGetUsersQuery: vi.fn(() => ({
+    data: { data: [], meta: { total: 0 } },
+    isLoading: false,
+    isFetching: false,
+    refetch: vi.fn(),
+  })),
+}))
+
+vi.mock('@/store/api/userManagementApi', () => ({
+  useGetUsersQuery,
+  useGetStatisticsQuery: vi.fn(() => ({ data: undefined })),
+  useDeactivateUserMutation: vi.fn(() => [vi.fn(), {}]),
+  useUnlockUserMutation: vi.fn(() => [vi.fn(), {}]),
+  useUpdateUserMutation: vi.fn(() => [vi.fn(), {}]),
+}))
+
+vi.mock('@/hooks/useNotification', () => ({
+  useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
+}))
+
+vi.mock('@/components/settings/UserFormDialog', () => ({
+  default: () => <div>UserFormDialog</div>,
+}))
+
+function renderPage(initialUrl = '/') {
+  const store = configureStore({
+    reducer: { auth: authReducer },
+    preloadedState: {
+      auth: {
+        user: {
+          id: 'u1',
+          username: 'admin',
+          email: 'admin@example.com',
+          firstName: 'Admin',
+          lastName: 'User',
+          role: 'admin',
+          status: 'active',
+          isActive: true,
+          failedLoginAttempts: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+        accessToken: 'tok',
+        refreshToken: 'refresh',
+        isAuthenticated: true,
+        loading: false,
+        error: null,
+        lastActivityTime: null,
+        inactivityTimeoutMinutes: 30,
+        rememberMe: false,
+      },
+    },
+  })
+
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <UserManagementPage />
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('UserManagementPage FilterBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the search input', () => {
+    renderPage()
+    expect(screen.getByPlaceholderText(/search by name, email, or username/i)).toBeInTheDocument()
+  })
+
+  it('restores filters from URL and passes to query', () => {
+    renderPage('/?role=manager&status=active&search=john')
+    expect(useGetUsersQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ role: 'manager', status: 'active', search: 'john' }),
+    )
+  })
+
+  it('does not render More Filters button (no advanced filters)', () => {
+    renderPage()
+    expect(screen.queryByText(/more filters/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/settings/__tests__/UserManagementPage.filterbar.test.tsx
+++ b/frontend/src/pages/settings/__tests__/UserManagementPage.filterbar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import { MemoryRouter } from 'react-router-dom'
@@ -9,7 +9,7 @@ import authReducer from '@/store/slices/authSlice'
 
 const { useGetUsersQuery } = vi.hoisted(() => ({
   useGetUsersQuery: vi.fn(() => ({
-    data: { data: [], meta: { total: 0 } },
+    data: { data: [], meta: { total: 40 } },
     isLoading: false,
     isFetching: false,
     refetch: vi.fn(),
@@ -91,5 +91,30 @@ describe('UserManagementPage FilterBar', () => {
   it('does not render More Filters button (no advanced filters)', () => {
     renderPage()
     expect(screen.queryByText(/more filters/i)).not.toBeInTheDocument()
+  })
+
+  it('resets pagination before querying filtered users', async () => {
+    renderPage()
+
+    fireEvent.click(screen.getByLabelText(/go to next page/i))
+
+    const callsBeforeFilter = useGetUsersQuery.mock.calls.length
+
+    fireEvent.mouseDown(screen.getByRole('combobox', { name: /role/i }))
+    fireEvent.click(screen.getByRole('option', { name: /manager/i }))
+
+    await waitFor(() => {
+      expect(useGetUsersQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1, role: 'manager' }),
+      )
+    })
+
+    const callsAfterFilter = useGetUsersQuery.mock.calls.slice(callsBeforeFilter)
+    expect(
+      callsAfterFilter.some(([args]) => {
+        const params = args as { page?: number; role?: string }
+        return params?.page === 2 && params?.role === 'manager'
+      }),
+    ).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

- **Shared polish:** Reset button upgraded to outlined/ghost style, chip row spacing increased to 7px, `ListSkeleton` component added for standardized list loading states
- **Backend fix:** Wired `search` param into `payment.service.ts findAll` (payment number + customer name ILIKE)
- **Page rollout:** Migrated Customers, Suppliers, Payments, Stock Adjustments, and User Management to the shared `FilterBar` system with URL persistence, active chips, and reset — all with filterbar integration tests

## Notable implementation details

- Payments page supports a context preset: when navigated from a customer profile, `customerId` is injected into the URL before `useFilterBar` mounts, rendering as a locked chip (no × button, `variant="filled"`)
- Stock Adjustments filter includes `cancelled` status option (restored from backend enum)
- User Management filter changes reset pagination to page 1 before querying
- Loading pattern: skeleton on initial/filter load (`isLoading || (isFetching && !data)`), dim + inline spinner on background refetch

## Test Plan

- [x] All 5 migrated pages show FilterBar with search, quick filters, chips, and reset
- [x] Filter state persists in URL and restores on reload
- [x] Payments: navigate from a customer profile — customer chip appears locked (no ×)
- [x] Reset button renders as outlined/ghost style
- [x] Chip row has visible breathing room above the filter bar
- [x] `cd frontend && npm run test` — 544 tests pass
- [x] `cd backend && npm run test` — 656 tests pass

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)