### PR TITLE
feat: Refactor Radar — smart pattern detection in maintain.sh (issue #193)

### DIFF
--- a/maintain.sh
+++ b/maintain.sh
@@ -215,7 +215,7 @@ do_refactor_radar() {
     if grep -q "@CurrentUser('userId')" "$file" 2>/dev/null && \
        grep -q "currentUserId" "$file" 2>/dev/null; then
       local count
-      count=$(grep -c "currentUserId" "$file" 2>/dev/null || echo 0)
+      count=$(grep -c "@CurrentUser('userId') currentUserId" "$file" 2>/dev/null)
       audit_found=1
       local rel="${file#$ROOT_DIR/backend/src/}"
       echo -e "  ${RED}⚠  ${rel}${RESET}"

--- a/maintain.sh
+++ b/maintain.sh
@@ -230,7 +230,45 @@ do_refactor_radar() {
   fi
   echo ""
 
-  # detector 3 will be added in the next task
+  # ── [3/3] Dependency/Bloat Detector ──────────────────────────────────────
+  echo -e "${BOLD}${YELLOW}[3/3] Dependency/Bloat Detector${RESET}"
+
+  # Frontend: >10 useState calls in a single page component
+  echo -e "  ${BOLD}Frontend bloat (>10 useState calls):${RESET}"
+  local fe_bloat_found=0
+  while IFS= read -r -d '' file; do
+    local count
+    count=$(grep -c "useState" "$file" 2>/dev/null)
+    if [[ $count -gt 10 ]]; then
+      fe_bloat_found=1
+      local rel="${file#$ROOT_DIR/frontend/src/}"
+      echo -e "    ${RED}⚠  ${rel}${RESET}"
+      echo -e "       ${count} useState calls — component may need splitting"
+    fi
+  done < <(find "$frontend_pages" -name "*.tsx" -print0 2>/dev/null)
+  if [[ $fe_bloat_found -eq 0 ]]; then
+    echo -e "    ${GREEN}✓  No issues found.${RESET}"
+  fi
+  echo ""
+
+  # Backend: >5 constructor-injected dependencies
+  echo -e "  ${BOLD}Backend bloat (>5 constructor deps):${RESET}"
+  local be_bloat_found=0
+  while IFS= read -r -d '' file; do
+    local count
+    count=$(awk '/constructor\(/{found=1} found && /private |readonly /{n++} found && /\)/{if(found){print n; n=0; found=0}}' "$file" 2>/dev/null | sort -rn | head -1)
+    count=${count:-0}
+    if [[ $count -gt 5 ]]; then
+      be_bloat_found=1
+      local rel="${file#$ROOT_DIR/backend/src/}"
+      echo -e "    ${RED}⚠  ${rel}${RESET}"
+      echo -e "       ${count} constructor dependencies — consider splitting responsibilities"
+    fi
+  done < <(find "$backend_modules" -name "*.ts" -print0 2>/dev/null)
+  if [[ $be_bloat_found -eq 0 ]]; then
+    echo -e "    ${GREEN}✓  No issues found.${RESET}"
+  fi
+  echo ""
 }
 
 STEPS=(

--- a/maintain.sh
+++ b/maintain.sh
@@ -205,7 +205,32 @@ do_refactor_radar() {
   fi
   echo ""
 
-  # detectors 2 and 3 will be added in subsequent tasks
+  # ── [2/3] Audit Manualism Detector ───────────────────────────────────────
+  echo -e "${BOLD}${YELLOW}[2/3] Audit Manualism Detector (Backend)${RESET}"
+  local backend_modules="$ROOT_DIR/backend/src/modules"
+  local audit_found=0
+
+  while IFS= read -r -d '' file; do
+    # Must contain both signals to be flagged
+    if grep -q "@CurrentUser('userId')" "$file" 2>/dev/null && \
+       grep -q "currentUserId" "$file" 2>/dev/null; then
+      local count
+      count=$(grep -c "currentUserId" "$file" 2>/dev/null || echo 0)
+      audit_found=1
+      local rel="${file#$ROOT_DIR/backend/src/}"
+      echo -e "  ${RED}⚠  ${rel}${RESET}"
+      echo -e "     ${count} endpoint(s) pass currentUserId manually"
+      echo -e "     ${CYAN}→ Consider a @CurrentUserAudit() interceptor or shared AuditService${RESET}"
+      echo ""
+    fi
+  done < <(find "$backend_modules" -name "*.controller.ts" -print0 2>/dev/null)
+
+  if [[ $audit_found -eq 0 ]]; then
+    echo -e "  ${GREEN}✓  No audit manualism found.${RESET}"
+  fi
+  echo ""
+
+  # detector 3 will be added in the next task
 }
 
 STEPS=(

--- a/maintain.sh
+++ b/maintain.sh
@@ -177,7 +177,35 @@ do_jscpd() {
 do_refactor_radar() {
   echo -e "${BOLD}${YELLOW}--- REFACTOR RADAR (Smart Detection) ---${RESET}"
   echo ""
-  # detectors will be added in subsequent tasks
+  # ── [1/3] State Cluster Detector ─────────────────────────────────────────
+  echo -e "${BOLD}${YELLOW}[1/3] State Cluster Detector (Frontend)${RESET}"
+  local frontend_pages="$ROOT_DIR/frontend/src/pages"
+  local state_vars=("dateFrom" "dateTo" "loading" "categories" "products" "selectedProduct" "selectedCategory")
+  local cluster_found=0
+
+  while IFS= read -r -d '' file; do
+    local hits=()
+    for var in "${state_vars[@]}"; do
+      if grep -q "useState.*${var}\|${var}.*useState\|const \[${var}" "$file" 2>/dev/null; then
+        hits+=("$var")
+      fi
+    done
+    if [[ ${#hits[@]} -ge 3 ]]; then
+      cluster_found=1
+      local rel="${file#$ROOT_DIR/frontend/src/}"
+      echo -e "  ${RED}⚠  ${rel}${RESET}"
+      echo -e "     Found: $(IFS=', '; echo "${hits[*]}")"
+      echo -e "     ${CYAN}→ Extract into useReportFilters hook${RESET}"
+      echo ""
+    fi
+  done < <(find "$frontend_pages" -name "*.tsx" -print0 2>/dev/null)
+
+  if [[ $cluster_found -eq 0 ]]; then
+    echo -e "  ${GREEN}✓  No state clusters found.${RESET}"
+  fi
+  echo ""
+
+  # detectors 2 and 3 will be added in subsequent tasks
 }
 
 STEPS=(

--- a/maintain.sh
+++ b/maintain.sh
@@ -174,6 +174,12 @@ do_jscpd() {
     --reporters console) || true
 }
 
+do_refactor_radar() {
+  echo -e "${BOLD}${YELLOW}--- REFACTOR RADAR (Smart Detection) ---${RESET}"
+  echo ""
+  # detectors will be added in subsequent tasks
+}
+
 STEPS=(
   "Knip (dead code / unused deps check)"
   "Outdated packages"
@@ -181,6 +187,7 @@ STEPS=(
   "Audit (security vulnerabilities)"
   "Top 5 files by line count"
   "jscpd (copy-paste detection)"
+  "Refactor Radar (Smart Detection)"
   "Docker: prune + rebuild + up"
 )
 
@@ -192,7 +199,8 @@ run_step() {
     3) do_audit ;;
     4) do_top_lines ;;
     5) do_jscpd ;;
-    6) do_docker_rebuild ;;
+    6) do_refactor_radar ;;
+    7) do_docker_rebuild ;;
   esac
 }
 
@@ -216,6 +224,7 @@ prompt_next() {
       5) echo "4" ; return ;;
       6) echo "5" ; return ;;
       7) echo "6" ; return ;;
+      8) echo "7" ; return ;;
       [Rr]) echo "$current" ; return ;;
       [Qq]) echo "-1" ; return ;;
       *) echo -e "${RED}Invalid choice.${RESET}" >&2 ;;
