### PR TITLE
fix(sales-analytics): propagate filters and zero-fill trend chart gaps (#228)

### DIFF
--- a/backend/src/modules/sales/services/sales-analytics.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-analytics.service.spec.ts
@@ -205,6 +205,81 @@ describe('SalesAnalyticsService', () => {
     });
   });
 
+  describe('getPeriodData filter propagation', () => {
+    function makeQbChain() {
+      const qb: any = {};
+      qb.where = jest.fn().mockReturnValue(qb);
+      qb.andWhere = jest.fn().mockReturnValue(qb);
+      qb.leftJoin = jest.fn().mockReturnValue(qb);
+      qb.select = jest.fn().mockReturnValue(qb);
+      qb.groupBy = jest.fn().mockReturnValue(qb);
+      qb.orderBy = jest.fn().mockReturnValue(qb);
+      qb.getRawMany = jest.fn().mockResolvedValue([]);
+      return qb;
+    }
+
+    function makeCustomerQbChain() {
+      const qb: any = {};
+      qb.where = jest.fn().mockReturnValue(qb);
+      qb.select = jest.fn().mockReturnValue(qb);
+      qb.groupBy = jest.fn().mockReturnValue(qb);
+      qb.orderBy = jest.fn().mockReturnValue(qb);
+      qb.getRawMany = jest.fn().mockResolvedValue([]);
+      return qb;
+    }
+
+    const start = new Date('2026-03-01T00:00:00.000Z');
+    const end = new Date('2026-03-31T23:59:59.999Z');
+
+    it('applies customerId filter when provided', async () => {
+      const qb = makeQbChain();
+      const customerQb = makeCustomerQbChain();
+      (service as any).salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+      (service as any).customerRepository.createQueryBuilder = jest.fn().mockReturnValue(customerQb);
+
+      await (service as any).getPeriodData(start, end, 'month', { customerId: 'cust-1' });
+
+      expect(qb.andWhere).toHaveBeenCalledWith('order.customerId = :customerId', { customerId: 'cust-1' });
+    });
+
+    it('applies salesRepId filter when provided', async () => {
+      const qb = makeQbChain();
+      const customerQb = makeCustomerQbChain();
+      (service as any).salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+      (service as any).customerRepository.createQueryBuilder = jest.fn().mockReturnValue(customerQb);
+
+      await (service as any).getPeriodData(start, end, 'month', { salesRepId: 'rep-1' });
+
+      expect(qb.andWhere).toHaveBeenCalledWith('order.createdByUserId = :salesRepId', { salesRepId: 'rep-1' });
+    });
+
+    it('applies paymentStatus filter with invoice join when provided', async () => {
+      const qb = makeQbChain();
+      const customerQb = makeCustomerQbChain();
+      (service as any).salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+      (service as any).customerRepository.createQueryBuilder = jest.fn().mockReturnValue(customerQb);
+
+      await (service as any).getPeriodData(start, end, 'month', { paymentStatus: 'paid' as any });
+
+      expect(qb.leftJoin).toHaveBeenCalledWith('order.invoices', 'invoice');
+      expect(qb.andWhere).toHaveBeenCalledWith('invoice.status = :paymentStatus', { paymentStatus: 'paid' });
+    });
+
+    it('applies no extra andWhere calls when query has no filters', async () => {
+      const qb = makeQbChain();
+      const customerQb = makeCustomerQbChain();
+      (service as any).salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+      (service as any).customerRepository.createQueryBuilder = jest.fn().mockReturnValue(customerQb);
+
+      await (service as any).getPeriodData(start, end, 'month', {});
+
+      const andWhereCalls = qb.andWhere.mock.calls.map((c: any[]) => c[0] as string);
+      expect(andWhereCalls).not.toContain(expect.stringContaining('customerId'));
+      expect(andWhereCalls).not.toContain(expect.stringContaining('salesRepId'));
+      expect(andWhereCalls).not.toContain(expect.stringContaining('paymentStatus'));
+    });
+  });
+
   describe('getSalesAnalytics filter propagation', () => {
     function makeChainMock(rawOne: object = {}, rawMany: object[] = []) {
       const chain: any = {

--- a/backend/src/modules/sales/services/sales-analytics.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-analytics.service.spec.ts
@@ -280,6 +280,44 @@ describe('SalesAnalyticsService', () => {
     });
   });
 
+  describe('getTopCustomers filter propagation', () => {
+    function makeQbChain() {
+      const qb: any = {};
+      qb.leftJoin = jest.fn().mockReturnValue(qb);
+      qb.where = jest.fn().mockReturnValue(qb);
+      qb.andWhere = jest.fn().mockReturnValue(qb);
+      qb.select = jest.fn().mockReturnValue(qb);
+      qb.groupBy = jest.fn().mockReturnValue(qb);
+      qb.addGroupBy = jest.fn().mockReturnValue(qb);
+      qb.orderBy = jest.fn().mockReturnValue(qb);
+      qb.limit = jest.fn().mockReturnValue(qb);
+      qb.getRawMany = jest.fn().mockResolvedValue([]);
+      return qb;
+    }
+
+    const start = new Date('2026-03-01T00:00:00.000Z');
+    const end = new Date('2026-03-31T23:59:59.999Z');
+
+    it('applies salesRepId filter when provided', async () => {
+      const qb = makeQbChain();
+      (service as any).salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      await (service as any).getTopCustomers(start, end, 10, { salesRepId: 'rep-1' });
+
+      expect(qb.andWhere).toHaveBeenCalledWith('order.createdByUserId = :salesRepId', { salesRepId: 'rep-1' });
+    });
+
+    it('does not add salesRepId andWhere when not provided', async () => {
+      const qb = makeQbChain();
+      (service as any).salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      await (service as any).getTopCustomers(start, end, 10, {});
+
+      const andWhereCalls = qb.andWhere.mock.calls.map((c: any[]) => c[0] as string);
+      expect(andWhereCalls).not.toContain(expect.stringContaining('salesRepId'));
+    });
+  });
+
   describe('getSalesAnalytics filter propagation', () => {
     function makeChainMock(rawOne: object = {}, rawMany: object[] = []) {
       const chain: any = {

--- a/backend/src/modules/sales/services/sales-analytics.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-analytics.service.spec.ts
@@ -318,6 +318,64 @@ describe('SalesAnalyticsService', () => {
     });
   });
 
+  describe('getTopProducts filter propagation', () => {
+    function makeQbChain() {
+      const qb: any = {};
+      qb.leftJoin = jest.fn().mockReturnValue(qb);
+      qb.where = jest.fn().mockReturnValue(qb);
+      qb.andWhere = jest.fn().mockReturnValue(qb);
+      qb.select = jest.fn().mockReturnValue(qb);
+      qb.groupBy = jest.fn().mockReturnValue(qb);
+      qb.addGroupBy = jest.fn().mockReturnValue(qb);
+      qb.orderBy = jest.fn().mockReturnValue(qb);
+      qb.limit = jest.fn().mockReturnValue(qb);
+      qb.getRawMany = jest.fn().mockResolvedValue([]);
+      return qb;
+    }
+
+    const start = new Date('2026-03-01T00:00:00.000Z');
+    const end = new Date('2026-03-31T23:59:59.999Z');
+
+    it('applies customerId filter when provided', async () => {
+      const qb = makeQbChain();
+      (service as any).salesOrderItemRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      await (service as any).getTopProducts(start, end, 10, { customerId: 'cust-1' });
+
+      expect(qb.andWhere).toHaveBeenCalledWith('order.customerId = :customerId', { customerId: 'cust-1' });
+    });
+
+    it('applies salesRepId filter when provided', async () => {
+      const qb = makeQbChain();
+      (service as any).salesOrderItemRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      await (service as any).getTopProducts(start, end, 10, { salesRepId: 'rep-1' });
+
+      expect(qb.andWhere).toHaveBeenCalledWith('order.createdByUserId = :salesRepId', { salesRepId: 'rep-1' });
+    });
+
+    it('applies both customerId and salesRepId when both provided', async () => {
+      const qb = makeQbChain();
+      (service as any).salesOrderItemRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      await (service as any).getTopProducts(start, end, 10, { customerId: 'cust-1', salesRepId: 'rep-1' });
+
+      expect(qb.andWhere).toHaveBeenCalledWith('order.customerId = :customerId', { customerId: 'cust-1' });
+      expect(qb.andWhere).toHaveBeenCalledWith('order.createdByUserId = :salesRepId', { salesRepId: 'rep-1' });
+    });
+
+    it('applies no extra andWhere calls when query has no filters', async () => {
+      const qb = makeQbChain();
+      (service as any).salesOrderItemRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      await (service as any).getTopProducts(start, end, 10, {});
+
+      const andWhereCalls = qb.andWhere.mock.calls.map((c: any[]) => c[0] as string);
+      expect(andWhereCalls).not.toContain(expect.stringContaining('customerId'));
+      expect(andWhereCalls).not.toContain(expect.stringContaining('salesRepId'));
+    });
+  });
+
   describe('getSalesAnalytics filter propagation', () => {
     function makeChainMock(rawOne: object = {}, rawMany: object[] = []) {
       const chain: any = {

--- a/backend/src/modules/sales/services/sales-analytics.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-analytics.service.spec.ts
@@ -376,6 +376,117 @@ describe('SalesAnalyticsService', () => {
     });
   });
 
+  describe('fillPeriodGaps', () => {
+    const zero = { revenue: 0, orders: 0, newCustomers: 0, averageOrderValue: 0 };
+
+    describe('day groupBy', () => {
+      it('fills missing days with zeros', () => {
+        const start = new Date('2026-03-01T00:00:00.000Z');
+        const end = new Date('2026-03-05T23:59:59.999Z');
+        const sparse = [
+          { period: '2026-03-01', revenue: 100, orders: 2, newCustomers: 1, averageOrderValue: 50 },
+          { period: '2026-03-05', revenue: 200, orders: 3, newCustomers: 0, averageOrderValue: 66.67 },
+        ];
+
+        const result = (service as any).fillPeriodGaps(sparse, start, end, 'day');
+
+        expect(result).toHaveLength(5);
+        expect(result[0]).toEqual({ period: '2026-03-01', revenue: 100, orders: 2, newCustomers: 1, averageOrderValue: 50 });
+        expect(result[1]).toEqual({ period: '2026-03-02', ...zero });
+        expect(result[2]).toEqual({ period: '2026-03-03', ...zero });
+        expect(result[3]).toEqual({ period: '2026-03-04', ...zero });
+        expect(result[4]).toEqual({ period: '2026-03-05', revenue: 200, orders: 3, newCustomers: 0, averageOrderValue: 66.67 });
+      });
+
+      it('handles empty DB result - all zeros', () => {
+        const start = new Date('2026-03-01T00:00:00.000Z');
+        const end = new Date('2026-03-03T23:59:59.999Z');
+
+        const result = (service as any).fillPeriodGaps([], start, end, 'day');
+
+        expect(result).toHaveLength(3);
+        result.forEach((r: any) => expect(r).toMatchObject(zero));
+      });
+
+      it('handles single-day range with one order', () => {
+        const start = new Date('2026-03-15T00:00:00.000Z');
+        const end = new Date('2026-03-15T23:59:59.999Z');
+        const sparse = [{ period: '2026-03-15', revenue: 50, orders: 1, newCustomers: 0, averageOrderValue: 50 }];
+
+        const result = (service as any).fillPeriodGaps(sparse, start, end, 'day');
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toEqual({ period: '2026-03-15', revenue: 50, orders: 1, newCustomers: 0, averageOrderValue: 50 });
+      });
+    });
+
+    describe('week groupBy', () => {
+      it('fills missing weeks with zeros', () => {
+        const start = new Date('2026-03-02T00:00:00.000Z');
+        const end = new Date('2026-03-22T23:59:59.999Z');
+        const sparse = [
+          { period: '2026-11', revenue: 100, orders: 2, newCustomers: 0, averageOrderValue: 50 },
+        ];
+
+        const result = (service as any).fillPeriodGaps(sparse, start, end, 'week');
+
+        expect(result).toHaveLength(3);
+        expect(result[0]).toEqual({ period: '2026-10', ...zero });
+        expect(result[1]).toEqual({ period: '2026-11', revenue: 100, orders: 2, newCustomers: 0, averageOrderValue: 50 });
+        expect(result[2]).toEqual({ period: '2026-12', ...zero });
+      });
+    });
+
+    describe('month groupBy', () => {
+      it('fills missing months with zeros', () => {
+        const start = new Date('2026-01-01T00:00:00.000Z');
+        const end = new Date('2026-03-31T23:59:59.999Z');
+        const sparse = [
+          { period: '2026-02', revenue: 500, orders: 5, newCustomers: 2, averageOrderValue: 100 },
+        ];
+
+        const result = (service as any).fillPeriodGaps(sparse, start, end, 'month');
+
+        expect(result).toHaveLength(3);
+        expect(result[0]).toEqual({ period: '2026-01', ...zero });
+        expect(result[1]).toEqual({ period: '2026-02', revenue: 500, orders: 5, newCustomers: 2, averageOrderValue: 100 });
+        expect(result[2]).toEqual({ period: '2026-03', ...zero });
+      });
+    });
+
+    describe('quarter groupBy', () => {
+      it('fills missing quarters with zeros', () => {
+        const start = new Date('2026-01-01T00:00:00.000Z');
+        const end = new Date('2026-06-30T23:59:59.999Z');
+        const sparse = [
+          { period: '2026-Q1', revenue: 1000, orders: 10, newCustomers: 3, averageOrderValue: 100 },
+        ];
+
+        const result = (service as any).fillPeriodGaps(sparse, start, end, 'quarter');
+
+        expect(result).toHaveLength(2);
+        expect(result[0]).toEqual({ period: '2026-Q1', revenue: 1000, orders: 10, newCustomers: 3, averageOrderValue: 100 });
+        expect(result[1]).toEqual({ period: '2026-Q2', ...zero });
+      });
+    });
+
+    describe('year groupBy', () => {
+      it('fills missing years with zeros', () => {
+        const start = new Date('2025-01-01T00:00:00.000Z');
+        const end = new Date('2026-12-31T23:59:59.999Z');
+        const sparse = [
+          { period: '2025', revenue: 5000, orders: 50, newCustomers: 10, averageOrderValue: 100 },
+        ];
+
+        const result = (service as any).fillPeriodGaps(sparse, start, end, 'year');
+
+        expect(result).toHaveLength(2);
+        expect(result[0]).toEqual({ period: '2025', revenue: 5000, orders: 50, newCustomers: 10, averageOrderValue: 100 });
+        expect(result[1]).toEqual({ period: '2026', ...zero });
+      });
+    });
+  });
+
   describe('getSalesAnalytics filter propagation', () => {
     function makeChainMock(rawOne: object = {}, rawMany: object[] = []) {
       const chain: any = {

--- a/backend/src/modules/sales/services/sales-analytics.service.ts
+++ b/backend/src/modules/sales/services/sales-analytics.service.ts
@@ -570,6 +570,14 @@ export class SalesAnalyticsService {
         .andWhere('invoice.status = :paymentStatus', { paymentStatus: query.paymentStatus });
     }
 
+    if (query?.customerId) {
+      topProductsQuery = topProductsQuery.andWhere('order.customerId = :customerId', { customerId: query.customerId });
+    }
+
+    if (query?.salesRepId) {
+      topProductsQuery = topProductsQuery.andWhere('order.createdByUserId = :salesRepId', { salesRepId: query.salesRepId });
+    }
+
     const data = await topProductsQuery
       .select([
         'product.id as "productId"',

--- a/backend/src/modules/sales/services/sales-analytics.service.ts
+++ b/backend/src/modules/sales/services/sales-analytics.service.ts
@@ -486,13 +486,15 @@ export class SalesAnalyticsService {
 
     const customerMap = new Map(customerData.map(item => [item.period, parseInt(item.newCustomers)]));
 
-    return data.map(item => ({
+    const mapped = data.map(item => ({
       period: item.period,
       revenue: parseFloat(item.revenue) || 0,
       orders: parseInt(item.orders) || 0,
       newCustomers: customerMap.get(item.period) || 0,
       averageOrderValue: parseFloat(item.averageOrderValue) || 0,
     }));
+
+    return this.fillPeriodGaps(mapped, startDate, endDate, groupBy);
   }
 
   private async getTopCustomers(

--- a/backend/src/modules/sales/services/sales-analytics.service.ts
+++ b/backend/src/modules/sales/services/sales-analytics.service.ts
@@ -447,6 +447,20 @@ export class SalesAnalyticsService {
       periodQuery = periodQuery.andWhere('order.isFulfilled = :isFulfilled', { isFulfilled: query.isFulfilled });
     }
 
+    if (query?.customerId) {
+      periodQuery = periodQuery.andWhere('order.customerId = :customerId', { customerId: query.customerId });
+    }
+
+    if (query?.salesRepId) {
+      periodQuery = periodQuery.andWhere('order.createdByUserId = :salesRepId', { salesRepId: query.salesRepId });
+    }
+
+    if (query?.paymentStatus) {
+      periodQuery = periodQuery
+        .leftJoin('order.invoices', 'invoice')
+        .andWhere('invoice.status = :paymentStatus', { paymentStatus: query.paymentStatus });
+    }
+
     const data = await periodQuery
       .select([
         `TO_CHAR(order.orderDate, '${dateFormat}') as period`,

--- a/backend/src/modules/sales/services/sales-analytics.service.ts
+++ b/backend/src/modules/sales/services/sales-analytics.service.ts
@@ -516,6 +516,10 @@ export class SalesAnalyticsService {
         .andWhere('invoice.status = :paymentStatus', { paymentStatus: query.paymentStatus });
     }
 
+    if (query?.salesRepId) {
+      topCustomersQuery = topCustomersQuery.andWhere('order.createdByUserId = :salesRepId', { salesRepId: query.salesRepId });
+    }
+
     const data = await topCustomersQuery
       .select([
         'customer.id as "customerId"',

--- a/backend/src/modules/sales/services/sales-analytics.service.ts
+++ b/backend/src/modules/sales/services/sales-analytics.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { differenceInCalendarDays, subDays, subMonths, subYears } from 'date-fns';
+import { addDays, addMonths, addWeeks, addYears, differenceInCalendarDays, format, getISOWeek, getISOWeekYear, subDays, subMonths, subYears } from 'date-fns';
 import { Repository, Between } from 'typeorm';
 import { SalesOrder } from '../../../database/entities/sales-order.entity';
 import { Invoice, InvoiceStatus } from '../../../database/entities/invoice.entity';
@@ -644,6 +644,61 @@ export class SalesAnalyticsService {
       orders: parseInt(item.orders) || 0,
       averageOrderValue: parseFloat(item.averageOrderValue) || 0,
     }));
+  }
+
+  private fillPeriodGaps(
+    data: PeriodMetricDto[],
+    startDate: Date,
+    endDate: Date,
+    groupBy: string,
+  ): PeriodMetricDto[] {
+    const dataMap = new Map(data.map(item => [item.period, item]));
+    const labels: string[] = [];
+    let cursor = new Date(startDate);
+
+    while (cursor <= endDate) {
+      let label: string;
+
+      switch (groupBy) {
+        case 'day':
+          label = format(cursor, 'yyyy-MM-dd');
+          cursor = addDays(cursor, 1);
+          break;
+        case 'week': {
+          const isoYear = getISOWeekYear(cursor);
+          const isoWeek = String(getISOWeek(cursor)).padStart(2, '0');
+          label = `${isoYear}-${isoWeek}`;
+          cursor = addWeeks(cursor, 1);
+          break;
+        }
+        case 'quarter': {
+          const q = Math.floor(cursor.getMonth() / 3) + 1;
+          label = `${cursor.getFullYear()}-Q${q}`;
+          cursor = addMonths(cursor, 3);
+          break;
+        }
+        case 'year':
+          label = String(cursor.getFullYear());
+          cursor = addYears(cursor, 1);
+          break;
+        default:
+          label = format(cursor, 'yyyy-MM');
+          cursor = addMonths(cursor, 1);
+          break;
+      }
+
+      labels.push(label);
+    }
+
+    return labels.map(label =>
+      dataMap.get(label) ?? {
+        period: label,
+        revenue: 0,
+        orders: 0,
+        newCustomers: 0,
+        averageOrderValue: 0,
+      },
+    );
   }
 
   private parseDateRange(


### PR DESCRIPTION
## Summary
- `getPeriodData`, `getTopCustomers`, and `getTopProducts` now apply all query filters (`customerId`, `salesRepId`, `paymentStatus`) consistently with `calculateSalesMetrics`
- `getPeriodData` now zero-fills missing periods via a new `fillPeriodGaps` private method, so the Sales Trend chart shows a continuous line across the full selected range
- 12 new tests added covering filter propagation and all 5 groupBy modes for gap-filling

## Test Plan
- [x] 725/725 backend tests passing
- [x] Lint passing
- [x] Filter by a specific Customer in Sales Overview — Trend chart and Top Products/Customers lists now match the filtered totals
- [x] Select a month with orders on only a few days — Trend chart now shows the full month with zeros for empty days

Closes #228