### PR TITLE
style: standardize color palette, remove light-mode, add print tokens (issue #232)

### DIFF
--- a/docs/COLOR_PALETTE.md
+++ b/docs/COLOR_PALETTE.md
@@ -1,0 +1,66 @@
+# ERP Color Palette
+
+The frontend has two approved color sources:
+
+1. [`frontend/src/styles/theme.ts`](/home/blur/erp2/frontend/src/styles/theme.ts) for live UI
+2. [`frontend/src/styles/printTokens.ts`](/home/blur/erp2/frontend/src/styles/printTokens.ts) for print and PDF output
+
+Do not add hardcoded hex colors in component code unless the exception is explicitly documented.
+
+## UI Usage
+
+Use `useTheme()` and `theme.palette.*` in React components.
+
+```tsx
+import { alpha, useTheme } from '@mui/material/styles'
+
+const theme = useTheme()
+
+<Box sx={{ color: theme.palette.text.primary }} />
+<Box sx={{ bgcolor: theme.palette.background.paper }} />
+<Box sx={{ bgcolor: alpha(theme.palette.primary.main, 0.2) }} />
+```
+
+Preferred semantic tokens:
+
+- `theme.palette.background.default`: page background
+- `theme.palette.background.paper`: cards, dialogs, menus, elevated surfaces
+- `theme.palette.text.primary`: primary text
+- `theme.palette.text.secondary`: supporting text
+- `theme.palette.divider`: borders and separators
+- `theme.palette.action.hover`: hover state backgrounds
+- `theme.palette.action.selected`: selected or active backgrounds
+- `theme.palette.primary.main`: primary emphasis
+- `theme.palette.success.main`: success emphasis
+- `theme.palette.warning.main`: warning emphasis
+- `theme.palette.error.main`: error emphasis
+
+## Print Usage
+
+Use `printColors` for generated print HTML, print-only layouts, and PDF output.
+
+```ts
+import { printColors } from '@/styles/printTokens'
+
+`<tr style="background-color: ${printColors.groupRow};">`
+```
+
+Available print tokens:
+
+- `printColors.background`
+- `printColors.text`
+- `printColors.border`
+- `printColors.tableBorder`
+- `printColors.tableHeaderBg`
+- `printColors.tableRowAlt`
+- `printColors.successRow`
+- `printColors.infoRow`
+- `printColors.groupRow`
+
+## Rules
+
+- Use theme tokens for live React UI.
+- Use `printColors` for print and PDF contexts.
+- Prefer semantic theme tokens over raw greys.
+- If you need transparency in UI code, use `alpha(...)` with a theme token.
+- Current documented exceptions are the decorative auth gradient and the intentional sidebar `#0D0D0D`.

--- a/frontend/src/RootLayout.tsx
+++ b/frontend/src/RootLayout.tsx
@@ -74,10 +74,6 @@ export default function RootLayout() {
   }
 
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', 'dark')
-  }, [])
-
-  useEffect(() => {
     if (!isAuthenticated) {
       setShowIdleWarning(false)
     }

--- a/frontend/src/components/common/LoadingSpinner.tsx
+++ b/frontend/src/components/common/LoadingSpinner.tsx
@@ -6,6 +6,7 @@ import {
   Backdrop,
   Paper,
 } from '@mui/material'
+import { alpha, useTheme } from '@mui/material/styles'
 
 interface LoadingSpinnerProps {
   message?: string
@@ -24,6 +25,8 @@ const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
   fullScreen = false,
   sx = {},
 }) => {
+  const theme = useTheme()
+
   const content = (
     <Box
       sx={{
@@ -49,7 +52,7 @@ const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
       <Backdrop
         open
         sx={{
-          color: '#fff',
+          color: theme.palette.text.primary,
           zIndex: (theme) => theme.zIndex.drawer + 1,
         }}
       >
@@ -67,7 +70,7 @@ const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
           left: 0,
           right: 0,
           bottom: 0,
-          bgcolor: 'rgba(255, 255, 255, 0.8)',
+          bgcolor: alpha(theme.palette.common.white, 0.8),
           backdropFilter: 'blur(2px)',
           display: 'flex',
           alignItems: 'center',

--- a/frontend/src/components/common/MainLayout.tsx
+++ b/frontend/src/components/common/MainLayout.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { Outlet, useLocation } from 'react-router-dom'
 import { Box, Drawer } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
 
 import { DRAWER_WIDTH_COLLAPSED, DRAWER_WIDTH_EXPANDED } from '@/constants/layout'
 
@@ -8,6 +9,7 @@ import Sidebar from './Sidebar'
 import TopBar from './TopBar'
 
 const MainLayout: React.FC = () => {
+  const theme = useTheme()
   const location = useLocation()
   const [mobileOpen, setMobileOpen] = useState(false)
   const [collapsed, setCollapsed] = useState<boolean>(() => {
@@ -64,7 +66,7 @@ const MainLayout: React.FC = () => {
           sx={{
             display: { xs: 'none', lg: 'block' },
             '& .MuiDrawer-paper': {
-              bgcolor: '#0F172A',
+              bgcolor: theme.palette.background.default,
               boxSizing: 'border-box',
               width: collapsed ? DRAWER_WIDTH_COLLAPSED : DRAWER_WIDTH_EXPANDED,
               transition: 'width 0.22s ease',

--- a/frontend/src/components/common/SearchModal.tsx
+++ b/frontend/src/components/common/SearchModal.tsx
@@ -254,8 +254,8 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
           transform: 'translate(-50%, 0)',
           width: { xs: '92vw', sm: 560 },
           maxHeight: '70vh',
-          bgcolor: '#1E1E1E',
-          border: '1px solid #2A2A2A',
+          bgcolor: theme.palette.background.paper,
+          border: `1px solid ${theme.palette.divider}`,
           borderRadius: '12px',
           overflow: 'hidden',
           outline: 'none',
@@ -270,10 +270,10 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
             gap: 1.5,
             px: 2,
             py: 1.5,
-            bgcolor: '#232323',
+            bgcolor: theme.palette.divider,
           }}
         >
-          <SearchIcon sx={{ color: '#6B7280', fontSize: 20, flexShrink: 0 }} />
+          <SearchIcon sx={{ color: theme.palette.text.secondary, fontSize: 20, flexShrink: 0 }} />
           <InputBase
             inputRef={inputRef}
             value={query}
@@ -282,9 +282,9 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
             placeholder="Search pages, customers, products, transactions..."
             fullWidth
             sx={{
-              color: '#E0E0E0',
+              color: theme.palette.text.primary,
               fontSize: '0.9375rem',
-              '& input::placeholder': { color: '#6B7280' },
+              '& input::placeholder': { color: theme.palette.text.secondary },
             }}
             inputProps={{ 'aria-label': 'search' }}
           />
@@ -293,13 +293,13 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
           )}
         </Box>
 
-        <Divider sx={{ bgcolor: '#2A2A2A' }} />
+        <Divider sx={{ bgcolor: theme.palette.divider }} />
 
         <Box sx={{ overflowY: 'auto', maxHeight: 'calc(70vh - 61px)' }}>
           {showHelp && (
             <Typography
               variant="body2"
-              sx={{ color: '#A0A0A0', textAlign: 'center', px: 3, py: 4 }}
+              sx={{ color: theme.palette.text.secondary, textAlign: 'center', px: 3, py: 4 }}
             >
               Type at least 2 characters to search pages, customers, products,
               and transactions.
@@ -309,7 +309,7 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
           {showRecent && recentSearches.length === 0 && (
             <Typography
               variant="body2"
-              sx={{ color: '#A0A0A0', textAlign: 'center', px: 3, py: 4 }}
+              sx={{ color: theme.palette.text.secondary, textAlign: 'center', px: 3, py: 4 }}
             >
               Start typing to search
             </Typography>
@@ -323,7 +323,7 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
                   display: 'block',
                   px: 2,
                   py: 1,
-                  color: '#6B7280',
+                  color: theme.palette.text.secondary,
                   textTransform: 'uppercase',
                   letterSpacing: '0.08em',
                 }}
@@ -354,7 +354,7 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
           {showError && (
             <Typography
               variant="body2"
-              sx={{ color: '#F87171', textAlign: 'center', px: 3, py: 4 }}
+              sx={{ color: theme.palette.error.light, textAlign: 'center', px: 3, py: 4 }}
             >
               Search unavailable, please try again.
             </Typography>
@@ -362,12 +362,12 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
 
           {showEmpty && (
             <Box sx={{ textAlign: 'center', px: 3, py: 4 }}>
-              <Typography variant="body2" sx={{ color: '#A0A0A0' }}>
+              <Typography variant="body2" sx={{ color: theme.palette.text.secondary }}>
                 No results for "{trimmedQuery}"
               </Typography>
               <Typography
                 variant="caption"
-                sx={{ color: '#6B7280', mt: 0.5, display: 'block' }}
+                sx={{ color: theme.palette.text.secondary, mt: 0.5, display: 'block' }}
               >
                 Try searching by name, code, SKU, or order number
               </Typography>
@@ -382,7 +382,7 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
                   display: 'block',
                   px: 2,
                   py: 1,
-                  color: '#6B7280',
+                  color: theme.palette.text.secondary,
                   textTransform: 'uppercase',
                   letterSpacing: '0.08em',
                 }}
@@ -443,24 +443,24 @@ function SearchResultRow({
         px: 2,
         py: 1.25,
         cursor: 'pointer',
-        bgcolor: isSelected ? 'rgba(255, 255, 255, 0.08)' : 'transparent',
+        bgcolor: isSelected ? 'action.selected' : 'transparent',
         '&:hover': {
-          bgcolor: 'rgba(255, 255, 255, 0.08)',
+          bgcolor: 'action.selected',
         },
       }}
     >
       {isRecent && (
-        <HistoryIcon sx={{ color: '#6B7280', fontSize: 16, flexShrink: 0 }} />
+        <HistoryIcon sx={{ color: 'text.secondary', fontSize: 16, flexShrink: 0 }} />
       )}
 
       <Box sx={{ minWidth: 0, flex: 1 }}>
-        <Typography sx={{ color: '#E0E0E0', fontWeight: 600 }}>
+        <Typography sx={{ color: 'text.primary', fontWeight: 600 }}>
           {highlightText(item.label, query, 700, highlightColor)}
         </Typography>
         {item.description && (
           <Typography
             variant="caption"
-            sx={{ color: '#A0A0A0', display: 'block', mt: 0.25 }}
+            sx={{ color: 'text.secondary', display: 'block', mt: 0.25 }}
           >
             {highlightText(item.description, query, 400, highlightColor)}
           </Typography>
@@ -471,8 +471,8 @@ function SearchResultRow({
         <Typography
           variant="caption"
           sx={{
-            color: '#6B7280',
-            bgcolor: 'rgba(255, 255, 255, 0.05)',
+            color: 'text.secondary',
+            bgcolor: 'action.hover',
             borderRadius: '999px',
             px: 1,
             py: 0.5,

--- a/frontend/src/components/common/Sidebar.tsx
+++ b/frontend/src/components/common/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
   Fade,
   Paper,
 } from '@mui/material'
+import { alpha, useTheme } from '@mui/material/styles'
 import {
   ExpandMore,
   ChevronLeft,
@@ -39,25 +40,32 @@ interface SidebarProps {
   onToggleCollapse?: () => void
 }
 
-const SIDEBAR_COLORS = {
-  bg: '#0D0D0D',
-  activeBg: '#1F2937',
-  hoverBg: '#1E1E1E',
-  text: '#9CA3AF',
-  activeText: '#FFFFFF',
-  hoverText: '#CBD5E1',
-  activeIcon: '#3B82F6',
-  icon: '#6B7280',
-  sectionLabel: '#6B7280',
-  border: '#1F2937',
-  accentBar: '#42a5f5',
-} as const
+const useSidebarColors = () => {
+  const theme = useTheme()
+
+  return {
+    bg: '#0D0D0D',
+    activeBg: theme.palette.action.selected,
+    hoverBg: theme.palette.action.hover,
+    text: theme.palette.text.secondary,
+    activeText: theme.palette.text.primary,
+    hoverText: theme.palette.grey[300],
+    activeIcon: theme.palette.primary.main,
+    icon: theme.palette.text.secondary,
+    sectionLabel: theme.palette.text.secondary,
+    border: theme.palette.divider,
+    accentBar: theme.palette.primary.main,
+    outline: alpha(theme.palette.common.white, 0.03),
+    flyoutShadow: alpha(theme.palette.common.black, 0.4),
+  }
+}
 
 const Sidebar: React.FC<SidebarProps> = ({
   onItemClick,
   collapsed = false,
   onToggleCollapse,
 }) => {
+  const colors = useSidebarColors()
   const location = useLocation()
   const navigate = useNavigate()
   const user = useAppSelector(selectCurrentUser)
@@ -304,8 +312,8 @@ const Sidebar: React.FC<SidebarProps> = ({
             transition: 'background-color 0.18s ease',
             // Leaf active: pill background + left accent bar
             ...(isActive && !hasChildren && {
-              bgcolor: SIDEBAR_COLORS.activeBg,
-              boxShadow: 'inset 0 0 0 1px rgba(255,255,255,0.03)',
+              bgcolor: colors.activeBg,
+              boxShadow: `inset 0 0 0 1px ${colors.outline}`,
               '&::before': {
                 content: '""',
                 position: 'absolute',
@@ -315,25 +323,25 @@ const Sidebar: React.FC<SidebarProps> = ({
                 width: 3,
                 height: '60%',
                 borderRadius: '0 2px 2px 0',
-                bgcolor: SIDEBAR_COLORS.accentBar,
+                bgcolor: colors.accentBar,
               },
             }),
             // Parent active: brighten icon/text when a descendant is current route
             ...(isActive && hasChildren && {
-              '& .MuiListItemIcon-root': { color: SIDEBAR_COLORS.activeText },
-              '& .MuiListItemText-primary': { color: SIDEBAR_COLORS.activeText },
+              '& .MuiListItemIcon-root': { color: colors.activeText },
+              '& .MuiListItemText-primary': { color: colors.activeText },
             }),
-            '&:hover': { bgcolor: SIDEBAR_COLORS.hoverBg },
+            '&:hover': { bgcolor: colors.hoverBg },
             ...(!isActive && {
-              '&:hover .MuiListItemIcon-root': { color: SIDEBAR_COLORS.hoverText },
-              '&:hover .MuiListItemText-primary': { color: SIDEBAR_COLORS.hoverText },
+              '&:hover .MuiListItemIcon-root': { color: colors.hoverText },
+              '&:hover .MuiListItemText-primary': { color: colors.hoverText },
             }),
           }}
         >
           <ListItemIcon
             sx={{
               minWidth: 32,
-              color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.icon,
+              color: isActive ? colors.activeIcon : colors.icon,
               '& .MuiSvgIcon-root': { fontSize: '1.25rem' },
               transition: 'color 0.18s ease',
             }}
@@ -346,7 +354,7 @@ const Sidebar: React.FC<SidebarProps> = ({
               '& .MuiListItemText-primary': {
                 fontSize: '0.8125rem',
                 fontWeight: isActive && !hasChildren ? 600 : 400,
-                color: isActive ? SIDEBAR_COLORS.activeText : SIDEBAR_COLORS.text,
+                color: isActive ? colors.activeText : colors.text,
                 transition: 'color 0.18s ease',
               },
             }}
@@ -355,7 +363,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             <Box
               component="span"
               sx={{
-                color: SIDEBAR_COLORS.icon,
+                color: colors.icon,
                 display: 'flex',
                 alignItems: 'center',
                 transition: 'transform 0.2s',
@@ -394,7 +402,7 @@ const Sidebar: React.FC<SidebarProps> = ({
         px: 2,
         pt: 1.5,
         pb: 0.5,
-        color: SIDEBAR_COLORS.sectionLabel,
+        color: colors.sectionLabel,
         fontWeight: 600,
         fontSize: '0.6875rem',
         textTransform: 'uppercase',
@@ -413,8 +421,8 @@ const Sidebar: React.FC<SidebarProps> = ({
     const activeLeafSx =
       isActive && !hasChildren
         ? {
-            bgcolor: SIDEBAR_COLORS.activeBg,
-            boxShadow: 'inset 0 0 0 1px rgba(255,255,255,0.03)',
+            bgcolor: colors.activeBg,
+            boxShadow: `inset 0 0 0 1px ${colors.outline}`,
             '&::before': {
               content: '""',
               position: 'absolute',
@@ -424,7 +432,7 @@ const Sidebar: React.FC<SidebarProps> = ({
               width: 3,
               height: '60%',
               borderRadius: '0 2px 2px 0',
-              bgcolor: SIDEBAR_COLORS.accentBar,
+              bgcolor: colors.accentBar,
             },
           }
         : {}
@@ -432,8 +440,8 @@ const Sidebar: React.FC<SidebarProps> = ({
     const activeParentSx =
       isActive && hasChildren
         ? {
-            '& .MuiListItemIcon-root': { color: SIDEBAR_COLORS.activeText },
-            '& .MuiListItemText-primary': { color: SIDEBAR_COLORS.activeText },
+            '& .MuiListItemIcon-root': { color: colors.activeText },
+            '& .MuiListItemText-primary': { color: colors.activeText },
           }
         : {}
 
@@ -470,9 +478,9 @@ const Sidebar: React.FC<SidebarProps> = ({
                 position: 'relative',
                 transition: 'background-color 0.18s ease',
                 ...activeParentSx,
-                '&:hover': { bgcolor: SIDEBAR_COLORS.hoverBg },
+                '&:hover': { bgcolor: colors.hoverBg },
                 ...(!isActive && {
-                  '&:hover .MuiListItemIcon-root': { color: SIDEBAR_COLORS.hoverText },
+                  '&:hover .MuiListItemIcon-root': { color: colors.hoverText },
                 }),
                 '&.Mui-selected': { bgcolor: 'transparent' },
               }}
@@ -480,7 +488,7 @@ const Sidebar: React.FC<SidebarProps> = ({
               <ListItemIcon
                 sx={{
                   minWidth: 0,
-                  color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.icon,
+                  color: isActive ? colors.activeIcon : colors.icon,
                   justifyContent: 'center',
                   '& .MuiSvgIcon-root': { fontSize: '1.25rem' },
                   transition: 'color 0.18s ease',
@@ -512,9 +520,9 @@ const Sidebar: React.FC<SidebarProps> = ({
                   position: 'relative',
                   transition: 'background-color 0.18s ease',
                   ...activeLeafSx,
-                  '&:hover': { bgcolor: SIDEBAR_COLORS.hoverBg },
+                  '&:hover': { bgcolor: colors.hoverBg },
                   ...(!isActive && {
-                    '&:hover .MuiListItemIcon-root': { color: SIDEBAR_COLORS.hoverText },
+                    '&:hover .MuiListItemIcon-root': { color: colors.hoverText },
                   }),
                   '&.Mui-selected': { bgcolor: 'transparent' },
                 }}
@@ -522,7 +530,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                 <ListItemIcon
                   sx={{
                     minWidth: 0,
-                    color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.icon,
+                    color: isActive ? colors.activeIcon : colors.icon,
                     justifyContent: 'center',
                     '& .MuiSvgIcon-root': { fontSize: '1.25rem' },
                     transition: 'color 0.18s ease',
@@ -555,10 +563,10 @@ const Sidebar: React.FC<SidebarProps> = ({
               transition: 'background-color 0.18s ease',
               ...activeLeafSx,
               ...activeParentSx,
-              '&:hover': { bgcolor: SIDEBAR_COLORS.hoverBg },
+              '&:hover': { bgcolor: colors.hoverBg },
               ...(!isActive && {
-                '&:hover .MuiListItemIcon-root': { color: SIDEBAR_COLORS.hoverText },
-                '&:hover .MuiListItemText-primary': { color: SIDEBAR_COLORS.hoverText },
+                '&:hover .MuiListItemIcon-root': { color: colors.hoverText },
+                '&:hover .MuiListItemText-primary': { color: colors.hoverText },
               }),
               '&.Mui-selected': { bgcolor: 'transparent' },
             }}
@@ -566,7 +574,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             <ListItemIcon
               sx={{
                 minWidth: 40,
-                color: isActive ? SIDEBAR_COLORS.activeIcon : SIDEBAR_COLORS.icon,
+                color: isActive ? colors.activeIcon : colors.icon,
                 '& .MuiSvgIcon-root': { fontSize: '1.25rem' },
                 transition: 'color 0.18s ease',
               }}
@@ -579,7 +587,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                 '& .MuiListItemText-primary': {
                   fontSize: '0.875rem',
                   fontWeight: isActive && !hasChildren ? 600 : 400,
-                  color: isActive ? SIDEBAR_COLORS.activeText : SIDEBAR_COLORS.text,
+                  color: isActive ? colors.activeText : colors.text,
                   transition: 'color 0.18s ease',
                 },
               }}
@@ -595,7 +603,7 @@ const Sidebar: React.FC<SidebarProps> = ({
               <Box
                 component="span"
                 sx={{
-                  color: SIDEBAR_COLORS.icon,
+                  color: colors.icon,
                   display: 'flex',
                   alignItems: 'center',
                   transition: 'transform 0.2s',
@@ -627,7 +635,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   return (
     <Box
       data-testid="sidebar-root"
-      sx={{ height: '100%', display: 'flex', flexDirection: 'column', bgcolor: SIDEBAR_COLORS.bg }}
+      sx={{ height: '100%', display: 'flex', flexDirection: 'column', bgcolor: colors.bg }}
     >
       <Box
         sx={{
@@ -638,7 +646,7 @@ const Sidebar: React.FC<SidebarProps> = ({
           boxSizing: 'border-box',
           height: TOPBAR_HEIGHT,
           minHeight: TOPBAR_HEIGHT,
-          borderBottom: '1px solid #2A2A2A',
+          borderBottom: `1px solid ${colors.border}`,
           flexShrink: 0,
         }}
       >
@@ -654,10 +662,10 @@ const Sidebar: React.FC<SidebarProps> = ({
                 justifyContent: 'center',
                 overflow: 'hidden',
                 ...(company?.logoUrl && !imageError
-                  ? { bgcolor: 'rgba(255,255,255,0.04)' }
+                  ? { bgcolor: colors.hoverBg }
                   : {
                       bgcolor: 'primary.main',
-                      color: 'white',
+                      color: 'common.white',
                       fontWeight: 'bold',
                       fontSize: '0.875rem',
                     }),
@@ -680,7 +688,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                   variant="h6"
                   sx={{
                     fontWeight: 600,
-                    color: SIDEBAR_COLORS.activeText,
+                    color: colors.activeText,
                     whiteSpace: 'nowrap',
                     lineHeight: 1.2,
                   }}
@@ -691,7 +699,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                   <Typography
                     variant="caption"
                     noWrap
-                    sx={{ color: SIDEBAR_COLORS.text, display: 'block', lineHeight: 1.2 }}
+                    sx={{ color: colors.text, display: 'block', lineHeight: 1.2 }}
                   >
                     {company.name}
                   </Typography>
@@ -707,10 +715,10 @@ const Sidebar: React.FC<SidebarProps> = ({
             size="small"
             sx={{
               display: { xs: 'none', lg: 'flex' },
-              color: SIDEBAR_COLORS.icon,
+              color: colors.icon,
               width: 28,
               height: 28,
-              '&:hover': { bgcolor: SIDEBAR_COLORS.hoverBg },
+              '&:hover': { bgcolor: colors.hoverBg },
               flexShrink: 0,
             }}
           >
@@ -726,7 +734,7 @@ const Sidebar: React.FC<SidebarProps> = ({
               <Divider
                 sx={{
                   my: collapsed ? 1 : 0.5,
-                  borderColor: SIDEBAR_COLORS.border,
+                  borderColor: colors.border,
                   display: collapsed && section.id !== 'administration' ? 'none' : 'block',
                 }}
               />
@@ -740,7 +748,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                     pt: 2,
                     pb: 1,
                     display: 'block',
-                    color: SIDEBAR_COLORS.sectionLabel,
+                    color: colors.sectionLabel,
                     fontWeight: 600,
                   fontSize: '0.75rem',
                 }}
@@ -787,14 +795,14 @@ const Sidebar: React.FC<SidebarProps> = ({
                 onMouseEnter={handleFlyoutMouseEnter}
                 onMouseLeave={handleFlyoutMouseLeave}
                 sx={{
-                  bgcolor: SIDEBAR_COLORS.hoverBg,
+                  bgcolor: colors.hoverBg,
                   minWidth: 240,
                   maxWidth: 280,
                   maxHeight: 'calc(100vh - 24px)',
                   overflowY: 'auto',
                   py: 1,
                   borderRadius: 1,
-                  boxShadow: '0 4px 20px rgba(0,0,0,0.4)',
+                  boxShadow: `0 4px 20px ${colors.flyoutShadow}`,
                   '@keyframes flyoutEnter': {
                     from: { transform: 'translateX(-4px)' },
                     to: { transform: 'translateX(0)' },
@@ -836,17 +844,17 @@ const Sidebar: React.FC<SidebarProps> = ({
                                     py: 0.75,
                                     minHeight: 40,
                                     color: isGroupActive
-                                      ? SIDEBAR_COLORS.activeText
-                                      : SIDEBAR_COLORS.text,
+                                      ? colors.activeText
+                                      : colors.text,
                                     '&.Mui-selected': {
-                                      bgcolor: SIDEBAR_COLORS.activeBg,
-                                      color: SIDEBAR_COLORS.activeText,
+                                      bgcolor: colors.activeBg,
+                                      color: colors.activeText,
                                     },
                                     '&.Mui-selected:hover': {
-                                      bgcolor: SIDEBAR_COLORS.activeBg,
+                                      bgcolor: colors.activeBg,
                                     },
                                     '&:hover': {
-                                      bgcolor: SIDEBAR_COLORS.hoverBg,
+                                      bgcolor: colors.hoverBg,
                                     },
                                   }}
                                 >
@@ -861,8 +869,8 @@ const Sidebar: React.FC<SidebarProps> = ({
                                     component="span"
                                     sx={{
                                       color: isGroupActive
-                                        ? SIDEBAR_COLORS.activeText
-                                        : SIDEBAR_COLORS.icon,
+                                        ? colors.activeText
+                                        : colors.icon,
                                       display: 'flex',
                                       alignItems: 'center',
                                       transition: 'transform 0.2s',

--- a/frontend/src/components/common/SidebarFooter.tsx
+++ b/frontend/src/components/common/SidebarFooter.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Box } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
 import SidebarUserMenu from './SidebarUserMenu'
 
 interface SidebarFooterProps {
@@ -7,11 +8,13 @@ interface SidebarFooterProps {
 }
 
 const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
+  const theme = useTheme()
+
   return (
     <Box
       sx={{
-        backgroundColor: '#141414',
-        borderTop: '1px solid #1F2937',
+        backgroundColor: theme.palette.background.default,
+        borderTop: `1px solid ${theme.palette.divider}`,
         py: 1,
         display: 'flex',
         flexDirection: 'column',

--- a/frontend/src/components/common/SidebarUserMenu.tsx
+++ b/frontend/src/components/common/SidebarUserMenu.tsx
@@ -8,6 +8,7 @@ import {
   MenuItem,
   Typography,
 } from '@mui/material'
+import { alpha, useTheme } from '@mui/material/styles'
 import {
   Logout as LogoutIcon,
   Settings as SettingsIcon,
@@ -22,23 +23,12 @@ import {
 } from '@/store/slices/authSlice'
 import { persistor } from '@/store'
 
-// Local color constants intentionally duplicate the sidebar palette.
-// The original sidebar colors are module-private, so this keeps the scope
-// small for the sidebar footer refactor.
-const COLORS = {
-  icon: '#6B7280',
-  hoverText: '#CBD5E1',
-  text: '#9CA3AF',
-  mutedText: '#6B7280',
-  menuBg: '#1E1E1E',
-  border: '#1F2937',
-} as const
-
 interface SidebarUserMenuProps {
   collapsed: boolean
 }
 
 const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
+  const theme = useTheme()
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
   const user = useSelector(selectCurrentUser)
@@ -149,7 +139,7 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
             textAlign: 'left',
             transition: 'background-color 0.15s ease, transform 0.15s ease',
             '&:hover': {
-              backgroundColor: '#1E1E1E',
+              backgroundColor: theme.palette.action.hover,
               transform: 'translateX(1px)',
             },
           }}
@@ -162,7 +152,7 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
             <Typography
               noWrap
               sx={{
-                color: '#FFFFFF',
+                color: theme.palette.common.white,
                 fontSize: '0.875rem',
                 lineHeight: 1.3,
                 overflow: 'hidden',
@@ -173,7 +163,7 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
             </Typography>
             <Typography
               sx={{
-                color: COLORS.mutedText,
+                color: theme.palette.text.secondary,
                 fontSize: '0.7rem',
                 lineHeight: 1.2,
                 mt: '4px',
@@ -192,29 +182,29 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
         PaperProps={{
           sx: {
             minWidth: 220,
-            bgcolor: COLORS.menuBg,
+            bgcolor: theme.palette.background.paper,
             borderRadius: 1,
-            boxShadow: '0 4px 20px rgba(0,0,0,0.4)',
+            boxShadow: `0 4px 20px ${alpha(theme.palette.common.black, 0.4)}`,
           },
         }}
         anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
         transformOrigin={{ vertical: 'bottom', horizontal: 'right' }}
       >
         <Box sx={{ px: 2, py: 1, cursor: 'default', userSelect: 'none' }}>
-          <Typography sx={{ color: '#D1D5DB', fontSize: '0.8rem', fontWeight: 500 }}>
+          <Typography sx={{ color: theme.palette.text.primary, fontSize: '0.8rem', fontWeight: 500 }}>
             {username}
           </Typography>
         </Box>
 
-        <Divider sx={{ borderColor: COLORS.border }} />
+        <Divider sx={{ borderColor: theme.palette.divider }} />
 
         <MenuItem
           onClick={handleSettingsClick}
           sx={{
             minHeight: 40,
             alignItems: 'center',
-            '& .MuiListItemIcon-root': { color: COLORS.icon },
-            '&:hover .MuiListItemIcon-root': { color: COLORS.hoverText },
+            '& .MuiListItemIcon-root': { color: theme.palette.text.secondary },
+            '&:hover .MuiListItemIcon-root': { color: theme.palette.grey[300] },
           }}
         >
           <ListItemIcon>
@@ -228,8 +218,8 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
           sx={{
             minHeight: 40,
             alignItems: 'center',
-            '& .MuiListItemIcon-root': { color: COLORS.icon },
-            '&:hover .MuiListItemIcon-root': { color: COLORS.hoverText },
+            '& .MuiListItemIcon-root': { color: theme.palette.text.secondary },
+            '&:hover .MuiListItemIcon-root': { color: theme.palette.grey[300] },
           }}
         >
           <ListItemIcon>
@@ -238,10 +228,10 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
           Logout
         </MenuItem>
 
-        <Divider sx={{ borderColor: COLORS.border }} />
+        <Divider sx={{ borderColor: theme.palette.divider }} />
 
         <Box sx={{ px: 2, py: 1, mt: '4px' }}>
-          <Typography sx={{ color: COLORS.mutedText, fontSize: '0.65rem', opacity: 0.7, letterSpacing: '0.02em' }}>
+          <Typography sx={{ color: theme.palette.text.secondary, fontSize: '0.65rem', opacity: 0.7, letterSpacing: '0.02em' }}>
             v{version}
           </Typography>
         </Box>

--- a/frontend/src/components/common/SystemStatus.tsx
+++ b/frontend/src/components/common/SystemStatus.tsx
@@ -14,6 +14,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
 import {
   CloudQueue as NginxIcon,
   Computer as BackendIcon,
@@ -48,6 +49,7 @@ const statusPulse = keyframes`
 `
 
 const SystemStatus: React.FC = () => {
+  const theme = useTheme()
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const [health, setHealth] = useState<HealthResponse | null>(null)
   const [loading, setLoading] = useState(false)
@@ -108,13 +110,13 @@ const SystemStatus: React.FC = () => {
   const getDotColor = (status: 'healthy' | 'degraded' | 'unhealthy' | 'unknown'): string => {
     switch (status) {
       case 'healthy':
-        return '#22C55E'
+        return theme.palette.success.main
       case 'degraded':
-        return '#F59E0B'
+        return theme.palette.warning.main
       case 'unhealthy':
-        return '#EF4444'
+        return theme.palette.error.main
       default:
-        return '#6B7280'
+        return theme.palette.text.secondary
     }
   }
 
@@ -149,10 +151,10 @@ const SystemStatus: React.FC = () => {
           onClick={handleClick}
           color="inherit"
           size="small"
-          sx={{ '&:hover': { bgcolor: '#2A2A2A', borderRadius: '8px' } }}
+          sx={{ '&:hover': { bgcolor: theme.palette.action.hover, borderRadius: '8px' } }}
         >
           <Box sx={{ position: 'relative', display: 'inline-flex' }}>
-            <DnsRoundedIcon sx={{ fontSize: 22, color: '#A0A0A0' }} />
+            <DnsRoundedIcon sx={{ fontSize: 22, color: theme.palette.text.secondary }} />
             <Box
               sx={{
                 position: 'absolute',

--- a/frontend/src/components/common/TopBar.tsx
+++ b/frontend/src/components/common/TopBar.tsx
@@ -229,13 +229,13 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
         sx={{
           width: { lg: `calc(100% - ${sidebarWidth}px)` },
           ml: { lg: `${sidebarWidth}px` },
-          bgcolor: '#1E1E1E',
+          bgcolor: theme.palette.background.paper,
           color: 'text.primary',
           boxShadow: 'none',
           boxSizing: 'border-box',
           height: TOPBAR_HEIGHT,
           minHeight: TOPBAR_HEIGHT,
-          borderBottom: '1px solid #2A2A2A',
+          borderBottom: `1px solid ${theme.palette.divider}`,
           transition: 'width 0.22s ease, margin-left 0.22s ease',
         }}
       >
@@ -254,12 +254,12 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
 
           <Box sx={{ flexGrow: 1, overflow: 'hidden', display: 'flex', alignItems: 'center', height: '100%' }}>
             {isMobile ? (
-              <Typography noWrap sx={{ fontSize: '0.875rem', color: '#E0E0E0', fontWeight: 500 }}>
+              <Typography noWrap sx={{ fontSize: '0.875rem', color: theme.palette.text.primary, fontWeight: 500 }}>
                 {leafLabel}
               </Typography>
             ) : breadcrumbs.length > 0 ? (
               <Breadcrumbs
-                separator={<NavigateNextIcon sx={{ fontSize: 14, color: '#5A5A5A', mx: 0.5 }} />}
+                separator={<NavigateNextIcon sx={{ fontSize: 14, color: theme.palette.text.secondary, mx: 0.5 }} />}
                 aria-label="breadcrumb"
                 sx={{
                   display: 'flex',
@@ -275,7 +275,7 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
                     return (
                       <Typography
                         key={segment.path}
-                        sx={{ fontSize: '13px', color: '#E0E0E0', fontWeight: 500, display: 'flex', alignItems: 'center', lineHeight: 1.4 }}
+                        sx={{ fontSize: '13px', color: theme.palette.text.primary, fontWeight: 500, display: 'flex', alignItems: 'center', lineHeight: 1.4 }}
                       >
                         {segment.label}
                       </Typography>
@@ -292,12 +292,12 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
                         sx={{
                           fontSize: '13px',
                           fontWeight: 400,
-                          color: '#8A8A8A',
+                          color: theme.palette.text.secondary,
                           display: 'flex',
                           alignItems: 'center',
                           lineHeight: 1.4,
                           transition: 'color 0.15s ease',
-                          '&:hover': { color: '#CFCFCF' },
+                          '&:hover': { color: theme.palette.text.primary },
                         }}
                       >
                         {segment.label}
@@ -308,7 +308,7 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
                   return (
                     <Typography
                       key={segment.path}
-                      sx={{ fontSize: '13px', fontWeight: 400, color: '#8A8A8A', display: 'flex', alignItems: 'center', lineHeight: 1.4 }}
+                      sx={{ fontSize: '13px', fontWeight: 400, color: theme.palette.text.secondary, display: 'flex', alignItems: 'center', lineHeight: 1.4 }}
                     >
                       {segment.label}
                     </Typography>
@@ -330,28 +330,28 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
                 width: 220,
                 px: 1.5,
                 py: 0.75,
-                bgcolor: '#232323',
-                border: '1px solid #2A2A2A',
+                bgcolor: theme.palette.divider,
+                border: `1px solid ${theme.palette.divider}`,
                 borderRadius: '8px',
                 cursor: 'pointer',
-                '&:hover': { borderColor: '#3A3A3A' },
+                '&:hover': { borderColor: theme.palette.grey[700] },
               }}
             >
-              <SearchIcon sx={{ fontSize: 16, color: '#6B7280', flexShrink: 0 }} />
-              <Typography sx={{ fontSize: '0.8125rem', color: '#6B7280', flexGrow: 1 }}>
+              <SearchIcon sx={{ fontSize: 16, color: theme.palette.text.secondary, flexShrink: 0 }} />
+              <Typography sx={{ fontSize: '0.8125rem', color: theme.palette.text.secondary, flexGrow: 1 }}>
                 Search...
               </Typography>
               <Box
                 component="kbd"
                 sx={{
-                  bgcolor: '#1A1A1A',
-                  border: '1px solid #3A3A3A',
+                  bgcolor: theme.palette.background.default,
+                  border: `1px solid ${theme.palette.grey[700]}`,
                   borderRadius: '4px',
                   px: 0.75,
                   py: 0.25,
                   fontFamily: 'monospace',
                   fontSize: '11px',
-                  color: '#6B7280',
+                  color: theme.palette.text.secondary,
                   flexShrink: 0,
                 }}
               >
@@ -365,7 +365,7 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
               <IconButton
                 onClick={(event) => setNotificationAnchorEl(event.currentTarget)}
                 color="inherit"
-                sx={{ '&:hover': { bgcolor: '#2A2A2A', borderRadius: '8px' } }}
+                sx={{ '&:hover': { bgcolor: theme.palette.action.hover, borderRadius: '8px' } }}
               >
                 <Badge badgeContent={unreadCount} color="error">
                   <NotificationsIcon />

--- a/frontend/src/components/print/BasePrintTemplate.tsx
+++ b/frontend/src/components/print/BasePrintTemplate.tsx
@@ -12,6 +12,7 @@ import {
   Divider,
   Grid,
 } from '@mui/material'
+import { printColors } from '@/styles/printTokens'
 
 interface PrintSettings {
   logoUrl?: string
@@ -89,11 +90,11 @@ const BasePrintTemplate: React.FC<BasePrintTemplateProps> = ({
   return (
     <Box
       sx={{
-        bgcolor: '#ffffff',
-        color: '#000000',
+        bgcolor: printColors.background,
+        color: printColors.text,
         '@media print': {
-          bgcolor: '#ffffff',
-          color: '#000000',
+          bgcolor: printColors.background,
+          color: printColors.text,
         },
       }}
     >
@@ -103,8 +104,8 @@ const BasePrintTemplate: React.FC<BasePrintTemplateProps> = ({
           width: '210mm',
           minHeight: '297mm',
           mx: 'auto',
-          bgcolor: '#ffffff',
-          color: '#000000',
+          bgcolor: printColors.background,
+          color: printColors.text,
           boxShadow: 'none',
           '@media print': {
             boxShadow: 'none',
@@ -118,28 +119,28 @@ const BasePrintTemplate: React.FC<BasePrintTemplateProps> = ({
         <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 3, gap: 2 }}>
           {/* Company Info */}
           <Box sx={{ flex: 1 }}>
-            <Typography variant="h5" sx={{ fontWeight: 700, mb: 1, color: '#000000' }}>
+            <Typography variant="h5" sx={{ fontWeight: 700, mb: 1, color: printColors.text }}>
               {settings?.companyName || 'Company Name'}
             </Typography>
-            <Typography variant="body2" sx={{ color: '#000000', mb: 0.5 }}>
+            <Typography variant="body2" sx={{ color: printColors.text, mb: 0.5 }}>
               {settings?.address || 'Address'}
             </Typography>
-            <Typography variant="body2" sx={{ color: '#000000', mb: 0.5 }}>
+            <Typography variant="body2" sx={{ color: printColors.text, mb: 0.5 }}>
               {settings?.postalCode || ''}, {settings?.city || 'City'}
             </Typography>
-            <Typography variant="body2" sx={{ color: '#000000', mb: 1 }}>
+            <Typography variant="body2" sx={{ color: printColors.text, mb: 1 }}>
               {settings?.state || 'State'}, {settings?.country || 'Country'}
             </Typography>
-            <Typography variant="body2" sx={{ color: '#000000', mb: 0.5 }}>
+            <Typography variant="body2" sx={{ color: printColors.text, mb: 0.5 }}>
               {settings?.phone ? `Tel: ${settings.phone}` : 'Tel: '}
             </Typography>
             {settings?.email && (
-              <Typography variant="body2" sx={{ color: '#000000', mb: 0.5 }}>
+              <Typography variant="body2" sx={{ color: printColors.text, mb: 0.5 }}>
                 Email: {settings.email}
               </Typography>
             )}
             {settings?.website && (
-              <Typography variant="body2" sx={{ color: '#000000' }}>
+              <Typography variant="body2" sx={{ color: printColors.text }}>
                 Website: {settings.website}
               </Typography>
             )}
@@ -173,22 +174,22 @@ const BasePrintTemplate: React.FC<BasePrintTemplateProps> = ({
               variant="h4"
               sx={{
                 fontWeight: 700,
-                color: '#000000',
+                color: printColors.text,
                 mb: 1,
               }}
             >
               {documentTitle.toUpperCase()}
             </Typography>
-            <Typography variant="body2" sx={{ color: '#000000', mb: 0.5 }}>
+            <Typography variant="body2" sx={{ color: printColors.text, mb: 0.5 }}>
               <strong>Document No:</strong> {documentNumber}
             </Typography>
-            <Typography variant="body2" sx={{ color: '#000000' }}>
+            <Typography variant="body2" sx={{ color: printColors.text }}>
               <strong>Date:</strong> {documentDate}
             </Typography>
           </Box>
         </Box>
 
-        <Divider sx={{ mb: 3, borderColor: '#000000' }} />
+        <Divider sx={{ mb: 3, borderColor: printColors.border }} />
 
         {/* Recipient Details */}
         <Grid container spacing={3} sx={{ mb: 3 }}>
@@ -196,27 +197,27 @@ const BasePrintTemplate: React.FC<BasePrintTemplateProps> = ({
             {/* Empty space for alignment */}
           </Grid>
           <Grid size={6}>
-            <Box sx={{ border: '1px solid #000000', p: 2, borderRadius: 1 }}>
-              <Typography variant="body2" sx={{ color: '#000000', fontWeight: 600, mb: 0.5 }}>
+            <Box sx={{ border: `1px solid ${printColors.border}`, p: 2, borderRadius: 1 }}>
+              <Typography variant="body2" sx={{ color: printColors.text, fontWeight: 600, mb: 0.5 }}>
                 {recipient.name}
               </Typography>
               {recipient.address && (
-                <Typography variant="body2" sx={{ color: '#000000', mb: 0.5 }}>
+                <Typography variant="body2" sx={{ color: printColors.text, mb: 0.5 }}>
                   {recipient.address}
                 </Typography>
               )}
               {(recipient.postalCode || recipient.city) && (
-                <Typography variant="body2" sx={{ color: '#000000', mb: 0.5 }}>
+                <Typography variant="body2" sx={{ color: printColors.text, mb: 0.5 }}>
                   {recipient.postalCode}, {recipient.city}
                 </Typography>
               )}
               {(recipient.state || recipient.country) && (
-                <Typography variant="body2" sx={{ color: '#000000', mb: 0.5 }}>
+                <Typography variant="body2" sx={{ color: printColors.text, mb: 0.5 }}>
                   {recipient.state}, {recipient.country}
                 </Typography>
               )}
               {recipient.phone && (
-                <Typography variant="body2" sx={{ color: '#000000' }}>
+                <Typography variant="body2" sx={{ color: printColors.text }}>
                   Phone: {recipient.phone}
                 </Typography>
               )}
@@ -225,27 +226,27 @@ const BasePrintTemplate: React.FC<BasePrintTemplateProps> = ({
         </Grid>
 
         {/* Items Table */}
-        <TableContainer sx={{ mb: 3, border: '1px solid #000000' }}>
+        <TableContainer sx={{ mb: 3, border: `1px solid ${printColors.border}` }}>
           <Table size="small">
             <TableHead>
-              <TableRow sx={{ bgcolor: '#f0f0f0' }}>
-                <TableCell sx={{ fontWeight: 600, color: '#000000', border: '1px solid #000000' }}>
+              <TableRow sx={{ bgcolor: printColors.tableRowAlt }}>
+                <TableCell sx={{ fontWeight: 600, color: printColors.text, border: `1px solid ${printColors.border}` }}>
                   Product
                 </TableCell>
-                <TableCell align="right" sx={{ fontWeight: 600, color: '#000000', border: '1px solid #000000' }}>
+                <TableCell align="right" sx={{ fontWeight: 600, color: printColors.text, border: `1px solid ${printColors.border}` }}>
                   Qty
                 </TableCell>
                 {showPricing && (
                   <>
-                    <TableCell align="right" sx={{ fontWeight: 600, color: '#000000', border: '1px solid #000000' }}>
+                    <TableCell align="right" sx={{ fontWeight: 600, color: printColors.text, border: `1px solid ${printColors.border}` }}>
                       Unit Price
                     </TableCell>
                     {showDiscount && (
-                      <TableCell align="right" sx={{ fontWeight: 600, color: '#000000', border: '1px solid #000000' }}>
+                      <TableCell align="right" sx={{ fontWeight: 600, color: printColors.text, border: `1px solid ${printColors.border}` }}>
                         Discount
                       </TableCell>
                     )}
-                    <TableCell align="right" sx={{ fontWeight: 600, color: '#000000', border: '1px solid #000000' }}>
+                    <TableCell align="right" sx={{ fontWeight: 600, color: printColors.text, border: `1px solid ${printColors.border}` }}>
                       Amount
                     </TableCell>
                   </>
@@ -255,23 +256,23 @@ const BasePrintTemplate: React.FC<BasePrintTemplateProps> = ({
             <TableBody>
               {items.map((item, index) => (
                 <TableRow key={index}>
-                  <TableCell sx={{ color: '#000000', border: '1px solid #000000' }}>
+                  <TableCell sx={{ color: printColors.text, border: `1px solid ${printColors.border}` }}>
                     {item.description}
                   </TableCell>
-                  <TableCell align="right" sx={{ color: '#000000', border: '1px solid #000000' }}>
+                  <TableCell align="right" sx={{ color: printColors.text, border: `1px solid ${printColors.border}` }}>
                     {item.quantity}
                   </TableCell>
                   {showPricing && (
                     <>
-                      <TableCell align="right" sx={{ color: '#000000', border: '1px solid #000000' }}>
+                      <TableCell align="right" sx={{ color: printColors.text, border: `1px solid ${printColors.border}` }}>
                         {currency} {Number(item.unitPrice || 0).toFixed(2)}
                       </TableCell>
                       {showDiscount && (
-                        <TableCell align="right" sx={{ color: '#000000', border: '1px solid #000000' }}>
+                        <TableCell align="right" sx={{ color: printColors.text, border: `1px solid ${printColors.border}` }}>
                           {item.discountDisplay || '-'}
                         </TableCell>
                       )}
-                      <TableCell align="right" sx={{ color: '#000000', border: '1px solid #000000' }}>
+                      <TableCell align="right" sx={{ color: printColors.text, border: `1px solid ${printColors.border}` }}>
                         {currency} {Number(item.amount || 0).toFixed(2)}
                       </TableCell>
                     </>
@@ -285,50 +286,50 @@ const BasePrintTemplate: React.FC<BasePrintTemplateProps> = ({
         {/* Totals */}
         {showPricing ? (
           <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 3 }}>
-            <Box sx={{ width: 300, border: '1px solid #000000', p: 2 }}>
+            <Box sx={{ width: 300, border: `1px solid ${printColors.border}`, p: 2 }}>
               <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-                <Typography variant="body2" sx={{ color: '#000000' }}>
+                <Typography variant="body2" sx={{ color: printColors.text }}>
                   Subtotal:
                 </Typography>
-                <Typography variant="body2" sx={{ color: '#000000' }}>
+                <Typography variant="body2" sx={{ color: printColors.text }}>
                   {currency} {Number(totals.subtotal || 0).toFixed(2)}
                 </Typography>
               </Box>
               {totals.shipping !== undefined && (
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-                  <Typography variant="body2" sx={{ color: '#000000' }}>
+                  <Typography variant="body2" sx={{ color: printColors.text }}>
                     Shipping Cost:
                   </Typography>
-                  <Typography variant="body2" sx={{ color: '#000000' }}>
+                  <Typography variant="body2" sx={{ color: printColors.text }}>
                     {currency} {Number(totals.shipping || 0).toFixed(2)}
                   </Typography>
                 </Box>
               )}
-              <Divider sx={{ my: 1, borderColor: '#000000' }} />
+              <Divider sx={{ my: 1, borderColor: printColors.border }} />
               <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-                <Typography variant="body1" sx={{ fontWeight: 700, color: '#000000' }}>
+                <Typography variant="body1" sx={{ fontWeight: 700, color: printColors.text }}>
                   Total:
                 </Typography>
-                <Typography variant="body1" sx={{ fontWeight: 700, color: '#000000' }}>
+                <Typography variant="body1" sx={{ fontWeight: 700, color: printColors.text }}>
                   {currency} {Number(totals.total || 0).toFixed(2)}
                 </Typography>
               </Box>
               {totals.paid !== undefined && (
                 <>
                   <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-                    <Typography variant="body2" sx={{ color: '#000000' }}>
+                    <Typography variant="body2" sx={{ color: printColors.text }}>
                       Paid:
                     </Typography>
-                    <Typography variant="body2" sx={{ color: '#000000' }}>
+                    <Typography variant="body2" sx={{ color: printColors.text }}>
                       {currency} {Number(totals.paid || 0).toFixed(2)}
                     </Typography>
                   </Box>
-                  <Divider sx={{ my: 1, borderColor: '#000000' }} />
+                  <Divider sx={{ my: 1, borderColor: printColors.border }} />
                   <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                    <Typography variant="body1" sx={{ fontWeight: 700, color: '#000000' }}>
+                    <Typography variant="body1" sx={{ fontWeight: 700, color: printColors.text }}>
                       Balance:
                     </Typography>
-                    <Typography variant="body1" sx={{ fontWeight: 700, color: '#000000' }}>
+                    <Typography variant="body1" sx={{ fontWeight: 700, color: printColors.text }}>
                       {currency} {Number(totals.balance || 0).toFixed(2)}
                     </Typography>
                   </Box>
@@ -338,12 +339,12 @@ const BasePrintTemplate: React.FC<BasePrintTemplateProps> = ({
           </Box>
         ) : (
           <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 3 }}>
-            <Box sx={{ width: 300, border: '1px solid #000000', p: 2 }}>
+            <Box sx={{ width: 300, border: `1px solid ${printColors.border}`, p: 2 }}>
               <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                <Typography variant="body1" sx={{ fontWeight: 700, color: '#000000' }}>
+                <Typography variant="body1" sx={{ fontWeight: 700, color: printColors.text }}>
                   Total Quantity:
                 </Typography>
-                <Typography variant="body1" sx={{ fontWeight: 700, color: '#000000' }}>
+                <Typography variant="body1" sx={{ fontWeight: 700, color: printColors.text }}>
                   {totalQuantity}
                 </Typography>
               </Box>
@@ -354,10 +355,10 @@ const BasePrintTemplate: React.FC<BasePrintTemplateProps> = ({
         {/* Notes */}
         {notes && (
           <Box sx={{ mb: 3 }}>
-            <Typography variant="body2" sx={{ fontWeight: 600, mb: 1, color: '#000000' }}>
+            <Typography variant="body2" sx={{ fontWeight: 600, mb: 1, color: printColors.text }}>
               Notes:
             </Typography>
-            <Typography variant="body2" sx={{ color: '#000000' }}>
+            <Typography variant="body2" sx={{ color: printColors.text }}>
               {notes}
             </Typography>
           </Box>
@@ -366,8 +367,8 @@ const BasePrintTemplate: React.FC<BasePrintTemplateProps> = ({
         {/* Per-page footer */}
         {perPageFooter && (
           <>
-            <Divider sx={{ my: 2, borderColor: '#000000' }} />
-            <Typography variant="caption" sx={{ color: '#000000' }} align="center" display="block">
+            <Divider sx={{ my: 2, borderColor: printColors.border }} />
+            <Typography variant="caption" sx={{ color: printColors.text }} align="center" display="block">
               {perPageFooter}
             </Typography>
           </>
@@ -376,9 +377,9 @@ const BasePrintTemplate: React.FC<BasePrintTemplateProps> = ({
         {/* End of document footer */}
         {endOfDocFooter && (
           <>
-            <Divider sx={{ my: 2, borderColor: '#000000' }} />
-            <Box sx={{ bgcolor: '#f0f0f0', p: 2, borderRadius: 1, border: '1px solid #000000' }}>
-              <Typography variant="body2" sx={{ color: '#000000' }} align="center">
+            <Divider sx={{ my: 2, borderColor: printColors.border }} />
+            <Box sx={{ bgcolor: printColors.tableRowAlt, p: 2, borderRadius: 1, border: `1px solid ${printColors.border}` }}>
+              <Typography variant="body2" sx={{ color: printColors.text }} align="center">
                 {endOfDocFooter}
               </Typography>
             </Box>

--- a/frontend/src/pages/audit-logs/components/AnalyticsTab.tsx
+++ b/frontend/src/pages/audit-logs/components/AnalyticsTab.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import {
   Box, Paper, Typography, GridLegacy as Grid, CircularProgress,
 } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
 import {
   Chart as ChartJS,
   CategoryScale, LinearScale, BarElement, ArcElement,
@@ -12,23 +13,25 @@ import type { AuditLogStatistics } from '@/store/api/auditLogApi'
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, ArcElement, Title, Tooltip, Legend)
 
-const ACTION_COLORS: Record<string, string> = {
-  CREATE: '#4caf50',
-  UPDATE: '#2196f3',
-  DELETE: '#f44336',
-  RESTORE: '#ff9800',
-  BULK_DELETE: '#e91e63',
-  BULK_RESTORE: '#ff5722',
-  EXPORT: '#9c27b0',
-  IMPORT: '#00bcd4',
-}
-
 interface AnalyticsTabProps {
   statistics: AuditLogStatistics | null
   loading: boolean
 }
 
 const AnalyticsTab: React.FC<AnalyticsTabProps> = ({ statistics, loading }) => {
+  const theme = useTheme()
+
+  const actionPalette: Record<string, string> = {
+    CREATE: theme.palette.success.main,
+    UPDATE: theme.palette.primary.main,
+    DELETE: theme.palette.error.main,
+    RESTORE: theme.palette.warning.main,
+    BULK_DELETE: theme.palette.secondary.main,
+    BULK_RESTORE: theme.palette.error.light,
+    EXPORT: theme.palette.secondary.light,
+    IMPORT: theme.palette.info.main,
+  }
+
   if (loading) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
@@ -47,7 +50,7 @@ const AnalyticsTab: React.FC<AnalyticsTabProps> = ({ statistics, loading }) => {
 
   const actionLabels = statistics.byAction.map((a) => a.action)
   const actionCounts = statistics.byAction.map((a) => Number(a.count))
-  const actionColors = actionLabels.map((l) => ACTION_COLORS[l] ?? '#9e9e9e')
+  const actionColors = actionLabels.map((l) => actionPalette[l] ?? theme.palette.grey[500])
 
   const entityLabels = statistics.byEntityType.map((e) => e.entityType)
   const entityCounts = statistics.byEntityType.map((e) => Number(e.count))
@@ -122,7 +125,7 @@ const AnalyticsTab: React.FC<AnalyticsTabProps> = ({ statistics, loading }) => {
               datasets: [{
                 label: 'Actions',
                 data: userCounts,
-                backgroundColor: '#2196f3',
+                backgroundColor: theme.palette.primary.main,
               }],
             }}
             options={horizontalBarOptions}
@@ -142,7 +145,7 @@ const AnalyticsTab: React.FC<AnalyticsTabProps> = ({ statistics, loading }) => {
               datasets: [{
                 label: 'Count',
                 data: entityCounts,
-                backgroundColor: '#9c27b0',
+                backgroundColor: theme.palette.secondary.main,
               }],
             }}
             options={horizontalBarOptions}

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -14,6 +14,7 @@ import {
   CircularProgress,
   Link,
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import {
   Visibility,
   VisibilityOff,
@@ -38,6 +39,7 @@ const schema = yup.object({
 });
 
 const LoginPage: React.FC = () => {
+  const theme = useTheme();
   const navigate = useNavigate();
   const location = useLocation();
   const dispatch = useAppDispatch();
@@ -141,7 +143,7 @@ const LoginPage: React.FC = () => {
               mb: 2,
             }}
           >
-            <LockIcon sx={{ fontSize: 32, color: 'white' }} />
+            <LockIcon sx={{ fontSize: 32, color: theme.palette.common.white }} />
           </Box>
           <Typography variant="h4" component="h1" fontWeight="bold" gutterBottom>
             Welcome Back

--- a/frontend/src/pages/auth/MandatoryPasswordChangePage.tsx
+++ b/frontend/src/pages/auth/MandatoryPasswordChangePage.tsx
@@ -12,6 +12,7 @@ import {
   IconButton,
   LinearProgress,
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import {
   Visibility,
   VisibilityOff,
@@ -44,6 +45,7 @@ const passwordSchema = yup.object({
 });
 
 const MandatoryPasswordChangePage: React.FC = () => {
+  const theme = useTheme();
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const { loading, error, user, refreshToken } = useAppSelector((state) => state.auth);
@@ -308,7 +310,7 @@ const MandatoryPasswordChangePage: React.FC = () => {
           sx={{
             mt: 3,
             p: 2,
-            bgcolor: 'info.light',
+            bgcolor: theme.palette.info.light,
             borderRadius: 2,
           }}
         >

--- a/frontend/src/pages/dashboard/components/BusinessPerformanceChart.tsx
+++ b/frontend/src/pages/dashboard/components/BusinessPerformanceChart.tsx
@@ -84,19 +84,6 @@ const DATE_FILTER_OPTIONS = [
     { value: 'custom', label: 'Custom Date Range' },
 ]
 
-// Line colors mapping
-const LINE_COLORS: { [key: string]: string } = {
-    sales_completed: '#4caf50',
-    cogs: '#f44336',
-    sales_profit: '#2196f3',
-    sales_orders: '#9c27b0',
-    purchase_orders: '#ff9800',
-    cash_in: '#00bcd4',
-    cash_out: '#e91e63',
-    net_cash_flow: '#3f51b5',
-    inventory_value: '#795548',
-}
-
 interface ChartFilters {
     selectedLines: string[]
     dateFilter: string
@@ -119,6 +106,17 @@ interface BusinessPerformanceChartProps {
 const BusinessPerformanceChart: React.FC<BusinessPerformanceChartProps> = ({ rawData }) => {
     const theme = useTheme()
     const chartRef = useRef<any>(null)
+    const lineColors: Record<string, string> = {
+        sales_completed: theme.palette.success.main,
+        cogs: theme.palette.error.main,
+        sales_profit: theme.palette.primary.main,
+        sales_orders: theme.palette.secondary.main,
+        purchase_orders: theme.palette.warning.main,
+        cash_in: theme.palette.info.main,
+        cash_out: theme.palette.secondary.light,
+        net_cash_flow: theme.palette.primary.dark,
+        inventory_value: theme.palette.warning.dark,
+    }
 
     const [chartFilters, setChartFilters] = React.useState<ChartFilters>({
         selectedLines: ['sales_completed', 'cogs', 'sales_profit'],
@@ -300,7 +298,7 @@ const BusinessPerformanceChart: React.FC<BusinessPerformanceChartProps> = ({ raw
             })
 
             const lineOption = LINE_OPTIONS.find(o => o.value === lineType)
-            const color = LINE_COLORS[lineType] || theme.palette.primary.main
+            const color = lineColors[lineType] || theme.palette.primary.main
 
             return {
                 label: lineOption?.label || lineType,

--- a/frontend/src/pages/inventory/CreateProductPage.tsx
+++ b/frontend/src/pages/inventory/CreateProductPage.tsx
@@ -14,6 +14,7 @@ import {
   MenuItem,
   Chip,
 } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
 
 import { useForm, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
@@ -36,6 +37,7 @@ const PriceListPriceField: React.FC<{
   baseCost: number
   onChange: (value: number) => void
 }> = ({ priceList, currency, value, baseCost, onChange }) => {
+  const theme = useTheme()
   const [localValue, setLocalValue] = useState(value > 0 ? value.toFixed(2) : '')
   const [isFocused, setIsFocused] = useState(false)
 
@@ -95,7 +97,7 @@ const PriceListPriceField: React.FC<{
           type="text"
           slotProps={{
             input: {
-              startAdornment: <span style={{ marginRight: '4px', fontSize: '0.75rem', color: '#666' }}>{currency}</span>
+              startAdornment: <span style={{ marginRight: '4px', fontSize: '0.75rem', color: theme.palette.text.secondary }}>{currency}</span>
             }
           }}
           sx={{
@@ -166,6 +168,7 @@ const productSchema = yup.object({
 })
 
 const CreateProductPage: React.FC = () => {
+  const theme = useTheme()
   const navigate = useNavigate()
   const { id } = useParams<{ id: string }>()
   const isEditMode = !!id
@@ -624,7 +627,7 @@ const CreateProductPage: React.FC = () => {
                                 size="small"
                                 slotProps={{
                                   input: {
-                                    startAdornment: <span style={{ marginRight: '4px', fontSize: '0.75rem', color: '#666' }}>{currency}</span>
+                                    startAdornment: <span style={{ marginRight: '4px', fontSize: '0.75rem', color: theme.palette.text.secondary }}>{currency}</span>
                                   }
                                 }}
                                 sx={{

--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -382,10 +382,10 @@ const CreateStockAdjustmentPage: React.FC = () => {
                               border: 'none',
                             },
                             '&:hover fieldset': {
-                              border: '1px solid #1976d2',
+                              border: `1px solid ${theme.palette.primary.main}`,
                             },
                             '&.Mui-focused fieldset': {
-                              border: '1px solid #1976d2',
+                              border: `1px solid ${theme.palette.primary.main}`,
                             },
                             backgroundColor: 'transparent',
                             fontSize: '0.875rem',

--- a/frontend/src/pages/inventory/HistoricalInventoryReport.tsx
+++ b/frontend/src/pages/inventory/HistoricalInventoryReport.tsx
@@ -28,6 +28,7 @@ import {
   DialogActions,
   IconButton,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import {
   PictureAsPdf as PdfIcon,
   TableChart as ExcelIcon,
@@ -44,6 +45,7 @@ import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
 import { useGetProductsQuery, useGetCategoriesQuery } from '@/store/api/inventoryApi'
+import { printColors } from '@/styles/printTokens'
 
 interface HistoricalInventory {
   productName: string
@@ -348,7 +350,7 @@ const HistoricalInventoryReport: React.FC = () => {
 
       if (groupBy !== 'none' && currentGroupKey !== prevGroupKey) {
         const groupLabel = getPdfGroupLabel(row)
-        tableRows += `<tr style="background-color: #d3d3d3; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupKey = currentGroupKey
       }
 
@@ -399,9 +401,9 @@ const HistoricalInventoryReport: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }
-            th, td { border: 1px solid #ddd; padding: 6px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 6px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -812,7 +814,7 @@ const HistoricalInventoryReport: React.FC = () => {
                     <TableHead>
                       <TableRow sx={{ '& .MuiTableCell-head': {
                         fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                        backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                        backgroundColor: theme.palette.action.hover,
                         color: TYPOGRAPHY_STYLES.tableHeader.color,
                         fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                         textAlign: 'center',
@@ -864,7 +866,7 @@ const HistoricalInventoryReport: React.FC = () => {
                           <React.Fragment key={idx}>
                             {showGroupHeader && (
                               <TableRow sx={{
-                                backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                                backgroundColor: theme.palette.action.selected,
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',
@@ -913,7 +915,7 @@ const HistoricalInventoryReport: React.FC = () => {
                             {showGroupFooter && groupSubtotals && (
                               <>
                                 <TableRow sx={{
-                                  backgroundColor: 'rgba(33, 150, 243, 0.2)',
+                                  backgroundColor: alpha(theme.palette.primary.main, 0.2),
                                   '& .MuiTableCell-root': {
                                     fontWeight: 700,
                                     fontSize: '0.85rem',
@@ -951,7 +953,7 @@ const HistoricalInventoryReport: React.FC = () => {
                       {totals && (
                         <TableRow
                           sx={{
-                            backgroundColor: 'rgba(76, 175, 80, 0.3)',
+                            backgroundColor: alpha(theme.palette.success.main, 0.3),
                             '& .MuiTableCell-root': {
                               fontWeight: 800,
                               fontSize: '0.9rem',

--- a/frontend/src/pages/inventory/InventorySummaryReport.tsx
+++ b/frontend/src/pages/inventory/InventorySummaryReport.tsx
@@ -29,6 +29,7 @@ import {
   DialogActions,
   IconButton,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import {
   PictureAsPdf as PdfIcon,
   TableChart as ExcelIcon,
@@ -45,6 +46,7 @@ import { formatCurrency, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
 import { useGetEffectivePriceListsQuery } from '@/store/api/priceListApi'
+import { printColors } from '@/styles/printTokens'
 import type { PriceList } from '@/types'
 
 interface InventorySummary {
@@ -443,7 +445,7 @@ const InventorySummaryReport: React.FC = () => {
 
       if (groupBy !== 'none' && currentGroupKey !== prevGroupKey) {
         const groupLabel = getPdfGroupLabel(row)
-        tableRows += `<tr style="background-color: #d3d3d3; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupKey = currentGroupKey
       }
 
@@ -487,7 +489,7 @@ const InventorySummaryReport: React.FC = () => {
           totalCostValue: groupData.reduce((sum, r) => sum + r.inventoryValue, 0),
         }
 
-        tableRows += '<tr style="background-color: rgba(33, 150, 243, 0.1); font-weight: bold; border-top: 2px solid #1976d2;">'
+        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold; border-top: 2px solid ${printColors.tableHeaderBg};">`
         selectedColumns.forEach((col, colIdx) => {
           if (colIdx === 0) {
             tableRows += '<td style="font-weight: bold;">Subtotal</td>'
@@ -505,7 +507,7 @@ const InventorySummaryReport: React.FC = () => {
     })
 
     if (totals) {
-      tableRows += '<tr style="background-color: rgba(76, 175, 80, 0.2); font-weight: bold; border-top: 3px solid #4caf50;">'
+      tableRows += `<tr style="background-color: ${printColors.successRow}; font-weight: bold; border-top: 3px solid ${printColors.border};">`
       selectedColumns.forEach((col, idx) => {
         if (idx === 0) {
           tableRows += '<td style="font-weight: 800;">GRAND TOTAL</td>'
@@ -542,9 +544,9 @@ const InventorySummaryReport: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }
-            th, td { border: 1px solid #ddd; padding: 6px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 6px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -976,7 +978,7 @@ const InventorySummaryReport: React.FC = () => {
                     <TableHead>
                       <TableRow sx={{ '& .MuiTableCell-head': {
                         fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                        backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                        backgroundColor: theme.palette.action.hover,
                         color: TYPOGRAPHY_STYLES.tableHeader.color,
                         fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                         textAlign: 'center',
@@ -1030,7 +1032,7 @@ const InventorySummaryReport: React.FC = () => {
                           <React.Fragment key={`${row.productName}-${idx}`}>
                             {showGroupHeader && (
                               <TableRow sx={{
-                                backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                                backgroundColor: theme.palette.action.selected,
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',
@@ -1089,7 +1091,7 @@ const InventorySummaryReport: React.FC = () => {
                             {showGroupFooter && groupSubtotals && (
                               <>
                                 <TableRow sx={{
-                                  backgroundColor: 'rgba(33, 150, 243, 0.2)',
+                                  backgroundColor: alpha(theme.palette.primary.main, 0.2),
                                   '& .MuiTableCell-root': {
                                     fontWeight: 700,
                                     fontSize: '0.85rem',
@@ -1129,7 +1131,7 @@ const InventorySummaryReport: React.FC = () => {
                       {totals && (
                         <TableRow
                           sx={{
-                            backgroundColor: 'rgba(76, 175, 80, 0.3)',
+                            backgroundColor: alpha(theme.palette.success.main, 0.3),
                             '& .MuiTableCell-root': {
                               fontWeight: 800,
                               fontSize: '0.9rem',

--- a/frontend/src/pages/inventory/MovementSummaryReport.tsx
+++ b/frontend/src/pages/inventory/MovementSummaryReport.tsx
@@ -29,6 +29,7 @@ import {
   DialogActions,
   IconButton,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import {
   PictureAsPdf as PdfIcon,
   TableChart as ExcelIcon,
@@ -45,6 +46,7 @@ import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
 import { useGetProductsQuery, useGetCategoriesQuery } from '@/store/api/inventoryApi'
+import { printColors } from '@/styles/printTokens'
 
 interface MovementSummary {
   productName: string
@@ -341,7 +343,7 @@ const MovementSummaryReport: React.FC = () => {
 
       if (groupBy !== 'none' && currentGroupKey !== prevGroupKey) {
         const groupLabel = getPdfGroupLabel(row)
-        tableRows += `<tr style="background-color: #d3d3d3; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupKey = currentGroupKey
       }
 
@@ -392,9 +394,9 @@ const MovementSummaryReport: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }
-            th, td { border: 1px solid #ddd; padding: 6px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 6px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -793,7 +795,7 @@ const MovementSummaryReport: React.FC = () => {
                     <TableHead>
                       <TableRow sx={{ '& .MuiTableCell-head': {
                         fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                        backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                        backgroundColor: theme.palette.action.hover,
                         color: TYPOGRAPHY_STYLES.tableHeader.color,
                         fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                         textAlign: 'center',
@@ -846,7 +848,7 @@ const MovementSummaryReport: React.FC = () => {
                           <React.Fragment key={idx}>
                             {showGroupHeader && (
                               <TableRow sx={{
-                                backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                                backgroundColor: theme.palette.action.selected,
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',
@@ -895,7 +897,7 @@ const MovementSummaryReport: React.FC = () => {
                             {showGroupFooter && groupSubtotals && (
                               <>
                                 <TableRow sx={{
-                                  backgroundColor: 'rgba(33, 150, 243, 0.2)',
+                                  backgroundColor: alpha(theme.palette.primary.main, 0.2),
                                   '& .MuiTableCell-root': {
                                     fontWeight: 700,
                                     fontSize: '0.85rem',
@@ -937,7 +939,7 @@ const MovementSummaryReport: React.FC = () => {
                       {totals && (
                         <TableRow
                           sx={{
-                            backgroundColor: 'rgba(76, 175, 80, 0.3)',
+                            backgroundColor: alpha(theme.palette.success.main, 0.3),
                             '& .MuiTableCell-root': {
                               fontWeight: 800,
                               fontSize: '0.9rem',

--- a/frontend/src/pages/inventory/PriceListReport.tsx
+++ b/frontend/src/pages/inventory/PriceListReport.tsx
@@ -43,6 +43,7 @@ import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
+import { printColors } from '@/styles/printTokens'
 import { useGetProductsQuery, useGetCategoriesQuery } from '@/store/api/inventoryApi'
 import { useGetPriceListsQuery } from '@/store/api/priceListApi'
 
@@ -373,7 +374,7 @@ const PriceListReport: React.FC = () => {
 
       if (groupBy !== 'none' && currentGroupKey !== prevGroupKey) {
         const groupLabel = getPdfGroupLabel(row)
-        tableRows += `<tr style="background-color: #d3d3d3; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupKey = currentGroupKey
       }
 
@@ -429,9 +430,9 @@ const PriceListReport: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }
-            th, td { border: 1px solid #ddd; padding: 6px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 6px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -840,7 +841,7 @@ const PriceListReport: React.FC = () => {
                     <TableHead>
                       <TableRow sx={{ '& .MuiTableCell-head': {
                         fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                        backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                        backgroundColor: theme.palette.action.hover,
                         color: TYPOGRAPHY_STYLES.tableHeader.color,
                         fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                         textAlign: 'center',
@@ -876,7 +877,7 @@ const PriceListReport: React.FC = () => {
                           <React.Fragment key={idx}>
                             {showGroupHeader && (
                               <TableRow sx={{
-                                backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                                backgroundColor: theme.palette.action.selected,
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',

--- a/frontend/src/pages/inventory/ProductCostReport.tsx
+++ b/frontend/src/pages/inventory/ProductCostReport.tsx
@@ -44,6 +44,7 @@ import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
 import { useGetProductsQuery, useGetCategoriesQuery } from '@/store/api/inventoryApi'
+import { printColors } from '@/styles/printTokens'
 
 interface ProductCostItem {
   productName: string
@@ -378,7 +379,7 @@ const ProductCostReport: React.FC = () => {
         // Reset subtotals for new group
         groupSubtotals = { quantityChange: 0, costChange: 0 }
         const groupLabel = getPdfGroupLabel(row)
-        tableRows += `<tr style="background-color: #d3d3d3; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupKey = currentGroupKey
       }
 
@@ -435,9 +436,9 @@ const ProductCostReport: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }
-            th, td { border: 1px solid #ddd; padding: 6px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 6px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -825,7 +826,7 @@ const ProductCostReport: React.FC = () => {
                     <TableHead>
                       <TableRow sx={{ '& .MuiTableCell-head': {
                         fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                        backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                        backgroundColor: theme.palette.action.hover,
                         color: TYPOGRAPHY_STYLES.tableHeader.color,
                         fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                         textAlign: 'center',
@@ -894,7 +895,7 @@ const ProductCostReport: React.FC = () => {
                           if (showGroupHeader) {
                             rows.push(
                               <TableRow key={`header-${idx}`} sx={{
-                                backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                                backgroundColor: theme.palette.action.selected,
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',

--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -490,10 +490,10 @@ const CreatePurchaseOrderPage: React.FC = () => {
                               border: 'none',
                             },
                             '&:hover fieldset': {
-                              border: '1px solid #1976d2',
+                              border: `1px solid ${theme.palette.primary.main}`,
                             },
                             '&.Mui-focused fieldset': {
-                              border: '1px solid #1976d2',
+                              border: `1px solid ${theme.palette.primary.main}`,
                             },
                             backgroundColor: 'transparent',
                             fontSize: '0.875rem',
@@ -658,7 +658,7 @@ const CreatePurchaseOrderPage: React.FC = () => {
                                       variant="outlined"
                                       slotProps={{
                                         htmlInput: { style: { textAlign: 'right', fontSize: '0.875rem' } },
-                                        input: { startAdornment: <span style={{ marginRight: '4px', fontSize: '0.75rem', color: '#666' }}>{currency}</span> }
+                                        input: { startAdornment: <span style={{ marginRight: '4px', fontSize: '0.75rem', color: theme.palette.text.secondary }}>{currency}</span> }
                                       }}
                                       error={!!errors.items?.[index]?.unitPrice}
                                     />
@@ -871,7 +871,7 @@ const CreatePurchaseOrderPage: React.FC = () => {
                             size="small"
                             slotProps={{
                               htmlInput: { style: { textAlign: 'right', fontSize: '0.875rem' } },
-                              input: { startAdornment: <span style={{ marginRight: '4px', fontSize: '0.75rem', color: '#666' }}>{currency}</span> }
+                              input: { startAdornment: <span style={{ marginRight: '4px', fontSize: '0.75rem', color: theme.palette.text.secondary }}>{currency}</span> }
                             }}
                             sx={{
                               width: '120px',

--- a/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
@@ -37,6 +37,7 @@ import {
   OutlinedInput,
   Divider,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import {
   PictureAsPdf as PdfIcon,
   TableChart as ExcelIcon,
@@ -50,6 +51,7 @@ import {
   KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon,
 } from '@mui/icons-material'
 import PageHeader from '@/components/common/PageHeader'
+import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import api from '@/services/api'
@@ -471,7 +473,7 @@ const PurchaseOrderDetailsReport: React.FC = () => {
 
       if (groupBy !== 'none' && currentGroupKey !== prevGroupKey) {
         const groupLabel = getPdfGroupLabel(row)
-        tableRows += `<tr style="background-color: #d3d3d3; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupKey = currentGroupKey
       }
 
@@ -502,7 +504,7 @@ const PurchaseOrderDetailsReport: React.FC = () => {
           totalAmount: groupData.reduce((sum, r) => sum + r.totalAmount, 0),
         }
 
-        tableRows += '<tr style="background-color: rgba(33, 150, 243, 0.1); font-weight: bold; border-top: 2px solid #1976d2;">'
+        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold; border-top: 2px solid ${printColors.tableHeaderBg};">`
         selectedColumns.forEach((col, colIdx) => {
           if (colIdx === 0) {
             tableRows += '<td style="font-weight: bold;">Subtotal</td>'
@@ -520,7 +522,7 @@ const PurchaseOrderDetailsReport: React.FC = () => {
     })
 
     if (totals) {
-      tableRows += '<tr style="background-color: rgba(76, 175, 80, 0.2); font-weight: bold; border-top: 3px solid #4caf50;">'
+      tableRows += `<tr style="background-color: ${printColors.successRow}; font-weight: bold; border-top: 3px solid ${printColors.border};">`
       selectedColumns.forEach((col, idx) => {
         if (idx === 0) {
           tableRows += '<td style="font-weight: 800;">GRAND TOTAL</td>'
@@ -554,9 +556,9 @@ const PurchaseOrderDetailsReport: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }
-            th, td { border: 1px solid #ddd; padding: 6px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 6px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -1042,7 +1044,7 @@ const PurchaseOrderDetailsReport: React.FC = () => {
                   <TableHead>
                     <TableRow sx={{ '& .MuiTableCell-head': {
                       fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                      backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                      backgroundColor: theme.palette.action.hover,
                       color: TYPOGRAPHY_STYLES.tableHeader.color,
                       fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                       textAlign: 'center',
@@ -1108,7 +1110,7 @@ const PurchaseOrderDetailsReport: React.FC = () => {
                         <React.Fragment key={`${row.orderNumber}-${row.productName}-${idx}`}>
                           {showGroupHeader && (
                             <TableRow sx={{
-                              backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                              backgroundColor: theme.palette.action.selected,
                               '& .MuiTableCell-root': {
                                 fontWeight: 700,
                                 fontSize: '0.85rem',
@@ -1192,7 +1194,7 @@ const PurchaseOrderDetailsReport: React.FC = () => {
                           {showGroupFooter && groupSubtotals && (
                             <>
                               <TableRow sx={{
-                                backgroundColor: 'rgba(33, 150, 243, 0.2)',
+                                backgroundColor: alpha(theme.palette.primary.main, 0.2),
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',
@@ -1236,7 +1238,7 @@ const PurchaseOrderDetailsReport: React.FC = () => {
                     {totals && (
                       <TableRow
                         sx={{
-                          backgroundColor: 'rgba(76, 175, 80, 0.3)',
+                          backgroundColor: alpha(theme.palette.success.main, 0.3),
                           '& .MuiTableCell-root': {
                             fontWeight: 800,
                             fontSize: '0.9rem',

--- a/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
@@ -29,6 +29,7 @@ import {
   DialogActions,
   IconButton,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import {
   PictureAsPdf as PdfIcon,
   TableChart as ExcelIcon,
@@ -42,6 +43,7 @@ import {
   KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon,
 } from '@mui/icons-material'
 import PageHeader from '@/components/common/PageHeader'
+import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import api from '@/services/api'
@@ -446,7 +448,7 @@ const PurchaseOrderStatusReport: React.FC = () => {
 
       if (groupBy !== 'none' && currentGroupKey !== prevGroupKey) {
         const groupLabel = getPdfGroupLabel(row)
-        tableRows += `<tr style="background-color: #d3d3d3; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupKey = currentGroupKey
       }
 
@@ -479,7 +481,7 @@ const PurchaseOrderStatusReport: React.FC = () => {
           remainingQuantity: groupData.reduce((sum, r) => sum + r.remainingQuantity, 0),
         }
 
-        tableRows += '<tr style="background-color: rgba(33, 150, 243, 0.1); font-weight: bold; border-top: 2px solid #1976d2;">'
+        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold; border-top: 2px solid ${printColors.tableHeaderBg};">`
         selectedColumns.forEach((col, colIdx) => {
           if (colIdx === 0) {
             tableRows += '<td style="font-weight: bold;">Subtotal</td>'
@@ -497,7 +499,7 @@ const PurchaseOrderStatusReport: React.FC = () => {
     })
 
     if (totals) {
-      tableRows += '<tr style="background-color: rgba(76, 175, 80, 0.2); font-weight: bold; border-top: 3px solid #4caf50;">'
+      tableRows += `<tr style="background-color: ${printColors.successRow}; font-weight: bold; border-top: 3px solid ${printColors.border};">`
       selectedColumns.forEach((col, idx) => {
         if (idx === 0) {
           tableRows += '<td style="font-weight: 800;">GRAND TOTAL</td>'
@@ -536,9 +538,9 @@ const PurchaseOrderStatusReport: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }
-            th, td { border: 1px solid #ddd; padding: 6px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 6px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -976,7 +978,7 @@ const PurchaseOrderStatusReport: React.FC = () => {
                     <TableHead>
                       <TableRow sx={{ '& .MuiTableCell-head': {
                         fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                        backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                        backgroundColor: theme.palette.action.hover,
                         color: TYPOGRAPHY_STYLES.tableHeader.color,
                         fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                         textAlign: 'center',
@@ -1039,7 +1041,7 @@ const PurchaseOrderStatusReport: React.FC = () => {
                           <React.Fragment key={`${row.orderNumber}-${idx}`}>
                             {showGroupHeader && (
                               <TableRow sx={{
-                                backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                                backgroundColor: theme.palette.action.selected,
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',
@@ -1123,7 +1125,7 @@ const PurchaseOrderStatusReport: React.FC = () => {
                             {showGroupFooter && groupSubtotals && (
                               <>
                                 <TableRow sx={{
-                                  backgroundColor: 'rgba(33, 150, 243, 0.2)',
+                                  backgroundColor: alpha(theme.palette.primary.main, 0.2),
                                   '& .MuiTableCell-root': {
                                     fontWeight: 700,
                                     fontSize: '0.85rem',
@@ -1174,7 +1176,7 @@ const PurchaseOrderStatusReport: React.FC = () => {
                       {totals && (
                         <TableRow
                           sx={{
-                            backgroundColor: 'rgba(76, 175, 80, 0.3)',
+                            backgroundColor: alpha(theme.palette.success.main, 0.3),
                             '& .MuiTableCell-root': {
                               fontWeight: 800,
                               fontSize: '0.9rem',

--- a/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
@@ -24,6 +24,7 @@ import {
   useMediaQuery,
   Chip,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import {
   PictureAsPdf as PdfIcon,
   TableChart as ExcelIcon,
@@ -32,6 +33,7 @@ import {
   Summarize as PurchaseOrderIcon,
 } from '@mui/icons-material'
 import PageHeader from '@/components/common/PageHeader'
+import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import api from '@/services/api'
@@ -291,7 +293,7 @@ const PurchaseOrderSummary: React.FC = () => {
 
       if (groupBy !== 'none' && currentGroupKey !== prevGroupKey) {
         const groupLabel = getPdfGroupLabel(row)
-        tableRows += `<tr style="background-color: #d3d3d3; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupKey = currentGroupKey
       }
 
@@ -323,7 +325,7 @@ const PurchaseOrderSummary: React.FC = () => {
           balance: groupData.reduce((sum, r) => sum + r.balance, 0),
         }
 
-        tableRows += '<tr style="background-color: rgba(33, 150, 243, 0.1); font-weight: bold; border-top: 2px solid #1976d2;">'
+        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold; border-top: 2px solid ${printColors.tableHeaderBg};">`
         selectedColumns.forEach((col, colIdx) => {
           if (colIdx === 0) {
             tableRows += '<td style="font-weight: bold;">Subtotal</td>'
@@ -341,7 +343,7 @@ const PurchaseOrderSummary: React.FC = () => {
     })
 
     if (totals) {
-      tableRows += '<tr style="background-color: rgba(76, 175, 80, 0.2); font-weight: bold; border-top: 3px solid #4caf50;">'
+      tableRows += `<tr style="background-color: ${printColors.successRow}; font-weight: bold; border-top: 3px solid ${printColors.border};">`
       selectedColumns.forEach((col, idx) => {
         if (idx === 0) {
           tableRows += '<td style="font-weight: 800;">GRAND TOTAL</td>'
@@ -375,9 +377,9 @@ const PurchaseOrderSummary: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }
-            th, td { border: 1px solid #ddd; padding: 6px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 6px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -395,7 +397,7 @@ const PurchaseOrderSummary: React.FC = () => {
                 text-align: center;
                 font-size: 10px;
                 padding: 10px;
-                border-top: 1px solid #ddd;
+                border-top: 1px solid ${printColors.tableBorder};
               }
             }
             .footer {
@@ -833,7 +835,7 @@ const PurchaseOrderSummary: React.FC = () => {
                   <TableHead>
                     <TableRow sx={{ '& .MuiTableCell-head': {
                       fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                      backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                      backgroundColor: theme.palette.action.hover,
                       color: TYPOGRAPHY_STYLES.tableHeader.color,
                       fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                       textAlign: 'center',
@@ -895,7 +897,7 @@ const PurchaseOrderSummary: React.FC = () => {
                         <React.Fragment key={`${row.orderNumber}-${idx}`}>
                           {showGroupHeader && (
                             <TableRow sx={{
-                              backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                              backgroundColor: theme.palette.action.selected,
                               '& .MuiTableCell-root': {
                                 fontWeight: 700,
                                 fontSize: '0.85rem',
@@ -974,7 +976,7 @@ const PurchaseOrderSummary: React.FC = () => {
                           {showGroupFooter && groupSubtotals && (
                             <>
                               <TableRow sx={{
-                                backgroundColor: 'rgba(33, 150, 243, 0.2)',
+                                backgroundColor: alpha(theme.palette.primary.main, 0.2),
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',
@@ -1025,7 +1027,7 @@ const PurchaseOrderSummary: React.FC = () => {
                     {totals && (
                       <TableRow
                         sx={{
-                          backgroundColor: 'rgba(76, 175, 80, 0.3)',
+                          backgroundColor: alpha(theme.palette.success.main, 0.3),
                           '& .MuiTableCell-root': {
                             fontWeight: 800,
                             fontSize: '0.9rem',

--- a/frontend/src/pages/purchasing/VendorPaymentDetailsReport.tsx
+++ b/frontend/src/pages/purchasing/VendorPaymentDetailsReport.tsx
@@ -22,6 +22,7 @@ import {
   useTheme,
   useMediaQuery,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import {
   PictureAsPdf as PdfIcon,
   TableChart as ExcelIcon,
@@ -30,6 +31,7 @@ import {
   MonetizationOn as PaymentIcon,
 } from '@mui/icons-material'
 import PageHeader from '@/components/common/PageHeader'
+import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import api from '@/services/api'
@@ -256,7 +258,7 @@ const VendorPaymentDetailsReport: React.FC = () => {
 
       if (groupBy !== 'none' && currentGroupKey !== prevGroupKey) {
         const groupLabel = getPdfGroupLabel(row)
-        tableRows += `<tr style="background-color: #d3d3d3; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupKey = currentGroupKey
       }
 
@@ -284,7 +286,7 @@ const VendorPaymentDetailsReport: React.FC = () => {
           paymentAmount: groupData.reduce((sum, r) => sum + r.paymentAmount, 0),
         }
 
-        tableRows += '<tr style="background-color: rgba(33, 150, 243, 0.1); font-weight: bold; border-top: 2px solid #1976d2;">'
+        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold; border-top: 2px solid ${printColors.tableHeaderBg};">`
         selectedColumns.forEach((col, colIdx) => {
           if (colIdx === 0) {
             tableRows += '<td style="font-weight: bold;">Subtotal</td>'
@@ -301,7 +303,7 @@ const VendorPaymentDetailsReport: React.FC = () => {
     })
 
     if (totals) {
-      tableRows += '<tr style="background-color: rgba(76, 175, 80, 0.2); font-weight: bold; border-top: 3px solid #4caf50;">'
+      tableRows += `<tr style="background-color: ${printColors.successRow}; font-weight: bold; border-top: 3px solid ${printColors.border};">`
       selectedColumns.forEach((col, idx) => {
         if (idx === 0) {
           tableRows += '<td style="font-weight: 800;">GRAND TOTAL</td>'
@@ -336,9 +338,9 @@ const VendorPaymentDetailsReport: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }
-            th, td { border: 1px solid #ddd; padding: 6px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 6px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -709,7 +711,7 @@ const VendorPaymentDetailsReport: React.FC = () => {
                     <TableHead>
                       <TableRow sx={{ '& .MuiTableCell-head': {
                         fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                        backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                        backgroundColor: theme.palette.action.hover,
                         color: TYPOGRAPHY_STYLES.tableHeader.color,
                         fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                         textAlign: 'center',
@@ -763,7 +765,7 @@ const VendorPaymentDetailsReport: React.FC = () => {
                           <React.Fragment key={`${row.supplierName}-${idx}`}>
                             {showGroupHeader && (
                               <TableRow sx={{
-                                backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                                backgroundColor: theme.palette.action.selected,
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',
@@ -807,7 +809,7 @@ const VendorPaymentDetailsReport: React.FC = () => {
                             {showGroupFooter && groupSubtotals && (
                               <>
                                 <TableRow sx={{
-                                  backgroundColor: 'rgba(33, 150, 243, 0.2)',
+                                  backgroundColor: alpha(theme.palette.primary.main, 0.2),
                                   '& .MuiTableCell-root': {
                                     fontWeight: 700,
                                     fontSize: '0.85rem',
@@ -840,7 +842,7 @@ const VendorPaymentDetailsReport: React.FC = () => {
                       {totals && (
                         <TableRow
                           sx={{
-                            backgroundColor: 'rgba(76, 175, 80, 0.3)',
+                            backgroundColor: alpha(theme.palette.success.main, 0.3),
                             '& .MuiTableCell-root': {
                               fontWeight: 800,
                               fontSize: '0.9rem',

--- a/frontend/src/pages/purchasing/VendorProductListReport.tsx
+++ b/frontend/src/pages/purchasing/VendorProductListReport.tsx
@@ -29,6 +29,7 @@ import {
   DialogActions,
   IconButton,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import {
   PictureAsPdf as PdfIcon,
   TableChart as ExcelIcon,
@@ -42,6 +43,7 @@ import {
   KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon,
 } from '@mui/icons-material'
 import PageHeader from '@/components/common/PageHeader'
+import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import api from '@/services/api'
@@ -425,7 +427,7 @@ const VendorProductListReport: React.FC = () => {
 
       if (groupBy !== 'none' && currentGroupKey !== prevGroupKey) {
         const groupLabel = getPdfGroupLabel(row)
-        tableRows += `<tr style="background-color: #d3d3d3; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupKey = currentGroupKey
       }
 
@@ -492,9 +494,9 @@ const VendorProductListReport: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }
-            th, td { border: 1px solid #ddd; padding: 6px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 6px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -941,7 +943,7 @@ const VendorProductListReport: React.FC = () => {
                     <TableHead>
                       <TableRow sx={{ '& .MuiTableCell-head': {
                         fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                        backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                        backgroundColor: theme.palette.action.hover,
                         color: TYPOGRAPHY_STYLES.tableHeader.color,
                         fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                         textAlign: 'center',
@@ -983,7 +985,7 @@ const VendorProductListReport: React.FC = () => {
                           <React.Fragment key={`${row.orderNumber}-${row.productName}-${idx}`}>
                             {showGroupHeader && (
                               <TableRow sx={{
-                                backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                                backgroundColor: theme.palette.action.selected,
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',

--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -570,10 +570,10 @@ const CreateSalesOrderPage: React.FC = () => {
                                 border: 'none',
                               },
                               '&:hover fieldset': {
-                                border: '1px solid #1976d2',
+                                border: `1px solid ${theme.palette.primary.main}`,
                               },
                               '&.Mui-focused fieldset': {
-                                border: '1px solid #1976d2',
+                                border: `1px solid ${theme.palette.primary.main}`,
                               },
                               backgroundColor: 'transparent',
                               fontSize: '0.875rem',
@@ -745,7 +745,7 @@ const CreateSalesOrderPage: React.FC = () => {
                                           style: { textAlign: 'right', fontSize: '0.875rem' }
                                         }}
                                         InputProps={{
-                                          startAdornment: <span style={{ marginRight: '4px', fontSize: '0.75rem', color: '#666' }}>{currency}</span>
+                                          startAdornment: <span style={{ marginRight: '4px', fontSize: '0.75rem', color: theme.palette.text.secondary }}>{currency}</span>
                                         }}
                                         error={!!errors.items?.[index]?.unitPrice}
                                       />
@@ -961,7 +961,7 @@ const CreateSalesOrderPage: React.FC = () => {
                                 },
                               }}
                               InputProps={{
-                                startAdornment: <span style={{ marginRight: '4px', fontSize: '0.75rem', color: '#666' }}>{currency}</span>
+                                startAdornment: <span style={{ marginRight: '4px', fontSize: '0.75rem', color: theme.palette.text.secondary }}>{currency}</span>
                               }}
                             />
                           );

--- a/frontend/src/pages/sales/CustomerOrderHistory.tsx
+++ b/frontend/src/pages/sales/CustomerOrderHistory.tsx
@@ -29,6 +29,7 @@ import {
   IconButton,
   Divider,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import {
   PictureAsPdf as PdfIcon,
   TableChart as ExcelIcon,
@@ -42,6 +43,7 @@ import {
   KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon,
 } from '@mui/icons-material'
 import PageHeader from '@/components/common/PageHeader'
+import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
@@ -501,7 +503,7 @@ const CustomerOrderHistory: React.FC = () => {
       // Add group header if group changed
       if (groupBy !== 'none' && currentGroupKey !== prevGroupKey) {
         const groupLabel = getPdfGroupLabel(row)
-        tableRows += `<tr style="background-color: #d3d3d3; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupKey = currentGroupKey
       }
 
@@ -536,7 +538,7 @@ const CustomerOrderHistory: React.FC = () => {
           profit: groupData.reduce((sum, r) => sum + r.profit, 0),
         }
 
-        tableRows += '<tr style="background-color: rgba(33, 150, 243, 0.1); font-weight: bold; border-top: 2px solid #1976d2;">'
+        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold; border-top: 2px solid ${printColors.tableHeaderBg};">`
         selectedColumns.forEach((col, colIdx) => {
           if (colIdx === 0) {
             tableRows += '<td style="font-weight: bold;">Subtotal</td>'
@@ -555,7 +557,7 @@ const CustomerOrderHistory: React.FC = () => {
 
     // Add totals
     if (totals) {
-      tableRows += '<tr style="background-color: rgba(76, 175, 80, 0.2); font-weight: bold; border-top: 3px solid #4caf50;">'
+      tableRows += `<tr style="background-color: ${printColors.successRow}; font-weight: bold; border-top: 3px solid ${printColors.border};">`
       selectedColumns.forEach((col, idx) => {
         if (idx === 0) {
           tableRows += '<td style="font-weight: 800;">GRAND TOTAL</td>'
@@ -589,9 +591,9 @@ const CustomerOrderHistory: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }
-            th, td { border: 1px solid #ddd; padding: 6px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 6px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -609,7 +611,7 @@ const CustomerOrderHistory: React.FC = () => {
                 text-align: center;
                 font-size: 10px;
                 padding: 10px;
-                border-top: 1px solid #ddd;
+                border-top: 1px solid ${printColors.tableBorder};
               }
             }
             .footer {
@@ -1133,7 +1135,7 @@ const CustomerOrderHistory: React.FC = () => {
                   <TableHead>
                     <TableRow sx={{ '& .MuiTableCell-head': {
                       fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                      backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                      backgroundColor: theme.palette.action.hover,
                       color: TYPOGRAPHY_STYLES.tableHeader.color,
                       fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                       textAlign: 'center',
@@ -1203,7 +1205,7 @@ const CustomerOrderHistory: React.FC = () => {
                         <React.Fragment key={`${row.orderId}-${idx}`}>
                           {showGroupHeader && (
                             <TableRow sx={{
-                              backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                              backgroundColor: theme.palette.action.selected,
                               '& .MuiTableCell-root': {
                                 fontWeight: 700,
                                 fontSize: '0.85rem',
@@ -1292,7 +1294,7 @@ const CustomerOrderHistory: React.FC = () => {
                           {showGroupFooter && groupSubtotals && (
                             <>
                               <TableRow sx={{
-                                backgroundColor: 'rgba(33, 150, 243, 0.2)',
+                                backgroundColor: alpha(theme.palette.primary.main, 0.2),
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',
@@ -1345,7 +1347,7 @@ const CustomerOrderHistory: React.FC = () => {
                     {totals && (
                       <TableRow
                         sx={{
-                          backgroundColor: 'rgba(76, 175, 80, 0.3)',
+                          backgroundColor: alpha(theme.palette.success.main, 0.3),
                           '& .MuiTableCell-root': {
                             fontWeight: 800,
                             fontSize: '0.9rem',

--- a/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
@@ -25,6 +25,7 @@ import {
   FormControlLabel,
   Checkbox,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import {
   PictureAsPdf as PdfIcon,
   TableChart as ExcelIcon,
@@ -33,6 +34,7 @@ import {
   ReceiptLongOutlined as PaymentOrderIcon,
 } from '@mui/icons-material'
 import PageHeader from '@/components/common/PageHeader'
+import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
@@ -285,7 +287,7 @@ const CustomerPaymentByOrder: React.FC = () => {
         const groupLabel = groupBy === 'customerName' ? `Customer: ${currentGroupValue}` :
                           groupBy === 'inventoryStatus' ? `Inventory: ${currentGroupValue.charAt(0).toUpperCase() + currentGroupValue.slice(1)}` :
                           groupBy === 'paymentStatus' ? `Payment: ${currentGroupValue.charAt(0).toUpperCase() + currentGroupValue.slice(1)}` : currentGroupValue
-        tableRows += `<tr style="background-color: #d3d3d3; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupValue = currentGroupValue
       }
 
@@ -319,7 +321,7 @@ const CustomerPaymentByOrder: React.FC = () => {
           balance: groupData.reduce((sum, r) => sum + r.balance, 0),
         }
 
-        tableRows += '<tr style="background-color: rgba(33, 150, 243, 0.1); font-weight: bold; border-top: 2px solid #1976d2;">'
+        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold; border-top: 2px solid ${printColors.tableHeaderBg};">`
         selectedColumns.forEach((col, colIdx) => {
           if (colIdx === 0) {
             tableRows += '<td style="font-weight: bold;">Subtotal</td>'
@@ -338,7 +340,7 @@ const CustomerPaymentByOrder: React.FC = () => {
 
     // Add totals
     if (totals) {
-      tableRows += '<tr style="background-color: rgba(76, 175, 80, 0.2); font-weight: bold; border-top: 3px solid #4caf50;">'
+      tableRows += `<tr style="background-color: ${printColors.successRow}; font-weight: bold; border-top: 3px solid ${printColors.border};">`
       selectedColumns.forEach((col, idx) => {
         if (idx === 0) {
           tableRows += '<td style="font-weight: 800;">GRAND TOTAL</td>'
@@ -372,9 +374,9 @@ const CustomerPaymentByOrder: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }
-            th, td { border: 1px solid #ddd; padding: 6px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 6px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -392,7 +394,7 @@ const CustomerPaymentByOrder: React.FC = () => {
                 text-align: center;
                 font-size: 10px;
                 padding: 10px;
-                border-top: 1px solid #ddd;
+                border-top: 1px solid ${printColors.tableBorder};
               }
             }
             .footer {
@@ -864,7 +866,7 @@ const CustomerPaymentByOrder: React.FC = () => {
                   <TableHead>
                     <TableRow sx={{ '& .MuiTableCell-head': {
                       fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                      backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                      backgroundColor: theme.palette.action.hover,
                       color: TYPOGRAPHY_STYLES.tableHeader.color,
                       fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                       textAlign: 'center',
@@ -919,7 +921,7 @@ const CustomerPaymentByOrder: React.FC = () => {
                         <React.Fragment key={`${row.invoiceNumber}-${idx}`}>
                           {showGroupHeader && (
                             <TableRow sx={{
-                              backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                              backgroundColor: theme.palette.action.selected,
                               '& .MuiTableCell-root': {
                                 fontWeight: 700,
                                 fontSize: '0.85rem',
@@ -998,7 +1000,7 @@ const CustomerPaymentByOrder: React.FC = () => {
                           {showGroupFooter && groupSubtotals && (
                             <>
                               <TableRow sx={{
-                                backgroundColor: 'rgba(33, 150, 243, 0.2)',
+                                backgroundColor: alpha(theme.palette.primary.main, 0.2),
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',
@@ -1048,7 +1050,7 @@ const CustomerPaymentByOrder: React.FC = () => {
                     {totals && (
                       <TableRow
                         sx={{
-                          backgroundColor: 'rgba(76, 175, 80, 0.3)',
+                          backgroundColor: alpha(theme.palette.success.main, 0.3),
                           '& .MuiTableCell-root': {
                             fontWeight: 800,
                             fontSize: '0.9rem',

--- a/frontend/src/pages/sales/CustomerPaymentDetails.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentDetails.tsx
@@ -22,6 +22,7 @@ import {
   useTheme,
   useMediaQuery,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import {
   PictureAsPdf as PdfIcon,
   TableChart as ExcelIcon,
@@ -30,6 +31,7 @@ import {
   MonetizationOn as PaymentDetailIcon,
 } from '@mui/icons-material'
 import PageHeader from '@/components/common/PageHeader'
+import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
@@ -269,7 +271,7 @@ const CustomerPaymentDetails: React.FC = () => {
         const groupLabel = groupBy === 'customerName' ? `Customer: ${currentGroupValue}` :
                           groupBy === 'paymentDate' ? `Payment Date: ${currentGroupValue ? formatDate(currentGroupValue) : 'N/A'}` :
                           groupBy === 'orderNumber' ? `Order: ${currentGroupValue}` : currentGroupValue
-        tableRows += `<tr style="background-color: #d3d3d3; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupValue = currentGroupValue
       }
 
@@ -304,7 +306,7 @@ const CustomerPaymentDetails: React.FC = () => {
           invoiceBalance: groupData.reduce((sum, r) => sum + r.invoiceBalance, 0),
         }
 
-        tableRows += '<tr style="background-color: rgba(33, 150, 243, 0.1); font-weight: bold; border-top: 2px solid #1976d2;">'
+        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold; border-top: 2px solid ${printColors.tableHeaderBg};">`
         selectedColumns.forEach((col, colIdx) => {
           if (colIdx === 0) {
             tableRows += '<td style="font-weight: bold;">Subtotal</td>'
@@ -323,7 +325,7 @@ const CustomerPaymentDetails: React.FC = () => {
 
     // Add totals
     if (totals) {
-      tableRows += '<tr style="background-color: rgba(76, 175, 80, 0.2); font-weight: bold; border-top: 3px solid #4caf50;">'
+      tableRows += `<tr style="background-color: ${printColors.successRow}; font-weight: bold; border-top: 3px solid ${printColors.border};">`
       selectedColumns.forEach((col, idx) => {
         if (idx === 0) {
           tableRows += '<td style="font-weight: 800;">GRAND TOTAL</td>'
@@ -357,9 +359,9 @@ const CustomerPaymentDetails: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }
-            th, td { border: 1px solid #ddd; padding: 6px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 6px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -377,7 +379,7 @@ const CustomerPaymentDetails: React.FC = () => {
                 text-align: center;
                 font-size: 10px;
                 padding: 10px;
-                border-top: 1px solid #ddd;
+                border-top: 1px solid ${printColors.tableBorder};
               }
             }
             .footer {
@@ -762,13 +764,13 @@ const CustomerPaymentDetails: React.FC = () => {
                     width: '8px'
                   },
                   '&::-webkit-scrollbar-track': {
-                    backgroundColor: 'rgba(0,0,0,0.05)'
+                    backgroundColor: theme.palette.action.hover
                   },
                   '&::-webkit-scrollbar-thumb': {
-                    backgroundColor: 'rgba(0,0,0,0.2)',
+                    backgroundColor: theme.palette.grey[700],
                     borderRadius: '4px',
                     '&:hover': {
-                      backgroundColor: 'rgba(0,0,0,0.3)'
+                      backgroundColor: theme.palette.grey[600]
                     }
                   }
                 }}>
@@ -788,7 +790,7 @@ const CustomerPaymentDetails: React.FC = () => {
                   <TableHead>
                     <TableRow sx={{ '& .MuiTableCell-head': {
                       fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                      backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                      backgroundColor: theme.palette.action.hover,
                       color: TYPOGRAPHY_STYLES.tableHeader.color,
                       fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                       textAlign: 'center',
@@ -836,7 +838,7 @@ const CustomerPaymentDetails: React.FC = () => {
                         <React.Fragment key={`${row.paymentId}-${idx}`}>
                           {showGroupHeader && (
                             <TableRow sx={{
-                              backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                              backgroundColor: theme.palette.action.selected,
                               '& .MuiTableCell-root': {
                                 fontWeight: 700,
                                 fontSize: '0.85rem',
@@ -880,7 +882,7 @@ const CustomerPaymentDetails: React.FC = () => {
                           {showGroupFooter && groupSubtotals && (
                             <>
                               <TableRow sx={{
-                                backgroundColor: 'rgba(33, 150, 243, 0.2)',
+                                backgroundColor: alpha(theme.palette.primary.main, 0.2),
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',
@@ -914,7 +916,7 @@ const CustomerPaymentDetails: React.FC = () => {
                     {totals && (
                       <TableRow
                         sx={{
-                          backgroundColor: 'rgba(76, 175, 80, 0.3)',
+                          backgroundColor: alpha(theme.palette.success.main, 0.3),
                           '& .MuiTableCell-root': {
                             fontWeight: 800,
                             fontSize: '0.9rem',

--- a/frontend/src/pages/sales/CustomerPaymentSummary.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentSummary.tsx
@@ -25,6 +25,7 @@ import {
   FormControlLabel,
   Checkbox,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import {
   PictureAsPdf as PdfIcon,
   TableChart as ExcelIcon,
@@ -33,6 +34,7 @@ import {
   AccountBalanceWallet as PaymentSummaryIcon,
 } from '@mui/icons-material'
 import PageHeader from '@/components/common/PageHeader'
+import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import api from '@/services/api'
@@ -254,7 +256,7 @@ const CustomerPaymentSummary: React.FC = () => {
 
     // Add totals
     if (totals) {
-      tableRows += '<tr style="background-color: rgba(76, 175, 80, 0.2); font-weight: bold; border-top: 3px solid #4caf50;">'
+      tableRows += `<tr style="background-color: ${printColors.successRow}; font-weight: bold; border-top: 3px solid ${printColors.border};">`
       selectedColumns.forEach((col, idx) => {
         if (idx === 0) {
           tableRows += '<td style="font-weight: 800;">GRAND TOTAL</td>'
@@ -291,9 +293,9 @@ const CustomerPaymentSummary: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }
-            th, td { border: 1px solid #ddd; padding: 6px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 6px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -311,7 +313,7 @@ const CustomerPaymentSummary: React.FC = () => {
                 text-align: center;
                 font-size: 10px;
                 padding: 10px;
-                border-top: 1px solid #ddd;
+                border-top: 1px solid ${printColors.tableBorder};
               }
             }
             .footer {
@@ -754,7 +756,7 @@ const CustomerPaymentSummary: React.FC = () => {
                   <TableHead>
                     <TableRow sx={{ '& .MuiTableCell-head': {
                       fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                      backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                      backgroundColor: theme.palette.action.hover,
                       color: TYPOGRAPHY_STYLES.tableHeader.color,
                       fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                       textAlign: 'center',
@@ -817,7 +819,7 @@ const CustomerPaymentSummary: React.FC = () => {
                     {totals && (
                       <TableRow
                         sx={{
-                          backgroundColor: 'rgba(76, 175, 80, 0.3)',
+                          backgroundColor: alpha(theme.palette.success.main, 0.3),
                           '& .MuiTableCell-root': {
                             fontWeight: 800,
                             fontSize: '0.9rem',

--- a/frontend/src/pages/sales/ProductCustomerReport.tsx
+++ b/frontend/src/pages/sales/ProductCustomerReport.tsx
@@ -28,6 +28,7 @@ import {
   DialogActions,
   IconButton,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import {
   PictureAsPdf as PdfIcon,
   TableChart as ExcelIcon,
@@ -41,6 +42,7 @@ import {
   KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon,
 } from '@mui/icons-material'
 import PageHeader from '@/components/common/PageHeader'
+import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
@@ -483,7 +485,7 @@ const ProductCustomerReport: React.FC = () => {
       // Add group header if group changed
       if (groupBy !== 'none' && currentGroupKey !== prevGroupKey) {
         const groupLabel = getPdfGroupLabel(row)
-        tableRows += `<tr style="background-color: #d3d3d3; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupKey = currentGroupKey
       }
 
@@ -518,7 +520,7 @@ const ProductCustomerReport: React.FC = () => {
           profit: groupData.reduce((sum, r) => sum + r.profit, 0),
         }
 
-        tableRows += '<tr style="background-color: rgba(33, 150, 243, 0.1); font-weight: bold; border-top: 2px solid #1976d2;">'
+        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold; border-top: 2px solid ${printColors.tableHeaderBg};">`
         selectedColumns.forEach((col, colIdx) => {
           if (colIdx === 0) {
             tableRows += '<td style="font-weight: bold;">Subtotal</td>'
@@ -537,7 +539,7 @@ const ProductCustomerReport: React.FC = () => {
 
     // Add totals
     if (totals) {
-      tableRows += '<tr style="background-color: rgba(76, 175, 80, 0.2); font-weight: bold; border-top: 3px solid #4caf50;">'
+      tableRows += `<tr style="background-color: ${printColors.successRow}; font-weight: bold; border-top: 3px solid ${printColors.border};">`
       selectedColumns.forEach((col, idx) => {
         if (idx === 0) {
           tableRows += '<td style="font-weight: 800;">GRAND TOTAL</td>'
@@ -571,9 +573,9 @@ const ProductCustomerReport: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }
-            th, td { border: 1px solid #ddd; padding: 6px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 6px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -591,7 +593,7 @@ const ProductCustomerReport: React.FC = () => {
                 text-align: center;
                 font-size: 10px;
                 padding: 10px;
-                border-top: 1px solid #ddd;
+                border-top: 1px solid ${printColors.tableBorder};
               }
             }
             .footer {
@@ -1091,7 +1093,7 @@ const ProductCustomerReport: React.FC = () => {
                   <TableHead>
                     <TableRow sx={{ '& .MuiTableCell-head': {
                       fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                      backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                      backgroundColor: theme.palette.action.hover,
                       color: TYPOGRAPHY_STYLES.tableHeader.color,
                       fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                       textAlign: 'center',
@@ -1159,7 +1161,7 @@ const ProductCustomerReport: React.FC = () => {
                         <React.Fragment key={`${row.orderId}-${idx}`}>
                           {showGroupHeader && (
                             <TableRow sx={{
-                              backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                              backgroundColor: theme.palette.action.selected,
                               '& .MuiTableCell-root': {
                                 fontWeight: 700,
                                 fontSize: '0.85rem',
@@ -1248,7 +1250,7 @@ const ProductCustomerReport: React.FC = () => {
                           {showGroupFooter && groupSubtotals && (
                             <>
                               <TableRow sx={{
-                                backgroundColor: 'rgba(33, 150, 243, 0.2)',
+                                backgroundColor: alpha(theme.palette.primary.main, 0.2),
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',
@@ -1301,7 +1303,7 @@ const ProductCustomerReport: React.FC = () => {
                     {totals && (
                       <TableRow
                         sx={{
-                          backgroundColor: 'rgba(76, 175, 80, 0.3)',
+                          backgroundColor: alpha(theme.palette.success.main, 0.3),
                           '& .MuiTableCell-root': {
                             fontWeight: 800,
                             fontSize: '0.9rem',

--- a/frontend/src/pages/sales/SalesByProductDetails.tsx
+++ b/frontend/src/pages/sales/SalesByProductDetails.tsx
@@ -36,6 +36,7 @@ import {
   Divider,
   OutlinedInput,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import {
   PictureAsPdf as PdfIcon,
   TableChart as ExcelIcon,
@@ -50,6 +51,7 @@ import {
   ViewColumn as ViewColumnIcon,
 } from '@mui/icons-material'
 import PageHeader from '@/components/common/PageHeader'
+import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import api from '@/services/api'
@@ -325,7 +327,7 @@ const SalesByProductDetails: React.FC = () => {
     if (groupedData) {
       Object.entries(groupedData).forEach(([groupName, items]) => {
         // Group header
-        tableRows += `<tr style="background-color: #e3f2fd; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupName}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupName}</td></tr>`
 
         // Items
         items.forEach(row => {
@@ -347,7 +349,7 @@ const SalesByProductDetails: React.FC = () => {
 
         // Subtotal
         const subtotal = calculateGroupSubtotal(items)
-        tableRows += '<tr style="background-color: rgba(33, 150, 243, 0.1); font-weight: bold; border-top: 2px solid #1976d2;">'
+        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold; border-top: 2px solid ${printColors.tableHeaderBg};">`
         selectedColumns.forEach((col, idx) => {
           if (idx === 0) {
             tableRows += '<td style="font-weight: bold;">Subtotal</td>'
@@ -386,7 +388,7 @@ const SalesByProductDetails: React.FC = () => {
 
     // Add totals
     if (totals) {
-      tableRows += '<tr style="background-color: rgba(76, 175, 80, 0.2); font-weight: bold; border-top: 3px solid #4caf50;">'
+      tableRows += `<tr style="background-color: ${printColors.successRow}; font-weight: bold; border-top: 3px solid ${printColors.border};">`
       selectedColumns.forEach((col, idx) => {
         if (idx === 0) {
           tableRows += '<td style="font-weight: 800;">GRAND TOTAL</td>'
@@ -423,9 +425,9 @@ const SalesByProductDetails: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }
-            th, td { border: 1px solid #ddd; padding: 6px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 6px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -443,7 +445,7 @@ const SalesByProductDetails: React.FC = () => {
                 text-align: center;
                 font-size: 10px;
                 padding: 10px;
-                border-top: 1px solid #ddd;
+                border-top: 1px solid ${printColors.tableBorder};
               }
             }
             .footer {
@@ -1103,7 +1105,7 @@ const SalesByProductDetails: React.FC = () => {
                   <TableHead>
                     <TableRow sx={{ '& .MuiTableCell-head': {
                       fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                      backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                      backgroundColor: theme.palette.action.hover,
                       color: TYPOGRAPHY_STYLES.tableHeader.color,
                       fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                       textAlign: 'center',
@@ -1133,7 +1135,7 @@ const SalesByProductDetails: React.FC = () => {
                             {/* Group Header Row */}
                             <TableRow
                               sx={{
-                                backgroundColor: 'rgba(33, 150, 243, 0.1)',
+                                backgroundColor: alpha(theme.palette.primary.main, 0.1),
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',
@@ -1214,7 +1216,7 @@ const SalesByProductDetails: React.FC = () => {
                             {/* Group Subtotal Row */}
                             <TableRow
                               sx={{
-                                backgroundColor: 'rgba(33, 150, 243, 0.2)',
+                                backgroundColor: alpha(theme.palette.primary.main, 0.2),
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',
@@ -1336,7 +1338,7 @@ const SalesByProductDetails: React.FC = () => {
                     {totals && (
                       <TableRow
                         sx={{
-                          backgroundColor: 'rgba(76, 175, 80, 0.3)',
+                          backgroundColor: alpha(theme.palette.success.main, 0.3),
                           '& .MuiTableCell-root': {
                             fontWeight: 800,
                             fontSize: '0.9rem',

--- a/frontend/src/pages/sales/SalesByProductSummary.tsx
+++ b/frontend/src/pages/sales/SalesByProductSummary.tsx
@@ -36,6 +36,7 @@ import {
   Divider,
   OutlinedInput,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import {
   PictureAsPdf as PdfIcon,
   TableChart as ExcelIcon,
@@ -50,6 +51,7 @@ import {
   ViewColumn as ViewColumnIcon,
 } from '@mui/icons-material'
 import PageHeader from '@/components/common/PageHeader'
+import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import { ApiService } from '@/services/api'
@@ -317,7 +319,7 @@ const SalesByProductSummary: React.FC = () => {
     if (groupedData) {
       Object.entries(groupedData).forEach(([categoryName, items]) => {
         // Category header
-        tableRows += `<tr style="background-color: #e3f2fd; font-weight: bold;"><td colspan="${selectedColumns.length}">${categoryName}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${categoryName}</td></tr>`
 
         // Items
         items.forEach(row => {
@@ -337,7 +339,7 @@ const SalesByProductSummary: React.FC = () => {
 
         // Subtotal
         const subtotal = calculateCategorySubtotal(items)
-        tableRows += '<tr style="background-color: rgba(33, 150, 243, 0.1); font-weight: bold; border-top: 2px solid #1976d2;">'
+        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold; border-top: 2px solid ${printColors.tableHeaderBg};">`
         selectedColumns.forEach((col, idx) => {
           if (idx === 0) {
             tableRows += '<td style="font-weight: bold;">Subtotal</td>'
@@ -374,7 +376,7 @@ const SalesByProductSummary: React.FC = () => {
 
     // Add totals
     if (totals) {
-      tableRows += '<tr style="background-color: rgba(76, 175, 80, 0.2); font-weight: bold; border-top: 3px solid #4caf50;">'
+      tableRows += `<tr style="background-color: ${printColors.successRow}; font-weight: bold; border-top: 3px solid ${printColors.border};">`
       selectedColumns.forEach((col, idx) => {
         if (idx === 0) {
           tableRows += '<td style="font-weight: 800;">GRAND TOTAL</td>'
@@ -411,9 +413,9 @@ const SalesByProductSummary: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 12px; }
-            th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 8px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -431,7 +433,7 @@ const SalesByProductSummary: React.FC = () => {
                 text-align: center;
                 font-size: 10px;
                 padding: 10px;
-                border-top: 1px solid #ddd;
+                border-top: 1px solid ${printColors.tableBorder};
               }
             }
             .footer {
@@ -1049,13 +1051,13 @@ const SalesByProductSummary: React.FC = () => {
                     width: '8px'
                   },
                   '&::-webkit-scrollbar-track': {
-                    backgroundColor: 'rgba(0,0,0,0.05)'
+                    backgroundColor: theme.palette.action.hover
                   },
                   '&::-webkit-scrollbar-thumb': {
-                    backgroundColor: 'rgba(0,0,0,0.2)',
+                    backgroundColor: theme.palette.grey[700],
                     borderRadius: '4px',
                     '&:hover': {
-                      backgroundColor: 'rgba(0,0,0,0.3)'
+                      backgroundColor: theme.palette.grey[600]
                     }
                   }
                 }}>
@@ -1077,7 +1079,7 @@ const SalesByProductSummary: React.FC = () => {
                   <TableHead>
                     <TableRow sx={{ '& .MuiTableCell-head': {
                       fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                      backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                      backgroundColor: theme.palette.action.hover,
                       color: TYPOGRAPHY_STYLES.tableHeader.color,
                       fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                       textAlign: 'center',
@@ -1106,7 +1108,7 @@ const SalesByProductSummary: React.FC = () => {
                             {/* Category Header Row */}
                             <TableRow
                               sx={{
-                                backgroundColor: 'rgba(33, 150, 243, 0.1)',
+                                backgroundColor: alpha(theme.palette.primary.main, 0.1),
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',
@@ -1185,7 +1187,7 @@ const SalesByProductSummary: React.FC = () => {
                             {/* Category Subtotal Row */}
                             <TableRow
                               sx={{
-                                backgroundColor: 'rgba(33, 150, 243, 0.2)',
+                                backgroundColor: alpha(theme.palette.primary.main, 0.2),
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',
@@ -1321,7 +1323,7 @@ const SalesByProductSummary: React.FC = () => {
                     {totals && (
                       <TableRow
                         sx={{
-                          backgroundColor: 'rgba(76, 175, 80, 0.3)',
+                          backgroundColor: alpha(theme.palette.success.main, 0.3),
                           '& .MuiTableCell-root': {
                             fontWeight: 800,
                             fontSize: '0.9rem',

--- a/frontend/src/pages/sales/SalesOrderProfitReport.tsx
+++ b/frontend/src/pages/sales/SalesOrderProfitReport.tsx
@@ -23,6 +23,7 @@ import {
   useMediaQuery,
   Chip,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import {
   PictureAsPdf as PdfIcon,
   TableChart as ExcelIcon,
@@ -31,6 +32,7 @@ import {
   TrendingUp as ProfitIcon,
 } from '@mui/icons-material'
 import PageHeader from '@/components/common/PageHeader'
+import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import api from '@/services/api'
@@ -304,7 +306,7 @@ const SalesOrderProfitReport: React.FC = () => {
         const groupLabel = groupBy === 'customerName' ? `Customer: ${currentGroupValue}` :
                           groupBy === 'inventoryStatus' ? `Inventory: ${currentGroupValue.charAt(0).toUpperCase() + currentGroupValue.slice(1)}` :
                           groupBy === 'paymentStatus' ? `Payment: ${currentGroupValue.charAt(0).toUpperCase() + currentGroupValue.slice(1)}` : currentGroupValue
-        tableRows += `<tr style="background-color: #d3d3d3; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupValue = currentGroupValue
       }
 
@@ -347,7 +349,7 @@ const SalesOrderProfitReport: React.FC = () => {
           grossProfit: groupData.reduce((sum, r) => sum + r.grossProfit, 0),
         }
 
-        tableRows += '<tr style="background-color: rgba(33, 150, 243, 0.1); font-weight: bold; border-top: 2px solid #1976d2;">'
+        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold; border-top: 2px solid ${printColors.tableHeaderBg};">`
         selectedColumns.forEach((col, colIdx) => {
           if (colIdx === 0) {
             tableRows += '<td style="font-weight: bold;">Subtotal</td>'
@@ -366,7 +368,7 @@ const SalesOrderProfitReport: React.FC = () => {
 
     // Add totals
     if (totals) {
-      tableRows += '<tr style="background-color: rgba(76, 175, 80, 0.2); font-weight: bold; border-top: 3px solid #4caf50;">'
+      tableRows += `<tr style="background-color: ${printColors.successRow}; font-weight: bold; border-top: 3px solid ${printColors.border};">`
       selectedColumns.forEach((col, idx) => {
         if (idx === 0) {
           tableRows += '<td style="font-weight: 800;">GRAND TOTAL</td>'
@@ -400,9 +402,9 @@ const SalesOrderProfitReport: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }
-            th, td { border: 1px solid #ddd; padding: 6px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 6px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -420,7 +422,7 @@ const SalesOrderProfitReport: React.FC = () => {
                 text-align: center;
                 font-size: 10px;
                 padding: 10px;
-                border-top: 1px solid #ddd;
+                border-top: 1px solid ${printColors.tableBorder};
               }
             }
             .footer {
@@ -861,7 +863,7 @@ const SalesOrderProfitReport: React.FC = () => {
                   <TableHead>
                     <TableRow sx={{ '& .MuiTableCell-head': {
                       fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                      backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                      backgroundColor: theme.palette.action.hover,
                       color: TYPOGRAPHY_STYLES.tableHeader.color,
                       fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                       textAlign: 'center',
@@ -938,7 +940,7 @@ const SalesOrderProfitReport: React.FC = () => {
                         <React.Fragment key={`${row.orderNumber}-${idx}`}>
                           {showGroupHeader && (
                             <TableRow sx={{
-                              backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                              backgroundColor: theme.palette.action.selected,
                               '& .MuiTableCell-root': {
                                 fontWeight: 700,
                                 fontSize: '0.85rem',
@@ -1020,7 +1022,7 @@ const SalesOrderProfitReport: React.FC = () => {
                           {showGroupFooter && groupSubtotals && (
                             <>
                               <TableRow sx={{
-                                backgroundColor: 'rgba(33, 150, 243, 0.2)',
+                                backgroundColor: alpha(theme.palette.primary.main, 0.2),
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',
@@ -1069,7 +1071,7 @@ const SalesOrderProfitReport: React.FC = () => {
                     {totals && (
                       <TableRow
                         sx={{
-                          backgroundColor: 'rgba(76, 175, 80, 0.3)',
+                          backgroundColor: alpha(theme.palette.success.main, 0.3),
                           '& .MuiTableCell-root': {
                             fontWeight: 800,
                             fontSize: '0.9rem',

--- a/frontend/src/pages/sales/SalesOrderSummary.tsx
+++ b/frontend/src/pages/sales/SalesOrderSummary.tsx
@@ -23,6 +23,7 @@ import {
   useMediaQuery,
   Chip,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import {
   PictureAsPdf as PdfIcon,
   TableChart as ExcelIcon,
@@ -31,6 +32,7 @@ import {
   Receipt as OrderIcon,
 } from '@mui/icons-material'
 import PageHeader from '@/components/common/PageHeader'
+import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TYPOGRAPHY_STYLES, TABLE_STYLES } from '@/constants/typography'
 import api from '@/services/api'
@@ -330,7 +332,7 @@ const SalesOrderSummary: React.FC = () => {
         const groupLabel = groupBy === 'customerName' ? `Customer: ${currentGroupValue}` :
                           groupBy === 'inventoryStatus' ? `Inventory: ${currentGroupValue}` :
                           groupBy === 'paymentStatus' ? `Payment: ${currentGroupValue}` : currentGroupValue
-        tableRows += `<tr style="background-color: #d3d3d3; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupValue = currentGroupValue
       }
 
@@ -379,7 +381,7 @@ const SalesOrderSummary: React.FC = () => {
           balanceDue: groupData.reduce((sum, r) => sum + r.balanceDue, 0),
         }
 
-        tableRows += '<tr style="background-color: rgba(33, 150, 243, 0.1); font-weight: bold; border-top: 2px solid #1976d2;">'
+        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold; border-top: 2px solid ${printColors.tableHeaderBg};">`
         selectedColumns.forEach((col, colIdx) => {
           if (colIdx === 0) {
             tableRows += '<td style="font-weight: bold;">Subtotal</td>'
@@ -401,7 +403,7 @@ const SalesOrderSummary: React.FC = () => {
 
     // Add totals
     if (totals) {
-      tableRows += '<tr style="background-color: rgba(76, 175, 80, 0.2); font-weight: bold; border-top: 3px solid #4caf50;">'
+      tableRows += `<tr style="background-color: ${printColors.successRow}; font-weight: bold; border-top: 3px solid ${printColors.border};">`
       selectedColumns.forEach((col, idx) => {
         if (idx === 0) {
           tableRows += '<td style="font-weight: 800;">GRAND TOTAL</td>'
@@ -438,9 +440,9 @@ const SalesOrderSummary: React.FC = () => {
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }
-            th, td { border: 1px solid #ddd; padding: 6px; text-align: left; }
-            th { background-color: #1976d2; color: white; font-weight: bold; }
-            tr:nth-child(even) { background-color: #f9f9f9; }
+            th, td { border: 1px solid ${printColors.tableBorder}; padding: 6px; text-align: left; }
+            th { background-color: ${printColors.tableHeaderBg}; color: ${printColors.background}; font-weight: bold; }
+            tr:nth-child(even) { background-color: ${printColors.tableRowAlt}; }
             .text-right { text-align: right; }
             @media print {
               body { margin: 0; padding: 20px 20px 40px 20px; }
@@ -458,7 +460,7 @@ const SalesOrderSummary: React.FC = () => {
                 text-align: center;
                 font-size: 10px;
                 padding: 10px;
-                border-top: 1px solid #ddd;
+                border-top: 1px solid ${printColors.tableBorder};
               }
             }
             .footer {
@@ -909,7 +911,7 @@ const SalesOrderSummary: React.FC = () => {
                   <TableHead>
                     <TableRow sx={{ '& .MuiTableCell-head': {
                       fontWeight: TYPOGRAPHY_STYLES.tableHeader.fontWeight,
-                      backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                      backgroundColor: theme.palette.action.hover,
                       color: TYPOGRAPHY_STYLES.tableHeader.color,
                       fontSize: TYPOGRAPHY_STYLES.tableHeader.fontSize,
                       textAlign: 'center',
@@ -991,7 +993,7 @@ const SalesOrderSummary: React.FC = () => {
                         <React.Fragment key={`${row.orderNumber}-${idx}`}>
                           {showGroupHeader && (
                             <TableRow sx={{
-                              backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                              backgroundColor: theme.palette.action.selected,
                               '& .MuiTableCell-root': {
                                 fontWeight: 700,
                                 fontSize: '0.85rem',
@@ -1055,7 +1057,7 @@ const SalesOrderSummary: React.FC = () => {
                           {showGroupFooter && groupSubtotals && (
                             <>
                               <TableRow sx={{
-                                backgroundColor: 'rgba(33, 150, 243, 0.2)',
+                                backgroundColor: alpha(theme.palette.primary.main, 0.2),
                                 '& .MuiTableCell-root': {
                                   fontWeight: 700,
                                   fontSize: '0.85rem',
@@ -1091,7 +1093,7 @@ const SalesOrderSummary: React.FC = () => {
                     {totals && (
                       <TableRow
                         sx={{
-                          backgroundColor: 'rgba(76, 175, 80, 0.3)',
+                          backgroundColor: alpha(theme.palette.success.main, 0.3),
                           '& .MuiTableCell-root': {
                             fontWeight: 800,
                             fontSize: '0.9rem',

--- a/frontend/src/pages/settings/PrintSettings/TemplatePreview.tsx
+++ b/frontend/src/pages/settings/PrintSettings/TemplatePreview.tsx
@@ -11,9 +11,11 @@ import {
   TableRow,
   Divider,
   Grid,
+  useTheme,
 } from '@mui/material'
 import { useCurrency } from '@/hooks/useCurrency'
 import { formatDate } from '@/utils/formatters'
+import { printColors } from '@/styles/printTokens'
 
 interface TemplatePreviewProps {
   template: any
@@ -21,6 +23,7 @@ interface TemplatePreviewProps {
 }
 
 const TemplatePreview: React.FC<TemplatePreviewProps> = ({ template, settings }) => {
+  const theme = useTheme()
   const { currency } = useCurrency()
   const [displayCurrency, setDisplayCurrency] = useState(currency)
 
@@ -102,15 +105,15 @@ const TemplatePreview: React.FC<TemplatePreviewProps> = ({ template, settings })
   const footers = getFooterText()
 
   return (
-    <Box sx={{ bgcolor: '#f5f5f5', p: 2 }}>
+    <Box sx={{ bgcolor: theme.palette.grey[100], p: 2 }}>
       <Paper
         sx={{
           p: 4,
           width: '210mm', // A4 width
           minHeight: '297mm', // A4 height
           mx: 'auto',
-          bgcolor: '#ffffff', // Pure white for printing
-          color: '#000000', // Black text for printing
+          bgcolor: printColors.background,
+          color: printColors.text,
           '@media print': {
             boxShadow: 'none',
             p: 2,
@@ -121,28 +124,28 @@ const TemplatePreview: React.FC<TemplatePreviewProps> = ({ template, settings })
         <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 3, gap: 2 }}>
           {/* Company Info */}
           <Box sx={{ flex: 1 }}>
-            <Typography variant="h5" sx={{ fontWeight: 700, mb: 1, color: '#000000' }}>
+            <Typography variant="h5" sx={{ fontWeight: 700, mb: 1, color: printColors.text }}>
               {settings?.companyName || 'Company Name'}
             </Typography>
-            <Typography variant="body2" sx={{ color: '#000000', mb: 0.5 }}>
+            <Typography variant="body2" sx={{ color: printColors.text, mb: 0.5 }}>
               {settings?.address || 'No. 123, Jalan Perdana 1/2'}
             </Typography>
-            <Typography variant="body2" sx={{ color: '#000000', mb: 0.5 }}>
+            <Typography variant="body2" sx={{ color: printColors.text, mb: 0.5 }}>
               {settings?.postalCode || '47650'}, {settings?.city || 'Subang Jaya'}
             </Typography>
-            <Typography variant="body2" sx={{ color: '#000000', mb: 1 }}>
+            <Typography variant="body2" sx={{ color: printColors.text, mb: 1 }}>
               {settings?.state || 'Selangor'}, {settings?.country || 'Malaysia'}
             </Typography>
-            <Typography variant="body2" sx={{ color: '#000000', mb: 0.5 }}>
+            <Typography variant="body2" sx={{ color: printColors.text, mb: 0.5 }}>
               {settings?.phone ? `Tel: ${settings.phone}` : 'Tel: +60 3-1234 5678'}
             </Typography>
             {settings?.email && (
-              <Typography variant="body2" sx={{ color: '#000000', mb: 0.5 }}>
+              <Typography variant="body2" sx={{ color: printColors.text, mb: 0.5 }}>
                 Email: {settings.email}
               </Typography>
             )}
             {settings?.website && (
-              <Typography variant="body2" sx={{ color: '#000000' }}>
+              <Typography variant="body2" sx={{ color: printColors.text }}>
                 Website: {settings.website}
               </Typography>
             )}
@@ -176,13 +179,13 @@ const TemplatePreview: React.FC<TemplatePreviewProps> = ({ template, settings })
               variant="h4"
               sx={{
                 fontWeight: 700,
-                color: '#000000',
+                color: printColors.text,
                 mb: 1,
               }}
             >
               {template.title.toUpperCase()}
             </Typography>
-            <Typography variant="body2" sx={{ color: '#000000', mb: 0.5 }}>
+            <Typography variant="body2" sx={{ color: printColors.text, mb: 0.5 }}>
               <strong>Document No:</strong> {
                 template.id === 'salesOrder' ? 'SO-000001' :
                 template.id === 'invoice' ? 'INV-000001' :
@@ -193,13 +196,13 @@ const TemplatePreview: React.FC<TemplatePreviewProps> = ({ template, settings })
                 'DOC-000001'
               }
             </Typography>
-            <Typography variant="body2" sx={{ color: '#000000' }}>
+            <Typography variant="body2" sx={{ color: printColors.text }}>
               <strong>Date:</strong> {formatDate(new Date())}
             </Typography>
           </Box>
         </Box>
 
-        <Divider sx={{ mb: 3, borderColor: '#000000' }} />
+        <Divider sx={{ mb: 3, borderColor: printColors.border }} />
 
         {/* Customer Details */}
         <Grid container spacing={3} sx={{ mb: 3 }}>
@@ -207,20 +210,20 @@ const TemplatePreview: React.FC<TemplatePreviewProps> = ({ template, settings })
             {/* Empty space for alignment */}
           </Grid>
           <Grid size={6}>
-            <Box sx={{ border: '1px solid #000000', p: 2, borderRadius: 1 }}>
-              <Typography variant="body2" sx={{ color: '#000000', fontWeight: 600, mb: 0.5 }}>
+            <Box sx={{ border: `1px solid ${printColors.border}`, p: 2, borderRadius: 1 }}>
+              <Typography variant="body2" sx={{ color: printColors.text, fontWeight: 600, mb: 0.5 }}>
                 ABC Trading Sdn Bhd
               </Typography>
-              <Typography variant="body2" sx={{ color: '#000000', mb: 0.5 }}>
+              <Typography variant="body2" sx={{ color: printColors.text, mb: 0.5 }}>
                 No. 45, Jalan SS15/4D
               </Typography>
-              <Typography variant="body2" sx={{ color: '#000000', mb: 0.5 }}>
+              <Typography variant="body2" sx={{ color: printColors.text, mb: 0.5 }}>
                 47500, Subang Jaya
               </Typography>
-              <Typography variant="body2" sx={{ color: '#000000', mb: 0.5 }}>
+              <Typography variant="body2" sx={{ color: printColors.text, mb: 0.5 }}>
                 Selangor, Malaysia
               </Typography>
-              <Typography variant="body2" sx={{ color: '#000000' }}>
+              <Typography variant="body2" sx={{ color: printColors.text }}>
                 Phone: +60 3-5632 8888
               </Typography>
             </Box>
@@ -228,19 +231,19 @@ const TemplatePreview: React.FC<TemplatePreviewProps> = ({ template, settings })
         </Grid>
 
         {/* Items Table */}
-        <TableContainer sx={{ mb: 3, border: '1px solid #000000' }}>
+        <TableContainer sx={{ mb: 3, border: `1px solid ${printColors.border}` }}>
           <Table size="small">
             <TableHead>
-              <TableRow sx={{ bgcolor: '#f0f0f0' }}>
-                <TableCell sx={{ fontWeight: 600, color: '#000000', border: '1px solid #000000' }}>Product</TableCell>
-                <TableCell align="right" sx={{ fontWeight: 600, color: '#000000', border: '1px solid #000000' }}>Qty</TableCell>
+              <TableRow sx={{ bgcolor: printColors.tableRowAlt }}>
+                <TableCell sx={{ fontWeight: 600, color: printColors.text, border: `1px solid ${printColors.border}` }}>Product</TableCell>
+                <TableCell align="right" sx={{ fontWeight: 600, color: printColors.text, border: `1px solid ${printColors.border}` }}>Qty</TableCell>
                 {!isGRN && (
                   <>
-                    <TableCell align="right" sx={{ fontWeight: 600, color: '#000000', border: '1px solid #000000' }}>Unit Price</TableCell>
+                    <TableCell align="right" sx={{ fontWeight: 600, color: printColors.text, border: `1px solid ${printColors.border}` }}>Unit Price</TableCell>
                     {showDiscountColumn && (
-                      <TableCell align="right" sx={{ fontWeight: 600, color: '#000000', border: '1px solid #000000' }}>Discount</TableCell>
+                      <TableCell align="right" sx={{ fontWeight: 600, color: printColors.text, border: `1px solid ${printColors.border}` }}>Discount</TableCell>
                     )}
-                    <TableCell align="right" sx={{ fontWeight: 600, color: '#000000', border: '1px solid #000000' }}>Amount</TableCell>
+                    <TableCell align="right" sx={{ fontWeight: 600, color: printColors.text, border: `1px solid ${printColors.border}` }}>Amount</TableCell>
                   </>
                 )}
               </TableRow>
@@ -248,15 +251,15 @@ const TemplatePreview: React.FC<TemplatePreviewProps> = ({ template, settings })
             <TableBody>
               {sampleItems.map((item) => (
                 <TableRow key={item.no}>
-                  <TableCell sx={{ color: '#000000', border: '1px solid #000000' }}>{item.description}</TableCell>
-                  <TableCell align="right" sx={{ color: '#000000', border: '1px solid #000000' }}>{item.quantity}</TableCell>
+                  <TableCell sx={{ color: printColors.text, border: `1px solid ${printColors.border}` }}>{item.description}</TableCell>
+                  <TableCell align="right" sx={{ color: printColors.text, border: `1px solid ${printColors.border}` }}>{item.quantity}</TableCell>
                   {!isGRN && (
                     <>
-                      <TableCell align="right" sx={{ color: '#000000', border: '1px solid #000000' }}>{displayCurrency} {item.unitPrice.toFixed(2)}</TableCell>
+                      <TableCell align="right" sx={{ color: printColors.text, border: `1px solid ${printColors.border}` }}>{displayCurrency} {item.unitPrice.toFixed(2)}</TableCell>
                       {showDiscountColumn && (
-                        <TableCell align="right" sx={{ color: '#000000', border: '1px solid #000000' }}>{displayCurrency} {item.discount.toFixed(2)}</TableCell>
+                        <TableCell align="right" sx={{ color: printColors.text, border: `1px solid ${printColors.border}` }}>{displayCurrency} {item.discount.toFixed(2)}</TableCell>
                       )}
-                      <TableCell align="right" sx={{ color: '#000000', border: '1px solid #000000' }}>{displayCurrency} {item.amount.toFixed(2)}</TableCell>
+                      <TableCell align="right" sx={{ color: printColors.text, border: `1px solid ${printColors.border}` }}>{displayCurrency} {item.amount.toFixed(2)}</TableCell>
                     </>
                   )}
                 </TableRow>
@@ -269,12 +272,12 @@ const TemplatePreview: React.FC<TemplatePreviewProps> = ({ template, settings })
         {isGRN ? (
           // GRN: Show only total quantity
           (<Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 3 }}>
-            <Box sx={{ width: 300, border: '1px solid #000000', p: 2 }}>
+            <Box sx={{ width: 300, border: `1px solid ${printColors.border}`, p: 2 }}>
               <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                <Typography variant="body1" sx={{ fontWeight: 700, color: '#000000' }}>
+                <Typography variant="body1" sx={{ fontWeight: 700, color: printColors.text }}>
                   Total Quantity:
                 </Typography>
-                <Typography variant="body1" sx={{ fontWeight: 700, color: '#000000' }}>
+                <Typography variant="body1" sx={{ fontWeight: 700, color: printColors.text }}>
                   {totalQuantity}
                 </Typography>
               </Box>
@@ -283,36 +286,36 @@ const TemplatePreview: React.FC<TemplatePreviewProps> = ({ template, settings })
         ) : (
           // Other templates: Show standard totals
           (<Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 3 }}>
-            <Box sx={{ width: 300, border: '1px solid #000000', p: 2 }}>
+            <Box sx={{ width: 300, border: `1px solid ${printColors.border}`, p: 2 }}>
               <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-                <Typography variant="body2" sx={{ color: '#000000' }}>Subtotal:</Typography>
-                <Typography variant="body2" sx={{ color: '#000000' }}>{displayCurrency} {subtotal.toFixed(2)}</Typography>
+                <Typography variant="body2" sx={{ color: printColors.text }}>Subtotal:</Typography>
+                <Typography variant="body2" sx={{ color: printColors.text }}>{displayCurrency} {subtotal.toFixed(2)}</Typography>
               </Box>
               <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-                <Typography variant="body2" sx={{ color: '#000000' }}>Shipping Cost:</Typography>
-                <Typography variant="body2" sx={{ color: '#000000' }}>{displayCurrency} {shipping.toFixed(2)}</Typography>
+                <Typography variant="body2" sx={{ color: printColors.text }}>Shipping Cost:</Typography>
+                <Typography variant="body2" sx={{ color: printColors.text }}>{displayCurrency} {shipping.toFixed(2)}</Typography>
               </Box>
-              <Divider sx={{ my: 1, borderColor: '#000000' }} />
+              <Divider sx={{ my: 1, borderColor: printColors.border }} />
               <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-                <Typography variant="body1" sx={{ fontWeight: 700, color: '#000000' }}>
+                <Typography variant="body1" sx={{ fontWeight: 700, color: printColors.text }}>
                   Total:
                 </Typography>
-                <Typography variant="body1" sx={{ fontWeight: 700, color: '#000000' }}>
+                <Typography variant="body1" sx={{ fontWeight: 700, color: printColors.text }}>
                   {displayCurrency} {total.toFixed(2)}
                 </Typography>
               </Box>
               {(template.id === 'invoice' || template.id === 'paymentReceipt' || template.id === 'vendorPayment') && (
                 <>
                   <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-                    <Typography variant="body2" sx={{ color: '#000000' }}>Paid:</Typography>
-                    <Typography variant="body2" sx={{ color: '#000000' }}>{displayCurrency} {paid.toFixed(2)}</Typography>
+                    <Typography variant="body2" sx={{ color: printColors.text }}>Paid:</Typography>
+                    <Typography variant="body2" sx={{ color: printColors.text }}>{displayCurrency} {paid.toFixed(2)}</Typography>
                   </Box>
-                  <Divider sx={{ my: 1, borderColor: '#000000' }} />
+                  <Divider sx={{ my: 1, borderColor: printColors.border }} />
                   <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                    <Typography variant="body1" sx={{ fontWeight: 700, color: '#000000' }}>
+                    <Typography variant="body1" sx={{ fontWeight: 700, color: printColors.text }}>
                       Balance:
                     </Typography>
-                    <Typography variant="body1" sx={{ fontWeight: 700, color: '#000000' }}>
+                    <Typography variant="body1" sx={{ fontWeight: 700, color: printColors.text }}>
                       {displayCurrency} {balance.toFixed(2)}
                     </Typography>
                   </Box>
@@ -324,10 +327,10 @@ const TemplatePreview: React.FC<TemplatePreviewProps> = ({ template, settings })
 
         {/* Notes */}
         <Box sx={{ mb: 3 }}>
-          <Typography variant="body2" sx={{ fontWeight: 600, mb: 1, color: '#000000' }}>
+          <Typography variant="body2" sx={{ fontWeight: 600, mb: 1, color: printColors.text }}>
             Notes:
           </Typography>
-          <Typography variant="body2" sx={{ color: '#000000' }}>
+          <Typography variant="body2" sx={{ color: printColors.text }}>
             Thank you for your business. Please contact us if you have any questions.
           </Typography>
         </Box>
@@ -335,8 +338,8 @@ const TemplatePreview: React.FC<TemplatePreviewProps> = ({ template, settings })
         {/* Per-page footer */}
         {footers.perPage && (
           <>
-            <Divider sx={{ my: 2, borderColor: '#000000' }} />
-            <Typography variant="caption" sx={{ color: '#000000' }} align="center" display="block">
+            <Divider sx={{ my: 2, borderColor: printColors.border }} />
+            <Typography variant="caption" sx={{ color: printColors.text }} align="center" display="block">
               {footers.perPage}
             </Typography>
           </>
@@ -345,9 +348,9 @@ const TemplatePreview: React.FC<TemplatePreviewProps> = ({ template, settings })
         {/* End of document footer */}
         {footers.endOfDoc && (
           <>
-            <Divider sx={{ my: 2, borderColor: '#000000' }} />
-            <Box sx={{ bgcolor: '#f0f0f0', p: 2, borderRadius: 1, border: '1px solid #000000' }}>
-              <Typography variant="body2" sx={{ color: '#000000' }} align="center">
+            <Divider sx={{ my: 2, borderColor: printColors.border }} />
+            <Box sx={{ bgcolor: printColors.tableRowAlt, p: 2, borderRadius: 1, border: `1px solid ${printColors.border}` }}>
+              <Typography variant="body2" sx={{ color: printColors.text }} align="center">
                 {footers.endOfDoc}
               </Typography>
             </Box>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -14,12 +14,6 @@ body {
   padding: 0;
   font-family: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
   line-height: 1.5;
-  color: #333;
-  background-color: #fafafa;
-}
-
-/* Dark theme support */
-[data-theme='dark'] body {
   color: #ffffff;
   background-color: #121212;
 }
@@ -35,29 +29,17 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #bdbdbd;
+  background: #616161;
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #9e9e9e;
-}
-
-[data-theme='dark'] ::-webkit-scrollbar-thumb {
-  background: #616161;
-}
-
-[data-theme='dark'] ::-webkit-scrollbar-thumb:hover {
   background: #757575;
 }
 
 /* Firefox scrollbar */
 html {
   scrollbar-width: thin;
-  scrollbar-color: #bdbdbd transparent;
-}
-
-[data-theme='dark'] html {
   scrollbar-color: #616161 transparent;
 }
 
@@ -101,14 +83,9 @@ button {
 
 /* Skeleton loading animation */
 .skeleton {
-  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
-  background-size: 200% 100%;
-  animation: loading 1.5s infinite;
-}
-
-[data-theme='dark'] .skeleton {
   background: linear-gradient(90deg, #2c2c2c 25%, #3c3c3c 50%, #2c2c2c 75%);
   background-size: 200% 100%;
+  animation: loading 1.5s infinite;
 }
 
 @keyframes loading {
@@ -206,7 +183,7 @@ button {
 
 /* Status indicators */
 .status-active {
-  color: #4caf50;
+  color: #66bb6a;
   font-weight: 500;
 }
 
@@ -216,12 +193,12 @@ button {
 }
 
 .status-pending {
-  color: #ff9800;
+  color: #ffca28;
   font-weight: 500;
 }
 
 .status-error {
-  color: #f44336;
+  color: #ef5350;
   font-weight: 500;
 }
 

--- a/frontend/src/styles/printTokens.ts
+++ b/frontend/src/styles/printTokens.ts
@@ -1,0 +1,13 @@
+// Colors for print/PDF output — intentionally NOT dark theme colors.
+// These produce black-on-white output suitable for printing and PDF generation.
+export const printColors = {
+  background: '#ffffff',
+  text: '#000000',
+  border: '#000000',
+  tableBorder: '#ddd',
+  tableHeaderBg: '#1976d2',
+  tableRowAlt: '#f9f9f9',
+  successRow: 'rgba(76, 175, 80, 0.2)',
+  infoRow: 'rgba(33, 150, 243, 0.1)',
+  groupRow: '#d3d3d3',
+}

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -290,8 +290,7 @@ const darkTheme = createTheme({
     },
     grey: {
       ...colors.grey,
-      // Override grey.50 for dark mode to use a darker shade
-      50: colors.grey[800], // Map grey.50 to grey.800 for dark mode
+      50: colors.grey[800],
     },
     background: {
       default: '#121212',


### PR DESCRIPTION
## Summary
- Removed all light-mode remnants (`[data-theme='dark']` conditionals in `global.css`, `data-theme` setter in `RootLayout.tsx`) — app is now dark-only with dark values as unconditional defaults
- Replaced hardcoded hex colors across 38 files with `useTheme()` + `theme.palette.*`; created `frontend/src/styles/printTokens.ts` to make intentional black-on-white print colors explicit
- Added `docs/COLOR_PALETTE.md` as the authoritative color usage reference

## Three approved exceptions (intentional, not mistakes)
- `LoginPage.tsx` / `MandatoryPasswordChangePage.tsx` — decorative auth gradient
- `Sidebar.tsx` — `#0D0D0D` intentional sidebar depth (deeper than `background.default`)

## Test Plan
- [x] `npm run lint` — passed
- [x] `npm run type-check` — passed
- [x] `npm run test` — 686 tests across 101 files passed
- [x] Repo-wide hardcoded color audit returns only the 3 approved exceptions

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)