### PR TITLE
chore: upgrade TypeScript to 6.0.2 (closes #235)

### DIFF
--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -4,8 +4,7 @@
   "sourceRoot": "src",
   "compilerOptions": {
     "deleteOutDir": true,
-    "webpack": true,
-    "tsConfigPath": "tsconfig.json",
+    "tsConfigPath": "tsconfig.build.json",
     "typeCheck": false
   }
 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erp-backend",
-  "version": "1.40.0",
+  "version": "1.40.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-backend",
-      "version": "1.40.0",
+      "version": "1.40.1",
       "license": "MIT",
       "dependencies": {
         "@nestjs/bull": "^11.0.3",
@@ -65,11 +65,11 @@
         "jest-progress-bar-reporter": "^1.0.25",
         "prettier": "^3.0.0",
         "supertest": "^7.2.2",
-        "ts-jest": "^29.1.0",
+        "ts-jest": "^29.4.9",
         "ts-loader": "^9.5.4",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "5.9.3"
+        "typescript": "6.0.2"
       }
     },
     "node_modules/@angular-devkit/core": {
@@ -2010,6 +2010,20 @@
         "@swc/core": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/cli/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@nestjs/common": {
@@ -11474,9 +11488,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -82,11 +82,11 @@
     "jest-progress-bar-reporter": "^1.0.25",
     "prettier": "^3.0.0",
     "supertest": "^7.2.2",
-    "ts-jest": "^29.1.0",
+    "ts-jest": "^29.4.9",
     "ts-loader": "^9.5.4",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.2"
   },
   "overrides": {
     "glob": "11.1.0",

--- a/backend/src/common/security/middleware/security-application.service.ts
+++ b/backend/src/common/security/middleware/security-application.service.ts
@@ -1,7 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import helmet from 'helmet';
-import * as compression from 'compression';
+import compression from 'compression';
 import { SecurityConfig, SecurityConfigBuilder } from '../config/security.config';
 
 /**

--- a/backend/src/database/entities/account-mapping.entity.ts
+++ b/backend/src/database/entities/account-mapping.entity.ts
@@ -71,7 +71,7 @@ export class AccountMapping extends BaseEntity {
     comment: 'Whether the mapping is active',
   })
   @IsBoolean()
-  isActive: boolean;
+  declare isActive: boolean;
 
   // Relationships
   @ManyToOne(() => ChartOfAccount, (account) => account.accountMappings, {

--- a/backend/src/database/entities/backup-settings.entity.ts
+++ b/backend/src/database/entities/backup-settings.entity.ts
@@ -24,5 +24,5 @@ export class BackupRetentionSettings extends BaseEntity {
   maximumTotalSize: number | null;
 
   @Column({ type: 'boolean', default: true, comment: 'Only one active settings record should exist' })
-  isActive: boolean;
+  declare isActive: boolean;
 }

--- a/backend/src/database/entities/chart-of-account.entity.ts
+++ b/backend/src/database/entities/chart-of-account.entity.ts
@@ -77,7 +77,7 @@ export class ChartOfAccount extends BaseEntity {
     comment: 'Whether the account is active',
   })
   @IsBoolean()
-  isActive: boolean;
+  declare isActive: boolean;
 
   @Column({
     type: 'boolean',

--- a/backend/src/database/entities/customer.entity.ts
+++ b/backend/src/database/entities/customer.entity.ts
@@ -137,7 +137,7 @@ export class Customer extends BaseEntity {
     comment: 'Whether the customer is active',
   })
   @IsBoolean()
-  isActive: boolean;
+  declare isActive: boolean;
 
   // Normalized price list relationship
   @Column({

--- a/backend/src/database/entities/price-list-item.entity.ts
+++ b/backend/src/database/entities/price-list-item.entity.ts
@@ -56,7 +56,7 @@ export class PriceListItem extends BaseEntity {
   @Column({ type: 'boolean', default: true })
   @IsBoolean()
   @IsOptional()
-  isActive: boolean;
+  declare isActive: boolean;
 
   @Column({ type: 'timestamp', nullable: true })
   @IsDate()

--- a/backend/src/database/entities/price-list.entity.ts
+++ b/backend/src/database/entities/price-list.entity.ts
@@ -45,7 +45,7 @@ export class PriceList extends BaseEntity {
   @Column({ type: 'boolean', default: true })
   @IsBoolean()
   @IsOptional()
-  isActive: boolean;
+  declare isActive: boolean;
 
   @Column({ type: 'timestamp', nullable: true })
   @IsDate()

--- a/backend/src/database/entities/product.entity.ts
+++ b/backend/src/database/entities/product.entity.ts
@@ -82,7 +82,7 @@ export class Product extends BaseEntity {
     comment: 'Whether the product is active for sales',
   })
   @IsBoolean()
-  isActive: boolean;
+  declare isActive: boolean;
 
 
   // Pricing - Multi-level pricing support

--- a/backend/src/database/entities/user.entity.ts
+++ b/backend/src/database/entities/user.entity.ts
@@ -127,7 +127,7 @@ export class User extends BaseEntity {
     comment: 'Whether the user account is active',
   })
   @IsBoolean()
-  isActive: boolean;
+  declare isActive: boolean;
 
   @Column({
     type: 'timestamptz',

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
-import * as request from 'supertest';
+import request from 'supertest';
 import { AppModule } from '../src/app.module';
 import { DataSource } from 'typeorm';
 import { User, UserRole, UserStatus } from '../src/database/entities/user.entity';

--- a/backend/test/e2e/account-mappings.e2e-spec.ts
+++ b/backend/test/e2e/account-mappings.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { ConflictException, INestApplication, NotFoundException, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { AccountMappingController } from '../../src/modules/accounting/controllers/account-mapping.controller';
 import { AccountMappingService } from '../../src/modules/accounting/services/account-mapping.service';
 import { MappingType } from '../../src/database/entities/account-mapping.entity';

--- a/backend/test/e2e/price-lists.e2e-spec.ts
+++ b/backend/test/e2e/price-lists.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
-import * as request from 'supertest';
+import request from 'supertest';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { PriceListsModule } from '../../src/modules/price-lists/price-lists.module';
 import { PriceList } from '../../src/database/entities/price-list.entity';

--- a/backend/test/search.e2e-spec.ts
+++ b/backend/test/search.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
-import * as request from 'supertest';
+import request from 'supertest';
 import { DataSource, Repository } from 'typeorm';
 import * as bcrypt from 'bcrypt';
 import { AppModule } from '../src/app.module';

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": [
+    "src/modules/reports/**/*"
+  ]
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -6,10 +6,9 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
-    "target": "ES2018",
+    "target": "ES2025",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": false,
@@ -19,12 +18,13 @@
     "noFallthroughCasesInSwitch": false,
     "strict": false,
     "strictPropertyInitialization": false,
