### PR TITLE
fix(deps): resolve high-severity backend vulnerabilities (issue #251)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erp-backend",
-  "version": "1.40.1",
+  "version": "1.40.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-backend",
-      "version": "1.40.1",
+      "version": "1.40.2",
       "license": "MIT",
       "dependencies": {
         "@nestjs/bull": "^11.0.3",
@@ -8443,9 +8443,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -97,6 +97,7 @@
     "multer": "2.1.1",
     "file-type": "21.3.2",
     "path-to-regexp": "8.4.0",
+    "lodash": "^4.18.1",
     "@angular-devkit/core": {
       "ajv": "8.18.0"
     },

--- a/docs/superpowers/plans/2026-04-02-issue-251-security-vulnerabilities.md
+++ b/docs/superpowers/plans/2026-04-02-issue-251-security-vulnerabilities.md
@@ -2,42 +2,55 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Resolve all high and moderate npm security vulnerabilities in the root and backend directories without breaking changes.
+**Goal:** Resolve all actionable npm security vulnerabilities in the root and backend directories without breaking changes.
 
-**Architecture:** Root vulnerabilities (picomatch, brace-expansion) are resolved via `npm audit fix` since they are dev-only sub-deps of semantic-release. Backend vulnerabilities all trace to `lodash@4.17.23`; rather than downgrading NestJS packages (which would break the app), we add `"lodash": "^4.18.1"` to the existing `overrides` block in `backend/package.json` to force all transitive consumers to the patched version.
+**Architecture:** Root vulnerabilities (picomatch, brace-expansion) are bundled inside `npm@11.12.1`, which is pulled by `@semantic-release/npm@13.1.5`. Because they are bundled deps, `npm audit fix` and `overrides` cannot reach them — and `npm@11.12.1` is already the latest published version. These vulns are dev/CI-only (`npm audit --omit=dev` returns 0) and cannot be fixed until npm publishes a new release with patched bundled deps. They are documented but deferred. Backend vulnerabilities all trace to `lodash@4.17.23`; rather than downgrading NestJS packages (which would break the app), we add `"lodash": "^4.18.1"` to the existing `overrides` block in `backend/package.json` to force all transitive consumers to the patched version.
 
 **Tech Stack:** npm, NestJS 11, Jest
 
 ---
 
-### Task 1: Fix root vulnerabilities
+### Task 1: Document root vulnerability blocker
+
+**Context:** `picomatch` and `brace-expansion` are bundled inside `npm@11.12.1`
+(`node_modules/npm/node_modules/`). npm `overrides` cannot reach inside another package's bundled
+dependency tree. `npm@11.12.1` is the latest published version. These are dev/CI-only deps —
+`npm audit --omit=dev` returns 0 vulnerabilities. No fix is possible until npm publishes `11.12.2+`
+with patched bundled deps.
 
 **Files:**
-- Modify: `/home/blur/erp2/package-lock.json` (updated by npm)
+- Modify: `docs/superpowers/specs/2026-04-02-issue-251-security-vulnerabilities-design.md`
 
-- [ ] **Step 1: Run `npm audit fix` in root**
+- [ ] **Step 1: Update the spec to document the root blocker**
+
+In `docs/superpowers/specs/2026-04-02-issue-251-security-vulnerabilities-design.md`, replace the Root section under `## Approach`:
+
+```markdown
+### Root: Deferred (upstream blocker)
+
+`picomatch` and `brace-expansion` are bundled inside `npm@11.12.1`, which is pulled by
+`@semantic-release/npm@13.1.5`. Bundled dependencies cannot be overridden from outside the
+package — npm `overrides` in `package.json` only affect the top-level dependency resolution
+tree, not the private bundled tree inside `node_modules/npm/node_modules/`.
+
+`npm@11.12.1` is the latest published version as of 2026-04-02. No fix is available until npm
+publishes a new release with patched versions of `brace-expansion` (needs >=5.0.5) and
+`picomatch` (needs >=4.0.4) in its bundled tree.
+
+**Impact:** Dev/CI-only. `npm audit --omit=dev` returns 0 vulnerabilities. These packages are
+only executed during the `semantic-release` publish step in CI — not in production, not in
+the Docker image. Risk is low and limited to CI environment.
+
+**Action:** Monitor npm releases. When `npm` ships a version with patched bundled deps,
+`@semantic-release/npm` will pick it up automatically on the next `npm install`.
+```
+
+- [ ] **Step 2: Commit the spec update**
 
 ```bash
 cd /home/blur/erp2
-npm audit fix
-```
-
-Expected output: something like `fixed 2 of 2 vulnerabilities`
-
-- [ ] **Step 2: Verify root is clean**
-
-```bash
-npm audit
-```
-
-Expected: `found 0 vulnerabilities`
-
-- [ ] **Step 3: Commit**
-
-```bash
-cd /home/blur/erp2
-git add package-lock.json
-git commit -m "fix(deps): resolve root picomatch and brace-expansion vulnerabilities"
+git add docs/superpowers/specs/2026-04-02-issue-251-security-vulnerabilities-design.md
+git commit -m "docs: document root vulnerability blocker — bundled in npm@11.12.1, no fix available"
 ```
 
 ---
@@ -86,7 +99,7 @@ cd /home/blur/erp2/backend
 npm list lodash
 ```
 
-Expected: all instances of lodash should show `4.18.1` (not `4.17.23`).
+Expected: all instances of lodash show `4.18.1` (not `4.17.23`).
 
 - [ ] **Step 4: Verify backend audit is clean**
 
@@ -104,7 +117,7 @@ cd /home/blur/erp2/backend
 npm run test
 ```
 
-Expected: all tests pass (same pass/fail as before).
+Expected: all tests pass.
 
 - [ ] **Step 6: Commit**
 
@@ -118,16 +131,26 @@ git commit -m "fix(deps): pin lodash to ^4.18.1 via overrides to resolve high-se
 
 ### Task 3: Final verification and close issue
 
-- [ ] **Step 1: Confirm both directories are clean**
+- [ ] **Step 1: Confirm backend is clean**
 
 ```bash
-cd /home/blur/erp2 && npm audit && cd backend && npm audit
+cd /home/blur/erp2/backend && npm audit
 ```
 
-Expected: two consecutive `found 0 vulnerabilities` outputs.
+Expected: `found 0 vulnerabilities`
 
-- [ ] **Step 2: Close issue #251**
+- [ ] **Step 2: Confirm root production deps are clean**
 
 ```bash
-gh issue close 251 --comment "Resolved via npm overrides (lodash ^4.18.1 in backend) and npm audit fix (root). All vulnerabilities cleared."
+cd /home/blur/erp2 && npm audit --omit=dev
+```
+
+Expected: `found 0 vulnerabilities`
+
+- [ ] **Step 3: Close issue #251 with explanation**
+
+```bash
+gh issue close 251 --comment "Backend: resolved via \`overrides: { lodash: '^4.18.1' }\` in backend/package.json — all 3 high-severity backend vulns cleared.
+
+Root: picomatch and brace-expansion are bundled inside npm@11.12.1 (pulled by @semantic-release/npm@13.1.5). These cannot be fixed via overrides or audit fix — bundled deps are private to the package. npm@11.12.1 is the latest published version. These are dev/CI-only (npm audit --omit=dev returns 0). Will resolve automatically when npm ships a patched release."
 ```

--- a/docs/superpowers/specs/2026-04-02-issue-251-security-vulnerabilities-design.md
+++ b/docs/superpowers/specs/2026-04-02-issue-251-security-vulnerabilities-design.md
@@ -34,9 +34,23 @@ Both are dev-only sub-dependencies of `semantic-release`. `npm audit fix` resolv
 
 ## Approach
 
-### Root: `npm audit fix`
+### Root: Deferred (upstream blocker)
 
-Standard audit fix. Only dev dependencies affected; no app code or production behavior changes.
+`picomatch` and `brace-expansion` are bundled inside `npm@11.12.1`, which is pulled by
+`@semantic-release/npm@13.1.5`. Bundled dependencies cannot be overridden from outside the
+package — npm `overrides` in `package.json` only affect the top-level dependency resolution
+tree, not the private bundled tree inside `node_modules/npm/node_modules/`.
+
+`npm@11.12.1` is the latest published version as of 2026-04-02. No fix is available until npm
+publishes a new release with patched versions of `brace-expansion` (needs >=5.0.5) and
+`picomatch` (needs >=4.0.4) in its bundled tree.
+
+**Impact:** Dev/CI-only. `npm audit --omit=dev` returns 0 vulnerabilities. These packages are
+only executed during the `semantic-release` publish step in CI — not in production, not in
+the Docker image. Risk is low and limited to CI environment.
+
+**Action:** Monitor npm releases. When `npm` ships a version with patched bundled deps,
+`@semantic-release/npm` will pick it up automatically on the next `npm install`.
 
 ### Backend: npm `overrides`
 


### PR DESCRIPTION
## Summary

- Pins `lodash` to `^4.18.1` via the existing `overrides` block in `backend/package.json`, resolving all 3 high-severity backend vulnerabilities (code injection via `_.template`, prototype pollution via `_.unset`/`_.omit`)
- Documents the root `picomatch`/`brace-expansion` blocker — these are bundled inside `npm@11.12.1` and cannot be fixed until npm ships a patched release

## Details

**Backend (fixed):**
- `lodash@4.17.23` was a transitive dep of `@nestjs/config`, `@nestjs/swagger`, `@nestjs/cli`, `bull`, `archiver`
- Lodash is not imported directly in any backend source file
- Override forces all consumers to `4.18.1` without touching direct dependency versions
- `npm audit` → 0 vulnerabilities

**Root (deferred — upstream blocker):**
- `picomatch` and `brace-expansion` live inside `node_modules/npm/node_modules/` (bundled deps of `npm@11.12.1`, pulled by `@semantic-release/npm@13.1.5`)
- npm `overrides` cannot reach inside bundled dep trees
- `npm@11.12.1` is the latest published version — no fix available upstream yet
- `npm audit --omit=dev` → 0 vulnerabilities (dev/CI-only, not in production)

## Test plan

- [x] `cd backend && npm audit` → `found 0 vulnerabilities`
- [x] `cd backend && npm list lodash` → all instances at `4.18.1`
- [x] `cd backend && npm run test` → 725/725 passing
- [x] `npm audit --omit=dev` (root) → `found 0 vulnerabilities`

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)