### PR TITLE
feat(purchasing): add Supplier, Order Status, and Payment Status filters to Purchasing Overview (#217)

### DIFF
--- a/backend/src/modules/purchasing/dto/purchasing-analytics.dto.ts
+++ b/backend/src/modules/purchasing/dto/purchasing-analytics.dto.ts
@@ -1,5 +1,5 @@
 // backend/src/modules/purchasing/dto/purchasing-analytics.dto.ts
-import { IsOptional, IsEnum, IsIn, IsDate } from 'class-validator';
+import { IsOptional, IsEnum, IsIn, IsDate, IsUUID } from 'class-validator';
 import { ApiPropertyOptional, ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { DateRange, GroupByPeriod } from '@/common/dto/analytics.dto';
@@ -33,6 +33,21 @@ export class PurchasingAnalyticsQueryDto {
   @IsOptional()
   @IsEnum(GroupByPeriod)
   groupBy?: GroupByPeriod;
+
+  @ApiPropertyOptional({ description: 'Filter by supplier ID' })
+  @IsOptional()
+  @IsUUID()
+  supplierId?: string;
+
+  @ApiPropertyOptional({ enum: ['received', 'pending'] })
+  @IsOptional()
+  @IsIn(['received', 'pending'])
+  status?: 'received' | 'pending';
+
+  @ApiPropertyOptional({ enum: ['paid', 'partial', 'unpaid'] })
+  @IsOptional()
+  @IsIn(['paid', 'partial', 'unpaid'])
+  paymentStatus?: 'paid' | 'partial' | 'unpaid';
 }
 
 export class PurchasingMetricsDto {

--- a/backend/src/modules/purchasing/services/purchasing-analytics.service.spec.ts
+++ b/backend/src/modules/purchasing/services/purchasing-analytics.service.spec.ts
@@ -1,0 +1,283 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  PurchaseOrder,
+  PurchaseOrderItem,
+  Supplier,
+  Product,
+  VendorPayment,
+} from '../../../database/entities';
+import { PurchasingAnalyticsService } from './purchasing-analytics.service';
+import { PurchasingAnalyticsQueryDto } from '../dto/purchasing-analytics.dto';
+import { DateRange } from '@/common/dto/analytics.dto';
+
+function makeChainableQb(rawManyResult: any[] = [], manyResult: any[] = [], rawOneResult: any = {}) {
+  const qb: any = {
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    addGroupBy: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn().mockResolvedValue(rawManyResult),
+    getRawOne: jest.fn().mockResolvedValue(rawOneResult),
+    getMany: jest.fn().mockResolvedValue(manyResult),
+    getOne: jest.fn().mockResolvedValue(null),
+  };
+  return qb;
+}
+
+describe('PurchasingAnalyticsService', () => {
+  let service: PurchasingAnalyticsService;
+  let purchaseOrderRepository: { createQueryBuilder: jest.Mock };
+
+  beforeEach(async () => {
+    purchaseOrderRepository = { createQueryBuilder: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PurchasingAnalyticsService,
+        { provide: getRepositoryToken(PurchaseOrder), useValue: purchaseOrderRepository },
+        { provide: getRepositoryToken(PurchaseOrderItem), useValue: { createQueryBuilder: jest.fn() } },
+        { provide: getRepositoryToken(Supplier), useValue: { createQueryBuilder: jest.fn() } },
+        { provide: getRepositoryToken(Product), useValue: { createQueryBuilder: jest.fn() } },
+        { provide: getRepositoryToken(VendorPayment), useValue: { createQueryBuilder: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get<PurchasingAnalyticsService>(PurchasingAnalyticsService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // Helper: minimal valid analytics query
+  const baseQuery = (): PurchasingAnalyticsQueryDto => ({
+    dateRange: DateRange.THIS_MONTH,
+  } as PurchasingAnalyticsQueryDto);
+
+  describe('getPurchasingAnalytics — filter propagation', () => {
+    it('passes supplierId WHERE clause to calculatePurchasingMetrics query builders', async () => {
+      const qb = makeChainableQb(
+        [], // getRawMany (period data)
+        [], // getMany (recent orders)
+        { totalSpent: '0', totalOrders: '0', averageOrderValue: '0', activeSuppliers: '0' },
+      );
+      purchaseOrderRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const query = { ...baseQuery(), supplierId: 'supplier-uuid-123' };
+      await service.getPurchasingAnalytics(query);
+
+      // andWhere should have been called with supplierId filter at least once
+      const andWhereCalls: string[] = qb.andWhere.mock.calls.map((c: any[]) => c[0]);
+      expect(andWhereCalls.some((call) => call.includes('supplierId'))).toBe(true);
+    });
+
+    it('passes status=received as isFullyReceived=true WHERE clause', async () => {
+      const qb = makeChainableQb([], [], {
+        totalSpent: '0', totalOrders: '0', averageOrderValue: '0', activeSuppliers: '0',
+      });
+      purchaseOrderRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const query = { ...baseQuery(), status: 'received' as const };
+      await service.getPurchasingAnalytics(query);
+
+      const andWhereCalls: string[] = qb.andWhere.mock.calls.map((c: any[]) => c[0]);
+      expect(andWhereCalls.some((call) => call.includes('isFullyReceived'))).toBe(true);
+
+      // Verify the parameter value is true
+      const isFullyReceivedCall = qb.andWhere.mock.calls.find((c: any[]) =>
+        typeof c[0] === 'string' && c[0].includes('isFullyReceived'),
+      );
+      expect(isFullyReceivedCall?.[1]?.isFullyReceived).toBe(true);
+    });
+
+    it('passes status=pending as isFullyReceived=false WHERE clause', async () => {
+      const qb = makeChainableQb([], [], {
+        totalSpent: '0', totalOrders: '0', averageOrderValue: '0', activeSuppliers: '0',
+      });
+      purchaseOrderRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const query = { ...baseQuery(), status: 'pending' as const };
+      await service.getPurchasingAnalytics(query);
+
+      const isFullyReceivedCall = qb.andWhere.mock.calls.find((c: any[]) =>
+        typeof c[0] === 'string' && c[0].includes('isFullyReceived'),
+      );
+      expect(isFullyReceivedCall?.[1]?.isFullyReceived).toBe(false);
+    });
+  });
+
+  describe('getRecentPurchaseOrders — paymentStatus post-query filtering', () => {
+    it('returns only paid orders when paymentStatus=paid filter is active', async () => {
+      const mockOrders = [
+        {
+          orderNumber: 'PO-001',
+          orderDate: new Date('2026-03-01'),
+          supplier: { companyName: 'Supplier A' },
+          totalAmount: '1000',
+          isFullyReceived: false,
+          vendorPayments: [{ amount: '1000' }], // fully paid
+        },
+        {
+          orderNumber: 'PO-002',
+          orderDate: new Date('2026-03-02'),
+          supplier: { companyName: 'Supplier B' },
+          totalAmount: '500',
+          isFullyReceived: false,
+          vendorPayments: [], // unpaid
+        },
+        {
+          orderNumber: 'PO-003',
+          orderDate: new Date('2026-03-03'),
+          supplier: { companyName: 'Supplier C' },
+          totalAmount: '300',
+          isFullyReceived: false,
+          vendorPayments: [{ amount: '150' }], // partial
+        },
+      ];
+
+      const qb = makeChainableQb([], mockOrders, {
+        totalSpent: '0', totalOrders: '0', averageOrderValue: '0', activeSuppliers: '0',
+      });
+      purchaseOrderRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const query = { ...baseQuery(), paymentStatus: 'paid' as const };
+      const result = await service.getPurchasingAnalytics(query);
+
+      expect(result.recentOrders).toHaveLength(1);
+      expect(result.recentOrders[0].orderNumber).toBe('PO-001');
+    });
+
+    it('returns only unpaid orders when paymentStatus=unpaid filter is active', async () => {
+      const mockOrders = [
+        {
+          orderNumber: 'PO-001',
+          orderDate: new Date('2026-03-01'),
+          supplier: { companyName: 'Supplier A' },
+          totalAmount: '1000',
+          isFullyReceived: false,
+          vendorPayments: [{ amount: '1000' }], // paid
+        },
+        {
+          orderNumber: 'PO-002',
+          orderDate: new Date('2026-03-02'),
+          supplier: { companyName: 'Supplier B' },
+          totalAmount: '500',
+          isFullyReceived: false,
+          vendorPayments: [], // unpaid
+        },
+      ];
+
+      const qb = makeChainableQb([], mockOrders, {
+        totalSpent: '0', totalOrders: '0', averageOrderValue: '0', activeSuppliers: '0',
+      });
+      purchaseOrderRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const query = { ...baseQuery(), paymentStatus: 'unpaid' as const };
+      const result = await service.getPurchasingAnalytics(query);
+
+      expect(result.recentOrders).toHaveLength(1);
+      expect(result.recentOrders[0].orderNumber).toBe('PO-002');
+    });
+
+    it('returns only partial orders when paymentStatus=partial filter is active', async () => {
+      const mockOrders = [
+        {
+          orderNumber: 'PO-001',
+          orderDate: new Date('2026-03-01'),
+          supplier: { companyName: 'Supplier A' },
+          totalAmount: '1000',
+          isFullyReceived: false,
+          vendorPayments: [{ amount: '1000' }], // paid
+        },
+        {
+          orderNumber: 'PO-002',
+          orderDate: new Date('2026-03-02'),
+          supplier: { companyName: 'Supplier B' },
+          totalAmount: '500',
+          isFullyReceived: false,
+          vendorPayments: [{ amount: '250' }], // partial
+        },
+      ];
+
+      const qb = makeChainableQb([], mockOrders, {
+        totalSpent: '0', totalOrders: '0', averageOrderValue: '0', activeSuppliers: '0',
+      });
+      purchaseOrderRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const query = { ...baseQuery(), paymentStatus: 'partial' as const };
+      const result = await service.getPurchasingAnalytics(query);
+
+      expect(result.recentOrders).toHaveLength(1);
+      expect(result.recentOrders[0].orderNumber).toBe('PO-002');
+    });
+
+    it('does not apply DB LIMIT when paymentStatus filter is active (fetches all for in-app filtering)', async () => {
+      const qb = makeChainableQb([], [], {
+        totalSpent: '0', totalOrders: '0', averageOrderValue: '0', activeSuppliers: '0',
+      });
+      purchaseOrderRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const query = { ...baseQuery(), paymentStatus: 'paid' as const };
+      await service.getPurchasingAnalytics(query);
+
+      // limit() should have been called with undefined (no limit) for the recent orders QB
+      // when paymentStatus filter is active
+      const limitCalls: any[][] = qb.limit.mock.calls;
+      expect(limitCalls.some((args) => args[0] === undefined)).toBe(true);
+    });
+  });
+
+  describe('getPurchasingPeriodData — paymentStatus in-app aggregation', () => {
+    it('groups paid orders by period when paymentStatus=paid', async () => {
+      const mockOrders = [
+        {
+          orderNumber: 'PO-001',
+          orderDate: new Date('2026-03-05'),
+          supplier: { companyName: 'Supplier A' },
+          totalAmount: '1000',
+          isFullyReceived: false,
+          vendorPayments: [{ amount: '1000' }], // paid
+        },
+        {
+          orderNumber: 'PO-002',
+          orderDate: new Date('2026-03-10'),
+          supplier: { companyName: 'Supplier B' },
+          totalAmount: '500',
+          isFullyReceived: false,
+          vendorPayments: [], // unpaid — should be excluded
+        },
+        {
+          orderNumber: 'PO-003',
+          orderDate: new Date('2026-02-15'),
+          supplier: { companyName: 'Supplier C' },
+          totalAmount: '800',
+          isFullyReceived: false,
+          vendorPayments: [{ amount: '800' }], // paid, different month
+        },
+      ];
+
+      const qb = makeChainableQb([], mockOrders, {
+        totalSpent: '0', totalOrders: '0', averageOrderValue: '0', activeSuppliers: '0',
+      });
+      purchaseOrderRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const query = { ...baseQuery(), paymentStatus: 'paid' as const };
+      const result = await service.getPurchasingAnalytics(query);
+
+      // Period data should only include paid orders, grouped by month
+      const marchEntry = result.current.periodData.find((p) => p.period.startsWith('2026-03'));
+      const febEntry = result.current.periodData.find((p) => p.period.startsWith('2026-02'));
+
+      // PO-001 (paid, March) should appear; PO-002 (unpaid, March) should be excluded
+      expect(marchEntry?.orders).toBe(1);
+      expect(marchEntry?.spent).toBe(1000);
+      expect(febEntry?.orders).toBe(1);
+      expect(febEntry?.spent).toBe(800);
+    });
+  });
+});

--- a/backend/src/modules/purchasing/services/purchasing-analytics.service.spec.ts
+++ b/backend/src/modules/purchasing/services/purchasing-analytics.service.spec.ts
@@ -76,7 +76,7 @@ describe('PurchasingAnalyticsService', () => {
       expect(andWhereCalls.some((call) => call.includes('supplierId'))).toBe(true);
     });
 
-    it('passes status=received as isFullyReceived=true WHERE clause', async () => {
+    it('passes status=received as NOT EXISTS subquery WHERE clause', async () => {
       const qb = makeChainableQb([], [], {
         totalSpent: '0', totalOrders: '0', averageOrderValue: '0', activeSuppliers: '0',
       });
@@ -86,16 +86,10 @@ describe('PurchasingAnalyticsService', () => {
       await service.getPurchasingAnalytics(query);
 
       const andWhereCalls: string[] = qb.andWhere.mock.calls.map((c: any[]) => c[0]);
-      expect(andWhereCalls.some((call) => call.includes('isFullyReceived'))).toBe(true);
-
-      // Verify the parameter value is true
-      const isFullyReceivedCall = qb.andWhere.mock.calls.find((c: any[]) =>
-        typeof c[0] === 'string' && c[0].includes('isFullyReceived'),
-      );
-      expect(isFullyReceivedCall?.[1]?.isFullyReceived).toBe(true);
+      expect(andWhereCalls.some((call) => typeof call === 'string' && call.includes('NOT EXISTS'))).toBe(true);
     });
 
-    it('passes status=pending as isFullyReceived=false WHERE clause', async () => {
+    it('passes status=pending as EXISTS subquery WHERE clause', async () => {
       const qb = makeChainableQb([], [], {
         totalSpent: '0', totalOrders: '0', averageOrderValue: '0', activeSuppliers: '0',
       });
@@ -104,10 +98,9 @@ describe('PurchasingAnalyticsService', () => {
       const query = { ...baseQuery(), status: 'pending' as const };
       await service.getPurchasingAnalytics(query);
 
-      const isFullyReceivedCall = qb.andWhere.mock.calls.find((c: any[]) =>
-        typeof c[0] === 'string' && c[0].includes('isFullyReceived'),
-      );
-      expect(isFullyReceivedCall?.[1]?.isFullyReceived).toBe(false);
+      const andWhereCalls: string[] = qb.andWhere.mock.calls.map((c: any[]) => c[0]);
+      // EXISTS but NOT "NOT EXISTS"
+      expect(andWhereCalls.some((call) => typeof call === 'string' && call.includes('EXISTS') && !call.includes('NOT EXISTS'))).toBe(true);
     });
   });
 
@@ -119,7 +112,8 @@ describe('PurchasingAnalyticsService', () => {
           orderDate: new Date('2026-03-01'),
           supplier: { companyName: 'Supplier A' },
           totalAmount: '1000',
-          isFullyReceived: false,
+          items: [],
+          isFullyReceived: () => false,
           vendorPayments: [{ amount: '1000' }], // fully paid
         },
         {
@@ -127,7 +121,8 @@ describe('PurchasingAnalyticsService', () => {
           orderDate: new Date('2026-03-02'),
           supplier: { companyName: 'Supplier B' },
           totalAmount: '500',
-          isFullyReceived: false,
+          items: [],
+          isFullyReceived: () => false,
           vendorPayments: [], // unpaid
         },
         {
@@ -135,7 +130,8 @@ describe('PurchasingAnalyticsService', () => {
           orderDate: new Date('2026-03-03'),
           supplier: { companyName: 'Supplier C' },
           totalAmount: '300',
-          isFullyReceived: false,
+          items: [],
+          isFullyReceived: () => false,
           vendorPayments: [{ amount: '150' }], // partial
         },
       ];
@@ -159,7 +155,8 @@ describe('PurchasingAnalyticsService', () => {
           orderDate: new Date('2026-03-01'),
           supplier: { companyName: 'Supplier A' },
           totalAmount: '1000',
-          isFullyReceived: false,
+          items: [],
+          isFullyReceived: () => false,
           vendorPayments: [{ amount: '1000' }], // paid
         },
         {
@@ -167,7 +164,8 @@ describe('PurchasingAnalyticsService', () => {
           orderDate: new Date('2026-03-02'),
           supplier: { companyName: 'Supplier B' },
           totalAmount: '500',
-          isFullyReceived: false,
+          items: [],
+          isFullyReceived: () => false,
           vendorPayments: [], // unpaid
         },
       ];
@@ -191,7 +189,8 @@ describe('PurchasingAnalyticsService', () => {
           orderDate: new Date('2026-03-01'),
           supplier: { companyName: 'Supplier A' },
           totalAmount: '1000',
-          isFullyReceived: false,
+          items: [],
+          isFullyReceived: () => false,
           vendorPayments: [{ amount: '1000' }], // paid
         },
         {
@@ -199,7 +198,8 @@ describe('PurchasingAnalyticsService', () => {
           orderDate: new Date('2026-03-02'),
           supplier: { companyName: 'Supplier B' },
           totalAmount: '500',
-          isFullyReceived: false,
+          items: [],
+          isFullyReceived: () => false,
           vendorPayments: [{ amount: '250' }], // partial
         },
       ];
@@ -240,7 +240,8 @@ describe('PurchasingAnalyticsService', () => {
           orderDate: new Date('2026-03-05'),
           supplier: { companyName: 'Supplier A' },
           totalAmount: '1000',
-          isFullyReceived: false,
+          items: [],
+          isFullyReceived: () => false,
           vendorPayments: [{ amount: '1000' }], // paid
         },
         {
@@ -248,7 +249,8 @@ describe('PurchasingAnalyticsService', () => {
           orderDate: new Date('2026-03-10'),
           supplier: { companyName: 'Supplier B' },
           totalAmount: '500',
-          isFullyReceived: false,
+          items: [],
+          isFullyReceived: () => false,
           vendorPayments: [], // unpaid — should be excluded
         },
         {
@@ -256,7 +258,8 @@ describe('PurchasingAnalyticsService', () => {
           orderDate: new Date('2026-02-15'),
           supplier: { companyName: 'Supplier C' },
           totalAmount: '800',
-          isFullyReceived: false,
+          items: [],
+          isFullyReceived: () => false,
           vendorPayments: [{ amount: '800' }], // paid, different month
         },
       ];

--- a/backend/src/modules/purchasing/services/purchasing-analytics.service.ts
+++ b/backend/src/modules/purchasing/services/purchasing-analytics.service.ts
@@ -690,8 +690,90 @@ export class PurchasingAnalyticsService {
     groupBy: string,
     filters: PurchasingAnalyticsFilters = {},
   ): Promise<PurchasingPeriodDataDto[]> {
-    let dateFormat: string;
+    const formatPeriodKey = (date: Date): string => {
+      const y = date.getFullYear();
+      const m = String(date.getMonth() + 1).padStart(2, '0');
+      const d = String(date.getDate()).padStart(2, '0');
+      switch (groupBy) {
+        case 'day':
+          return `${y}-${m}-${d}`;
+        case 'week': {
+          // ISO week: IYYY-IW
+          const jan4 = new Date(y, 0, 4);
+          const startOfWeek1 = new Date(jan4);
+          startOfWeek1.setDate(jan4.getDate() - ((jan4.getDay() + 6) % 7));
+          const diffMs = date.getTime() - startOfWeek1.getTime();
+          const isoWeek = Math.floor(diffMs / 604800000) + 1;
+          const isoYear =
+            isoWeek < 1
+              ? y - 1
+              : isoWeek > 52 && date < new Date(y + 1, 0, 4)
+              ? y
+              : y;
+          return `${isoYear}-${String(isoWeek).padStart(2, '0')}`;
+        }
+        case 'quarter':
+          return `${y}-Q${Math.ceil((date.getMonth() + 1) / 3)}`;
+        case 'year':
+          return `${y}`;
+        default: // month
+          return `${y}-${m}`;
+      }
+    };
 
+    // When paymentStatus filter is active, payment status is a computed field (no DB column).
+    // Load full orders with vendor payments, compute per-order, filter, then aggregate in-app.
+    if (filters.paymentStatus) {
+      const qb = this.purchaseOrderRepository
+        .createQueryBuilder('po')
+        .leftJoinAndSelect('po.vendorPayments', 'vendorPayments')
+        .where('po.orderDate BETWEEN :startDate AND :endDate', { startDate, endDate })
+        .andWhere('po.deletedAt IS NULL')
+        .andWhere('po.isActive = :isActive', { isActive: true });
+
+      if (filters.supplierId) {
+        qb.andWhere('po.supplierId = :supplierId', { supplierId: filters.supplierId });
+      }
+      if (filters.status) {
+        qb.andWhere('po.isFullyReceived = :isFullyReceived', {
+          isFullyReceived: filters.status === 'received',
+        });
+      }
+
+      const orders = await qb.getMany();
+
+      const periodMap = new Map<string, { spent: number; orders: number }>();
+
+      for (const po of orders) {
+        const paidAmount = (po.vendorPayments || []).reduce(
+          (sum, payment) => sum + parseFloat(payment.amount?.toString() || '0'),
+          0,
+        );
+        const total = parseFloat(po.totalAmount?.toString() || '0');
+        let computedStatus: 'paid' | 'partial' | 'unpaid';
+        if (paidAmount >= total && total > 0) {
+          computedStatus = 'paid';
+        } else if (paidAmount > 0) {
+          computedStatus = 'partial';
+        } else {
+          computedStatus = 'unpaid';
+        }
+
+        if (computedStatus !== filters.paymentStatus) continue;
+
+        const orderDate = po.orderDate instanceof Date ? po.orderDate : new Date(po.orderDate);
+        const key = formatPeriodKey(orderDate);
+        const existing = periodMap.get(key) ?? { spent: 0, orders: 0 };
+        periodMap.set(key, { spent: existing.spent + total, orders: existing.orders + 1 });
+      }
+
+      return Array.from(periodMap.entries())
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([period, agg]) => ({ period, spent: agg.spent, orders: agg.orders }));
+    }
+
+    // Fast SQL aggregate path when no paymentStatus filter
+    let dateFormat: string;
     switch (groupBy) {
       case 'day':
         dateFormat = 'YYYY-MM-DD';
@@ -789,8 +871,6 @@ export class PurchasingAnalyticsService {
     limit: number,
     filters: PurchasingAnalyticsFilters = {},
   ): Promise<RecentPurchaseOrderDto[]> {
-    const fetchLimit = filters.paymentStatus ? limit * 5 : limit;
-
     const qb = this.purchaseOrderRepository
       .createQueryBuilder('po')
       .leftJoinAndSelect('po.supplier', 'supplier')
@@ -809,7 +889,7 @@ export class PurchasingAnalyticsService {
 
     const orders = await qb
       .orderBy('po.orderDate', 'DESC')
-      .limit(fetchLimit)
+      .limit(filters.paymentStatus ? undefined : limit)
       .getMany();
 
     const mapped = orders.map((po) => {

--- a/backend/src/modules/purchasing/services/purchasing-analytics.service.ts
+++ b/backend/src/modules/purchasing/services/purchasing-analytics.service.ts
@@ -30,6 +30,12 @@ interface PurchaseOrderSummaryQuery {
   paymentStatus?: string;
 }
 
+interface PurchasingAnalyticsFilters {
+  supplierId?: string;
+  status?: 'received' | 'pending';
+  paymentStatus?: 'paid' | 'partial' | 'unpaid';
+}
+
 export interface PurchaseOrderSummaryItem {
   orderNumber: string;
   orderDate: string;
@@ -596,11 +602,17 @@ export class PurchasingAnalyticsService {
       ? this.computePurchasingComparePeriod(startDate, endDate, query.compareWith)
       : null;
 
+    const filters: PurchasingAnalyticsFilters = {
+      supplierId: query.supplierId,
+      status: query.status,
+      paymentStatus: query.paymentStatus,
+    };
+
     const [metrics, periodData, topSuppliers, recentOrders] = await Promise.all([
-      this.calculatePurchasingMetrics(startDate, endDate),
-      this.getPurchasingPeriodData(startDate, endDate, groupBy),
-      this.getTopSuppliers(startDate, endDate, 5),
-      this.getRecentPurchaseOrders(5),
+      this.calculatePurchasingMetrics(startDate, endDate, filters),
+      this.getPurchasingPeriodData(startDate, endDate, groupBy, filters),
+      this.getTopSuppliers(startDate, endDate, 5, filters),
+      this.getRecentPurchaseOrders(5, filters),
     ]);
 
     const current: PurchasingPeriodBlockDto = {
@@ -613,8 +625,8 @@ export class PurchasingAnalyticsService {
     let comparison: PurchasingPeriodBlockDto | undefined;
     if (comparePeriod) {
       const [compareMetrics, comparePeriodData] = await Promise.all([
-        this.calculatePurchasingMetrics(comparePeriod.compareStart, comparePeriod.compareEnd),
-        this.getPurchasingPeriodData(comparePeriod.compareStart, comparePeriod.compareEnd, groupBy),
+        this.calculatePurchasingMetrics(comparePeriod.compareStart, comparePeriod.compareEnd, filters),
+        this.getPurchasingPeriodData(comparePeriod.compareStart, comparePeriod.compareEnd, groupBy, filters),
       ]);
       comparison = {
         metrics: compareMetrics,
@@ -630,24 +642,36 @@ export class PurchasingAnalyticsService {
   private async calculatePurchasingMetrics(
     startDate: Date,
     endDate: Date,
+    filters: PurchasingAnalyticsFilters = {},
   ): Promise<PurchasingMetricsDto> {
-    const [orderStats, supplierStats] = await Promise.all([
+    const baseQb = () =>
       this.purchaseOrderRepository
         .createQueryBuilder('po')
         .where('po.orderDate BETWEEN :startDate AND :endDate', { startDate, endDate })
         .andWhere('po.deletedAt IS NULL')
-        .andWhere('po.isActive = :isActive', { isActive: true })
+        .andWhere('po.isActive = :isActive', { isActive: true });
+
+    const applyFilters = (qb: ReturnType<typeof baseQb>) => {
+      if (filters.supplierId) {
+        qb.andWhere('po.supplierId = :supplierId', { supplierId: filters.supplierId });
+      }
+      if (filters.status) {
+        qb.andWhere('po.isFullyReceived = :isFullyReceived', {
+          isFullyReceived: filters.status === 'received',
+        });
+      }
+      return qb;
+    };
+
+    const [orderStats, supplierStats] = await Promise.all([
+      applyFilters(baseQb())
         .select([
           'COALESCE(SUM(po.totalAmount), 0) as "totalSpent"',
           'COUNT(*) as "totalOrders"',
           'COALESCE(AVG(po.totalAmount), 0) as "averageOrderValue"',
         ])
         .getRawOne(),
-      this.purchaseOrderRepository
-        .createQueryBuilder('po')
-        .where('po.orderDate BETWEEN :startDate AND :endDate', { startDate, endDate })
-        .andWhere('po.deletedAt IS NULL')
-        .andWhere('po.isActive = :isActive', { isActive: true })
+      applyFilters(baseQb())
         .select('COUNT(DISTINCT po.supplierId) as "activeSuppliers"')
         .getRawOne(),
     ]);
@@ -664,6 +688,7 @@ export class PurchasingAnalyticsService {
     startDate: Date,
     endDate: Date,
     groupBy: string,
+    filters: PurchasingAnalyticsFilters = {},
   ): Promise<PurchasingPeriodDataDto[]> {
     let dateFormat: string;
 
@@ -685,11 +710,22 @@ export class PurchasingAnalyticsService {
         break;
     }
 
-    const data = await this.purchaseOrderRepository
+    const qb = this.purchaseOrderRepository
       .createQueryBuilder('po')
       .where('po.orderDate BETWEEN :startDate AND :endDate', { startDate, endDate })
       .andWhere('po.deletedAt IS NULL')
-      .andWhere('po.isActive = :isActive', { isActive: true })
+      .andWhere('po.isActive = :isActive', { isActive: true });
+
+    if (filters.supplierId) {
+      qb.andWhere('po.supplierId = :supplierId', { supplierId: filters.supplierId });
+    }
+    if (filters.status) {
+      qb.andWhere('po.isFullyReceived = :isFullyReceived', {
+        isFullyReceived: filters.status === 'received',
+      });
+    }
+
+    const data = await qb
       .select([
         `TO_CHAR(po.orderDate, '${dateFormat}') as period`,
         'COUNT(*) as orders',
@@ -710,13 +746,25 @@ export class PurchasingAnalyticsService {
     startDate: Date,
     endDate: Date,
     limit: number,
+    filters: PurchasingAnalyticsFilters = {},
   ): Promise<TopSupplierDto[]> {
-    const data = await this.purchaseOrderRepository
+    const qb = this.purchaseOrderRepository
       .createQueryBuilder('po')
       .leftJoin('po.supplier', 'supplier')
       .where('po.orderDate BETWEEN :startDate AND :endDate', { startDate, endDate })
       .andWhere('po.deletedAt IS NULL')
-      .andWhere('po.isActive = :isActive', { isActive: true })
+      .andWhere('po.isActive = :isActive', { isActive: true });
+
+    if (filters.supplierId) {
+      qb.andWhere('po.supplierId = :supplierId', { supplierId: filters.supplierId });
+    }
+    if (filters.status) {
+      qb.andWhere('po.isFullyReceived = :isFullyReceived', {
+        isFullyReceived: filters.status === 'received',
+      });
+    }
+
+    const data = await qb
       .select([
         'supplier.id as "supplierId"',
         'supplier.companyName as "supplierName"',
@@ -737,26 +785,63 @@ export class PurchasingAnalyticsService {
     }));
   }
 
-  private async getRecentPurchaseOrders(limit: number): Promise<RecentPurchaseOrderDto[]> {
-    const orders = await this.purchaseOrderRepository
+  private async getRecentPurchaseOrders(
+    limit: number,
+    filters: PurchasingAnalyticsFilters = {},
+  ): Promise<RecentPurchaseOrderDto[]> {
+    const fetchLimit = filters.paymentStatus ? limit * 5 : limit;
+
+    const qb = this.purchaseOrderRepository
       .createQueryBuilder('po')
       .leftJoinAndSelect('po.supplier', 'supplier')
+      .leftJoinAndSelect('po.vendorPayments', 'vendorPayments')
       .where('po.deletedAt IS NULL')
-      .andWhere('po.isActive = :isActive', { isActive: true })
+      .andWhere('po.isActive = :isActive', { isActive: true });
+
+    if (filters.supplierId) {
+      qb.andWhere('po.supplierId = :supplierId', { supplierId: filters.supplierId });
+    }
+    if (filters.status) {
+      qb.andWhere('po.isFullyReceived = :isFullyReceived', {
+        isFullyReceived: filters.status === 'received',
+      });
+    }
+
+    const orders = await qb
       .orderBy('po.orderDate', 'DESC')
-      .limit(limit)
+      .limit(fetchLimit)
       .getMany();
 
-    return orders.map((po) => {
+    const mapped = orders.map((po) => {
       const date = po.orderDate instanceof Date ? po.orderDate : new Date(po.orderDate);
+      const paidAmount = (po.vendorPayments ?? []).reduce(
+        (sum, vp) => sum + parseFloat(vp.amount?.toString() || '0'),
+        0,
+      );
+      const total = parseFloat(po.totalAmount?.toString() || '0');
+      let computedPaymentStatus: 'paid' | 'partial' | 'unpaid';
+      if (paidAmount >= total && total > 0) {
+        computedPaymentStatus = 'paid';
+      } else if (paidAmount > 0) {
+        computedPaymentStatus = 'partial';
+      } else {
+        computedPaymentStatus = 'unpaid';
+      }
       return {
         orderNumber: po.orderNumber,
         orderDate: date.toISOString().split('T')[0],
         supplierName: po.supplier?.companyName || 'N/A',
-        totalAmount: parseFloat(po.totalAmount?.toString() || '0'),
-        status: po.isFullyReceived ? 'received' : 'pending',
+        totalAmount: total,
+        status: (po.isFullyReceived ? 'received' : 'pending') as 'received' | 'pending',
+        computedPaymentStatus,
       };
     });
+
+    const filtered = filters.paymentStatus
+      ? mapped.filter((order) => order.computedPaymentStatus === filters.paymentStatus)
+      : mapped;
+
+    return filtered.slice(0, limit).map(({ computedPaymentStatus: _, ...rest }) => rest);
   }
 
   private parsePurchasingDateRange(

--- a/backend/src/modules/purchasing/services/purchasing-analytics.service.ts
+++ b/backend/src/modules/purchasing/services/purchasing-analytics.service.ts
@@ -655,10 +655,14 @@ export class PurchasingAnalyticsService {
       if (filters.supplierId) {
         qb.andWhere('po.supplierId = :supplierId', { supplierId: filters.supplierId });
       }
-      if (filters.status) {
-        qb.andWhere('po.isFullyReceived = :isFullyReceived', {
-          isFullyReceived: filters.status === 'received',
-        });
+      if (filters.status === 'received') {
+        qb.andWhere(
+          'NOT EXISTS (SELECT 1 FROM purchase_order_items poi WHERE poi."purchaseOrderId" = po.id AND poi."receivedQuantity" < poi.quantity AND poi."deletedAt" IS NULL)',
+        );
+      } else if (filters.status === 'pending') {
+        qb.andWhere(
+          'EXISTS (SELECT 1 FROM purchase_order_items poi WHERE poi."purchaseOrderId" = po.id AND poi."receivedQuantity" < poi.quantity AND poi."deletedAt" IS NULL)',
+        );
       }
       return qb;
     };
@@ -734,10 +738,14 @@ export class PurchasingAnalyticsService {
       if (filters.supplierId) {
         qb.andWhere('po.supplierId = :supplierId', { supplierId: filters.supplierId });
       }
-      if (filters.status) {
-        qb.andWhere('po.isFullyReceived = :isFullyReceived', {
-          isFullyReceived: filters.status === 'received',
-        });
+      if (filters.status === 'received') {
+        qb.andWhere(
+          'NOT EXISTS (SELECT 1 FROM purchase_order_items poi WHERE poi."purchaseOrderId" = po.id AND poi."receivedQuantity" < poi.quantity AND poi."deletedAt" IS NULL)',
+        );
+      } else if (filters.status === 'pending') {
+        qb.andWhere(
+          'EXISTS (SELECT 1 FROM purchase_order_items poi WHERE poi."purchaseOrderId" = po.id AND poi."receivedQuantity" < poi.quantity AND poi."deletedAt" IS NULL)',
+        );
       }
 
       const orders = await qb.getMany();
@@ -801,10 +809,14 @@ export class PurchasingAnalyticsService {
     if (filters.supplierId) {
       qb.andWhere('po.supplierId = :supplierId', { supplierId: filters.supplierId });
     }
-    if (filters.status) {
-      qb.andWhere('po.isFullyReceived = :isFullyReceived', {
-        isFullyReceived: filters.status === 'received',
-      });
+    if (filters.status === 'received') {
+      qb.andWhere(
+        'NOT EXISTS (SELECT 1 FROM purchase_order_items poi WHERE poi."purchaseOrderId" = po.id AND poi."receivedQuantity" < poi.quantity AND poi."deletedAt" IS NULL)',
+      );
+    } else if (filters.status === 'pending') {
+      qb.andWhere(
+        'EXISTS (SELECT 1 FROM purchase_order_items poi WHERE poi."purchaseOrderId" = po.id AND poi."receivedQuantity" < poi.quantity AND poi."deletedAt" IS NULL)',
+      );
     }
 
     const data = await qb
@@ -840,10 +852,14 @@ export class PurchasingAnalyticsService {
     if (filters.supplierId) {
       qb.andWhere('po.supplierId = :supplierId', { supplierId: filters.supplierId });
     }
-    if (filters.status) {
-      qb.andWhere('po.isFullyReceived = :isFullyReceived', {
-        isFullyReceived: filters.status === 'received',
-      });
+    if (filters.status === 'received') {
+      qb.andWhere(
+        'NOT EXISTS (SELECT 1 FROM purchase_order_items poi WHERE poi."purchaseOrderId" = po.id AND poi."receivedQuantity" < poi.quantity AND poi."deletedAt" IS NULL)',
+      );
+    } else if (filters.status === 'pending') {
+      qb.andWhere(
+        'EXISTS (SELECT 1 FROM purchase_order_items poi WHERE poi."purchaseOrderId" = po.id AND poi."receivedQuantity" < poi.quantity AND poi."deletedAt" IS NULL)',
+      );
     }
 
     const data = await qb
@@ -874,6 +890,7 @@ export class PurchasingAnalyticsService {
     const qb = this.purchaseOrderRepository
       .createQueryBuilder('po')
       .leftJoinAndSelect('po.supplier', 'supplier')
+      .leftJoinAndSelect('po.items', 'items')
       .leftJoinAndSelect('po.vendorPayments', 'vendorPayments')
       .where('po.deletedAt IS NULL')
       .andWhere('po.isActive = :isActive', { isActive: true });
@@ -881,10 +898,14 @@ export class PurchasingAnalyticsService {
     if (filters.supplierId) {
       qb.andWhere('po.supplierId = :supplierId', { supplierId: filters.supplierId });
     }
-    if (filters.status) {
-      qb.andWhere('po.isFullyReceived = :isFullyReceived', {
-        isFullyReceived: filters.status === 'received',
-      });
+    if (filters.status === 'received') {
+      qb.andWhere(
+        'NOT EXISTS (SELECT 1 FROM purchase_order_items poi WHERE poi."purchaseOrderId" = po.id AND poi."receivedQuantity" < poi.quantity AND poi."deletedAt" IS NULL)',
+      );
+    } else if (filters.status === 'pending') {
+      qb.andWhere(
+        'EXISTS (SELECT 1 FROM purchase_order_items poi WHERE poi."purchaseOrderId" = po.id AND poi."receivedQuantity" < poi.quantity AND poi."deletedAt" IS NULL)',
+      );
     }
 
     const orders = await qb
@@ -912,7 +933,7 @@ export class PurchasingAnalyticsService {
         orderDate: date.toISOString().split('T')[0],
         supplierName: po.supplier?.companyName || 'N/A',
         totalAmount: total,
-        status: (po.isFullyReceived ? 'received' : 'pending') as 'received' | 'pending',
+        status: (po.isFullyReceived() ? 'received' : 'pending') as 'received' | 'pending',
         computedPaymentStatus,
       };
     });

--- a/frontend/src/components/filters/DashboardFilterBar.tsx
+++ b/frontend/src/components/filters/DashboardFilterBar.tsx
@@ -203,9 +203,9 @@ export function DashboardFilterBar({
 
       {status !== undefined && onStatusChange && (
         <FormControl size="small" sx={{ minWidth: 150 }}>
-          <InputLabel id="dashboard-order-status-label">Order Status</InputLabel>
+          <InputLabel id="dashboard-purchasing-order-status-label">Order Status</InputLabel>
           <Select
-            labelId="dashboard-order-status-label"
+            labelId="dashboard-purchasing-order-status-label"
             id="dashboard-order-status-purchasing"
             value={status ?? ''}
             label="Order Status"

--- a/frontend/src/components/filters/DashboardFilterBar.tsx
+++ b/frontend/src/components/filters/DashboardFilterBar.tsx
@@ -2,7 +2,7 @@ import { Box, Button, CircularProgress, FormControl, InputLabel, MenuItem, Selec
 import { DatePicker } from '@mui/x-date-pickers'
 import { format, parseISO } from 'date-fns'
 import { toMuiDatePickerFormat } from '@/utils/formatters'
-import type { DashboardCompare, DashboardPeriod, PaymentStatusFilter } from '@/hooks/useDashboardFilters'
+import type { DashboardCompare, DashboardPeriod } from '@/hooks/useDashboardFilters'
 
 interface DashboardFilterBarProps {
   period: DashboardPeriod
@@ -20,10 +20,16 @@ interface DashboardFilterBarProps {
   customers?: { id: string; name: string }[]
   customerId?: string | null
   onCustomerChange?: (id: string | null) => void
+  suppliers?: { id: string; name: string }[]
+  supplierId?: string | null
+  onSupplierChange?: (id: string | null) => void
   isFulfilled?: boolean | null
   onFulfilledChange?: (value: boolean | null) => void
-  paymentStatus?: PaymentStatusFilter | null
-  onPaymentStatusChange?: (value: PaymentStatusFilter | null) => void
+  status?: string | null
+  onStatusChange?: (value: string | null) => void
+  paymentStatus?: string | null
+  onPaymentStatusChange?: (value: string | null) => void
+  paymentStatusOptions?: { value: string; label: string }[]
 }
 
 export function DashboardFilterBar({
@@ -42,13 +48,24 @@ export function DashboardFilterBar({
   customers,
   customerId,
   onCustomerChange,
+  suppliers,
+  supplierId,
+  onSupplierChange,
   isFulfilled,
   onFulfilledChange,
+  status,
+  onStatusChange,
   paymentStatus,
   onPaymentStatusChange,
+  paymentStatusOptions,
 }: DashboardFilterBarProps) {
   const compareDisabled = period === 'today'
   const pickerFormat = toMuiDatePickerFormat(localStorage.getItem('dateFormat') || 'DD/MM/YYYY')
+  const resolvedPaymentStatusOptions = paymentStatusOptions ?? [
+    { value: 'paid', label: 'Paid' },
+    { value: 'partial_paid', label: 'Partially Paid' },
+    { value: 'draft', label: 'Draft' },
+  ]
 
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap', mb: 3 }}>
@@ -146,6 +163,24 @@ export function DashboardFilterBar({
         </FormControl>
       )}
 
+      {suppliers !== undefined && onSupplierChange && (
+        <FormControl size="small" sx={{ minWidth: 170 }}>
+          <InputLabel id="dashboard-supplier-label">Supplier</InputLabel>
+          <Select
+            labelId="dashboard-supplier-label"
+            id="dashboard-supplier"
+            value={supplierId ?? ''}
+            label="Supplier"
+            onChange={(e) => onSupplierChange(e.target.value || null)}
+          >
+            <MenuItem value="">All Suppliers</MenuItem>
+            {suppliers.map((supplier) => (
+              <MenuItem key={supplier.id} value={supplier.id}>{supplier.name}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      )}
+
       {isFulfilled !== undefined && onFulfilledChange && (
         <FormControl size="small" sx={{ minWidth: 150 }}>
           <InputLabel id="dashboard-order-status-label">Order Status</InputLabel>
@@ -166,6 +201,23 @@ export function DashboardFilterBar({
         </FormControl>
       )}
 
+      {status !== undefined && onStatusChange && (
+        <FormControl size="small" sx={{ minWidth: 150 }}>
+          <InputLabel id="dashboard-order-status-label">Order Status</InputLabel>
+          <Select
+            labelId="dashboard-order-status-label"
+            id="dashboard-order-status-purchasing"
+            value={status ?? ''}
+            label="Order Status"
+            onChange={(e) => onStatusChange(e.target.value || null)}
+          >
+            <MenuItem value="">All</MenuItem>
+            <MenuItem value="received">Received</MenuItem>
+            <MenuItem value="pending">Pending</MenuItem>
+          </Select>
+        </FormControl>
+      )}
+
       {paymentStatus !== undefined && onPaymentStatusChange && (
         <FormControl size="small" sx={{ minWidth: 170 }}>
           <InputLabel id="dashboard-payment-status-label">Payment Status</InputLabel>
@@ -174,12 +226,12 @@ export function DashboardFilterBar({
             id="dashboard-payment-status"
             value={paymentStatus ?? ''}
             label="Payment Status"
-            onChange={(e) => onPaymentStatusChange((e.target.value || null) as PaymentStatusFilter | null)}
+            onChange={(e) => onPaymentStatusChange(e.target.value || null)}
           >
             <MenuItem value="">All</MenuItem>
-            <MenuItem value="paid">Paid</MenuItem>
-            <MenuItem value="partial_paid">Partially Paid</MenuItem>
-            <MenuItem value="draft">Draft</MenuItem>
+            {resolvedPaymentStatusOptions.map((option) => (
+              <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
+            ))}
           </Select>
         </FormControl>
       )}

--- a/frontend/src/components/filters/__tests__/DashboardFilterBar.test.tsx
+++ b/frontend/src/components/filters/__tests__/DashboardFilterBar.test.tsx
@@ -41,6 +41,11 @@ describe('DashboardFilterBar', () => {
     expect(screen.queryByLabelText('Order Status')).toBeNull()
   })
 
+  it('does not render Supplier select when suppliers prop is absent', () => {
+    wrap(<DashboardFilterBar {...baseProps()} />)
+    expect(screen.queryByLabelText('Supplier')).toBeNull()
+  })
+
   it('does not render Payment Status select when paymentStatus prop is absent', () => {
     wrap(<DashboardFilterBar {...baseProps()} />)
     expect(screen.queryByLabelText('Payment Status')).toBeNull()
@@ -69,12 +74,51 @@ describe('DashboardFilterBar', () => {
     expect(screen.getByLabelText('Order Status')).toBeTruthy()
   })
 
+  it('renders Supplier select when suppliers prop is provided', () => {
+    wrap(
+      <DashboardFilterBar
+        {...baseProps()}
+        suppliers={[{ id: 's1', name: 'Acme Supplies' }]}
+        supplierId={null}
+        onSupplierChange={vi.fn()}
+      />,
+    )
+    expect(screen.getByLabelText('Supplier')).toBeTruthy()
+  })
+
+  it('renders Order Status select when status prop is provided', () => {
+    wrap(
+      <DashboardFilterBar
+        {...baseProps()}
+        status={null}
+        onStatusChange={vi.fn()}
+      />,
+    )
+    expect(screen.getByLabelText('Order Status')).toBeTruthy()
+  })
+
   it('renders Payment Status select when paymentStatus prop is provided', () => {
     wrap(
       <DashboardFilterBar
         {...baseProps()}
         paymentStatus={null}
         onPaymentStatusChange={vi.fn()}
+      />,
+    )
+    expect(screen.getByLabelText('Payment Status')).toBeTruthy()
+  })
+
+  it('renders custom payment status labels when paymentStatusOptions are provided', () => {
+    wrap(
+      <DashboardFilterBar
+        {...baseProps()}
+        paymentStatus={null}
+        onPaymentStatusChange={vi.fn()}
+        paymentStatusOptions={[
+          { value: 'paid', label: 'Paid' },
+          { value: 'partial', label: 'Partially Paid' },
+          { value: 'unpaid', label: 'Unpaid' },
+        ]}
       />,
     )
     expect(screen.getByLabelText('Payment Status')).toBeTruthy()
@@ -109,6 +153,35 @@ describe('DashboardFilterBar', () => {
     expect(onFulfilledChange).toHaveBeenCalledWith(true)
   })
 
+  it('calls onSupplierChange with null when All Suppliers is selected', async () => {
+    const onSupplierChange = vi.fn()
+    wrap(
+      <DashboardFilterBar
+        {...baseProps()}
+        suppliers={[{ id: 's1', name: 'Acme Supplies' }]}
+        supplierId="s1"
+        onSupplierChange={onSupplierChange}
+      />,
+    )
+    await userEvent.click(screen.getByLabelText('Supplier'))
+    await userEvent.click(screen.getByText('All Suppliers'))
+    expect(onSupplierChange).toHaveBeenCalledWith(null)
+  })
+
+  it('calls onStatusChange with pending when Pending is selected', async () => {
+    const onStatusChange = vi.fn()
+    wrap(
+      <DashboardFilterBar
+        {...baseProps()}
+        status={null}
+        onStatusChange={onStatusChange}
+      />,
+    )
+    await userEvent.click(screen.getByLabelText('Order Status'))
+    await userEvent.click(screen.getByText('Pending'))
+    expect(onStatusChange).toHaveBeenCalledWith('pending')
+  })
+
   it('calls onPaymentStatusChange with paid when Paid is selected', async () => {
     const onPaymentStatusChange = vi.fn()
     wrap(
@@ -121,6 +194,25 @@ describe('DashboardFilterBar', () => {
     await userEvent.click(screen.getByLabelText('Payment Status'))
     await userEvent.click(screen.getByText('Paid'))
     expect(onPaymentStatusChange).toHaveBeenCalledWith('paid')
+  })
+
+  it('calls onPaymentStatusChange with unpaid when custom options are selected', async () => {
+    const onPaymentStatusChange = vi.fn()
+    wrap(
+      <DashboardFilterBar
+        {...baseProps()}
+        paymentStatus={null}
+        onPaymentStatusChange={onPaymentStatusChange}
+        paymentStatusOptions={[
+          { value: 'paid', label: 'Paid' },
+          { value: 'partial', label: 'Partially Paid' },
+          { value: 'unpaid', label: 'Unpaid' },
+        ]}
+      />,
+    )
+    await userEvent.click(screen.getByLabelText('Payment Status'))
+    await userEvent.click(screen.getByText('Unpaid'))
+    expect(onPaymentStatusChange).toHaveBeenCalledWith('unpaid')
   })
 
   it('renders Reset as an outlined button with left margin when filters are not default', () => {

--- a/frontend/src/hooks/useDashboardFilters.test.ts
+++ b/frontend/src/hooks/useDashboardFilters.test.ts
@@ -160,12 +160,14 @@ describe('useDashboardFilters', () => {
     expect(purchasingResult.current.period).toBe('last_month')
   })
 
-  describe('new filters: customerId, isFulfilled, paymentStatus', () => {
-    it('returns null for all three when URL is empty', () => {
+  describe('new filters: customerId, supplierId, isFulfilled, status, paymentStatus', () => {
+    it('returns null for all five when URL is empty', () => {
       setUrl('')
       const { result } = renderHook(() => useDashboardFilters('sales'))
       expect(result.current.customerId).toBeNull()
+      expect(result.current.supplierId).toBeNull()
       expect(result.current.isFulfilled).toBeNull()
+      expect(result.current.status).toBeNull()
       expect(result.current.paymentStatus).toBeNull()
     })
 
@@ -181,6 +183,18 @@ describe('useDashboardFilters', () => {
       expect(result.current.customerId).toBeNull()
     })
 
+    it('reads valid UUID supplierId from URL on mount', () => {
+      setUrl('?purchasing_supplier=550e8400-e29b-41d4-a716-446655440001')
+      const { result } = renderHook(() => useDashboardFilters('purchasing'))
+      expect(result.current.supplierId).toBe('550e8400-e29b-41d4-a716-446655440001')
+    })
+
+    it('ignores non-UUID supplierId value from URL', () => {
+      setUrl('?purchasing_supplier=not-a-uuid')
+      const { result } = renderHook(() => useDashboardFilters('purchasing'))
+      expect(result.current.supplierId).toBeNull()
+    })
+
     it('reads isFulfilled=true from URL on mount', () => {
       setUrl('?sales_fulfilled=true')
       const { result } = renderHook(() => useDashboardFilters('sales'))
@@ -193,10 +207,22 @@ describe('useDashboardFilters', () => {
       expect(result.current.isFulfilled).toBe(false)
     })
 
+    it('reads status from URL on mount', () => {
+      setUrl('?purchasing_status=received')
+      const { result } = renderHook(() => useDashboardFilters('purchasing'))
+      expect(result.current.status).toBe('received')
+    })
+
     it('reads paymentStatus from URL on mount', () => {
       setUrl('?sales_payment=paid')
       const { result } = renderHook(() => useDashboardFilters('sales'))
       expect(result.current.paymentStatus).toBe('paid')
+    })
+
+    it('reads purchasing paymentStatus from URL on mount', () => {
+      setUrl('?purchasing_payment=partial')
+      const { result } = renderHook(() => useDashboardFilters('purchasing'))
+      expect(result.current.paymentStatus).toBe('partial')
     })
 
     it('ignores invalid paymentStatus value', () => {
@@ -214,11 +240,29 @@ describe('useDashboardFilters', () => {
       expect(replaceState).toHaveBeenCalled()
     })
 
+    it('setSupplierId writes to URL and updates state', () => {
+      setUrl('')
+      const { result } = renderHook(() => useDashboardFilters('purchasing'))
+      act(() => { result.current.setSupplierId('550e8400-e29b-41d4-a716-446655440001') })
+      expect(result.current.supplierId).toBe('550e8400-e29b-41d4-a716-446655440001')
+      const replaceState = window.history.replaceState as ReturnType<typeof vi.fn>
+      expect(replaceState).toHaveBeenCalled()
+    })
+
     it('setFulfilled writes to URL and updates state', () => {
       setUrl('')
       const { result } = renderHook(() => useDashboardFilters('sales'))
       act(() => { result.current.setFulfilled(true) })
       expect(result.current.isFulfilled).toBe(true)
+      const replaceState = window.history.replaceState as ReturnType<typeof vi.fn>
+      expect(replaceState).toHaveBeenCalled()
+    })
+
+    it('setStatus writes to URL and updates state', () => {
+      setUrl('')
+      const { result } = renderHook(() => useDashboardFilters('purchasing'))
+      act(() => { result.current.setStatus('pending') })
+      expect(result.current.status).toBe('pending')
       const replaceState = window.history.replaceState as ReturnType<typeof vi.fn>
       expect(replaceState).toHaveBeenCalled()
     })
@@ -232,12 +276,13 @@ describe('useDashboardFilters', () => {
       expect(replaceState).toHaveBeenCalled()
     })
 
-    it('reset clears all three new filters', () => {
-      setUrl('?sales_customer=550e8400-e29b-41d4-a716-446655440000&sales_fulfilled=true&sales_payment=paid')
-      const { result } = renderHook(() => useDashboardFilters('sales'))
+    it('reset clears all filter extensions', () => {
+      setUrl('?purchasing_supplier=550e8400-e29b-41d4-a716-446655440001&purchasing_status=received&purchasing_payment=partial')
+      const { result } = renderHook(() => useDashboardFilters('purchasing'))
       act(() => { result.current.reset() })
-      expect(result.current.customerId).toBeNull()
+      expect(result.current.supplierId).toBeNull()
       expect(result.current.isFulfilled).toBeNull()
+      expect(result.current.status).toBeNull()
       expect(result.current.paymentStatus).toBeNull()
     })
 
@@ -247,10 +292,22 @@ describe('useDashboardFilters', () => {
       expect(result.current.isDefault).toBe(false)
     })
 
+    it('isDefault is false when supplierId is set', () => {
+      setUrl('?purchasing_supplier=550e8400-e29b-41d4-a716-446655440001')
+      const { result } = renderHook(() => useDashboardFilters('purchasing'))
+      expect(result.current.isDefault).toBe(false)
+    })
+
     it('resolvedApiParams includes customerId when set', () => {
       setUrl('?sales_customer=550e8400-e29b-41d4-a716-446655440000')
       const { result } = renderHook(() => useDashboardFilters('sales'))
       expect(result.current.resolvedApiParams.customerId).toBe('550e8400-e29b-41d4-a716-446655440000')
+    })
+
+    it('resolvedApiParams includes supplierId when set', () => {
+      setUrl('?purchasing_supplier=550e8400-e29b-41d4-a716-446655440001')
+      const { result } = renderHook(() => useDashboardFilters('purchasing'))
+      expect(result.current.resolvedApiParams.supplierId).toBe('550e8400-e29b-41d4-a716-446655440001')
     })
 
     it('resolvedApiParams includes isFulfilled when set', () => {
@@ -259,10 +316,22 @@ describe('useDashboardFilters', () => {
       expect(result.current.resolvedApiParams.isFulfilled).toBe(true)
     })
 
+    it('resolvedApiParams includes status when set', () => {
+      setUrl('?purchasing_status=received')
+      const { result } = renderHook(() => useDashboardFilters('purchasing'))
+      expect(result.current.resolvedApiParams.status).toBe('received')
+    })
+
     it('resolvedApiParams includes paymentStatus when set', () => {
       setUrl('?sales_payment=partial_paid')
       const { result } = renderHook(() => useDashboardFilters('sales'))
       expect(result.current.resolvedApiParams.paymentStatus).toBe('partial_paid')
+    })
+
+    it('resolvedApiParams includes purchasing paymentStatus when set', () => {
+      setUrl('?purchasing_payment=unpaid')
+      const { result } = renderHook(() => useDashboardFilters('purchasing'))
+      expect(result.current.resolvedApiParams.paymentStatus).toBe('unpaid')
     })
   })
 })

--- a/frontend/src/hooks/useDashboardFilters.test.ts
+++ b/frontend/src/hooks/useDashboardFilters.test.ts
@@ -277,9 +277,10 @@ describe('useDashboardFilters', () => {
     })
 
     it('reset clears all filter extensions', () => {
-      setUrl('?purchasing_supplier=550e8400-e29b-41d4-a716-446655440001&purchasing_status=received&purchasing_payment=partial')
-      const { result } = renderHook(() => useDashboardFilters('purchasing'))
+      setUrl('?sales_customer=550e8400-e29b-41d4-a716-446655440000&purchasing_supplier=550e8400-e29b-41d4-a716-446655440001&purchasing_status=received&purchasing_payment=partial')
+      const { result } = renderHook(() => useDashboardFilters('sales'))
       act(() => { result.current.reset() })
+      expect(result.current.customerId).toBeNull()
       expect(result.current.supplierId).toBeNull()
       expect(result.current.isFulfilled).toBeNull()
       expect(result.current.status).toBeNull()

--- a/frontend/src/hooks/useDashboardFilters.ts
+++ b/frontend/src/hooks/useDashboardFilters.ts
@@ -3,7 +3,7 @@ import { subDays, format } from 'date-fns'
 
 export type DashboardPeriod = 'today' | 'last_7_days' | 'this_month' | 'last_month' | 'custom'
 export type DashboardCompare = 'previous_period' | 'last_month' | 'last_year' | null
-export type PaymentStatusFilter = 'draft' | 'partial_paid' | 'paid'
+export type PaymentStatusFilter = 'draft' | 'partial_paid' | 'paid' | 'partial' | 'unpaid'
 export interface DashboardResolvedApiParams {
   dateRange?: string
   startDate?: string
@@ -11,13 +11,15 @@ export interface DashboardResolvedApiParams {
   groupBy?: string
   compareWith?: string
   customerId?: string
+  supplierId?: string
+  status?: string
   isFulfilled?: boolean
-  paymentStatus?: PaymentStatusFilter
+  paymentStatus?: string
 }
 
 const VALID_PERIODS: DashboardPeriod[] = ['today', 'last_7_days', 'this_month', 'last_month', 'custom']
 const VALID_COMPARES: NonNullable<DashboardCompare>[] = ['previous_period', 'last_month', 'last_year']
-const VALID_PAYMENT_STATUSES: PaymentStatusFilter[] = ['draft', 'partial_paid', 'paid']
+const VALID_PAYMENT_STATUSES: PaymentStatusFilter[] = ['draft', 'partial_paid', 'paid', 'partial', 'unpaid']
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -27,7 +29,9 @@ function parseUrl(namespace: string): {
   customFrom: string | null
   customTo: string | null
   customerId: string | null
+  supplierId: string | null
   isFulfilled: boolean | null
+  status: string | null
   paymentStatus: PaymentStatusFilter | null
 } {
   const params = new URLSearchParams(window.location.search)
@@ -36,7 +40,9 @@ function parseUrl(namespace: string): {
   const rawFrom = params.get(`${namespace}_from`)
   const rawTo = params.get(`${namespace}_to`)
   const rawCustomer = params.get(`${namespace}_customer`) ?? null
+  const rawSupplier = params.get(`${namespace}_supplier`) ?? null
   const rawFulfilled = params.get(`${namespace}_fulfilled`)
+  const rawStatus = params.get(`${namespace}_status`) ?? null
   const rawPayment = params.get(`${namespace}_payment`)
 
   const period: DashboardPeriod = VALID_PERIODS.includes(rawPeriod as DashboardPeriod)
@@ -49,9 +55,12 @@ function parseUrl(namespace: string): {
       : null
 
   const customerId = rawCustomer && UUID_RE.test(rawCustomer) ? rawCustomer : null
+  const supplierId = rawSupplier && UUID_RE.test(rawSupplier) ? rawSupplier : null
 
   const isFulfilled: boolean | null =
     rawFulfilled === 'true' ? true : rawFulfilled === 'false' ? false : null
+
+  const status: string | null = rawStatus
 
   const paymentStatus: PaymentStatusFilter | null =
     rawPayment && VALID_PAYMENT_STATUSES.includes(rawPayment as PaymentStatusFilter)
@@ -64,13 +73,43 @@ function parseUrl(namespace: string): {
     const rangeOk = fromOk && toOk && rawFrom <= rawTo
 
     if (!rangeOk) {
-      return { period: 'this_month', compareWith, customFrom: null, customTo: null, customerId, isFulfilled, paymentStatus }
+      return {
+        period: 'this_month',
+        compareWith,
+        customFrom: null,
+        customTo: null,
+        customerId,
+        supplierId,
+        isFulfilled,
+        status,
+        paymentStatus,
+      }
     }
 
-    return { period: 'custom', compareWith, customFrom: rawFrom, customTo: rawTo, customerId, isFulfilled, paymentStatus }
+    return {
+      period: 'custom',
+      compareWith,
+      customFrom: rawFrom,
+      customTo: rawTo,
+      customerId,
+      supplierId,
+      isFulfilled,
+      status,
+      paymentStatus,
+    }
   }
 
-  return { period, compareWith, customFrom: null, customTo: null, customerId, isFulfilled, paymentStatus }
+  return {
+    period,
+    compareWith,
+    customFrom: null,
+    customTo: null,
+    customerId,
+    supplierId,
+    isFulfilled,
+    status,
+    paymentStatus,
+  }
 }
 
 function toApiParams(
@@ -131,7 +170,9 @@ function writeUrl(
   customFrom: string | null,
   customTo: string | null,
   customerId: string | null,
+  supplierId: string | null,
   isFulfilled: boolean | null,
+  status: string | null,
   paymentStatus: PaymentStatusFilter | null,
 ): void {
   const params = new URLSearchParams()
@@ -150,8 +191,14 @@ function writeUrl(
   if (customerId) {
     params.set(`${namespace}_customer`, customerId)
   }
+  if (supplierId) {
+    params.set(`${namespace}_supplier`, supplierId)
+  }
   if (isFulfilled !== null) {
     params.set(`${namespace}_fulfilled`, String(isFulfilled))
+  }
+  if (status !== null) {
+    params.set(`${namespace}_status`, status)
   }
   if (paymentStatus) {
     params.set(`${namespace}_payment`, paymentStatus)
@@ -173,65 +220,78 @@ export function useDashboardFilters(namespace: string) {
   const [customFrom, setCustomFrom] = useState<string | null>(initial.customFrom)
   const [customTo, setCustomTo] = useState<string | null>(initial.customTo)
   const [customerId, setCustomerIdState] = useState<string | null>(initial.customerId)
+  const [supplierId, setSupplierIdState] = useState<string | null>(initial.supplierId)
   const [isFulfilled, setIsFulfilledState] = useState<boolean | null>(initial.isFulfilled)
+  const [status, setStatusState] = useState<string | null>(initial.status)
   const [paymentStatus, setPaymentStatusState] = useState<PaymentStatusFilter | null>(initial.paymentStatus)
 
   const setPeriod = useCallback((next: DashboardPeriod) => {
-    const nextFrom = next === 'custom' ? customFrom : null
-    const nextTo = next === 'custom' ? customTo : null
-
     setPeriodState(next)
+    let nextFrom = customFrom
+    let nextTo = customTo
     if (next !== 'custom') {
       setCustomFrom(null)
       setCustomTo(null)
+      nextFrom = null
+      nextTo = null
     }
-    writeUrl(namespace, next, compareWith, nextFrom, nextTo, customerId, isFulfilled, paymentStatus)
-  }, [namespace, compareWith, customFrom, customTo, customerId, isFulfilled, paymentStatus])
+    writeUrl(namespace, next, compareWith, nextFrom, nextTo, customerId, supplierId, isFulfilled, status, paymentStatus)
+  }, [namespace, compareWith, customFrom, customTo, customerId, supplierId, isFulfilled, status, paymentStatus])
 
   const setCompare = useCallback((next: DashboardCompare) => {
     setCompareWith(next)
-    writeUrl(namespace, period, next, customFrom, customTo, customerId, isFulfilled, paymentStatus)
-  }, [namespace, period, customFrom, customTo, customerId, isFulfilled, paymentStatus])
+    writeUrl(namespace, period, next, customFrom, customTo, customerId, supplierId, isFulfilled, status, paymentStatus)
+  }, [namespace, period, customFrom, customTo, customerId, supplierId, isFulfilled, status, paymentStatus])
 
   const setCustomRange = useCallback((from: string, to: string) => {
     setCustomFrom(from)
     setCustomTo(to)
     if (DATE_RE.test(from) && DATE_RE.test(to) && from <= to) {
       setPeriodState('custom')
-      writeUrl(namespace, 'custom', compareWith, from, to, customerId, isFulfilled, paymentStatus)
+      writeUrl(namespace, 'custom', compareWith, from, to, customerId, supplierId, isFulfilled, status, paymentStatus)
     }
-  }, [namespace, compareWith, customerId, isFulfilled, paymentStatus])
+  }, [namespace, compareWith, customerId, supplierId, isFulfilled, status, paymentStatus])
 
   const setCustomFromOnly = useCallback((from: string | null) => {
     setPeriodState('custom')
     setCustomFrom(from)
     if (from && customTo && DATE_RE.test(from) && DATE_RE.test(customTo) && from <= customTo) {
-      writeUrl(namespace, 'custom', compareWith, from, customTo, customerId, isFulfilled, paymentStatus)
+      writeUrl(namespace, 'custom', compareWith, from, customTo, customerId, supplierId, isFulfilled, status, paymentStatus)
     }
-  }, [namespace, compareWith, customTo, customerId, isFulfilled, paymentStatus])
+  }, [namespace, compareWith, customTo, customerId, supplierId, isFulfilled, status, paymentStatus])
 
   const setCustomToOnly = useCallback((to: string | null) => {
     setPeriodState('custom')
     setCustomTo(to)
     if (customFrom && to && DATE_RE.test(customFrom) && DATE_RE.test(to) && customFrom <= to) {
-      writeUrl(namespace, 'custom', compareWith, customFrom, to, customerId, isFulfilled, paymentStatus)
+      writeUrl(namespace, 'custom', compareWith, customFrom, to, customerId, supplierId, isFulfilled, status, paymentStatus)
     }
-  }, [namespace, compareWith, customFrom, customerId, isFulfilled, paymentStatus])
+  }, [namespace, compareWith, customFrom, customerId, supplierId, isFulfilled, status, paymentStatus])
 
   const setCustomerId = useCallback((next: string | null) => {
     setCustomerIdState(next)
-    writeUrl(namespace, period, compareWith, customFrom, customTo, next, isFulfilled, paymentStatus)
-  }, [namespace, period, compareWith, customFrom, customTo, isFulfilled, paymentStatus])
+    writeUrl(namespace, period, compareWith, customFrom, customTo, next, supplierId, isFulfilled, status, paymentStatus)
+  }, [namespace, period, compareWith, customFrom, customTo, supplierId, isFulfilled, status, paymentStatus])
+
+  const setSupplierId = useCallback((next: string | null) => {
+    setSupplierIdState(next)
+    writeUrl(namespace, period, compareWith, customFrom, customTo, customerId, next, isFulfilled, status, paymentStatus)
+  }, [namespace, period, compareWith, customFrom, customTo, customerId, isFulfilled, status, paymentStatus])
 
   const setFulfilled = useCallback((next: boolean | null) => {
     setIsFulfilledState(next)
-    writeUrl(namespace, period, compareWith, customFrom, customTo, customerId, next, paymentStatus)
-  }, [namespace, period, compareWith, customFrom, customTo, customerId, paymentStatus])
+    writeUrl(namespace, period, compareWith, customFrom, customTo, customerId, supplierId, next, status, paymentStatus)
+  }, [namespace, period, compareWith, customFrom, customTo, customerId, supplierId, status, paymentStatus])
+
+  const setStatus = useCallback((next: string | null) => {
+    setStatusState(next)
+    writeUrl(namespace, period, compareWith, customFrom, customTo, customerId, supplierId, isFulfilled, next, paymentStatus)
+  }, [namespace, period, compareWith, customFrom, customTo, customerId, supplierId, isFulfilled, paymentStatus])
 
   const setPaymentStatus = useCallback((next: PaymentStatusFilter | null) => {
     setPaymentStatusState(next)
-    writeUrl(namespace, period, compareWith, customFrom, customTo, customerId, isFulfilled, next)
-  }, [namespace, period, compareWith, customFrom, customTo, customerId, isFulfilled])
+    writeUrl(namespace, period, compareWith, customFrom, customTo, customerId, supplierId, isFulfilled, status, next)
+  }, [namespace, period, compareWith, customFrom, customTo, customerId, supplierId, isFulfilled, status])
 
   const reset = useCallback(() => {
     setPeriodState('this_month')
@@ -239,25 +299,31 @@ export function useDashboardFilters(namespace: string) {
     setCustomFrom(null)
     setCustomTo(null)
     setCustomerIdState(null)
+    setSupplierIdState(null)
     setIsFulfilledState(null)
+    setStatusState(null)
     setPaymentStatusState(null)
-    writeUrl(namespace, 'this_month', null, null, null, null, null, null)
+    writeUrl(namespace, 'this_month', null, null, null, null, null, null, null, null)
   }, [namespace])
 
   const isDefault = period === 'this_month'
     && compareWith === null
     && customerId === null
+    && supplierId === null
     && isFulfilled === null
+    && status === null
     && paymentStatus === null
 
   const resolvedApiParams = useMemo(
     (): DashboardResolvedApiParams => ({
       ...toApiParams(period, compareWith, customFrom, customTo),
       ...(customerId ? { customerId } : {}),
+      ...(supplierId ? { supplierId } : {}),
       ...(isFulfilled !== null ? { isFulfilled } : {}),
+      ...(status !== null ? { status } : {}),
       ...(paymentStatus ? { paymentStatus } : {}),
     }),
-    [period, compareWith, customFrom, customTo, customerId, isFulfilled, paymentStatus],
+    [period, compareWith, customFrom, customTo, customerId, supplierId, isFulfilled, status, paymentStatus],
   )
 
   return {
@@ -266,7 +332,9 @@ export function useDashboardFilters(namespace: string) {
     customFrom,
     customTo,
     customerId,
+    supplierId,
     isFulfilled,
+    status,
     paymentStatus,
     setPeriod,
     setCompare,
@@ -274,7 +342,9 @@ export function useDashboardFilters(namespace: string) {
     setCustomFrom: setCustomFromOnly,
     setCustomTo: setCustomToOnly,
     setCustomerId,
+    setSupplierId,
     setFulfilled,
+    setStatus,
     setPaymentStatus,
     reset,
     isDefault,

--- a/frontend/src/pages/purchasing/PurchasingPage.tsx
+++ b/frontend/src/pages/purchasing/PurchasingPage.tsx
@@ -44,6 +44,7 @@ import { useNavigate } from 'react-router-dom'
 import PageHeader from '@/components/common/PageHeader'
 import { DashboardFilterBar } from '@/components/filters/DashboardFilterBar'
 import { useDashboardFilters } from '@/hooks/useDashboardFilters'
+import { useGetSuppliersQuery } from '@/store/api/purchasingApi'
 import { usePurchasingAnalytics } from './hooks/usePurchasingAnalytics'
 
 ChartJS.register(
@@ -67,15 +68,27 @@ const PurchasingPage: React.FC = () => {
     compareWith,
     customFrom,
     customTo,
+    supplierId,
+    status,
+    paymentStatus,
     setPeriod,
     setCompare,
     setCustomRange,
     setCustomFrom,
     setCustomTo,
+    setSupplierId,
+    setStatus,
+    setPaymentStatus,
     reset,
     isDefault,
     resolvedApiParams,
   } = useDashboardFilters('purchasing')
+
+  const { data: suppliersData } = useGetSuppliersQuery({})
+  const supplierOptions = suppliersData?.data?.map((supplier) => ({
+    id: supplier.id,
+    name: supplier.companyName,
+  })) ?? []
 
   const { data, isLoading, isFetching, error } = usePurchasingAnalytics(resolvedApiParams)
 
@@ -189,6 +202,18 @@ const PurchasingPage: React.FC = () => {
         onCustomFromChange={setCustomFrom}
         onCustomToChange={setCustomTo}
         onReset={reset}
+        suppliers={supplierOptions}
+        supplierId={supplierId}
+        onSupplierChange={setSupplierId}
+        status={status}
+        onStatusChange={setStatus}
+        paymentStatus={paymentStatus}
+        onPaymentStatusChange={setPaymentStatus}
+        paymentStatusOptions={[
+          { value: 'paid', label: 'Paid' },
+          { value: 'partial', label: 'Partially Paid' },
+          { value: 'unpaid', label: 'Unpaid' },
+        ]}
       />
 
       {error && (

--- a/frontend/src/pages/purchasing/__tests__/PurchasingPage.filters.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/PurchasingPage.filters.test.tsx
@@ -1,0 +1,93 @@
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import PurchasingPage from '../PurchasingPage'
+
+const mockUseGetSuppliersQuery = vi.fn()
+const mockUsePurchasingAnalytics = vi.fn()
+const dashboardFilterBarSpy = vi.fn()
+
+vi.mock('@/store/api/purchasingApi', () => ({
+  useGetSuppliersQuery: (...args: unknown[]) => mockUseGetSuppliersQuery(...args),
+}))
+
+vi.mock('../hooks/usePurchasingAnalytics', () => ({
+  usePurchasingAnalytics: (...args: unknown[]) => mockUsePurchasingAnalytics(...args),
+}))
+
+vi.mock('@/components/filters/DashboardFilterBar', () => ({
+  DashboardFilterBar: (props: unknown) => {
+    dashboardFilterBarSpy(props)
+    return <div data-testid="dashboard-filter-bar" />
+  },
+}))
+
+vi.mock('react-chartjs-2', () => ({
+  Line: () => <div data-testid="purchasing-line-chart" />,
+}))
+
+describe('PurchasingPage filters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseGetSuppliersQuery.mockReturnValue({
+      data: {
+        data: [
+          { id: '550e8400-e29b-41d4-a716-446655440001', companyName: 'Acme Supplies' },
+        ],
+      },
+    })
+    mockUsePurchasingAnalytics.mockReturnValue({
+      data: {
+        current: {
+          metrics: { totalSpent: 0, totalOrders: 0, averageOrderValue: 0, activeSuppliers: 0 },
+          periodData: [],
+          periodStart: '2026-03-01',
+          periodEnd: '2026-03-31',
+        },
+        topSuppliers: [],
+        recentOrders: [],
+      },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+    })
+    window.history.replaceState({}, '', '/?purchasing_supplier=550e8400-e29b-41d4-a716-446655440001&purchasing_status=received&purchasing_payment=partial')
+  })
+
+  it('passes purchasing filter state into analytics and the shared filter bar', () => {
+    render(
+      <MemoryRouter>
+        <PurchasingPage />
+      </MemoryRouter>,
+    )
+
+    expect(mockUsePurchasingAnalytics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        supplierId: '550e8400-e29b-41d4-a716-446655440001',
+        status: 'received',
+        paymentStatus: 'partial',
+      }),
+    )
+
+    expect(dashboardFilterBarSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        suppliers: [{ id: '550e8400-e29b-41d4-a716-446655440001', name: 'Acme Supplies' }],
+        supplierId: '550e8400-e29b-41d4-a716-446655440001',
+        status: 'received',
+        paymentStatus: 'partial',
+      }),
+    )
+  })
+
+  it('renders the purchasing overview heading', () => {
+    render(
+      <MemoryRouter>
+        <PurchasingPage />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('Purchasing Overview')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/purchasing/hooks/usePurchasingAnalytics.ts
+++ b/frontend/src/pages/purchasing/hooks/usePurchasingAnalytics.ts
@@ -49,6 +49,9 @@ export interface PurchasingAnalyticsParams {
   endDate?: string
   groupBy?: string
   compareWith?: string
+  supplierId?: string
+  status?: string
+  paymentStatus?: string
 }
 
 export function usePurchasingAnalytics(params: PurchasingAnalyticsParams) {


### PR DESCRIPTION
## Summary

- Adds Supplier, Order Status (received/pending), and Payment Status (paid/partial/unpaid) filters to the Purchasing Overview dashboard, mirroring the Sales Overview filter pattern
- Extends `useDashboardFilters` with `supplierId` and `status` state (URL-persisted), and widens `paymentStatus` in `DashboardResolvedApiParams` to `string` to support both Sales and Purchasing enums
- Extends `DashboardFilterBar` with optional `suppliers`, `supplierId`, `onSupplierChange`, `status`, `onStatusChange`, and `paymentStatusOptions` props (fully backwards-compatible)
- Backend uses `EXISTS`/`NOT EXISTS` subqueries on `purchase_order_items` for order status filtering (isFullyReceived is a computed method, not a DB column); payment status is a post-query in-app filter

## Test plan

- [x] Backend compiles: `cd backend && npx tsc --noEmit`
- [x] Backend tests pass: `cd backend && npx jest src/modules/purchasing/services/purchasing-analytics.service.spec.ts --no-coverage`
- [x] Frontend type-check: `cd frontend && npm run type-check`
- [x] Frontend targeted tests: `cd frontend && npx vitest run src/hooks/useDashboardFilters.test.ts src/components/filters/__tests__/DashboardFilterBar.test.tsx src/pages/purchasing/__tests__/PurchasingPage.filters.test.tsx`
- [x] Manual: open Purchasing Overview, apply each filter (Supplier, Order Status, Received/Pending, Payment Status paid/partial/unpaid), verify dashboard updates without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)