### PR TITLE
perf(test): re-enable 2 Vitest workers, reduce heap to 1536 MB (closes #198)

### DIFF
--- a/frontend/src/config/__tests__/viteModeConfig.test.ts
+++ b/frontend/src/config/__tests__/viteModeConfig.test.ts
@@ -27,7 +27,7 @@ describe('vite config in test mode', () => {
     })
   })
 
-  it('forces a single Vitest worker to avoid suite hangs in this workspace', async () => {
+  it('uses 2 Vitest workers with a 1536 MB heap cap in test mode', async () => {
     const originalVitestEnv = process.env.VITEST
     delete process.env.VITEST
 
@@ -45,6 +45,7 @@ describe('vite config in test mode', () => {
         })
       : viteConfig
 
-    expect(config.test?.maxWorkers).toBe(1)
+    expect(config.test?.maxWorkers).toBe(2)
+    expect(config.test?.execArgv).toEqual(['--max-old-space-size=1536'])
   })
 })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -112,8 +112,8 @@ export default defineConfig(({ mode }) => {
       environmentMatchGlobs: [['src/**/*.test.ts', 'node']],
       setupFiles: ['./src/test/setup.ts', './src/setupTests.ts'],
       api: false,
-      maxWorkers: 1,
-      execArgv: ['--max-old-space-size=4096'],
+      maxWorkers: 2,
+      execArgv: ['--max-old-space-size=1536'],
       testTimeout: 30000,
     },
   }


### PR DESCRIPTION
## Summary

- `maxWorkers: 1` → `2` to re-enable parallel test execution
- `--max-old-space-size=4096` → `1536` (was preemptive; safe for 2 workers on this machine's 9.7 GB RAM)
- Updated `viteModeConfig.test.ts` assertion to match new values and added missing `execArgv` coverage

## Background

`maxWorkers: 1` was set on 2026-03-26 to fix parallel instability caused by `vi.useFakeTimers()` leaking between workers. That isolation issue was already fixed in prior commits (`3a5345d2d`, `109db0887`). This PR re-enables parallelism now that the root cause is resolved.

## Verification

3 consecutive full-suite runs passed: **93 files / 568 tests** (~629–687s each). Suite is stable with 2 workers.

> Note: runtime did not drop to the originally estimated 3–5 min — actual ~10-11 min due to CPU contention on a 4-core machine with heavy jsdom overhead. Further reduction would require sharding.

## Test plan

- [x] `npm test` passes (93 files / 568 tests)
- [x] 3 consecutive runs with no flaky failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)