### PR TITLE
feat: unify font usage and standardize Roboto (issue #238)

### DIFF
--- a/docs/superpowers/specs/2026-04-01-font-unification-design.md
+++ b/docs/superpowers/specs/2026-04-01-font-unification-design.md
@@ -9,7 +9,7 @@ Font declarations are scattered across the codebase:
 - `global.css` duplicates the font stack already defined in `theme.ts`
 - 13 components hardcode `fontFamily: 'monospace'`
 - 18 components hardcode `fontFamily: 'inherit'` to work around browser button font defaults
-- 17 print report files use `font-family: Arial, sans-serif` instead of Roboto
+- 19 print report files use `font-family: Arial, sans-serif` instead of Roboto
 
 ## Design
 
@@ -71,7 +71,7 @@ Remove all per-component `fontFamily: 'inherit'` props — the `MuiButtonBase` t
 
 Each print report opens a `window.open()` HTML document. Add the Google Fonts Roboto CDN `<link>` to each print window `<head>`, and change `font-family: Arial, sans-serif` to `'Roboto', sans-serif`.
 
-The 17 files are:
+The 19 files are:
 - `src/pages/purchasing/VendorProductListReport.tsx`
 - `src/pages/purchasing/VendorPaymentDetailsReport.tsx`
 - `src/pages/purchasing/PurchaseOrderStatusReport.tsx`

--- a/frontend/src/components/auth/IdleWarningDialog.tsx
+++ b/frontend/src/components/auth/IdleWarningDialog.tsx
@@ -109,7 +109,6 @@ const IdleWarningDialog: React.FC<IdleWarningDialogProps> = ({
             sx={{
               fontWeight: 700,
               color: `${getColor()}.main`,
-              fontFamily: 'monospace',
             }}
           >
             {formatTime(remainingSeconds)}

--- a/frontend/src/components/backup/BackupDetailsDialog.tsx
+++ b/frontend/src/components/backup/BackupDetailsDialog.tsx
@@ -74,7 +74,7 @@ const BackupDetailsDialog: React.FC<BackupDetailsDialogProps> = ({ open, onClose
             </Typography>
             <Typography
               variant="body1"
-              sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}
+              sx={{ wordBreak: 'break-all' }}
             >
               {currentBackup.filename}
             </Typography>
@@ -168,7 +168,7 @@ const BackupDetailsDialog: React.FC<BackupDetailsDialogProps> = ({ open, onClose
             </Typography>
             <Typography
               variant="body2"
-              sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}
+              sx={{ wordBreak: 'break-all' }}
             >
               {currentBackup.filepath}
             </Typography>
@@ -183,7 +183,6 @@ const BackupDetailsDialog: React.FC<BackupDetailsDialogProps> = ({ open, onClose
                 </Typography>
                 <Box
                   sx={{
-                    fontFamily: 'monospace',
                     fontSize: '0.875rem',
                     backgroundColor: 'grey.100',
                     color: 'grey.900',
@@ -212,7 +211,6 @@ const BackupDetailsDialog: React.FC<BackupDetailsDialogProps> = ({ open, onClose
                   variant="body2"
                   color="error"
                   sx={{
-                    fontFamily: 'monospace',
                     backgroundColor: 'error.light',
                     p: 2,
                     borderRadius: 1,

--- a/frontend/src/components/backup/BackupList.tsx
+++ b/frontend/src/components/backup/BackupList.tsx
@@ -135,7 +135,7 @@ const BackupList: React.FC<BackupListProps> = ({ backups }) => {
               paginatedBackups.map((backup) => (
                 <TableRow key={backup.id} hover>
                   <TableCell>
-                    <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                    <Typography variant="body2">
                       {backup.filename}
                     </Typography>
                   </TableCell>

--- a/frontend/src/components/backup/RestoreConfirmationDialog.tsx
+++ b/frontend/src/components/backup/RestoreConfirmationDialog.tsx
@@ -99,7 +99,6 @@ const RestoreConfirmationDialog: React.FC<RestoreConfirmationDialogProps> = ({
                 <ListItemText
                   primary="Filename"
                   secondary={currentBackup.filename}
-                  secondaryTypographyProps={{ sx: { fontFamily: 'monospace' } }}
                 />
               </ListItem>
               <ListItem>

--- a/frontend/src/components/calculator/components/CalculatorDisplay.tsx
+++ b/frontend/src/components/calculator/components/CalculatorDisplay.tsx
@@ -42,7 +42,6 @@ export const CalculatorDisplay: React.FC<CalculatorDisplayProps> = ({
               fontSize: compact ? '1.2rem' : '1.5rem',
               fontWeight: 600,
               color: 'text.primary',
-              fontFamily: 'monospace',
             }
           }
         }}

--- a/frontend/src/components/calculator/components/CalculatorHistory.tsx
+++ b/frontend/src/components/calculator/components/CalculatorHistory.tsx
@@ -27,7 +27,6 @@ export const CalculatorHistory: React.FC<CalculatorHistoryProps> = ({
               variant="caption"
               sx={{
                 display: 'block',
-                fontFamily: 'monospace',
                 color: 'text.secondary',
                 py: 0.25,
               }}

--- a/frontend/src/components/common/TopBar.tsx
+++ b/frontend/src/components/common/TopBar.tsx
@@ -349,7 +349,6 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
                   borderRadius: '4px',
                   px: 0.75,
                   py: 0.25,
-                  fontFamily: 'monospace',
                   fontSize: '11px',
                   color: theme.palette.text.secondary,
                   flexShrink: 0,

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -245,7 +245,7 @@ const LoginPage: React.FC = () => {
             <Typography variant="subtitle2" color="info.dark" gutterBottom fontWeight="bold">
               Default Admin Credentials:
             </Typography>
-            <Box sx={{ mt: 1.5, p: 1.5, bgcolor: 'background.paper', borderRadius: 1, fontFamily: 'monospace' }}>
+            <Box sx={{ mt: 1.5, p: 1.5, bgcolor: 'background.paper', borderRadius: 1 }}>
               <Typography variant="body2" color="text.primary">
                 <strong>Username:</strong> admin
               </Typography>

--- a/frontend/src/pages/inventory/HistoricalInventoryReport.tsx
+++ b/frontend/src/pages/inventory/HistoricalInventoryReport.tsx
@@ -396,8 +396,9 @@ const HistoricalInventoryReport: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }

--- a/frontend/src/pages/inventory/InventorySummaryReport.tsx
+++ b/frontend/src/pages/inventory/InventorySummaryReport.tsx
@@ -539,8 +539,9 @@ const InventorySummaryReport: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }

--- a/frontend/src/pages/inventory/MovementSummaryReport.tsx
+++ b/frontend/src/pages/inventory/MovementSummaryReport.tsx
@@ -389,8 +389,9 @@ const MovementSummaryReport: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }

--- a/frontend/src/pages/inventory/PriceListReport.tsx
+++ b/frontend/src/pages/inventory/PriceListReport.tsx
@@ -425,8 +425,9 @@ const PriceListReport: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }

--- a/frontend/src/pages/inventory/ProductCostReport.tsx
+++ b/frontend/src/pages/inventory/ProductCostReport.tsx
@@ -431,8 +431,9 @@ const ProductCostReport: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }

--- a/frontend/src/pages/purchasing/GoodsReceivedPage.tsx
+++ b/frontend/src/pages/purchasing/GoodsReceivedPage.tsx
@@ -701,7 +701,6 @@ const GoodsReceivedPage: React.FC = () => {
                                       border: 'none',
                                       background: 'none',
                                       padding: 0,
-                                      fontFamily: 'inherit',
                                       '&:hover': {
                                         color: 'primary.dark'
                                       }
@@ -728,7 +727,6 @@ const GoodsReceivedPage: React.FC = () => {
                                         border: 'none',
                                         background: 'none',
                                         padding: 0,
-                                        fontFamily: 'inherit',
                                         '&:hover': {
                                           color: 'primary.dark'
                                         }
@@ -762,7 +760,6 @@ const GoodsReceivedPage: React.FC = () => {
                                     border: 'none',
                                     background: 'none',
                                     padding: 0,
-                                    fontFamily: 'inherit',
                                     '&:hover': {
                                       color: 'primary.dark'
                                     }

--- a/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
@@ -551,8 +551,9 @@ const PurchaseOrderDetailsReport: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }

--- a/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
@@ -533,8 +533,9 @@ const PurchaseOrderStatusReport: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }

--- a/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
@@ -372,8 +372,9 @@ const PurchaseOrderSummary: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }

--- a/frontend/src/pages/purchasing/VendorPaymentDetailsReport.tsx
+++ b/frontend/src/pages/purchasing/VendorPaymentDetailsReport.tsx
@@ -333,8 +333,9 @@ const VendorPaymentDetailsReport: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }

--- a/frontend/src/pages/purchasing/VendorPaymentsPage.tsx
+++ b/frontend/src/pages/purchasing/VendorPaymentsPage.tsx
@@ -779,7 +779,6 @@ const VendorPaymentsPage: React.FC = () => {
                                     border: 'none',
                                     background: 'none',
                                     padding: 0,
-                                    fontFamily: 'inherit',
                                     '&:hover': {
                                       color: 'primary.dark'
                                     }
@@ -807,7 +806,6 @@ const VendorPaymentsPage: React.FC = () => {
                                     border: 'none',
                                     background: 'none',
                                     padding: 0,
-                                    fontFamily: 'inherit',
                                     '&:hover': {
                                       color: 'primary.dark'
                                     }
@@ -835,7 +833,6 @@ const VendorPaymentsPage: React.FC = () => {
                                     border: 'none',
                                     background: 'none',
                                     padding: 0,
-                                    fontFamily: 'inherit',
                                     '&:hover': {
                                       color: 'primary.dark'
                                     }

--- a/frontend/src/pages/purchasing/VendorProductListReport.tsx
+++ b/frontend/src/pages/purchasing/VendorProductListReport.tsx
@@ -489,8 +489,9 @@ const VendorProductListReport: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }

--- a/frontend/src/pages/purchasing/components/PurchaseOrderDetailsPanel.tsx
+++ b/frontend/src/pages/purchasing/components/PurchaseOrderDetailsPanel.tsx
@@ -124,7 +124,7 @@ const PurchaseOrderDetailsPanel: React.FC<PurchaseOrderDetailsPanelProps> = ({
                         ? selectedOrder.goodsReceivedNotes.map((grn: any, index: number) => (
                             <Box key={grn.id} component="span">
                               {index > 0 && ', '}
-                              <Typography component="button" onClick={() => onNavigateToGoodsReceived(grn.id)} sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize, color: 'primary.main', cursor: 'pointer', textDecoration: 'none', border: 'none', background: 'none', padding: 0, fontFamily: 'inherit' }}>
+                              <Typography component="button" onClick={() => onNavigateToGoodsReceived(grn.id)} sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize, color: 'primary.main', cursor: 'pointer', textDecoration: 'none', border: 'none', background: 'none', padding: 0 }}>
                                 {grn.grnNumber}
                               </Typography>
                             </Box>
@@ -139,7 +139,7 @@ const PurchaseOrderDetailsPanel: React.FC<PurchaseOrderDetailsPanelProps> = ({
                         ? selectedOrder.vendorPayments.map((payment: any, index: number) => (
                             <Box key={payment.id} component="span">
                               {index > 0 && ', '}
-                              <Typography component="button" onClick={() => onNavigateToVendorPayment(payment.id)} sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize, color: 'primary.main', cursor: 'pointer', textDecoration: 'none', border: 'none', background: 'none', padding: 0, fontFamily: 'inherit' }}>
+                              <Typography component="button" onClick={() => onNavigateToVendorPayment(payment.id)} sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize, color: 'primary.main', cursor: 'pointer', textDecoration: 'none', border: 'none', background: 'none', padding: 0 }}>
                                 {payment.paymentNumber}
                               </Typography>
                             </Box>
@@ -153,7 +153,7 @@ const PurchaseOrderDetailsPanel: React.FC<PurchaseOrderDetailsPanelProps> = ({
                       {journalEntryRefLoading ? (
                         <Typography sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize, color: 'text.secondary', fontStyle: 'italic' }}>Loading...</Typography>
                       ) : journalEntryRef ? (
-                        <Typography component="button" onClick={onNavigateToJournalEntry} sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize, color: 'primary.main', cursor: 'pointer', textDecoration: 'none', border: 'none', background: 'none', padding: 0, fontFamily: 'inherit' }}>
+                        <Typography component="button" onClick={onNavigateToJournalEntry} sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize, color: 'primary.main', cursor: 'pointer', textDecoration: 'none', border: 'none', background: 'none', padding: 0 }}>
                           {journalEntryRef.referenceNumber}
                         </Typography>
                       ) : (

--- a/frontend/src/pages/sales/CustomerOrderHistory.tsx
+++ b/frontend/src/pages/sales/CustomerOrderHistory.tsx
@@ -586,8 +586,9 @@ const CustomerOrderHistory: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }

--- a/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
@@ -369,8 +369,9 @@ const CustomerPaymentByOrder: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }

--- a/frontend/src/pages/sales/CustomerPaymentDetails.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentDetails.tsx
@@ -354,8 +354,9 @@ const CustomerPaymentDetails: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }

--- a/frontend/src/pages/sales/CustomerPaymentSummary.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentSummary.tsx
@@ -288,8 +288,9 @@ const CustomerPaymentSummary: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }

--- a/frontend/src/pages/sales/PaymentsPage.tsx
+++ b/frontend/src/pages/sales/PaymentsPage.tsx
@@ -803,7 +803,6 @@ const PaymentsPage: React.FC = () => {
                                     border: 'none',
                                     background: 'none',
                                     padding: 0,
-                                    fontFamily: 'inherit',
                                     '&:hover': {
                                       color: 'primary.dark'
                                     }
@@ -835,7 +834,6 @@ const PaymentsPage: React.FC = () => {
                                     border: 'none',
                                     background: 'none',
                                     padding: 0,
-                                    fontFamily: 'inherit',
                                     '&:hover': {
                                       color: 'primary.dark'
                                     }
@@ -877,7 +875,6 @@ const PaymentsPage: React.FC = () => {
                                     border: 'none',
                                     background: 'none',
                                     padding: 0,
-                                    fontFamily: 'inherit',
                                     '&:hover': { color: 'primary.dark' }
                                   }}
                                 >

--- a/frontend/src/pages/sales/ProductCustomerReport.tsx
+++ b/frontend/src/pages/sales/ProductCustomerReport.tsx
@@ -568,8 +568,9 @@ const ProductCustomerReport: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }

--- a/frontend/src/pages/sales/SalesByProductDetails.tsx
+++ b/frontend/src/pages/sales/SalesByProductDetails.tsx
@@ -420,8 +420,9 @@ const SalesByProductDetails: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }

--- a/frontend/src/pages/sales/SalesByProductSummary.tsx
+++ b/frontend/src/pages/sales/SalesByProductSummary.tsx
@@ -408,8 +408,9 @@ const SalesByProductSummary: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 12px; }

--- a/frontend/src/pages/sales/SalesOrderProfitReport.tsx
+++ b/frontend/src/pages/sales/SalesOrderProfitReport.tsx
@@ -397,8 +397,9 @@ const SalesOrderProfitReport: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }

--- a/frontend/src/pages/sales/SalesOrderSummary.tsx
+++ b/frontend/src/pages/sales/SalesOrderSummary.tsx
@@ -435,8 +435,9 @@ const SalesOrderSummary: React.FC = () => {
       <html>
         <head>
           <title>${reportTitle}</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
-            body { font-family: Arial, sans-serif; margin: 20px; }
+            body { font-family: 'Roboto', sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 10px; }
             .header-info { text-align: center; margin-bottom: 20px; font-size: 14px; }
             table { width: 100%; border-collapse: collapse; font-size: 11px; }

--- a/frontend/src/pages/sales/components/InvoiceDetailsPanel.tsx
+++ b/frontend/src/pages/sales/components/InvoiceDetailsPanel.tsx
@@ -157,7 +157,6 @@ const InvoiceDetailsPanel: React.FC<InvoiceDetailsPanelProps> = ({
                             border: 'none',
                             background: 'none',
                             padding: 0,
-                            fontFamily: 'inherit',
                             '&:hover': { color: 'primary.dark' },
                           }}
                         >
@@ -185,7 +184,6 @@ const InvoiceDetailsPanel: React.FC<InvoiceDetailsPanelProps> = ({
                                 border: 'none',
                                 background: 'none',
                                 padding: 0,
-                                fontFamily: 'inherit',
                                 '&:hover': { color: 'primary.dark' },
                               }}
                             >
@@ -226,7 +224,6 @@ const InvoiceDetailsPanel: React.FC<InvoiceDetailsPanelProps> = ({
                             border: 'none',
                             background: 'none',
                             padding: 0,
-                            fontFamily: 'inherit',
                             '&:hover': { color: 'primary.dark' },
                           }}
                         >

--- a/frontend/src/pages/sales/components/OrderDetailsPanel.tsx
+++ b/frontend/src/pages/sales/components/OrderDetailsPanel.tsx
@@ -165,7 +165,7 @@ const OrderDetailsPanel: React.FC<OrderDetailsPanelProps> = ({
                       {selectedOrder.invoices && selectedOrder.invoices.length > 0 ? (
                         selectedOrder.invoices.map((invoice: any, index: number) => (
                           <Box key={invoice.id} component="span">
-                            <Typography component="button" onClick={(event) => onNavigateToInvoice(invoice, event)} sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize, color: 'primary.main', cursor: 'pointer', textDecoration: 'none', border: 'none', background: 'none', padding: 0, fontFamily: 'inherit' }}>
+                            <Typography component="button" onClick={(event) => onNavigateToInvoice(invoice, event)} sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize, color: 'primary.main', cursor: 'pointer', textDecoration: 'none', border: 'none', background: 'none', padding: 0 }}>
                               {invoice.invoiceNumber}
                             </Typography>
                             {index < selectedOrder.invoices!.length - 1 && <Typography component="span" sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize }}>,</Typography>}
@@ -189,7 +189,7 @@ const OrderDetailsPanel: React.FC<OrderDetailsPanelProps> = ({
                         <Stack spacing={0.75}>
                           {allPayments.map((payment: any) => (
                             <Box key={payment.id} sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-                              <Typography component="button" onClick={(event) => onNavigateToPayment(payment.id, event)} sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize, color: 'primary.main', cursor: 'pointer', textDecoration: 'none', border: 'none', background: 'none', padding: 0, fontFamily: 'inherit' }}>
+                              <Typography component="button" onClick={(event) => onNavigateToPayment(payment.id, event)} sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize, color: 'primary.main', cursor: 'pointer', textDecoration: 'none', border: 'none', background: 'none', padding: 0 }}>
                                 {payment.paymentNumber}
                               </Typography>
                             </Box>
@@ -206,7 +206,7 @@ const OrderDetailsPanel: React.FC<OrderDetailsPanelProps> = ({
                       ) : journalEntryRefLoading ? (
                         <Typography sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize, color: 'text.secondary', fontStyle: 'italic' }}>Loading...</Typography>
                       ) : journalEntryRef ? (
-                        <Typography component="button" onClick={onNavigateToJournalEntry} sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize, color: 'primary.main', cursor: 'pointer', textDecoration: 'none', border: 'none', background: 'none', padding: 0, fontFamily: 'inherit' }}>
+                        <Typography component="button" onClick={onNavigateToJournalEntry} sx={{ fontSize: TYPOGRAPHY_STYLES.tableCell.primary.fontSize, color: 'primary.main', cursor: 'pointer', textDecoration: 'none', border: 'none', background: 'none', padding: 0 }}>
                           {journalEntryRef.referenceNumber}
                         </Typography>
                       ) : (

--- a/frontend/src/pages/settings/DocumentNumbersPage.tsx
+++ b/frontend/src/pages/settings/DocumentNumbersPage.tsx
@@ -187,10 +187,9 @@ const DocumentNumbersPage: React.FC = () => {
                           />
                         </TableCell>
                         <TableCell>
-                          <Typography
-                            variant="body2"
-                            sx={{
-                              fontFamily: 'monospace',
+                            <Typography
+                              variant="body2"
+                              sx={{
                               color: 'primary.main',
                               fontWeight: 600,
                               backgroundColor: 'action.hover',

--- a/frontend/src/pages/settings/RegionalSettingsPage.tsx
+++ b/frontend/src/pages/settings/RegionalSettingsPage.tsx
@@ -389,7 +389,7 @@ const RegionalSettingsPage: React.FC = () => {
             <Grid size={12}>
               <Typography variant="h6" sx={{ fontWeight: 600, mb: 1 }}>Preview</Typography>
               <Paper variant="outlined" sx={{ p: 2, bgcolor: 'action.hover' }}>
-                <Typography variant="body1" fontFamily="monospace">
+                <Typography variant="body1">
                   {preview}
                 </Typography>
               </Paper>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -12,7 +12,6 @@ html {
 body {
   margin: 0;
   padding: 0;
-  font-family: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
   line-height: 1.5;
   color: #ffffff;
   background-color: #121212;

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -86,15 +86,7 @@ const colors = {
 // Common theme options
 const baseThemeOptions: ThemeOptions = {
   typography: {
-    fontFamily: [
-      '"Roboto"',
-      '-apple-system',
-      'BlinkMacSystemFont',
-      '"Segoe UI"',
-      '"Helvetica Neue"',
-      'Arial',
-      'sans-serif',
-    ].join(','),
+    fontFamily: '"Roboto", sans-serif',
     h1: {
       fontSize: '2.5rem',
       fontWeight: 600,
@@ -253,6 +245,13 @@ const baseThemeOptions: ThemeOptions = {
         paper: {
           borderRight: 'none',
           boxShadow: '0px 0px 20px rgba(0, 0, 0, 0.08)',
+        },
+      },
+    },
+    MuiButtonBase: {
+      styleOverrides: {
+        root: {
+          fontFamily: 'inherit',
         },
       },
     },


### PR DESCRIPTION
## Summary

- Remove redundant `font-family` from `global.css` body — `CssBaseline` already applies the theme font
- Simplify theme font stack to `"Roboto", sans-serif` and add `MuiButtonBase` override to fix browser button font defaults globally
- Remove 13× hardcoded `fontFamily: 'monospace'` from components (backup, calculator, auth, settings, TopBar)
- Remove 18× hardcoded `fontFamily: 'inherit'` from components (purchasing and sales detail panels/pages) — now redundant thanks to the `MuiButtonBase` override
- Update 19 print report windows to load Roboto via CDN and use it instead of Arial

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] Vitest targeted run: `npx vitest run src/components/backup/ src/components/calculator/ src/components/auth/ src/components/common/` — 11 files, 114 tests pass
- [x] No remaining `fontFamily.*monospace`, `fontFamily.*inherit`, or `font-family: Arial` in `src/`
- [x] Visual check: backup dialogs, calculator, idle timer, detail panel buttons all render in Roboto
- [x] Print a report and confirm Roboto loads correctly

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)