### PR TITLE
feat(filter-period): add dividers between period groups (#230)

### DIFF
--- a/frontend/src/components/filters/FilterPeriod.test.tsx
+++ b/frontend/src/components/filters/FilterPeriod.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { LocalizationProvider } from '@mui/x-date-pickers'
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { FilterPeriod } from './FilterPeriod'
+
+function renderFilterPeriod(value = 'today', onChange = vi.fn()) {
+  return render(
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <FilterPeriod value={value as any} customFrom={null} customTo={null} onChange={onChange} />
+    </LocalizationProvider>,
+  )
+}
+
+describe('FilterPeriod', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('renders the period select', () => {
+    renderFilterPeriod()
+
+    expect(screen.getByLabelText('Period')).toBeInTheDocument()
+  })
+
+  it('renders dividers between groups in the dropdown', async () => {
+    const user = userEvent.setup()
+    renderFilterPeriod()
+
+    await user.click(screen.getByLabelText('Period'))
+
+    const listbox = screen.getByRole('listbox')
+    const dividers = listbox.querySelectorAll('hr')
+
+    expect(dividers).toHaveLength(3)
+  })
+
+  it('renders all period options', async () => {
+    const user = userEvent.setup()
+    renderFilterPeriod()
+
+    await user.click(screen.getByLabelText('Period'))
+
+    expect(screen.getByRole('option', { name: 'Today' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Yesterday' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Last 7 Days' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Custom Range' })).toBeInTheDocument()
+  })
+
+  it('calls onChange when an option is selected', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+
+    render(
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <FilterPeriod value="today" customFrom={null} customTo={null} onChange={onChange} />
+      </LocalizationProvider>,
+    )
+
+    await user.click(screen.getByLabelText('Period'))
+    await user.click(screen.getByRole('option', { name: 'Yesterday' }))
+
+    expect(onChange).toHaveBeenCalledWith('yesterday')
+  })
+
+  it('shows date pickers when custom is selected', () => {
+    renderFilterPeriod('custom')
+
+    expect(screen.getAllByText('From').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('To').length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/components/filters/FilterPeriod.tsx
+++ b/frontend/src/components/filters/FilterPeriod.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useId, useMemo, useState } from 'react'
-import { FormControl, InputLabel, MenuItem, Select, Stack } from '@mui/material'
+import { Divider, FormControl, InputLabel, MenuItem, Select, Stack } from '@mui/material'
 import { DatePicker } from '@mui/x-date-pickers'
 import { format, parseISO } from 'date-fns'
 
-import { PERIOD_KEYS, PERIOD_LABELS, type PeriodKey } from '@/constants/periods'
+import { PERIOD_GROUPS, PERIOD_LABELS, type PeriodKey } from '@/constants/periods'
 import { toMuiDatePickerFormat } from '@/utils/formatters'
 
 interface FilterPeriodProps {
@@ -69,11 +69,16 @@ export function FilterPeriod({ value, customFrom, customTo, onChange }: FilterPe
           label="Period"
           onChange={(event) => handleKeyChange(event.target.value as PeriodKey)}
         >
-          {PERIOD_KEYS.map((key) => (
-            <MenuItem key={key} value={key}>
-              {PERIOD_LABELS[key]}
-            </MenuItem>
-          ))}
+          {PERIOD_GROUPS.map((group, groupIndex) => [
+            ...group.map((key) => (
+              <MenuItem key={key} value={key}>
+                {PERIOD_LABELS[key]}
+              </MenuItem>
+            )),
+            groupIndex < PERIOD_GROUPS.length - 1 ? (
+              <Divider key={`divider-${groupIndex}`} />
+            ) : null,
+          ])}
         </Select>
       </FormControl>
 

--- a/frontend/src/constants/periods.test.ts
+++ b/frontend/src/constants/periods.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { PERIOD_GROUPS, PERIOD_KEYS } from './periods'
+
+describe('PERIOD_GROUPS', () => {
+  it('contains exactly four groups', () => {
+    expect(PERIOD_GROUPS).toHaveLength(4)
+  })
+
+  it('covers every key in PERIOD_KEYS exactly once', () => {
+    const flat = PERIOD_GROUPS.flat()
+
+    expect(flat.slice().sort()).toEqual([...PERIOD_KEYS].sort())
+    expect(flat).toHaveLength(PERIOD_KEYS.length)
+  })
+
+  it('has the correct group order', () => {
+    expect(PERIOD_GROUPS[0]).toEqual(['today', 'this_week', 'this_month', 'this_year'])
+    expect(PERIOD_GROUPS[1]).toEqual(['yesterday', 'last_week', 'last_month', 'last_year'])
+    expect(PERIOD_GROUPS[2]).toEqual(['last_7_days', 'last_30_days', 'last_365_days'])
+    expect(PERIOD_GROUPS[3]).toEqual(['custom'])
+  })
+})

--- a/frontend/src/constants/periods.ts
+++ b/frontend/src/constants/periods.ts
@@ -29,3 +29,10 @@ export const PERIOD_LABELS: Record<PeriodKey, string> = {
   last_365_days: 'Last 365 Days',
   custom: 'Custom Range',
 }
+
+export const PERIOD_GROUPS: PeriodKey[][] = [
+  ['today', 'this_week', 'this_month', 'this_year'],
+  ['yesterday', 'last_week', 'last_month', 'last_year'],
+  ['last_7_days', 'last_30_days', 'last_365_days'],
+  ['custom'],
+]


### PR DESCRIPTION
## Summary
- Adds `PERIOD_GROUPS` constant to `periods.ts` defining four logical groups (Current, Past, Rolling, Custom) in display order
- Updates `FilterPeriod.tsx` to render from groups with `<Divider />` between each group
- Adds unit tests for the new grouping constant and divider rendering

## Test Plan
- [x] `npx vitest run src/constants/periods.test.ts` — passes
- [x] `npx vitest run src/components/filters/FilterPeriod.test.tsx` — passes
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — clean

Closes #230