### PR TITLE
feat(filter): filter system architectural enhancements

### DIFF
--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -18,7 +18,7 @@ interface Props<TFilters extends object> {
 }
 
 function renderQuickField<TFilters extends object>(
-  field: FilterBarConfig<TFilters>['quick'][number],
+  field: FilterBarConfig<TFilters>['fields'][number],
   draftFilters: TFilters,
   handlers: FilterBarHandlers<TFilters>,
 ) {
@@ -75,7 +75,7 @@ export function FilterBar<TFilters extends object>({
           inputRef={searchInputRef}
         />
       ) : null}
-      {config.quick.map((field) => renderQuickField(field, draftFilters, handlers))}
+      {config.fields.map((field) => renderQuickField(field, draftFilters, handlers))}
       {hasActiveFilters ? (
         <Button size="small" variant="outlined" color="inherit" sx={{ ml: 1 }} onClick={handlers.onClearAll}>
           Reset

--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -1,10 +1,12 @@
 import { Button, Stack } from '@mui/material'
 
+import { FilterPeriod } from './FilterPeriod'
 import { FilterSearch } from './FilterSearch'
 import { FilterSelect } from './FilterSelect'
 import type {
   FilterBarConfig,
   FilterBarHandlers,
+  PeriodValue,
 } from '@/types/filterBar.types'
 
 interface Props<TFilters extends object> {
@@ -33,6 +35,21 @@ function renderQuickField<TFilters extends object>(
         value={value as string | null | string[]}
         options={field.options}
         onChange={onChange}
+      />
+    )
+  }
+
+  if (field.type === 'period') {
+    const periodValue = value as PeriodValue
+    return (
+      <FilterPeriod
+        key={String(field.field)}
+        value={periodValue.key}
+        customFrom={periodValue.from}
+        customTo={periodValue.to}
+        onChange={(key, from, to) =>
+          onChange({ key, from: from ?? null, to: to ?? null } satisfies PeriodValue)
+        }
       />
     )
   }

--- a/frontend/src/components/filters/__tests__/FilterBar.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterBar.test.tsx
@@ -1,7 +1,9 @@
+import { LocalizationProvider } from '@mui/x-date-pickers'
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
-import type { FilterBarConfig, FilterBarHandlers } from '@/types/filterBar.types'
+import type { FilterBarConfig, FilterBarHandlers, PeriodValue } from '@/types/filterBar.types'
 import { FilterBar } from '../FilterBar'
 
 interface Filters {
@@ -45,5 +47,38 @@ describe('FilterBar', () => {
     rerender(<FilterBar {...baseProps} hasActiveFilters={true} />)
     fireEvent.click(screen.getByRole('button', { name: /reset/i }))
     expect(handlers.onClearAll).toHaveBeenCalled()
+  })
+})
+
+describe('FilterBar — period field', () => {
+  it('renders FilterPeriod when type is period', () => {
+    interface PeriodFilters {
+      period: PeriodValue
+    }
+
+    const periodConfig: FilterBarConfig<PeriodFilters> = {
+      quick: [{ field: 'period', label: 'Period', type: 'period' }],
+    }
+
+    const periodHandlers: FilterBarHandlers<PeriodFilters> = {
+      onSearchChange: vi.fn(),
+      onSearchCommit: vi.fn(),
+      onQuickFilterChange: vi.fn(),
+      onClearField: vi.fn(),
+      onClearAll: vi.fn(),
+    }
+
+    render(
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <FilterBar
+          config={periodConfig}
+          draftFilters={{ period: { key: 'this_month', from: null, to: null } }}
+          handlers={periodHandlers}
+          hasActiveFilters={false}
+        />
+      </LocalizationProvider>,
+    )
+
+    expect(screen.getByLabelText(/period/i)).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/filters/__tests__/FilterBar.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterBar.test.tsx
@@ -13,7 +13,7 @@ interface Filters {
 
 const config: FilterBarConfig<Filters> = {
   search: { placeholder: 'Search...' },
-  quick: [
+  fields: [
     { field: 'status', label: 'Status', type: 'select', options: [{ value: 'active', label: 'Active' }] },
   ],
   defaults: { search: '', status: null },
@@ -57,7 +57,7 @@ describe('FilterBar — period field', () => {
     }
 
     const periodConfig: FilterBarConfig<PeriodFilters> = {
-      quick: [{ field: 'period', label: 'Period', type: 'period' }],
+      fields: [{ field: 'period', label: 'Period', type: 'period' }],
     }
 
     const periodHandlers: FilterBarHandlers<PeriodFilters> = {

--- a/frontend/src/hooks/useFilterBar.test.tsx
+++ b/frontend/src/hooks/useFilterBar.test.tsx
@@ -13,7 +13,7 @@ interface Filters {
 
 const config: FilterBarConfig<Filters> = {
   search: { placeholder: '', debounceMs: 0 },
-  quick: [
+  fields: [
     { field: 'status', label: 'Status', type: 'select', options: [{ value: 'active', label: 'Active' }] },
   ],
   defaults: { search: '', status: null },
@@ -77,7 +77,7 @@ describe('useFilterBar — period field', () => {
     }
 
     const periodConfig: FilterBarConfig<PeriodFilters> = {
-      quick: [{ field: 'period', label: 'Period', type: 'period' }],
+      fields: [{ field: 'period', label: 'Period', type: 'period' }],
     }
 
     const { result } = renderHook(() => useFilterBar(periodConfig), { wrapper: makeWrapper() })
@@ -95,7 +95,7 @@ describe('useFilterBar — period field', () => {
     }
 
     const periodConfig: FilterBarConfig<PeriodFilters> = {
-      quick: [{ field: 'period', label: 'Period', type: 'period' }],
+      fields: [{ field: 'period', label: 'Period', type: 'period' }],
     }
 
     const { result } = renderHook(() => useFilterBar(periodConfig), { wrapper: makeWrapper() })

--- a/frontend/src/hooks/useFilterBar.test.tsx
+++ b/frontend/src/hooks/useFilterBar.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it } from 'vitest'
 
-import type { FilterBarConfig } from '@/types/filterBar.types'
+import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
 import { useFilterBar } from '@/hooks/useFilterBar'
 
 interface Filters {
@@ -67,5 +67,43 @@ describe('useFilterBar', () => {
       result.current.handlers.onClearAll()
     })
     expect(result.current.hasActiveFilters).toBe(false)
+  })
+})
+
+describe('useFilterBar — period field', () => {
+  it('defaults period to this_month when no default configured', () => {
+    interface PeriodFilters {
+      period: PeriodValue
+    }
+
+    const periodConfig: FilterBarConfig<PeriodFilters> = {
+      quick: [{ field: 'period', label: 'Period', type: 'period' }],
+    }
+
+    const { result } = renderHook(() => useFilterBar(periodConfig), { wrapper: makeWrapper() })
+
+    expect(result.current.appliedFilters.period).toEqual({
+      key: 'this_month',
+      from: null,
+      to: null,
+    })
+  })
+
+  it('updates period value via onQuickFilterChange', () => {
+    interface PeriodFilters {
+      period: PeriodValue
+    }
+
+    const periodConfig: FilterBarConfig<PeriodFilters> = {
+      quick: [{ field: 'period', label: 'Period', type: 'period' }],
+    }
+
+    const { result } = renderHook(() => useFilterBar(periodConfig), { wrapper: makeWrapper() })
+
+    act(() => {
+      result.current.handlers.onQuickFilterChange('period', { key: 'last_week', from: null, to: null })
+    })
+
+    expect(result.current.appliedFilters.period).toEqual({ key: 'last_week', from: null, to: null })
   })
 })

--- a/frontend/src/hooks/useFilterBar.ts
+++ b/frontend/src/hooks/useFilterBar.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
-import type { FilterBarConfig, FilterBarHandlers } from '@/types/filterBar.types'
+import type { FilterBarConfig, FilterBarHandlers, PeriodValue } from '@/types/filterBar.types'
 import { parseFilters, serializeFilters } from '@/utils/filterBar.url'
 
 function getDefaults<TFilters extends object>(
@@ -20,7 +20,10 @@ function getDefaults<TFilters extends object>(
     }
 
     if (field.type === 'select') defaults[key] = null
-    else defaults[key] = []
+    else if (field.type === 'multi-select') defaults[key] = []
+    else if (field.type === 'period') {
+      defaults[key] = { key: 'this_month', from: null, to: null } satisfies PeriodValue
+    }
   }
 
   return defaults as TFilters

--- a/frontend/src/hooks/useFilterBar.ts
+++ b/frontend/src/hooks/useFilterBar.ts
@@ -11,7 +11,7 @@ function getDefaults<TFilters extends object>(
 
   if (config.search) defaults.search = ''
 
-  for (const field of config.quick) {
+  for (const field of config.fields) {
     const key = String(field.field)
     const configuredDefault = config.defaults?.[field.field]
     if (configuredDefault !== undefined) {

--- a/frontend/src/pages/inventory/ProductsPage.tsx
+++ b/frontend/src/pages/inventory/ProductsPage.tsx
@@ -44,7 +44,7 @@ export const ProductsPage: React.FC = () => {
   const filterConfig = useMemo<FilterBarConfig<InventoryProductFilters>>(
     () => ({
       search: { placeholder: 'Search by name, barcode, or brand...' },
-      quick: [
+      fields: [
         {
           field: 'status',
           label: 'Status',

--- a/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
@@ -136,7 +136,7 @@ const StockAdjustmentsPage: React.FC = () => {
   const filterConfig = useMemo<FilterBarConfig<StockAdjustmentFilters>>(
     () => ({
       search: { placeholder: 'Search by adjustment number or notes...' },
-      quick: [
+      fields: [
         {
           field: 'status',
           label: 'Status',

--- a/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
@@ -51,7 +51,7 @@ export const PurchaseOrdersPage: React.FC = () => {
   const filterConfig = useMemo<FilterBarConfig<PurchaseOrderFilters>>(
     () => ({
       search: { placeholder: 'Search purchase orders...' },
-      quick: [
+      fields: [
         {
           field: 'supplierId',
           label: 'Supplier',

--- a/frontend/src/pages/purchasing/SuppliersPage.tsx
+++ b/frontend/src/pages/purchasing/SuppliersPage.tsx
@@ -102,7 +102,7 @@ const SuppliersPage: React.FC = () => {
   const filterConfig = useMemo<FilterBarConfig<SupplierFilters>>(
     () => ({
       search: { placeholder: 'Search by company name...' },
-      quick: [
+      fields: [
         {
           field: 'status',
           label: 'Status',

--- a/frontend/src/pages/sales/CustomersPage.tsx
+++ b/frontend/src/pages/sales/CustomersPage.tsx
@@ -129,7 +129,7 @@ const CustomersPage: React.FC = () => {
   const filterConfig = useMemo<FilterBarConfig<CustomerFilters>>(
     () => ({
       search: { placeholder: 'Search by name or phone...' },
-      quick: [
+      fields: [
         {
           field: 'status',
           label: 'Status',

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -59,7 +59,7 @@ export const OrdersPage: React.FC = () => {
   const filterConfig = useMemo<FilterBarConfig<SalesOrderFilters>>(
     () => ({
       search: { placeholder: 'Search orders...' },
-      quick: [
+      fields: [
         {
           field: 'customerId',
           label: 'Customer',

--- a/frontend/src/pages/sales/PaymentsPage.tsx
+++ b/frontend/src/pages/sales/PaymentsPage.tsx
@@ -198,7 +198,7 @@ const PaymentsPage: React.FC = () => {
   const filterConfig = useMemo<FilterBarConfig<PaymentFilters>>(
     () => ({
       search: { placeholder: 'Search by payment number or customer...' },
-      quick: [],
+      fields: [],
       defaults: { search: '' },
     }),
     [],

--- a/frontend/src/pages/settings/UserManagementPage.tsx
+++ b/frontend/src/pages/settings/UserManagementPage.tsx
@@ -74,7 +74,7 @@ const UserManagementPage: React.FC = () => {
   const filterConfig = useMemo<FilterBarConfig<UserFilters>>(
     () => ({
       search: { placeholder: 'Search by name, email, or username...' },
-      quick: [
+      fields: [
         {
           field: 'role',
           label: 'Role',

--- a/frontend/src/types/filterBar.types.ts
+++ b/frontend/src/types/filterBar.types.ts
@@ -42,7 +42,7 @@ export interface FilterBarConfig<TFilters> {
     debounceMs?: number
     paramKey?: string
   }
-  quick: FilterFieldConfig<TFilters>[]
+  fields: FilterFieldConfig<TFilters>[]
   defaults?: Partial<TFilters>
   namespace?: string
 }

--- a/frontend/src/types/filterBar.types.ts
+++ b/frontend/src/types/filterBar.types.ts
@@ -1,8 +1,17 @@
+import type { PeriodKey } from '@/constants/periods'
+
 export type FilterOption = { value: string; label: string }
+
+export type PeriodValue = {
+  key: PeriodKey
+  from: string | null
+  to: string | null
+}
 
 export type FilterFieldType =
   | 'select'
   | 'multi-select'
+  | 'period'
 
 interface BaseFilterFieldConfig<TFilters, K extends keyof TFilters> {
   field: K
@@ -18,8 +27,14 @@ export interface SelectFilterFieldConfig<TFilters, K extends keyof TFilters>
   options: FilterOption[]
 }
 
+export interface PeriodFilterFieldConfig<TFilters, K extends keyof TFilters>
+  extends BaseFilterFieldConfig<TFilters, K> {
+  type: 'period'
+}
+
 export type FilterFieldConfig<TFilters> =
-  SelectFilterFieldConfig<TFilters, keyof TFilters>
+  | SelectFilterFieldConfig<TFilters, keyof TFilters>
+  | PeriodFilterFieldConfig<TFilters, keyof TFilters>
 
 export interface FilterBarConfig<TFilters> {
   search?: {
@@ -29,6 +44,7 @@ export interface FilterBarConfig<TFilters> {
   }
   quick: FilterFieldConfig<TFilters>[]
   defaults?: Partial<TFilters>
+  namespace?: string
 }
 
 export interface FilterBarHandlers<TFilters> {

--- a/frontend/src/utils/filterBar.url.test.ts
+++ b/frontend/src/utils/filterBar.url.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import type { FilterBarConfig } from '@/types/filterBar.types'
+import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
 import { getManagedParamKeys, parseFilters, serializeFilters } from '@/utils/filterBar.url'
 
 interface TestFilters {
@@ -94,5 +94,156 @@ describe('getManagedParamKeys', () => {
     expect(getManagedParamKeys(config)).toEqual(
       expect.arrayContaining(['search', 'status', 'tags']),
     )
+  })
+})
+
+interface PeriodFilters {
+  period: PeriodValue
+}
+
+const periodConfig: FilterBarConfig<PeriodFilters> = {
+  quick: [
+    { field: 'period', label: 'Period', type: 'period' },
+  ],
+  defaults: {
+    period: { key: 'this_month', from: null, to: null },
+  },
+}
+
+describe('serializeFilters — period field', () => {
+  it('serializes a preset period key as a single param', () => {
+    const params = serializeFilters(
+      { period: { key: 'last_week', from: null, to: null } },
+      periodConfig,
+      new URLSearchParams(),
+    )
+    expect(params.get('period')).toBe('last_week')
+    expect(params.get('period_from')).toBeNull()
+    expect(params.get('period_to')).toBeNull()
+  })
+
+  it('serializes custom range as three params', () => {
+    const params = serializeFilters(
+      { period: { key: 'custom', from: '2026-01-01', to: '2026-03-31' } },
+      periodConfig,
+      new URLSearchParams(),
+    )
+    expect(params.get('period')).toBe('custom')
+    expect(params.get('period_from')).toBe('2026-01-01')
+    expect(params.get('period_to')).toBe('2026-03-31')
+  })
+
+  it('omits period params when value equals default', () => {
+    const params = serializeFilters(
+      { period: { key: 'this_month', from: null, to: null } },
+      periodConfig,
+      new URLSearchParams(),
+    )
+    expect(params.toString()).toBe('')
+  })
+})
+
+describe('parseFilters — period field', () => {
+  it('parses a valid preset period key', () => {
+    const result = parseFilters(
+      new URLSearchParams('period=last_year'),
+      periodConfig,
+    )
+    expect(result.period).toEqual({ key: 'last_year', from: null, to: null })
+  })
+
+  it('parses custom range', () => {
+    const result = parseFilters(
+      new URLSearchParams('period=custom&period_from=2026-01-01&period_to=2026-03-31'),
+      periodConfig,
+    )
+    expect(result.period).toEqual({ key: 'custom', from: '2026-01-01', to: '2026-03-31' })
+  })
+
+  it('falls back to default on invalid period key', () => {
+    const result = parseFilters(
+      new URLSearchParams('period=not_a_real_period'),
+      periodConfig,
+    )
+    expect(result.period).toEqual({ key: 'this_month', from: null, to: null })
+  })
+
+  it('falls back to default when period param is absent', () => {
+    const result = parseFilters(new URLSearchParams(), periodConfig)
+    expect(result.period).toEqual({ key: 'this_month', from: null, to: null })
+  })
+})
+
+describe('getManagedParamKeys — period field', () => {
+  it('includes period key and its from/to companions', () => {
+    const keys = getManagedParamKeys(periodConfig)
+    expect(keys).toEqual(expect.arrayContaining(['period', 'period_from', 'period_to']))
+  })
+})
+
+interface NamespacedFilters {
+  search: string
+  status: string | null
+}
+
+const namespacedConfig: FilterBarConfig<NamespacedFilters> = {
+  search: { placeholder: 'Search...' },
+  quick: [
+    { field: 'status', label: 'Status', type: 'select', options: [{ value: 'active', label: 'Active' }] },
+  ],
+  defaults: { search: '', status: null },
+  namespace: 'orders',
+}
+
+describe('serializeFilters — namespace', () => {
+  it('prefixes all params with namespace', () => {
+    const params = serializeFilters(
+      { search: 'foo', status: 'active' },
+      namespacedConfig,
+      new URLSearchParams(),
+    )
+    expect(params.get('orders_search')).toBe('foo')
+    expect(params.get('orders_status')).toBe('active')
+    expect(params.get('search')).toBeNull()
+    expect(params.get('status')).toBeNull()
+  })
+
+  it('preserves unrelated params when namespace is set', () => {
+    const params = serializeFilters(
+      { search: 'foo', status: null },
+      namespacedConfig,
+      new URLSearchParams('tab=archived'),
+    )
+    expect(params.get('tab')).toBe('archived')
+    expect(params.get('orders_search')).toBe('foo')
+  })
+})
+
+describe('parseFilters — namespace', () => {
+  it('reads params using namespace prefix', () => {
+    const result = parseFilters(
+      new URLSearchParams('orders_search=foo&orders_status=active'),
+      namespacedConfig,
+    )
+    expect(result.search).toBe('foo')
+    expect(result.status).toBe('active')
+  })
+
+  it('does not read unprefixed params when namespace is set', () => {
+    const result = parseFilters(
+      new URLSearchParams('search=foo&status=active'),
+      namespacedConfig,
+    )
+    expect(result.search).toBe('')
+    expect(result.status).toBeNull()
+  })
+})
+
+describe('getManagedParamKeys — namespace', () => {
+  it('returns prefixed keys', () => {
+    const keys = getManagedParamKeys(namespacedConfig)
+    expect(keys).toEqual(expect.arrayContaining(['orders_search', 'orders_status']))
+    expect(keys).not.toContain('search')
+    expect(keys).not.toContain('status')
   })
 })

--- a/frontend/src/utils/filterBar.url.test.ts
+++ b/frontend/src/utils/filterBar.url.test.ts
@@ -11,7 +11,7 @@ interface TestFilters {
 
 const config: FilterBarConfig<TestFilters> = {
   search: { placeholder: 'Search...' },
-  quick: [
+  fields: [
     { field: 'status', label: 'Status', type: 'select', options: [{ value: 'active', label: 'Active' }, { value: 'inactive', label: 'Inactive' }] },
     { field: 'tags', label: 'Tags', type: 'multi-select', options: [{ value: 'a', label: 'A' }, { value: 'b', label: 'B' }] },
   ],
@@ -102,7 +102,7 @@ interface PeriodFilters {
 }
 
 const periodConfig: FilterBarConfig<PeriodFilters> = {
-  quick: [
+  fields: [
     { field: 'period', label: 'Period', type: 'period' },
   ],
   defaults: {
@@ -188,7 +188,7 @@ interface NamespacedFilters {
 
 const namespacedConfig: FilterBarConfig<NamespacedFilters> = {
   search: { placeholder: 'Search...' },
-  quick: [
+  fields: [
     { field: 'status', label: 'Status', type: 'select', options: [{ value: 'active', label: 'Active' }] },
   ],
   defaults: { search: '', status: null },

--- a/frontend/src/utils/filterBar.url.test.ts
+++ b/frontend/src/utils/filterBar.url.test.ts
@@ -141,6 +141,24 @@ describe('serializeFilters — period field', () => {
     )
     expect(params.toString()).toBe('')
   })
+
+  it('serializes custom range even when default key is also custom', () => {
+    const customDefaultConfig: FilterBarConfig<PeriodFilters> = {
+      fields: [{ field: 'period', label: 'Period', type: 'period' }],
+      defaults: {
+        period: { key: 'custom', from: '2026-01-01', to: '2026-01-31' },
+      },
+    }
+    // Same key ('custom') but different from/to — must NOT be omitted
+    const params = serializeFilters(
+      { period: { key: 'custom', from: '2026-03-01', to: '2026-03-31' } },
+      customDefaultConfig,
+      new URLSearchParams(),
+    )
+    expect(params.get('period')).toBe('custom')
+    expect(params.get('period_from')).toBe('2026-03-01')
+    expect(params.get('period_to')).toBe('2026-03-31')
+  })
 })
 
 describe('parseFilters — period field', () => {

--- a/frontend/src/utils/filterBar.url.ts
+++ b/frontend/src/utils/filterBar.url.ts
@@ -1,23 +1,36 @@
+import { PERIOD_KEYS, type PeriodKey } from '@/constants/periods'
 import type {
   FilterBarConfig,
   FilterFieldConfig,
+  PeriodValue,
 } from '@/types/filterBar.types'
 
-function effectiveKey<TFilters>(field: FilterFieldConfig<TFilters>): string {
-  return field.paramKey ?? String(field.field)
+function prefixed(key: string, namespace?: string): string {
+  return namespace ? `${namespace}_${key}` : key
+}
+
+function effectiveKey<TFilters>(field: FilterFieldConfig<TFilters>, namespace?: string): string {
+  const base = field.paramKey ?? String(field.field)
+  return prefixed(base, namespace)
 }
 
 export function getManagedParamKeys<TFilters>(
   config: FilterBarConfig<TFilters>,
 ): string[] {
+  const ns = config.namespace
   const keys: string[] = []
 
   if (config.search) {
-    keys.push(config.search.paramKey ?? 'search')
+    keys.push(prefixed(config.search.paramKey ?? 'search', ns))
   }
 
   for (const field of config.quick) {
-    keys.push(effectiveKey(field))
+    const key = effectiveKey(field, ns)
+    keys.push(key)
+    if (field.type === 'period') {
+      keys.push(`${key}_from`)
+      keys.push(`${key}_to`)
+    }
   }
 
   return keys
@@ -28,6 +41,7 @@ export function serializeFilters<TFilters extends object>(
   config: FilterBarConfig<TFilters>,
   currentSearchParams: URLSearchParams,
 ): URLSearchParams {
+  const ns = config.namespace
   const result = new URLSearchParams(currentSearchParams)
 
   for (const key of getManagedParamKeys(config)) {
@@ -38,7 +52,7 @@ export function serializeFilters<TFilters extends object>(
   const orderedEntries: Array<[string, string]> = []
 
   if (config.search) {
-    const searchKey = config.search.paramKey ?? 'search'
+    const searchKey = prefixed(config.search.paramKey ?? 'search', ns)
     const searchValue = ((filters as Record<string, unknown>).search as string | undefined) ?? ''
     const defaultSearch = (defaults.search as string | undefined) ?? ''
     if (searchValue && searchValue !== defaultSearch) {
@@ -47,7 +61,7 @@ export function serializeFilters<TFilters extends object>(
   }
 
   for (const field of config.quick) {
-    const key = effectiveKey(field)
+    const key = effectiveKey(field, ns)
     const value = filters[field.field]
     const defaultValue = defaults[String(field.field)]
 
@@ -64,6 +78,17 @@ export function serializeFilters<TFilters extends object>(
       }
       continue
     }
+
+    if (field.type === 'period') {
+      const period = value as PeriodValue | undefined
+      const defaultPeriod = defaultValue as PeriodValue | undefined
+      if (!period || period.key === (defaultPeriod?.key ?? 'this_month')) continue
+      orderedEntries.push([key, period.key])
+      if (period.key === 'custom' && period.from && period.to) {
+        orderedEntries.push([`${key}_from`, period.from])
+        orderedEntries.push([`${key}_to`, period.to])
+      }
+    }
   }
 
   for (const [key, value] of orderedEntries) {
@@ -77,16 +102,17 @@ export function parseFilters<TFilters extends object>(
   searchParams: URLSearchParams,
   config: FilterBarConfig<TFilters>,
 ): TFilters {
+  const ns = config.namespace
   const defaults = (config.defaults ?? {}) as Record<string, unknown>
   const result: Record<string, unknown> = {}
 
   if (config.search) {
-    const searchKey = config.search.paramKey ?? 'search'
+    const searchKey = prefixed(config.search.paramKey ?? 'search', ns)
     result.search = searchParams.get(searchKey) ?? (defaults.search ?? '')
   }
 
   for (const field of config.quick) {
-    const key = effectiveKey(field)
+    const key = effectiveKey(field, ns)
     const fieldKey = String(field.field)
     const defaultValue = defaults[fieldKey]
 
@@ -105,6 +131,30 @@ export function parseFilters<TFilters extends object>(
       const validOptions = new Set(field.options.map((option) => option.value))
       result[fieldKey] = searchParams.getAll(key).filter((value) => validOptions.has(value))
       continue
+    }
+
+    if (field.type === 'period') {
+      const defaultPeriod = (defaultValue as PeriodValue | undefined) ?? {
+        key: 'this_month' as PeriodKey,
+        from: null,
+        to: null,
+      }
+      const raw = searchParams.get(key)
+      if (raw === null || !(PERIOD_KEYS as readonly string[]).includes(raw)) {
+        result[fieldKey] = defaultPeriod
+        continue
+      }
+
+      const periodKey = raw as PeriodKey
+      if (periodKey === 'custom') {
+        result[fieldKey] = {
+          key: 'custom',
+          from: searchParams.get(`${key}_from`) ?? null,
+          to: searchParams.get(`${key}_to`) ?? null,
+        } satisfies PeriodValue
+      } else {
+        result[fieldKey] = { key: periodKey, from: null, to: null } satisfies PeriodValue
+      }
     }
   }
 

--- a/frontend/src/utils/filterBar.url.ts
+++ b/frontend/src/utils/filterBar.url.ts
@@ -24,7 +24,7 @@ export function getManagedParamKeys<TFilters>(
     keys.push(prefixed(config.search.paramKey ?? 'search', ns))
   }
 
-  for (const field of config.quick) {
+  for (const field of config.fields) {
     const key = effectiveKey(field, ns)
     keys.push(key)
     if (field.type === 'period') {
@@ -60,7 +60,7 @@ export function serializeFilters<TFilters extends object>(
     }
   }
 
-  for (const field of config.quick) {
+  for (const field of config.fields) {
     const key = effectiveKey(field, ns)
     const value = filters[field.field]
     const defaultValue = defaults[String(field.field)]
@@ -111,7 +111,7 @@ export function parseFilters<TFilters extends object>(
     result.search = searchParams.get(searchKey) ?? (defaults.search ?? '')
   }
 
-  for (const field of config.quick) {
+  for (const field of config.fields) {
     const key = effectiveKey(field, ns)
     const fieldKey = String(field.field)
     const defaultValue = defaults[fieldKey]

--- a/frontend/src/utils/filterBar.url.ts
+++ b/frontend/src/utils/filterBar.url.ts
@@ -82,12 +82,19 @@ export function serializeFilters<TFilters extends object>(
     if (field.type === 'period') {
       const period = value as PeriodValue | undefined
       const defaultPeriod = defaultValue as PeriodValue | undefined
-      if (!period || period.key === (defaultPeriod?.key ?? 'this_month')) continue
+      const defaultKey = defaultPeriod?.key ?? 'this_month'
+      const defaultFrom = defaultPeriod?.from ?? null
+      const defaultTo = defaultPeriod?.to ?? null
+      const isDefault =
+        !period ||
+        (period.key === defaultKey && period.from === defaultFrom && period.to === defaultTo)
+      if (isDefault) continue
       orderedEntries.push([key, period.key])
       if (period.key === 'custom' && period.from && period.to) {
         orderedEntries.push([`${key}_from`, period.from])
         orderedEntries.push([`${key}_to`, period.to])
       }
+      continue
     }
   }
 


### PR DESCRIPTION
## Summary

- **Period field type**: `FilterPeriod` is now a first-class field type in the `FilterBar` config system. Add `{ type: 'period', field: 'period' }` to any `FilterBarConfig.fields` array to get a full period selector with URL state management. Period state is stored as `PeriodValue = { key: PeriodKey, from: string | null, to: string | null }`.
- **`quick` → `fields` rename**: `FilterBarConfig.quick` is now `FilterBarConfig.fields`. Hard cutover across all 14 affected files — no deprecation shim.
- **URL namespacing**: `FilterBarConfig` now accepts an optional `namespace` string. When set, all URL params (including search) are prefixed with `${namespace}_` (e.g. `?orders_search=foo&orders_period=this_month`) to prevent collisions when multiple filtered lists share a route.

## Test Plan

- [x] `npx vitest run src/utils/filterBar.url.test.ts` — 23 tests pass (period serialize/parse, namespace, regression for custom-default edge case)
- [x] `npx vitest run src/hooks/useFilterBar.test.tsx` — period default + update tests pass
- [x] `npx vitest run src/components/filters/__tests__/FilterBar.test.tsx` — period rendering test passes
- [x] `npx vitest run src/components/filters/FilterPeriod.test.tsx` — FilterPeriod unchanged, still passes
- [x] All 8 page filterbar tests pass after `quick` → `fields` rename
- [x] `npm run type-check` — clean

Closes #250