@@ -237,10 +246,10 @@ echo ""
 
 # Pick starting step
 while true; do
-  read -rp "$(echo -e "${BOLD}Start with (1–7): ${RESET}")" start
+  read -rp "$(echo -e "${BOLD}Start with (1–8): ${RESET}")" start
   case "$start" in
-    1|2|3|4|5|6|7) current=$((start-1)) ; break ;;
-    *) echo -e "${RED}Please enter 1–7.${RESET}" ;;
+    1|2|3|4|5|6|7|8) current=$((start-1)) ; break ;;
+    *) echo -e "${RED}Please enter 1–8.${RESET}" ;;
   esac
 done
 


### PR DESCRIPTION
## Summary

- Adds `do_refactor_radar()` to `maintain.sh` as Step 7 (Docker shifts to Step 8)
- Three bash-based co-occurrence detectors with colored terminal output:
  - **State Cluster**: flags frontend pages with ≥3 shared report-state `useState` vars (dateFrom, dateTo, loading, categories, products, selectedProduct, selectedCategory) — suggests extracting into `useReportFilters`
  - **Audit Manualism**: flags backend controllers that manually pass `currentUserId` per endpoint — suggests interceptor/AuditService
  - **Dependency/Bloat**: flags frontend pages with >10 `useState` calls and backend files with >5 constructor deps

## Test Plan

- [x] Run `bash -n maintain.sh` — expect no output (syntax valid)
- [x] Run `printf '7\nq\n' | bash maintain.sh` — expect all three detector sections to appear with findings
- [x] Confirm menu shows 8 options and choice `8` reaches Docker step
- [x] Confirm starting from `1` still reaches Knip step

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)