### PR TITLE
fix(sidebar): refine active pill — opacity, radius, hover shift, flyout sync

### DIFF
--- a/frontend/src/components/common/Sidebar.tsx
+++ b/frontend/src/components/common/Sidebar.tsx
@@ -425,7 +425,6 @@ const Sidebar: React.FC<SidebarProps> = ({
         ? {
             bgcolor: colors.activeBg,
             boxShadow: `inset 0 0 0 1px ${colors.outline}`,
-            transform: 'translateX(4px)',
             '&::before': {
               content: '""',
               position: 'absolute',
@@ -563,7 +562,7 @@ const Sidebar: React.FC<SidebarProps> = ({
               mx: 1,
               mb: 0.5,
               position: 'relative',
-              transform: 'translateX(0)',
+              transform: isActive && !hasChildren ? 'translateX(4px)' : 'translateX(0)',
               transition: 'background-color 0.18s ease, transform 0.18s ease',
               ...activeLeafSx,
               ...activeParentSx,

--- a/frontend/src/components/common/Sidebar.tsx
+++ b/frontend/src/components/common/Sidebar.tsx
@@ -45,7 +45,7 @@ const useSidebarColors = () => {
 
   return {
     bg: theme.palette.background.sidebar,
-    activeBg: theme.palette.action.selected,
+    activeBg: alpha(theme.palette.primary.main, 0.13),
     hoverBg: theme.palette.action.hover,
     text: theme.palette.text.secondary,
     activeText: theme.palette.text.primary,
@@ -304,16 +304,18 @@ const Sidebar: React.FC<SidebarProps> = ({
             pl: 1.5 + level * 2,
             pr: 1.5,
             py: 0,
-            height: 36,
-            borderRadius: 2,
-            mx: 0.5,
+            height: 40,
+            borderRadius: 1,
+            mx: 1,
             mb: 0.25,
             position: 'relative',
-            transition: 'background-color 0.18s ease',
+            transform: 'translateX(0)',
+            transition: 'background-color 0.18s ease, transform 0.18s ease',
             // Leaf active: pill background + left accent bar
             ...(isActive && !hasChildren && {
               bgcolor: colors.activeBg,
               boxShadow: `inset 0 0 0 1px ${colors.outline}`,
+              transform: 'translateX(4px)',
               '&::before': {
                 content: '""',
                 position: 'absolute',
@@ -331,7 +333,7 @@ const Sidebar: React.FC<SidebarProps> = ({
               '& .MuiListItemIcon-root': { color: colors.activeText },
               '& .MuiListItemText-primary': { color: colors.activeText },
             }),
-            '&:hover': { bgcolor: colors.hoverBg },
+            '&:hover': { bgcolor: colors.hoverBg, transform: 'translateX(4px)' },
             ...(!isActive && {
               '&:hover .MuiListItemIcon-root': { color: colors.hoverText },
               '&:hover .MuiListItemText-primary': { color: colors.hoverText },
@@ -352,7 +354,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             primary={item.title}
             sx={{
               '& .MuiListItemText-primary': {
-                fontSize: '0.8125rem',
+                fontSize: '0.875rem',
                 fontWeight: isActive && !hasChildren ? 600 : 400,
                 color: isActive ? colors.activeText : colors.text,
                 transition: 'color 0.18s ease',
@@ -423,6 +425,7 @@ const Sidebar: React.FC<SidebarProps> = ({
         ? {
             bgcolor: colors.activeBg,
             boxShadow: `inset 0 0 0 1px ${colors.outline}`,
+            transform: 'translateX(4px)',
             '&::before': {
               content: '""',
               position: 'absolute',
@@ -556,14 +559,15 @@ const Sidebar: React.FC<SidebarProps> = ({
               pl: 2 + level * 2,
               py: 0,
               height: 40,
-              borderRadius: 2,
+              borderRadius: 1,
               mx: 1,
               mb: 0.5,
               position: 'relative',
-              transition: 'background-color 0.18s ease',
+              transform: 'translateX(0)',
+              transition: 'background-color 0.18s ease, transform 0.18s ease',
               ...activeLeafSx,
               ...activeParentSx,
-              '&:hover': { bgcolor: colors.hoverBg },
+              '&:hover': { bgcolor: colors.hoverBg, transform: 'translateX(4px)' },
               ...(!isActive && {
                 '&:hover .MuiListItemIcon-root': { color: colors.hoverText },
                 '&:hover .MuiListItemText-primary': { color: colors.hoverText },

--- a/frontend/src/components/common/SidebarFooter.tsx
+++ b/frontend/src/components/common/SidebarFooter.tsx
@@ -13,7 +13,7 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed }) => {
   return (
     <Box
       sx={{
-        backgroundColor: theme.palette.background.default,
+        backgroundColor: theme.palette.background.sidebar,
         borderTop: `1px solid ${theme.palette.divider}`,
         py: 1,
         display: 'flex',

--- a/frontend/src/components/common/SidebarUserMenu.tsx
+++ b/frontend/src/components/common/SidebarUserMenu.tsx
@@ -130,17 +130,22 @@ const SidebarUserMenu: React.FC<SidebarUserMenuProps> = ({ collapsed }) => {
           sx={{
             display: 'flex',
             alignItems: 'center',
-            width: '100%',
+            alignSelf: 'stretch',
             height: '40px',
             px: 2,
+            mx: 1,
+            mb: 0.5,
+            borderRadius: 1,
             cursor: 'pointer',
             background: 'transparent',
             border: 'none',
             textAlign: 'left',
+            boxSizing: 'border-box',
+            transform: 'translateX(0)',
             transition: 'background-color 0.15s ease, transform 0.15s ease',
             '&:hover': {
               backgroundColor: theme.palette.action.hover,
-              transform: 'translateX(1px)',
+              transform: 'translateX(4px)',
             },
           }}
           onClick={handleAvatarClick}

--- a/frontend/src/components/common/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/common/__tests__/Sidebar.test.tsx
@@ -1,7 +1,9 @@
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { ThemeProvider, alpha } from '@mui/material/styles'
 import { MemoryRouter, useLocation } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import Sidebar from '../Sidebar'
+import { darkTheme } from '@/styles/theme'
 
 const mockUseGetCompanySettingsQuery = vi.fn()
 const mockUseAppSelector = vi.fn()
@@ -39,6 +41,9 @@ vi.mock('../SidebarFooter', () => ({
 }))
 
 describe('Sidebar', () => {
+  const renderSidebarWithTheme = (ui: React.ReactElement) =>
+    render(<ThemeProvider theme={darkTheme}>{ui}</ThemeProvider>)
+
   beforeEach(() => {
     localStorage.clear()
     vi.useFakeTimers({ shouldAdvanceTime: true })
@@ -358,6 +363,40 @@ describe('Sidebar', () => {
     fireEvent.mouseLeave(salesButton)
 
     expect(screen.getByTestId('sidebar-root')).toBeInTheDocument()
+  })
+
+  it('styles the active expanded leaf as the refined sidebar pill', () => {
+    renderSidebarWithTheme(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Sidebar />
+      </MemoryRouter>
+    )
+
+    const dashboardButton = screen.getByRole('button', { name: 'Dashboard' })
+    const styles = window.getComputedStyle(dashboardButton)
+
+    expect(styles.backgroundColor).toBe(alpha(darkTheme.palette.primary.main, 0.13))
+    expect(styles.borderRadius).toBe('8px')
+    expect(styles.transform).toContain('4')
+  })
+
+  it('matches flyout item dimensions and type scale to the expanded sidebar pills', async () => {
+    renderSidebarWithTheme(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Sidebar collapsed={true} />
+      </MemoryRouter>
+    )
+
+    await openCollapsedFlyout('sales')
+
+    const customersButton = screen.getByRole('button', { name: 'Customers' })
+    const buttonStyles = window.getComputedStyle(customersButton)
+    const labelStyles = window.getComputedStyle(within(customersButton).getByText('Customers'))
+
+    expect(buttonStyles.height).toBe('40px')
+    expect(buttonStyles.borderRadius).toBe('8px')
+    expect(buttonStyles.transform).toBe('translateX(0)')
+    expect(labelStyles.fontSize).toBe('0.875rem')
   })
 
   it('closes flyout when Escape is pressed', async () => {

--- a/frontend/src/components/common/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/common/__tests__/Sidebar.test.tsx
@@ -380,6 +380,20 @@ describe('Sidebar', () => {
     expect(styles.transform).toContain('4')
   })
 
+  it('does not apply translateX to the active collapsed rail icon button', () => {
+    renderSidebarWithTheme(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Sidebar collapsed={true} />
+      </MemoryRouter>
+    )
+
+    // Dashboard is a leaf item active at /dashboard; in collapsed mode it renders
+    // as a centered rail icon — horizontal shift must not be applied.
+    const dashboardButton = screen.getByRole('button', { name: 'Dashboard' })
+    const styles = window.getComputedStyle(dashboardButton)
+    expect(styles.transform).not.toContain('4px')
+  })
+
   it('matches flyout item dimensions and type scale to the expanded sidebar pills', async () => {
     renderSidebarWithTheme(
       <MemoryRouter initialEntries={['/dashboard']}>

--- a/frontend/src/components/common/__tests__/SidebarFooter.test.tsx
+++ b/frontend/src/components/common/__tests__/SidebarFooter.test.tsx
@@ -1,10 +1,12 @@
 import { render, screen } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router-dom'
+import { ThemeProvider } from '@mui/material/styles'
 import { configureStore } from '@reduxjs/toolkit'
 import { describe, expect, it } from 'vitest'
 import SidebarFooter from '../SidebarFooter'
 import authReducer from '@/store/slices/authSlice'
+import { darkTheme } from '@/styles/theme'
 
 const makeStore = (authOverrides = {}) =>
   configureStore({
@@ -42,11 +44,13 @@ const makeStore = (authOverrides = {}) =>
 // has no Redux or router dependencies.
 const renderFooter = (props = {}, authOverrides = {}) =>
   render(
-    <Provider store={makeStore(authOverrides)}>
-      <MemoryRouter>
-        <SidebarFooter collapsed={false} {...props} />
-      </MemoryRouter>
-    </Provider>
+    <ThemeProvider theme={darkTheme}>
+      <Provider store={makeStore(authOverrides)}>
+        <MemoryRouter>
+          <SidebarFooter collapsed={false} {...props} />
+        </MemoryRouter>
+      </Provider>
+    </ThemeProvider>
   )
 
 describe('SidebarFooter (layout shell)', () => {
@@ -68,5 +72,12 @@ describe('SidebarFooter (layout shell)', () => {
   it('passes collapsed=true to SidebarUserMenu', () => {
     renderFooter({ collapsed: true })
     expect(screen.getByRole('button', { name: /open user menu/i })).toBeInTheDocument()
+  })
+
+  it('uses the sidebar background token for the footer shell', () => {
+    const { container } = renderFooter()
+    const footer = container.firstChild as HTMLElement
+
+    expect(window.getComputedStyle(footer).backgroundColor).toBe('rgb(13, 13, 13)')
   })
 })

--- a/frontend/src/components/common/__tests__/SidebarFooter.test.tsx
+++ b/frontend/src/components/common/__tests__/SidebarFooter.test.tsx
@@ -78,6 +78,9 @@ describe('SidebarFooter (layout shell)', () => {
     const { container } = renderFooter()
     const footer = container.firstChild as HTMLElement
 
-    expect(window.getComputedStyle(footer).backgroundColor).toBe('rgb(13, 13, 13)')
+    // Derive expected value from the theme token so this test survives palette changes
+    const hex = darkTheme.palette.background.sidebar // e.g. '#0D0D0D'
+    const [r, g, b] = [1, 3, 5].map(i => parseInt(hex.slice(i, i + 2), 16))
+    expect(window.getComputedStyle(footer).backgroundColor).toBe(`rgb(${r}, ${g}, ${b})`)
   })
 })

--- a/frontend/src/components/common/__tests__/SidebarUserMenu.test.tsx
+++ b/frontend/src/components/common/__tests__/SidebarUserMenu.test.tsx
@@ -1,10 +1,12 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { ThemeProvider } from '@mui/material/styles'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router-dom'
 import { configureStore } from '@reduxjs/toolkit'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import SidebarUserMenu from '../SidebarUserMenu'
 import authReducer from '@/store/slices/authSlice'
+import { darkTheme } from '@/styles/theme'
 
 vi.mock('@/store', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/store')>()
@@ -55,11 +57,13 @@ const renderMenu = (props = {}, authOverrides = {}) => {
   return {
     store,
     ...render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <SidebarUserMenu collapsed={false} {...props} />
-        </MemoryRouter>
-      </Provider>
+      <ThemeProvider theme={darkTheme}>
+        <Provider store={store}>
+          <MemoryRouter>
+            <SidebarUserMenu collapsed={false} {...props} />
+          </MemoryRouter>
+        </Provider>
+      </ThemeProvider>
     ),
   }
 }
@@ -121,5 +125,19 @@ describe('SidebarUserMenu', () => {
     await screen.findByRole('menu')
     fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' })
     await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument())
+  })
+
+  it('uses the refined expanded trigger pill layout', () => {
+    renderMenu()
+
+    const trigger = screen.getByRole('button', { name: /open user menu/i })
+    const styles = window.getComputedStyle(trigger)
+
+    expect(styles.alignSelf).toBe('stretch')
+    expect(styles.borderRadius).toBe('8px')
+    expect(styles.marginLeft).toBe('8px')
+    expect(styles.marginRight).toBe('8px')
+    expect(styles.marginBottom).toBe('4px')
+    expect(styles.transform).toBe('translateX(0)')
   })
 })


### PR DESCRIPTION
## Summary
- Active pill background raised from ~8% to 13% opacity via `alpha(primary.main, 0.13)` in `useSidebarColors`
- Border radius reduced from 16px → 8px (`borderRadius: 1`) app-wide in pill items
- `translateX(4px)` hover/active shift added to expanded nav items and user menu trigger; collapsed rail icons intentionally excluded
- Flyout items synced to match expanded sidebar: height 36→40px, font 0.8125→0.875rem, mx 0.5→1
- `SidebarFooter` background changed from `background.default` → `background.sidebar`
- User menu trigger given pill geometry (`borderRadius: 1`, `mx: 1`, `mb: 0.5`, `alignSelf: stretch`)

## Test Plan
- [x] Regression tests added for active pill styles, flyout dimension sync, collapsed rail icon no-transform
- [x] `SidebarFooter` background token test derives expected value from theme (not hardcoded RGB)
- [x] 51 targeted tests passing: Sidebar, SidebarFooter, SidebarUserMenu
- [x] `npm run type-check` passes
- [x] `npm run lint` passes

Closes #256