### PR TITLE
refactor: use FilterSelect in DashboardFilterBar for UI consistency (#244)

### DIFF
--- a/frontend/src/components/filters/DashboardFilterBar.tsx
+++ b/frontend/src/components/filters/DashboardFilterBar.tsx
@@ -146,58 +146,49 @@ export function DashboardFilterBar({
       )}
 
       {stockStatus !== undefined && onStockStatusChange && (
-        <FormControl size="small" sx={{ minWidth: 150 }}>
-          <InputLabel id="dashboard-stock-status-label">Stock Status</InputLabel>
-          <Select
-            labelId="dashboard-stock-status-label"
-            id="dashboard-stock-status"
-            value={stockStatus ?? ''}
-            label="Stock Status"
-            onChange={(e) => onStockStatusChange(e.target.value || null)}
-          >
-            <MenuItem value="">All</MenuItem>
-            <MenuItem value="in_stock">In Stock</MenuItem>
-            <MenuItem value="low_stock">Low Stock</MenuItem>
-            <MenuItem value="out_of_stock">Out of Stock</MenuItem>
-          </Select>
-        </FormControl>
+        <FilterSelect
+          field="stockStatus"
+          label="Stock Status"
+          type="select"
+          value={stockStatus ?? null}
+          options={[
+            { value: 'in_stock', label: 'In Stock' },
+            { value: 'low_stock', label: 'Low Stock' },
+            { value: 'out_of_stock', label: 'Out of Stock' },
+          ]}
+          onChange={(v) => onStockStatusChange(v as string | null)}
+          minWidth={150}
+        />
       )}
 
       {isFulfilled !== undefined && onFulfilledChange && (
-        <FormControl size="small" sx={{ minWidth: 150 }}>
-          <InputLabel id="dashboard-order-status-label">Order Status</InputLabel>
-          <Select
-            labelId="dashboard-order-status-label"
-            id="dashboard-order-status"
-            value={isFulfilled === null ? '' : String(isFulfilled)}
-            label="Order Status"
-            onChange={(e) => {
-              const value = e.target.value
-              onFulfilledChange(value === '' ? null : value === 'true')
-            }}
-          >
-            <MenuItem value="">All</MenuItem>
-            <MenuItem value="true">Fulfilled</MenuItem>
-            <MenuItem value="false">Pending</MenuItem>
-          </Select>
-        </FormControl>
+        <FilterSelect
+          field="isFulfilled"
+          label="Order Status"
+          type="select"
+          value={isFulfilled === null ? null : String(isFulfilled)}
+          options={[
+            { value: 'true', label: 'Fulfilled' },
+            { value: 'false', label: 'Pending' },
+          ]}
+          onChange={(v) => onFulfilledChange(v === null ? null : v === 'true')}
+          minWidth={150}
+        />
       )}
 
       {status !== undefined && onStatusChange && (
-        <FormControl size="small" sx={{ minWidth: 150 }}>
-          <InputLabel id="dashboard-purchasing-order-status-label">Order Status</InputLabel>
-          <Select
-            labelId="dashboard-purchasing-order-status-label"
-            id="dashboard-order-status-purchasing"
-            value={status ?? ''}
-            label="Order Status"
-            onChange={(e) => onStatusChange(e.target.value || null)}
-          >
-            <MenuItem value="">All</MenuItem>
-            <MenuItem value="received">Received</MenuItem>
-            <MenuItem value="pending">Pending</MenuItem>
-          </Select>
-        </FormControl>
+        <FilterSelect
+          field="status"
+          label="Order Status"
+          type="select"
+          value={status ?? null}
+          options={[
+            { value: 'received', label: 'Received' },
+            { value: 'pending', label: 'Pending' },
+          ]}
+          onChange={(v) => onStatusChange(v as string | null)}
+          minWidth={150}
+        />
       )}
 
       {paymentStatus !== undefined && onPaymentStatusChange && (

--- a/frontend/src/components/filters/DashboardFilterBar.tsx
+++ b/frontend/src/components/filters/DashboardFilterBar.tsx
@@ -3,6 +3,7 @@ import { Box, Button, CircularProgress, FormControl, InputLabel, MenuItem, Selec
 import type { DashboardCompare, DashboardPeriod } from '@/hooks/useDashboardFilters'
 
 import { FilterPeriod } from './FilterPeriod'
+import { FilterSelect } from './FilterSelect'
 
 interface DashboardFilterBarProps {
   period: DashboardPeriod
@@ -106,57 +107,42 @@ export function DashboardFilterBar({
       </Tooltip>
 
       {customers !== undefined && onCustomerChange && (
-        <FormControl size="small" sx={{ minWidth: 170 }}>
-          <InputLabel id="dashboard-customer-label">Customer</InputLabel>
-          <Select
-            labelId="dashboard-customer-label"
-            id="dashboard-customer"
-            value={customerId ?? ''}
-            label="Customer"
-            onChange={(e) => onCustomerChange(e.target.value || null)}
-          >
-            <MenuItem value="">All Customers</MenuItem>
-            {customers.map((customer) => (
-              <MenuItem key={customer.id} value={customer.id}>{customer.name}</MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+        <FilterSelect
+          field="customer"
+          label="Customer"
+          type="select"
+          value={customerId ?? null}
+          options={customers.map((c) => ({ value: c.id, label: c.name }))}
+          onChange={(v) => onCustomerChange(v as string | null)}
+          emptyLabel="All Customers"
+          minWidth={170}
+        />
       )}
 
       {suppliers !== undefined && onSupplierChange && (
-        <FormControl size="small" sx={{ minWidth: 170 }}>
-          <InputLabel id="dashboard-supplier-label">Supplier</InputLabel>
-          <Select
-            labelId="dashboard-supplier-label"
-            id="dashboard-supplier"
-            value={supplierId ?? ''}
-            label="Supplier"
-            onChange={(e) => onSupplierChange(e.target.value || null)}
-          >
-            <MenuItem value="">All Suppliers</MenuItem>
-            {suppliers.map((supplier) => (
-              <MenuItem key={supplier.id} value={supplier.id}>{supplier.name}</MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+        <FilterSelect
+          field="supplier"
+          label="Supplier"
+          type="select"
+          value={supplierId ?? null}
+          options={suppliers.map((s) => ({ value: s.id, label: s.name }))}
+          onChange={(v) => onSupplierChange(v as string | null)}
+          emptyLabel="All Suppliers"
+          minWidth={170}
+        />
       )}
 
       {categories !== undefined && onCategoryChange && (
-        <FormControl size="small" sx={{ minWidth: 170 }}>
-          <InputLabel id="dashboard-category-label">Category</InputLabel>
-          <Select
-            labelId="dashboard-category-label"
-            id="dashboard-category"
-            value={categoryId ?? ''}
-            label="Category"
-            onChange={(e) => onCategoryChange(e.target.value || null)}
-          >
-            <MenuItem value="">All Categories</MenuItem>
-            {categories.map((category) => (
-              <MenuItem key={category.id} value={category.id}>{category.name}</MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+        <FilterSelect
+          field="category"
+          label="Category"
+          type="select"
+          value={categoryId ?? null}
+          options={categories.map((c) => ({ value: c.id, label: c.name }))}
+          onChange={(v) => onCategoryChange(v as string | null)}
+          emptyLabel="All Categories"
+          minWidth={170}
+        />
       )}
 
       {stockStatus !== undefined && onStockStatusChange && (

--- a/frontend/src/components/filters/DashboardFilterBar.tsx
+++ b/frontend/src/components/filters/DashboardFilterBar.tsx
@@ -192,21 +192,15 @@ export function DashboardFilterBar({
       )}
 
       {paymentStatus !== undefined && onPaymentStatusChange && (
-        <FormControl size="small" sx={{ minWidth: 170 }}>
-          <InputLabel id="dashboard-payment-status-label">Payment Status</InputLabel>
-          <Select
-            labelId="dashboard-payment-status-label"
-            id="dashboard-payment-status"
-            value={paymentStatus ?? ''}
-            label="Payment Status"
-            onChange={(e) => onPaymentStatusChange(e.target.value || null)}
-          >
-            <MenuItem value="">All</MenuItem>
-            {resolvedPaymentStatusOptions.map((option) => (
-              <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+        <FilterSelect
+          field="paymentStatus"
+          label="Payment Status"
+          type="select"
+          value={paymentStatus ?? null}
+          options={resolvedPaymentStatusOptions}
+          onChange={(v) => onPaymentStatusChange(v as string | null)}
+          minWidth={170}
+        />
       )}
 
       {!isDefault && (

--- a/frontend/src/components/filters/FilterSelect.tsx
+++ b/frontend/src/components/filters/FilterSelect.tsx
@@ -17,15 +17,17 @@ interface Props {
   value: string | null | string[]
   options: FilterOption[]
   onChange: (value: string | null | string[]) => void
+  emptyLabel?: string
+  minWidth?: number
 }
 
-export function FilterSelect({ field, label, type, value, options, onChange }: Props) {
+export function FilterSelect({ field, label, type, value, options, onChange, emptyLabel, minWidth }: Props) {
   const labelId = `filter-${field}-label`
 
   if (type === 'multi-select') {
     const selected = (value as string[]) ?? []
     return (
-      <FormControl size="small" sx={{ minWidth: 140 }}>
+      <FormControl size="small" sx={{ minWidth: minWidth ?? 140 }}>
         <InputLabel id={labelId}>{label}</InputLabel>
         <Select
           labelId={labelId}
@@ -47,7 +49,7 @@ export function FilterSelect({ field, label, type, value, options, onChange }: P
   }
 
   return (
-    <FormControl size="small" sx={{ minWidth: 140 }}>
+    <FormControl size="small" sx={{ minWidth: minWidth ?? 140 }}>
       <InputLabel id={labelId}>{label}</InputLabel>
       <Select
         labelId={labelId}
@@ -55,9 +57,7 @@ export function FilterSelect({ field, label, type, value, options, onChange }: P
         label={label}
         onChange={(event) => onChange(event.target.value === '' ? null : event.target.value)}
       >
-        <MenuItem value="">
-          <em>All</em>
-        </MenuItem>
+        <MenuItem value="">{emptyLabel ?? 'All'}</MenuItem>
         {options.map((option) => (
           <MenuItem key={option.value} value={option.value}>
             {option.label}

--- a/frontend/src/components/filters/FilterSelect.tsx
+++ b/frontend/src/components/filters/FilterSelect.tsx
@@ -17,6 +17,7 @@ interface Props {
   value: string | null | string[]
   options: FilterOption[]
   onChange: (value: string | null | string[]) => void
+  /** Only applies to type="select" — has no effect on multi-select */
   emptyLabel?: string
   minWidth?: number
 }

--- a/frontend/src/components/filters/__tests__/FilterSelect.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterSelect.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { FilterSelect } from '../FilterSelect'
+
+describe('FilterSelect', () => {
+  it('renders a custom empty label for single-select filters', async () => {
+    render(
+      <FilterSelect
+        field="customer"
+        label="Customer"
+        type="select"
+        value={null}
+        options={[{ value: 'c1', label: 'Acme Corp' }]}
+        onChange={vi.fn()}
+        emptyLabel="All Customers"
+      />,
+    )
+
+    await userEvent.click(screen.getByLabelText('Customer'))
+
+    expect(screen.getByText('All Customers')).toBeInTheDocument()
+  })
+
+  it('applies a custom minWidth to single-select filters', () => {
+    const { container } = render(
+      <FilterSelect
+        field="customer"
+        label="Customer"
+        type="select"
+        value={null}
+        options={[{ value: 'c1', label: 'Acme Corp' }]}
+        onChange={vi.fn()}
+        minWidth={170}
+      />,
+    )
+
+    expect(container.querySelector('.MuiFormControl-root')).toHaveStyle({ minWidth: '170px' })
+  })
+})

--- a/frontend/src/components/filters/__tests__/FilterSelect.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterSelect.test.tsx
@@ -40,4 +40,67 @@ describe('FilterSelect', () => {
 
     expect(container.querySelector('.MuiFormControl-root')).toHaveStyle({ minWidth: '170px' })
   })
+
+  it('defaults empty label to All when emptyLabel is omitted', async () => {
+    render(
+      <FilterSelect
+        field="status"
+        label="Status"
+        type="select"
+        value={null}
+        options={[{ value: 'active', label: 'Active' }]}
+        onChange={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(screen.getByLabelText('Status'))
+
+    expect(screen.getByText('All')).toBeInTheDocument()
+  })
+
+  it('defaults minWidth to 140 when minWidth is omitted on single-select', () => {
+    const { container } = render(
+      <FilterSelect
+        field="status"
+        label="Status"
+        type="select"
+        value={null}
+        options={[{ value: 'active', label: 'Active' }]}
+        onChange={vi.fn()}
+      />,
+    )
+
+    expect(container.querySelector('.MuiFormControl-root')).toHaveStyle({ minWidth: '140px' })
+  })
+
+  it('defaults minWidth to 140 when minWidth is omitted on multi-select', () => {
+    const { container } = render(
+      <FilterSelect
+        field="tags"
+        label="Tags"
+        type="multi-select"
+        value={[]}
+        options={[{ value: 'a', label: 'A' }]}
+        onChange={vi.fn()}
+      />,
+    )
+
+    expect(container.querySelector('.MuiFormControl-root')).toHaveStyle({ minWidth: '140px' })
+  })
+
+  it('applies a custom minWidth to multi-select filters', () => {
+    const { container } = render(
+      <FilterSelect
+        field="tags"
+        label="Tags"
+        type="multi-select"
+        value={[]}
+        options={[{ value: 'a', label: 'A' }]}
+        onChange={vi.fn()}
+        minWidth={200}
+      />,
+    )
+
+    expect(container.querySelector('.MuiFormControl-root')).toHaveStyle({ minWidth: '200px' })
+  })
 })


### PR DESCRIPTION
## Summary

- Adds `emptyLabel` (default `"All"`) and `minWidth` (default `140`) optional props to `FilterSelect`
- Replaces 7 manually-implemented MUI dropdown blocks in `DashboardFilterBar` with `<FilterSelect />`, removing repetitive `FormControl`/`InputLabel`/`Select`/`MenuItem` boilerplate
- Boolean↔string conversion for `isFulfilled` handled at the boundary in `DashboardFilterBar`
- Compare filter (tooltip + disabled state) intentionally left as raw MUI
- Adds focused `FilterSelect.test.tsx` covering custom and default prop paths for both `select` and `multi-select` types

## Test plan

- [x] `npx vitest run src/components/filters/__tests__/FilterSelect.test.tsx` — 6 tests pass
- [x] `npx vitest run src/components/filters/__tests__/DashboardFilterBar.test.tsx` — 25 tests pass
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors
- [x] Visually verify all dashboard filter dropdowns render and function correctly
- [x] Verify Reset button clears all filters
- [x] Verify Compare filter tooltip still appears when period is "Today"

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)