+    "types": ["node", "jest", "multer", "archiver", "bcrypt", "compression", "express", "supertest"],
     "paths": {
-      "@/*": ["src/*"],
-      "@modules/*": ["src/modules/*"],
-      "@common/*": ["src/common/*"],
-      "@config/*": ["src/config/*"],
-      "@database/*": ["src/database/*"]
+      "@/*": ["./src/*"],
+      "@modules/*": ["./src/modules/*"],
+      "@common/*": ["./src/common/*"],
+      "@config/*": ["./src/config/*"],
+      "@database/*": ["./src/database/*"]
     }
   },
   "exclude": [

--- a/docs/superpowers/plans/2026-04-02-typescript6-upgrade.md
+++ b/docs/superpowers/plans/2026-04-02-typescript6-upgrade.md
@@ -4,7 +4,7 @@
 
 **Goal:** Upgrade TypeScript from 5.9.3 to 6.0.2 in both backend and frontend, resolving the blocker from issue #235.
 
-**Architecture:** Config + package version changes, plus two TS6 compatibility fixes discovered during execution: (1) split backend tsconfig so `rootDir` is enforced for builds but not for ts-jest test compilation, and (2) update supertest namespace imports that TS6 no longer treats as callable. Backend and frontend are upgraded together in a single atomic PR.
+**Architecture:** Config + package version changes, plus four TS6 compatibility fixes discovered during execution: (1) remove webpack from nest build to avoid ForkTsChecker/rootDir complications, (2) fix compression namespace import, (3) fix supertest namespace imports in e2e tests, (4) add `declare` to isActive overrides in 8 entity classes. Backend and frontend in a single atomic PR.
 
 **Tech Stack:** TypeScript 6.0.2, ts-jest 29.4.9, NestJS 11 (backend), React 19 + Vite 8 + Vitest 4 (frontend)
 
@@ -19,21 +19,34 @@
 | `backend/package.json` | `typescript` 5.9.3→6.0.2, `ts-jest` ^29.1.0→^29.4.9 |
 | `backend/tsconfig.json` | target ES2025, remove baseUrl+rootDir, add types, relative paths |
 | `backend/tsconfig.build.json` | new file — extends tsconfig.json, adds rootDir+include for nest build |
-| `backend/nest-cli.json` | point tsConfigPath to tsconfig.build.json |
+| `backend/nest-cli.json` | remove webpack:true, set tsConfigPath to tsconfig.build.json |
+| `backend/src/common/security/middleware/security-application.service.ts` | fix compression namespace import |
 | `backend/test/auth.e2e-spec.ts` | fix supertest namespace import |
 | `backend/test/search.e2e-spec.ts` | fix supertest namespace import |
 | `backend/test/e2e/price-lists.e2e-spec.ts` | fix supertest namespace import |
 | `backend/test/e2e/account-mappings.e2e-spec.ts` | fix supertest namespace import |
+| `backend/src/database/entities/price-list-item.entity.ts` | declare isActive override |
+| `backend/src/database/entities/backup-settings.entity.ts` | declare isActive override |
+| `backend/src/database/entities/chart-of-account.entity.ts` | declare isActive override |
+| `backend/src/database/entities/account-mapping.entity.ts` | declare isActive override |
+| `backend/src/database/entities/customer.entity.ts` | declare isActive override |
+| `backend/src/database/entities/user.entity.ts` | declare isActive override |
+| `backend/src/database/entities/product.entity.ts` | declare isActive override |
+| `backend/src/database/entities/price-list.entity.ts` | declare isActive override |
 | `frontend/package.json` | `typescript` 5.9.3→6.0.2 |
 | `frontend/tsconfig.json` | target ES2025, lib ES2025, remove baseUrl, add rootDir+types, relative paths |
 
 ---
 
-## Background: Two TS6 compatibility issues
+## Background: TS6 compatibility issues
 
-**Issue 1 — TS5011 (`rootDir` + test files):** TypeScript's `rootDir` does not control which files are included — it only constrains where included files may live. The backend `jest` config has `roots: ["src", "test"]`, so ts-jest compiles both directories. Setting `rootDir: "./src"` in `tsconfig.json` then causes TS5011 because `test/*.ts` files are outside `./src`. Fix: move `rootDir` (and `include: ["src"]`) into a dedicated `tsconfig.build.json` used only by nest build. `tsconfig.json` itself has no `rootDir`, so ts-jest can compile both `src/` and `test/` freely.
+**TS5011 (`rootDir` + test files):** TypeScript's `rootDir` does not control which files are included — it only constrains where included files may live. The backend jest config has `roots: ["src", "test"]`, so ts-jest compiles both directories. Setting `rootDir: "./src"` in `tsconfig.json` causes TS5011 because `test/*.ts` files are outside `./src`. Fix: move `rootDir` into `tsconfig.build.json` used only by `nest build`. `tsconfig.json` has no `rootDir`, so ts-jest compiles both `src/` and `test/` freely.
 
-**Issue 2 — TS2349 (supertest import not callable):** TS6 tightened `import * as X` to always produce a plain module namespace object, which is not callable. `supertest` exports a callable function, so `import * as request from 'supertest'` then used as `request(app)` fails. Fix: change to `import request from 'supertest'` — valid because `allowSyntheticDefaultImports: true` is already in tsconfig and `@types/supertest` uses `export =` which maps to a default import under that flag.
+**webpack removed from nest build:** `nest-cli.json` had `"webpack": true` which runs NestJS builds through webpack + ForkTsCheckerWebpackPlugin. `"webpack": true` takes precedence over `--builder tsc` on the CLI, making it impossible to bypass. Removing it switches `nest build` to plain tsc, which reads `tsconfig.build.json` directly — simpler, no ForkTsChecker layer, no bundling overhead that isn't needed server-side.
+
+**Namespace imports not callable (TS2349):** TS6 tightened `import * as X` to always produce a plain module namespace object. Both `compression` and `supertest` use `export =` and are called as functions. Fix: change to default imports (`import X from 'module'`) — valid because `allowSyntheticDefaultImports: true` is set and both packages use `export =` which maps to a default under that flag.
+
+**TS2612 — isActive property override:** TS6 tightened property override checking. Eight entity classes extend `BaseEntity` (which declares `isActive: boolean` with `@Column`) and redeclare `isActive: boolean` with their own `@Column` decorator. TS6 requires `declare` on child-class property overrides that don't change the type. Fix: prefix each redeclaration with `declare`. The `@Column` decorator is unaffected by `declare`.
 
 ---
 
@@ -71,7 +84,7 @@ Expected: both install cleanly at TypeScript 6.0.2.
 
 ---
 
-## Task 2: Fix backend tsconfig — split build config, update tsconfig.json
+## Task 2: Update backend tsconfig files and nest-cli.json
 
 **Files:**
 - Modify: `backend/tsconfig.json`
@@ -80,7 +93,7 @@ Expected: both install cleanly at TypeScript 6.0.2.
 
 - [ ] **Step 1: Replace backend/tsconfig.json**
 
-`rootDir` is intentionally omitted here — it lives in `tsconfig.build.json` instead.
+`rootDir` is intentionally omitted — it lives in `tsconfig.build.json` only.
 
 ```json
 {
@@ -118,16 +131,16 @@ Expected: both install cleanly at TypeScript 6.0.2.
 }
 ```
 
-Changes from pre-upgrade tsconfig.json:
+Changes from pre-upgrade:
 - `target`: `ES2018` → `ES2025`
 - Removed `baseUrl: "./"`
 - Removed `rootDir` (moved to tsconfig.build.json)
-- Added `types: [...]` (explicit, prevents type bleed)
+- Added `types: [...]`
 - `paths` values prefixed with `./` (e.g. `["./src/*"]`)
 
 - [ ] **Step 2: Create backend/tsconfig.build.json**
 
-This file is used exclusively by `nest build`. It extends `tsconfig.json` and adds `rootDir` + `include` so only `src/` is compiled during the production build.
+Used exclusively by `nest build`. Extends `tsconfig.json` and adds `rootDir` + `include: ["src"]` so only `src/` is compiled.
 
 ```json
 {
@@ -142,9 +155,9 @@ This file is used exclusively by `nest build`. It extends `tsconfig.json` and ad
 }
 ```
 
-- [ ] **Step 3: Update nest-cli.json to use tsconfig.build.json**
+- [ ] **Step 3: Update backend/nest-cli.json**
 
-Replace `backend/nest-cli.json` with:
+Remove `"webpack": true`. This switches `nest build` from webpack (with ForkTsCheckerWebpackPlugin) to plain tsc, which reads `tsconfig.build.json` directly. NestJS CLI auto-detects `tsconfig.build.json` when present, so `tsConfigPath` is optional but kept for explicitness.
 
 ```json
 {
@@ -153,14 +166,13 @@ Replace `backend/nest-cli.json` with:
   "sourceRoot": "src",
   "compilerOptions": {
     "deleteOutDir": true,
-    "webpack": true,
     "tsConfigPath": "tsconfig.build.json",
     "typeCheck": false
   }
 }
 ```
 
-(Changed `"tsConfigPath": "tsconfig.json"` → `"tsConfigPath": "tsconfig.build.json"`)
+(Removed `"webpack": true` from compilerOptions.)
 
 - [ ] **Step 4: Verify backend builds**
 
@@ -169,7 +181,9 @@ cd /path/to/erp2/backend
 npm run build
 ```
 
-Expected: exits 0, `dist/` populated, no TypeScript errors.
+Expected: exits 0, `dist/` populated. Uses plain tsc with `tsconfig.build.json`. No TS5011 (rootDir+include both scoped to src/).
+
+If build fails with TS errors, they are source-level incompatibilities — do not proceed, fix them first in Tasks 3 and 4.
 
 - [ ] **Step 5: Verify backend lint**
 
@@ -182,9 +196,38 @@ Expected: exits 0, no errors.
 
 ---
 
-## Task 3: Fix supertest imports in backend test files
+## Task 3: Fix compression import (TS2349)
 
-TS6 no longer allows `import * as X` from a module to be called as a function. All four files use `import * as request from 'supertest'` and then call `request(app)`. Fix each to use a default import.
+**File:**
+- Modify: `backend/src/common/security/middleware/security-application.service.ts`
+
+- [ ] **Step 1: Change the compression import on line 4**
+
+Change:
+```typescript
+import * as compression from 'compression';
+```
+To:
+```typescript
+import compression from 'compression';
+```
+
+The rest of the file is unchanged — `compression({...})` and `compression.filter(...)` both continue to work because the default export IS the callable function, and `filter` is a property on it.
+
+- [ ] **Step 2: Verify build still passes**
+
+```bash
+cd /path/to/erp2/backend
+npm run build
+```
+
+Expected: exits 0.
+
+---
+
+## Task 4: Fix supertest imports in e2e test files (TS2349)
+
+TS6 no longer allows `import * as X` from a module to be called as a function. All four e2e test files use `import * as request from 'supertest'` and then call `request(app)`.
 
 **Files:**
 - Modify: `backend/test/auth.e2e-spec.ts`
@@ -192,64 +235,102 @@ TS6 no longer allows `import * as X` from a module to be called as a function. A
 - Modify: `backend/test/e2e/price-lists.e2e-spec.ts`
 - Modify: `backend/test/e2e/account-mappings.e2e-spec.ts`
 
-- [ ] **Step 1: Fix auth.e2e-spec.ts**
+- [ ] **Step 1: Fix auth.e2e-spec.ts line 3**
 
-In `backend/test/auth.e2e-spec.ts`, change line 3 from:
+Change:
 ```typescript
 import * as request from 'supertest';
 ```
-to:
+To:
 ```typescript
 import request from 'supertest';
 ```
 
-- [ ] **Step 2: Fix search.e2e-spec.ts**
+- [ ] **Step 2: Fix search.e2e-spec.ts line 3**
 
-In `backend/test/search.e2e-spec.ts`, change line 3 from:
+Change:
 ```typescript
 import * as request from 'supertest';
 ```
-to:
+To:
 ```typescript
 import request from 'supertest';
 ```
 
-- [ ] **Step 3: Fix price-lists.e2e-spec.ts**
+- [ ] **Step 3: Fix price-lists.e2e-spec.ts line 3**
 
-In `backend/test/e2e/price-lists.e2e-spec.ts`, change line 3 from:
+Change:
 ```typescript
 import * as request from 'supertest';
 ```
-to:
+To:
 ```typescript
 import request from 'supertest';
 ```
 
-- [ ] **Step 4: Fix account-mappings.e2e-spec.ts**
+- [ ] **Step 4: Fix account-mappings.e2e-spec.ts line 3**
 
-In `backend/test/e2e/account-mappings.e2e-spec.ts`, change line 3 from:
+Change:
 ```typescript
 import * as request from 'supertest';
 ```
-to:
+To:
 ```typescript
 import request from 'supertest';
 ```
 
-- [ ] **Step 5: Verify backend tests pass**
+---
+
+## Task 5: Fix isActive property overrides in entity classes (TS2612)
+
+TS6 requires `declare` on child-class property declarations that override a property from a base class without changing the type. `BaseEntity` declares `isActive: boolean`. Eight child entities redeclare it with a different `@Column` configuration. Add `declare` to each.
+
+The `@Column` decorator is placed on the line(s) above the property declaration and is not affected by `declare`.
+
+**Files:**
+- Modify: `backend/src/database/entities/price-list-item.entity.ts`
+- Modify: `backend/src/database/entities/backup-settings.entity.ts`
+- Modify: `backend/src/database/entities/chart-of-account.entity.ts`
+- Modify: `backend/src/database/entities/account-mapping.entity.ts`
+- Modify: `backend/src/database/entities/customer.entity.ts`
+- Modify: `backend/src/database/entities/user.entity.ts`
+- Modify: `backend/src/database/entities/product.entity.ts`
+- Modify: `backend/src/database/entities/price-list.entity.ts`
+
+- [ ] **Step 1: Fix each entity — change `isActive: boolean` to `declare isActive: boolean`**
+
+In each of the 8 files listed above, find the line:
+```typescript
+  isActive: boolean;
+```
+And change it to:
+```typescript
+  declare isActive: boolean;
+```
+
+The line has decorators above it (e.g. `@Column({...})`, `@IsBoolean()`). Leave those untouched — only the property declaration line itself changes.
+
+- [ ] **Step 2: Verify backend build passes**
+
+```bash
+cd /path/to/erp2/backend
+npm run build
+```
+
+Expected: exits 0, no TypeScript errors.
+
+- [ ] **Step 3: Verify backend tests pass**
 
 ```bash
 cd /path/to/erp2/backend
 npm run test
 ```
 
-Expected: all unit tests pass. ts-jest 29.4.9 with TS 6.0.2 compiles `src/` and `test/` without TS5011 (no rootDir in tsconfig.json) and without TS2349 (supertest import fixed).
-
-Note: `npm run test` runs unit tests only (jest config roots: src + test/unit). E2e tests run separately via `npm run test:e2e` and are not part of this verification.
+Expected: all unit tests pass. ts-jest 29.4.9 compiles `src/` and `test/` with `tsconfig.json` (no rootDir, no TS5011). The `declare` modifier on entity properties does not affect runtime behavior.
 
 ---
 
-## Task 4: Update frontend/tsconfig.json
+## Task 6: Update frontend/tsconfig.json
 
 **Files:**
 - Modify: `frontend/tsconfig.json`
@@ -306,15 +387,13 @@ Note: `npm run test` runs unit tests only (jest config roots: src + test/unit). 
 }
 ```
 
-Changes from pre-upgrade tsconfig.json:
+Changes from pre-upgrade:
 - `target`: `ES2020` → `ES2025`
 - `lib`: `["ES2020", ...]` → `["ES2025", ...]`
 - Removed `baseUrl: "."`
-- Added `rootDir: "./src"` (safe here — `include: ["src"]` already excludes test files)
+- Added `rootDir: "./src"` (safe — `include: ["src"]` already present, no files outside src/ are included)
 - Added `types: ["node", "react", "react-dom"]`
-- `paths` values prefixed with `./src/`
-
-Note: Frontend `rootDir` is safe because `include: ["src"]` was already present, so there are no files outside `./src` included in compilation.
+- `paths` values changed to `["./src/*"]` form
 
 - [ ] **Step 2: Verify frontend type-check**
 
@@ -332,7 +411,7 @@ cd /path/to/erp2/frontend
 npm run lint
 ```
 
-Expected: exits 0, no errors.
+Expected: exits 0.
 
 - [ ] **Step 4: Spot-check frontend tests**
 
@@ -354,7 +433,7 @@ Expected: all 95 test files pass. Takes ~12 minutes — do not assume it is hung
 
 ---
 
-## Task 5: Commit and open PR
+## Task 7: Commit and open PR
 
 **Files:**
 - `backend/package.json`
@@ -362,10 +441,19 @@ Expected: all 95 test files pass. Takes ~12 minutes — do not assume it is hung
 - `backend/tsconfig.json`
 - `backend/tsconfig.build.json`
 - `backend/nest-cli.json`
+- `backend/src/common/security/middleware/security-application.service.ts`
 - `backend/test/auth.e2e-spec.ts`
 - `backend/test/search.e2e-spec.ts`
 - `backend/test/e2e/price-lists.e2e-spec.ts`
 - `backend/test/e2e/account-mappings.e2e-spec.ts`
+- `backend/src/database/entities/price-list-item.entity.ts`
+- `backend/src/database/entities/backup-settings.entity.ts`
+- `backend/src/database/entities/chart-of-account.entity.ts`
+- `backend/src/database/entities/account-mapping.entity.ts`
+- `backend/src/database/entities/customer.entity.ts`
+- `backend/src/database/entities/user.entity.ts`
+- `backend/src/database/entities/product.entity.ts`
+- `backend/src/database/entities/price-list.entity.ts`
 - `frontend/package.json`
 - `frontend/package-lock.json`
 - `frontend/tsconfig.json`
@@ -376,8 +464,17 @@ Expected: all 95 test files pass. Takes ~12 minutes — do not assume it is hung
 cd /path/to/erp2
 git add backend/package.json backend/package-lock.json
 git add backend/tsconfig.json backend/tsconfig.build.json backend/nest-cli.json
+git add backend/src/common/security/middleware/security-application.service.ts
 git add backend/test/auth.e2e-spec.ts backend/test/search.e2e-spec.ts
 git add backend/test/e2e/price-lists.e2e-spec.ts backend/test/e2e/account-mappings.e2e-spec.ts
+git add backend/src/database/entities/price-list-item.entity.ts
+git add backend/src/database/entities/backup-settings.entity.ts
+git add backend/src/database/entities/chart-of-account.entity.ts
+git add backend/src/database/entities/account-mapping.entity.ts
+git add backend/src/database/entities/customer.entity.ts
+git add backend/src/database/entities/user.entity.ts
+git add backend/src/database/entities/product.entity.ts
+git add backend/src/database/entities/price-list.entity.ts
 git add frontend/package.json frontend/package-lock.json frontend/tsconfig.json
 ```
 
@@ -394,8 +491,9 @@ chore: upgrade TypeScript to 6.0.2, ts-jest to 29.4.9
 - Both tsconfigs: remove baseUrl, add explicit types[], relative paths
 - Backend: split tsconfig into tsconfig.json (ts-jest) + tsconfig.build.json
   (nest build) to avoid TS5011 from rootDir + test/ files outside src/
-- Backend: nest-cli.json updated to use tsconfig.build.json
-- Backend: fix supertest namespace imports (TS6 TS2349 compatibility)
+- Backend: remove webpack:true from nest-cli.json — use plain tsc build
+- Backend: fix compression + supertest namespace imports (TS2349)
+- Backend: add declare to isActive overrides in 8 entities (TS2612)
 - Frontend: add rootDir (safe — include:["src"] already present)
 
 Closes #235
@@ -416,9 +514,10 @@ gh pr create \
 - Upgrades TypeScript from 5.9.3 → 6.0.2 in both backend and frontend
 - Upgrades ts-jest from ^29.1.0 → ^29.4.9 (blocker resolved: peer dep now `typescript <7`)
 - Both tsconfigs: ES2025 target, explicit `types[]`, relative `paths`, removed `baseUrl`
-- Backend tsconfig split into `tsconfig.json` (ts-jest) and `tsconfig.build.json` (nest build) — required to avoid TS5011 from `rootDir` conflicting with test files outside `src/`
-- `nest-cli.json` updated to use `tsconfig.build.json`
-- Fixed `import * as request from 'supertest'` → `import request from 'supertest'` in 4 e2e test files (TS6 TS2349: namespace imports are no longer callable)
+- Backend tsconfig split: `tsconfig.json` (ts-jest, no rootDir) + `tsconfig.build.json` (nest build, rootDir+include:src)
+- Removed `webpack: true` from `nest-cli.json` — switches to plain tsc build
+- Fixed `import * as compression/request` → default imports (TS2349: namespace imports not callable in TS6)
+- Added `declare` to `isActive` overrides in 8 entity classes (TS2612)
 
 ## Test plan
 

--- a/docs/superpowers/plans/2026-04-02-typescript6-upgrade.md
+++ b/docs/superpowers/plans/2026-04-02-typescript6-upgrade.md
@@ -4,7 +4,7 @@
 
 **Goal:** Upgrade TypeScript from 5.9.3 to 6.0.2 in both backend and frontend, resolving the blocker from issue #235.
 
-**Architecture:** Pure config + package version changes — no source code modifications required. Backend and frontend are upgraded together in a single atomic PR. Verification runs build, lint, and tests in sequence for each project.
+**Architecture:** Config + package version changes, plus two TS6 compatibility fixes discovered during execution: (1) split backend tsconfig so `rootDir` is enforced for builds but not for ts-jest test compilation, and (2) update supertest namespace imports that TS6 no longer treats as callable. Backend and frontend are upgraded together in a single atomic PR.
 
 **Tech Stack:** TypeScript 6.0.2, ts-jest 29.4.9, NestJS 11 (backend), React 19 + Vite 8 + Vitest 4 (frontend)
 
@@ -17,72 +17,70 @@
 | File | Change |
 |---|---|
 | `backend/package.json` | `typescript` 5.9.3→6.0.2, `ts-jest` ^29.1.0→^29.4.9 |
-| `backend/tsconfig.json` | target ES2025, remove baseUrl, add rootDir+types, relative paths |
+| `backend/tsconfig.json` | target ES2025, remove baseUrl+rootDir, add types, relative paths |
+| `backend/tsconfig.build.json` | new file — extends tsconfig.json, adds rootDir+include for nest build |
+| `backend/nest-cli.json` | point tsConfigPath to tsconfig.build.json |
+| `backend/test/auth.e2e-spec.ts` | fix supertest namespace import |
+| `backend/test/search.e2e-spec.ts` | fix supertest namespace import |
+| `backend/test/e2e/price-lists.e2e-spec.ts` | fix supertest namespace import |
+| `backend/test/e2e/account-mappings.e2e-spec.ts` | fix supertest namespace import |
 | `frontend/package.json` | `typescript` 5.9.3→6.0.2 |
 | `frontend/tsconfig.json` | target ES2025, lib ES2025, remove baseUrl, add rootDir+types, relative paths |
 
 ---
 
+## Background: Two TS6 compatibility issues
+
+**Issue 1 — TS5011 (`rootDir` + test files):** TypeScript's `rootDir` does not control which files are included — it only constrains where included files may live. The backend `jest` config has `roots: ["src", "test"]`, so ts-jest compiles both directories. Setting `rootDir: "./src"` in `tsconfig.json` then causes TS5011 because `test/*.ts` files are outside `./src`. Fix: move `rootDir` (and `include: ["src"]`) into a dedicated `tsconfig.build.json` used only by nest build. `tsconfig.json` itself has no `rootDir`, so ts-jest can compile both `src/` and `test/` freely.
+
+**Issue 2 — TS2349 (supertest import not callable):** TS6 tightened `import * as X` to always produce a plain module namespace object, which is not callable. `supertest` exports a callable function, so `import * as request from 'supertest'` then used as `request(app)` fails. Fix: change to `import request from 'supertest'` — valid because `allowSyntheticDefaultImports: true` is already in tsconfig and `@types/supertest` uses `export =` which maps to a default import under that flag.
+
+---
+
 ## Task 1: Bump package versions
+
+**Status:** ✅ Already completed on branch `chore/typescript-6-upgrade`
 
 **Files:**
 - Modify: `backend/package.json`
 - Modify: `frontend/package.json`
 
-- [ ] **Step 1: Update backend/package.json**
+- [x] **Step 1: Update backend/package.json**
 
-In `backend/package.json`, find the `devDependencies` section and change:
+In `backend/package.json` devDependencies:
 ```json
 "ts-jest": "^29.4.9",
 "typescript": "6.0.2"
 ```
-(Previously `"ts-jest": "^29.1.0"` and `"typescript": "5.9.3"`)
 
-- [ ] **Step 2: Update frontend/package.json**
+- [x] **Step 2: Update frontend/package.json**
 
-In `frontend/package.json`, find the `devDependencies` section and change:
+In `frontend/package.json` devDependencies:
 ```json
 "typescript": "6.0.2"
 ```
-(Previously `"typescript": "5.9.3"`)
 
-- [ ] **Step 3: Install backend dependencies**
-
-```bash
-cd /path/to/erp2/backend
-npm install
-```
-
-Expected: installs cleanly, no `ERESOLVE` errors. `package-lock.json` updated.
-
-- [ ] **Step 4: Install frontend dependencies**
+- [x] **Step 3: Install and verify**
 
 ```bash
-cd /path/to/erp2/frontend
-npm install
+cd backend && npm install
+cd frontend && npm install
 ```
 
-Expected: installs cleanly, no `ERESOLVE` errors. `package-lock.json` updated.
-
-- [ ] **Step 5: Verify installed versions**
-
-```bash
-cd /path/to/erp2/backend && node -e "console.log(require('./node_modules/typescript/package.json').version)"
-cd /path/to/erp2/frontend && node -e "console.log(require('./node_modules/typescript/package.json').version)"
-```
-
-Expected: both print `6.0.2`
+Expected: both install cleanly at TypeScript 6.0.2.
 
 ---
 
-## Task 2: Update backend/tsconfig.json
+## Task 2: Fix backend tsconfig — split build config, update tsconfig.json
 
 **Files:**
 - Modify: `backend/tsconfig.json`
+- Create: `backend/tsconfig.build.json`
+- Modify: `backend/nest-cli.json`
 
-- [ ] **Step 1: Replace the file contents**
+- [ ] **Step 1: Replace backend/tsconfig.json**
 
-Replace `backend/tsconfig.json` with:
+`rootDir` is intentionally omitted here — it lives in `tsconfig.build.json` instead.
 
 ```json
 {
@@ -96,7 +94,6 @@ Replace `backend/tsconfig.json` with:
     "target": "ES2025",
     "sourceMap": true,
     "outDir": "./dist",
-    "rootDir": "./src",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": false,
@@ -121,25 +118,60 @@ Replace `backend/tsconfig.json` with:
 }
 ```
 
-Key changes from previous version:
+Changes from pre-upgrade tsconfig.json:
 - `target`: `ES2018` → `ES2025`
 - Removed `baseUrl: "./"`
-- Added `rootDir: "./src"`
-- Added `types: [...]` array
-- `paths` values changed from `["src/*"]` to `["./src/*"]` (relative, explicit)
+- Removed `rootDir` (moved to tsconfig.build.json)
+- Added `types: [...]` (explicit, prevents type bleed)
+- `paths` values prefixed with `./` (e.g. `["./src/*"]`)
 
-- [ ] **Step 2: Verify backend builds**
+- [ ] **Step 2: Create backend/tsconfig.build.json**
+
+This file is used exclusively by `nest build`. It extends `tsconfig.json` and adds `rootDir` + `include` so only `src/` is compiled during the production build.
+
+```json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": [
+    "src/modules/reports/**/*"
+  ]
+}
+```
+
+- [ ] **Step 3: Update nest-cli.json to use tsconfig.build.json**
+
+Replace `backend/nest-cli.json` with:
+
+```json
+{
+  "$schema": "https://json.schemastore.org/nest-cli",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "deleteOutDir": true,
+    "webpack": true,
+    "tsConfigPath": "tsconfig.build.json",
+    "typeCheck": false
+  }
+}
+```
+
+(Changed `"tsConfigPath": "tsconfig.json"` → `"tsConfigPath": "tsconfig.build.json"`)
+
+- [ ] **Step 4: Verify backend builds**
 
 ```bash
 cd /path/to/erp2/backend
 npm run build
 ```
 
-Expected: exits 0, `dist/` directory populated, no TypeScript errors.
+Expected: exits 0, `dist/` populated, no TypeScript errors.
 
-If it fails with path resolution errors, the most likely cause is the `paths` change — double-check that all entries use `./src/` prefix.
-
-- [ ] **Step 3: Verify backend lint**
+- [ ] **Step 5: Verify backend lint**
 
 ```bash
 cd /path/to/erp2/backend
@@ -148,25 +180,81 @@ npm run lint
 
 Expected: exits 0, no errors.
 
-- [ ] **Step 4: Verify backend tests**
+---
+
+## Task 3: Fix supertest imports in backend test files
+
+TS6 no longer allows `import * as X` from a module to be called as a function. All four files use `import * as request from 'supertest'` and then call `request(app)`. Fix each to use a default import.
+
+**Files:**
+- Modify: `backend/test/auth.e2e-spec.ts`
+- Modify: `backend/test/search.e2e-spec.ts`
+- Modify: `backend/test/e2e/price-lists.e2e-spec.ts`
+- Modify: `backend/test/e2e/account-mappings.e2e-spec.ts`
+
+- [ ] **Step 1: Fix auth.e2e-spec.ts**
+
+In `backend/test/auth.e2e-spec.ts`, change line 3 from:
+```typescript
+import * as request from 'supertest';
+```
+to:
+```typescript
+import request from 'supertest';
+```
+
+- [ ] **Step 2: Fix search.e2e-spec.ts**
+
+In `backend/test/search.e2e-spec.ts`, change line 3 from:
+```typescript
+import * as request from 'supertest';
+```
+to:
+```typescript
+import request from 'supertest';
+```
+
+- [ ] **Step 3: Fix price-lists.e2e-spec.ts**
+
+In `backend/test/e2e/price-lists.e2e-spec.ts`, change line 3 from:
+```typescript
+import * as request from 'supertest';
+```
+to:
+```typescript
+import request from 'supertest';
+```
+
+- [ ] **Step 4: Fix account-mappings.e2e-spec.ts**
+
+In `backend/test/e2e/account-mappings.e2e-spec.ts`, change line 3 from:
+```typescript
+import * as request from 'supertest';
+```
+to:
+```typescript
+import request from 'supertest';
+```
+
+- [ ] **Step 5: Verify backend tests pass**
 
 ```bash
 cd /path/to/erp2/backend
 npm run test
 ```
 
-Expected: all tests pass. ts-jest 29.4.9 with TS 6.0.2 should work without configuration changes.
+Expected: all unit tests pass. ts-jest 29.4.9 with TS 6.0.2 compiles `src/` and `test/` without TS5011 (no rootDir in tsconfig.json) and without TS2349 (supertest import fixed).
+
+Note: `npm run test` runs unit tests only (jest config roots: src + test/unit). E2e tests run separately via `npm run test:e2e` and are not part of this verification.
 
 ---
 
-## Task 3: Update frontend/tsconfig.json
+## Task 4: Update frontend/tsconfig.json
 
 **Files:**
 - Modify: `frontend/tsconfig.json`
 
-- [ ] **Step 1: Replace the file contents**
-
-Replace `frontend/tsconfig.json` with:
+- [ ] **Step 1: Replace frontend/tsconfig.json**
 
 ```json
 {
@@ -218,13 +306,15 @@ Replace `frontend/tsconfig.json` with:
 }
 ```
 
-Key changes from previous version:
+Changes from pre-upgrade tsconfig.json:
 - `target`: `ES2020` → `ES2025`
-- `lib`: `["ES2020", "DOM", "DOM.Iterable"]` → `["ES2025", "DOM", "DOM.Iterable"]`
+- `lib`: `["ES2020", ...]` → `["ES2025", ...]`
 - Removed `baseUrl: "."`
-- Added `rootDir: "./src"`
+- Added `rootDir: "./src"` (safe here — `include: ["src"]` already excludes test files)
 - Added `types: ["node", "react", "react-dom"]`
-- `paths` values changed from `["src/*"]` to `["./src/*"]` (relative, explicit)
+- `paths` values prefixed with `./src/`
+
+Note: Frontend `rootDir` is safe because `include: ["src"]` was already present, so there are no files outside `./src` included in compilation.
 
 - [ ] **Step 2: Verify frontend type-check**
 
@@ -233,7 +323,7 @@ cd /path/to/erp2/frontend
 npm run type-check
 ```
 
-Expected: exits 0, no TypeScript errors. This runs `tsc --noEmit` using the updated tsconfig.
+Expected: exits 0, no TypeScript errors.
 
 - [ ] **Step 3: Verify frontend lint**
 
@@ -251,7 +341,7 @@ cd /path/to/erp2/frontend
 npx vitest run src/components/common/FilterSelect/FilterSelect.test.tsx
 ```
 
-Expected: passes. Vitest uses esbuild/Vite for transforms, not tsc directly, so tsconfig changes have minimal impact on test execution — but this confirms the setup is coherent.
+Expected: passes.
 
 - [ ] **Step 5: Run full frontend test suite**
 
@@ -260,16 +350,22 @@ cd /path/to/erp2/frontend
 npm run test
 ```
 
-Expected: all 95 test files pass. This takes ~12 minutes — do not assume it is hung.
+Expected: all 95 test files pass. Takes ~12 minutes — do not assume it is hung.
 
 ---
 
-## Task 4: Commit and open PR
+## Task 5: Commit and open PR
 
 **Files:**
 - `backend/package.json`
 - `backend/package-lock.json`
 - `backend/tsconfig.json`
+- `backend/tsconfig.build.json`
+- `backend/nest-cli.json`
+- `backend/test/auth.e2e-spec.ts`
+- `backend/test/search.e2e-spec.ts`
+- `backend/test/e2e/price-lists.e2e-spec.ts`
+- `backend/test/e2e/account-mappings.e2e-spec.ts`
 - `frontend/package.json`
 - `frontend/package-lock.json`
 - `frontend/tsconfig.json`
@@ -278,7 +374,10 @@ Expected: all 95 test files pass. This takes ~12 minutes — do not assume it is
 
 ```bash
 cd /path/to/erp2
-git add backend/package.json backend/package-lock.json backend/tsconfig.json
+git add backend/package.json backend/package-lock.json
+git add backend/tsconfig.json backend/tsconfig.build.json backend/nest-cli.json
+git add backend/test/auth.e2e-spec.ts backend/test/search.e2e-spec.ts
+git add backend/test/e2e/price-lists.e2e-spec.ts backend/test/e2e/account-mappings.e2e-spec.ts
 git add frontend/package.json frontend/package-lock.json frontend/tsconfig.json
 ```
 
@@ -292,8 +391,12 @@ chore: upgrade TypeScript to 6.0.2, ts-jest to 29.4.9
 - Upgrades typescript 5.9.3 → 6.0.2 in backend and frontend
 - Upgrades ts-jest ^29.1.0 → ^29.4.9 in backend
 - Both tsconfigs: target ES2018/ES2020 → ES2025, lib updated
-- Both tsconfigs: remove baseUrl, add rootDir, add explicit types[]
-- Both tsconfigs: paths values made relative (./src/*) per TS6 guidance
+- Both tsconfigs: remove baseUrl, add explicit types[], relative paths
+- Backend: split tsconfig into tsconfig.json (ts-jest) + tsconfig.build.json
+  (nest build) to avoid TS5011 from rootDir + test/ files outside src/
+- Backend: nest-cli.json updated to use tsconfig.build.json
+- Backend: fix supertest namespace imports (TS6 TS2349 compatibility)
+- Frontend: add rootDir (safe — include:["src"] already present)
 
 Closes #235
 
@@ -312,8 +415,10 @@ gh pr create \
 
 - Upgrades TypeScript from 5.9.3 → 6.0.2 in both backend and frontend
 - Upgrades ts-jest from ^29.1.0 → ^29.4.9 (blocker resolved: peer dep now `typescript <7`)
-- Both tsconfigs updated: ES2025 target, explicit `types[]`, relative `paths`, `rootDir`, removed `baseUrl`
-- No source code changes required — no breaking changes found in codebase
+- Both tsconfigs: ES2025 target, explicit `types[]`, relative `paths`, removed `baseUrl`
+- Backend tsconfig split into `tsconfig.json` (ts-jest) and `tsconfig.build.json` (nest build) — required to avoid TS5011 from `rootDir` conflicting with test files outside `src/`
+- `nest-cli.json` updated to use `tsconfig.build.json`
+- Fixed `import * as request from 'supertest'` → `import request from 'supertest'` in 4 e2e test files (TS6 TS2349: namespace imports are no longer callable)
 
 ## Test plan
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erp-frontend",
-  "version": "1.40.0",
+  "version": "1.40.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-frontend",
-      "version": "1.40.0",
+      "version": "1.40.1",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -55,7 +55,7 @@
         "jsdom": "^29.0.1",
         "msw": "^2.12.10",
         "react-transition-group": "^4.4.5",
-        "typescript": "5.9.3",
+        "typescript": "6.0.2",
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.3",
         "vitest": "^4.1.2"
@@ -3018,6 +3018,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5876,9 +5885,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6356,15 +6365,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,7 +63,7 @@
     "jsdom": "^29.0.1",
     "msw": "^2.12.10",
     "react-transition-group": "^4.4.5",
-    "typescript": "5.9.3",
+    "typescript": "6.0.2",
     "typescript-eslint": "^8.58.0",
     "vite": "^8.0.3",
     "vitest": "^4.1.2"

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,12 +1,11 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2025",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2025", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 
-    /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
@@ -14,25 +13,25 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
-    /* Linting */
     "strict": false,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
 
-    /* Path mapping */
-    "baseUrl": ".",
+    "types": ["node", "react", "react-dom"],
+    "rootDir": "./src",
+
     "paths": {
-      "@/*": ["src/*"],
-      "@/components/*": ["src/components/*"],
-      "@/pages/*": ["src/pages/*"],
-      "@/hooks/*": ["src/hooks/*"],
-      "@/services/*": ["src/services/*"],
-      "@/store/*": ["src/store/*"],
-      "@/utils/*": ["src/utils/*"],
-      "@/types/*": ["src/types/*"],
-      "@/styles/*": ["src/styles/*"],
-      "@/assets/*": ["src/assets/*"]
+      "@/*": ["./src/*"],
+      "@/components/*": ["./src/components/*"],
+      "@/pages/*": ["./src/pages/*"],
+      "@/hooks/*": ["./src/hooks/*"],
+      "@/services/*": ["./src/services/*"],
+      "@/store/*": ["./src/store/*"],
+      "@/utils/*": ["./src/utils/*"],
+      "@/types/*": ["./src/types/*"],
+      "@/styles/*": ["./src/styles/*"],
+      "@/assets/*": ["./src/assets/*"]
     }
   },
   "include": ["src"],


### PR DESCRIPTION
## Summary

- Upgrades TypeScript from 5.9.3 → 6.0.2 in both backend and frontend
- Upgrades ts-jest from ^29.1.0 → ^29.4.9 (blocker resolved: peer dep now `typescript <7`)
- Both tsconfigs: ES2025 target, explicit `types[]`, relative `paths`, removed `baseUrl`
- Backend tsconfig split: `tsconfig.json` (ts-jest, no rootDir) + `tsconfig.build.json` (nest build, rootDir+include:src)
- Removed `webpack: true` from `nest-cli.json` — switches to plain tsc build
- Fixed `import * as compression/request` → default imports (TS2349: namespace imports not callable in TS6)
- Added `declare` to `isActive` overrides in 8 entity classes (TS2612)

## Test Plan

- [x] `cd backend && npm run build`
- [x] `cd backend && npm run lint`
- [x] `cd backend && npm run test`
- [x] `cd frontend && npm run type-check`
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npx vitest run src/components/filters/__tests__/FilterSelect.test.tsx`
- [x] `cd frontend && npm run test`

Closes #235

🤖 Generated with [Claude Code](https://claude.ai/claude-code)