### PR TITLE
feat: master-detail-items workspace layout (#260)

### DIFF
--- a/frontend/src/components/common/MasterDetailWorkspace.test.tsx
+++ b/frontend/src/components/common/MasterDetailWorkspace.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import MasterDetailWorkspace from './MasterDetailWorkspace'
+
+describe('MasterDetailWorkspace', () => {
+  it('renders the three slots in desktop mode', () => {
+    render(
+      <MasterDetailWorkspace
+        listSlot={<div>List Slot</div>}
+        headerSlot={<div>Header Slot</div>}
+        workspaceSlot={<div>Workspace Slot</div>}
+        isMobile={false}
+      />,
+    )
+
+    expect(screen.getByText('List Slot')).toBeInTheDocument()
+    expect(screen.getByText('Header Slot')).toBeInTheDocument()
+    expect(screen.getByText('Workspace Slot')).toBeInTheDocument()
+  })
+
+  it('renders the same three slots in mobile mode', () => {
+    render(
+      <MasterDetailWorkspace
+        listSlot={<div>List Slot</div>}
+        headerSlot={<div>Header Slot</div>}
+        workspaceSlot={<div>Workspace Slot</div>}
+        isMobile
+      />,
+    )
+
+    expect(screen.getByText('List Slot')).toBeInTheDocument()
+    expect(screen.getByText('Header Slot')).toBeInTheDocument()
+    expect(screen.getByText('Workspace Slot')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/common/MasterDetailWorkspace.tsx
+++ b/frontend/src/components/common/MasterDetailWorkspace.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { Box } from '@mui/material'
+
+interface MasterDetailWorkspaceProps {
+  listSlot: React.ReactNode
+  headerSlot: React.ReactNode
+  workspaceSlot: React.ReactNode
+  isMobile: boolean
+}
+
+const MasterDetailWorkspace: React.FC<MasterDetailWorkspaceProps> = ({
+  listSlot,
+  headerSlot,
+  workspaceSlot,
+  isMobile,
+}) => {
+  if (isMobile) {
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        {listSlot}
+        {headerSlot}
+        {workspaceSlot}
+      </Box>
+    )
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'row', height: 'calc(100vh - 300px)', gap: 3 }}>
+      <Box
+        sx={{
+          width: '25%',
+          flexShrink: 0,
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        {listSlot}
+      </Box>
+      <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2, overflow: 'hidden' }}>
+        {headerSlot}
+        <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          {workspaceSlot}
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+
+export default MasterDetailWorkspace

--- a/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
@@ -1,14 +1,15 @@
 import React, { useCallback, useMemo } from 'react'
 import { ArrowDownward as ArrowDownIcon, ArrowUpward as ArrowUpIcon, Sort as SortIcon } from '@mui/icons-material'
 import { Alert, Box, Button, Stack, useMediaQuery, useTheme } from '@mui/material'
-import Grid from '@mui/material/GridLegacy'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
+import MasterDetailWorkspace from '@/components/common/MasterDetailWorkspace'
 import PageHeader from '@/components/common/PageHeader'
 import { FilterBar } from '@/components/filters'
-import PurchaseOrderDetailsPanel from './components/PurchaseOrderDetailsPanel'
+import PurchaseOrderContextHeader from './components/PurchaseOrderContextHeader'
 import PurchaseOrdersDialogs from './components/PurchaseOrdersDialogs'
 import PurchaseOrdersTable from './components/PurchaseOrdersTable'
+import PurchaseOrderWorkspaceCard from './components/PurchaseOrderWorkspaceCard'
 import { usePurchaseOrdersActions } from './hooks/usePurchaseOrdersActions'
 import { usePurchaseOrdersPageState } from './hooks/usePurchaseOrdersPageState'
 import { usePurchaseOrdersSelection } from './hooks/usePurchaseOrdersSelection'
@@ -176,12 +177,6 @@ export const PurchaseOrdersPage: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      {import.meta.env.DEV && (
-        <Alert severity="info" sx={{ mb: 2 }}>
-          Debug: PurchaseOrdersPage loaded | Orders: {purchaseOrders.length} | Loading: {String(loading)} | Error: {error || 'None'}
-        </Alert>
-      )}
-
       <PageHeader
         title="Purchase Orders"
         subtitle="Manage supplier purchase orders and procurement"
@@ -219,8 +214,9 @@ export const PurchaseOrdersPage: React.FC = () => {
         </Alert>
       )}
 
-      <Grid container spacing={3}>
-        <Grid item xs={12} md={3}>
+      <MasterDetailWorkspace
+        isMobile={isMobile}
+        listSlot={(
           <PurchaseOrdersTable
             purchaseOrders={purchaseOrders}
             loading={loading}
@@ -230,9 +226,9 @@ export const PurchaseOrdersPage: React.FC = () => {
             onOrderSelect={selection.handleOrderSelect}
             orderListRef={pageState.orderListRef}
           />
-        </Grid>
-        <Grid item xs={12} md={9}>
-          <PurchaseOrderDetailsPanel
+        )}
+        headerSlot={(
+          <PurchaseOrderContextHeader
             selectedOrder={selectedOrder}
             isLoading={pageState.isLoading}
             journalEntryRef={pageState.journalEntryRef}
@@ -248,8 +244,9 @@ export const PurchaseOrdersPage: React.FC = () => {
             onReturn={actions.handleReturn}
             onReceive={actions.handleReceive}
           />
-        </Grid>
-      </Grid>
+        )}
+        workspaceSlot={<PurchaseOrderWorkspaceCard selectedOrder={selectedOrder} />}
+      />
 
       <PurchaseOrdersDialogs
         selectedOrder={selectedOrder}

--- a/frontend/src/pages/purchasing/__tests__/PurchaseOrdersPage.filterbar.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/PurchaseOrdersPage.filterbar.test.tsx
@@ -29,8 +29,19 @@ vi.mock('@/store/api/purchasingApi', () => ({
   useDeletePurchaseOrderMutation: vi.fn(() => [vi.fn()]),
 }))
 
+vi.mock('@/components/common/MasterDetailWorkspace', () => ({
+  default: ({ listSlot, headerSlot, workspaceSlot }: any) => (
+    <div>
+      <div>MasterDetailWorkspace</div>
+      <div>{listSlot}</div>
+      <div>{headerSlot}</div>
+      <div>{workspaceSlot}</div>
+    </div>
+  ),
+}))
 vi.mock('../components/PurchaseOrdersTable', () => ({ default: () => <div>PurchaseOrdersTable</div> }))
-vi.mock('../components/PurchaseOrderDetailsPanel', () => ({ default: () => <div>PurchaseOrderDetailsPanel</div> }))
+vi.mock('../components/PurchaseOrderContextHeader', () => ({ default: () => <div>PurchaseOrderContextHeader</div> }))
+vi.mock('../components/PurchaseOrderWorkspaceCard', () => ({ default: () => <div>PurchaseOrderWorkspaceCard</div> }))
 vi.mock('../components/PurchaseOrdersDialogs', () => ({ default: () => <div>PurchaseOrdersDialogs</div> }))
 vi.mock('../hooks/usePurchaseOrdersActions', () => ({
   usePurchaseOrdersActions: () => ({
@@ -85,6 +96,15 @@ describe('PurchaseOrdersPage FilterBar integration', () => {
   it('renders the shared filter search input', () => {
     renderPage()
     expect(screen.getByPlaceholderText(/search purchase orders/i)).toBeInTheDocument()
+  })
+
+  it('renders the master-detail workspace with split purchasing detail cards', () => {
+    renderPage()
+
+    expect(screen.getByText('MasterDetailWorkspace')).toBeInTheDocument()
+    expect(screen.getByText('PurchaseOrdersTable')).toBeInTheDocument()
+    expect(screen.getByText('PurchaseOrderContextHeader')).toBeInTheDocument()
+    expect(screen.getByText('PurchaseOrderWorkspaceCard')).toBeInTheDocument()
   })
 
   it('restores new URL params into the purchase orders query', () => {

--- a/frontend/src/pages/purchasing/components/PurchaseOrderContextHeader.tsx
+++ b/frontend/src/pages/purchasing/components/PurchaseOrderContextHeader.tsx
@@ -5,7 +5,6 @@ import {
   Print as PrintIcon,
 } from '@mui/icons-material'
 import {
-  Alert,
   Box,
   Button,
   IconButton,
@@ -15,7 +14,6 @@ import {
   TableBody,
   TableCell,
   TableContainer,
-  TableHead,
   TableRow,
   Typography,
 } from '@mui/material'
@@ -27,7 +25,7 @@ import { formatCurrency, formatDate } from '@/utils/formatters'
 
 import type { PurchaseJournalEntryRef } from '../hooks/usePurchaseOrdersPageState'
 
-interface PurchaseOrderDetailsPanelProps {
+interface PurchaseOrderContextHeaderProps {
   selectedOrder: PurchaseOrder | null
   isLoading: boolean
   journalEntryRef: PurchaseJournalEntryRef | null
@@ -44,7 +42,36 @@ interface PurchaseOrderDetailsPanelProps {
   onReceive: () => void
 }
 
-const PurchaseOrderDetailsPanel: React.FC<PurchaseOrderDetailsPanelProps> = ({
+const actionIconSx = {
+  height: `${TABLE_STYLES.row.height * 0.75}px`,
+  width: `${TABLE_STYLES.row.height * 0.75}px`,
+  minHeight: 20,
+  minWidth: 20,
+  p: 0.125,
+}
+
+const detailTableSx = {
+  tableLayout: 'fixed',
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const labelCellSx = {
+  fontWeight: 600,
+  color: 'text.secondary',
+  fontSize: '0.8rem',
+}
+
+const valueCellSx = {
+  fontSize: '0.8rem',
+}
+
+const PurchaseOrderContextHeader: React.FC<PurchaseOrderContextHeaderProps> = ({
   selectedOrder,
   isLoading,
   journalEntryRef,
@@ -62,7 +89,7 @@ const PurchaseOrderDetailsPanel: React.FC<PurchaseOrderDetailsPanelProps> = ({
 }) => {
   if (!selectedOrder) {
     return (
-      <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
         <Typography variant="h6" color="text.secondary">
           Select a purchase order to view details
         </Typography>
@@ -78,29 +105,37 @@ const PurchaseOrderDetailsPanel: React.FC<PurchaseOrderDetailsPanelProps> = ({
   const hasPayment = !!(selectedOrder.vendorPayments && selectedOrder.vendorPayments.length > 0)
 
   return (
-    <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', flexDirection: 'column' }}>
-      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+    <Paper sx={{ overflow: 'hidden' }}>
+      <Box
+        sx={{
+          p: TABLE_STYLES.cell.padding.px,
+          borderBottom: TABLE_STYLES.cell.border,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
         <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
           PO Details - {selectedOrder.orderNumber}
         </Typography>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
-          <IconButton size="small" title="Edit Order" onClick={onEditClick} sx={{ height: `${TABLE_STYLES.row.height * 0.75}px`, width: `${TABLE_STYLES.row.height * 0.75}px`, color: 'primary.main' }}>
+          <IconButton size="small" title="Edit Order" onClick={onEditClick} sx={{ ...actionIconSx, color: 'primary.main' }}>
             <EditIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
           </IconButton>
-          <IconButton size="small" title="Delete Order" onClick={onDeleteClick} sx={{ height: `${TABLE_STYLES.row.height * 0.75}px`, width: `${TABLE_STYLES.row.height * 0.75}px`, color: 'error.main' }}>
+          <IconButton size="small" title="Delete Order" onClick={onDeleteClick} sx={{ ...actionIconSx, color: 'error.main' }}>
             <DeleteIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
           </IconButton>
-          <IconButton size="small" title="Print Purchase Order" onClick={onPrint} sx={{ height: `${TABLE_STYLES.row.height * 0.75}px`, width: `${TABLE_STYLES.row.height * 0.75}px`, color: 'info.main' }}>
+          <IconButton size="small" title="Print Purchase Order" onClick={onPrint} sx={{ ...actionIconSx, color: 'info.main' }}>
             <PrintIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
           </IconButton>
         </Box>
       </Box>
 
-      <Box sx={{ flex: 1, overflow: 'auto', p: TABLE_STYLES.cell.padding.px }}>
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
         <Grid container spacing={3}>
           <Grid item xs={12} md={6}>
             <TableContainer>
-              <Table size={TABLE_STYLES.size} sx={{ tableLayout: 'fixed', '& .MuiTableCell-root': { border: 'none', py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px, '&:nth-of-type(1)': { width: '40%' }, '&:nth-of-type(2)': { width: '60%' } } }}>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
                 <TableBody>
                   <TableRow>
                     <TableCell colSpan={2} sx={{ pb: TABLE_STYLES.cell.padding.py * 0.67, py: TABLE_STYLES.cell.padding.py * 0.67, borderTop: TABLE_STYLES.cell.border }}>
@@ -110,16 +145,16 @@ const PurchaseOrderDetailsPanel: React.FC<PurchaseOrderDetailsPanelProps> = ({
                     </TableCell>
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>Supplier</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>{selectedOrder.supplier?.companyName || 'N/A'}</TableCell>
+                    <TableCell sx={labelCellSx}>Supplier</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedOrder.supplier?.companyName || 'N/A'}</TableCell>
                   </TableRow>
                   <TableRow>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>PO Date</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>{formatDate(selectedOrder.orderDate)}</TableCell>
+                    <TableCell sx={labelCellSx}>PO Date</TableCell>
+                    <TableCell sx={valueCellSx}>{formatDate(selectedOrder.orderDate)}</TableCell>
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>GRN No</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>
+                    <TableCell sx={labelCellSx}>GRN No</TableCell>
+                    <TableCell sx={valueCellSx}>
                       {selectedOrder.goodsReceivedNotes && selectedOrder.goodsReceivedNotes.length > 0
                         ? selectedOrder.goodsReceivedNotes.map((grn: any, index: number) => (
                             <Box key={grn.id} component="span">
@@ -133,8 +168,8 @@ const PurchaseOrderDetailsPanel: React.FC<PurchaseOrderDetailsPanelProps> = ({
                     </TableCell>
                   </TableRow>
                   <TableRow>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>VP No</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>
+                    <TableCell sx={labelCellSx}>VP No</TableCell>
+                    <TableCell sx={valueCellSx}>
                       {selectedOrder.vendorPayments && selectedOrder.vendorPayments.length > 0
                         ? selectedOrder.vendorPayments.map((payment: any, index: number) => (
                             <Box key={payment.id} component="span">
@@ -148,8 +183,8 @@ const PurchaseOrderDetailsPanel: React.FC<PurchaseOrderDetailsPanelProps> = ({
                     </TableCell>
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>Journal Entry No</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>
+                    <TableCell sx={labelCellSx}>Journal Entry No</TableCell>
+                    <TableCell sx={valueCellSx}>
                       {journalEntryRefLoading ? (
                         <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}>Loading...</Typography>
                       ) : journalEntryRef ? (
@@ -168,7 +203,7 @@ const PurchaseOrderDetailsPanel: React.FC<PurchaseOrderDetailsPanelProps> = ({
 
           <Grid item xs={12} md={6}>
             <TableContainer>
-              <Table size={TABLE_STYLES.size} sx={{ tableLayout: 'fixed', '& .MuiTableCell-root': { border: 'none', py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px, '&:nth-of-type(1)': { width: '40%' }, '&:nth-of-type(2)': { width: '60%' } } }}>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
                 <TableBody>
                   <TableRow>
                     <TableCell colSpan={2} sx={{ pb: TABLE_STYLES.cell.padding.py * 0.67, py: TABLE_STYLES.cell.padding.py * 0.67, borderTop: TABLE_STYLES.cell.border }}>
@@ -178,24 +213,24 @@ const PurchaseOrderDetailsPanel: React.FC<PurchaseOrderDetailsPanelProps> = ({
                     </TableCell>
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>Sub-total</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>{formatCurrency((selectedOrder as any).subtotal || 0)}</TableCell>
+                    <TableCell sx={labelCellSx}>Sub-total</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency((selectedOrder as any).subtotal || 0)}</TableCell>
                   </TableRow>
                   <TableRow>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>Shipping</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>{formatCurrency(selectedOrder.shippingAmount || 0)}</TableCell>
+                    <TableCell sx={labelCellSx}>Shipping</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(selectedOrder.shippingAmount || 0)}</TableCell>
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50', borderTop: TABLE_STYLES.cell.border }}>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>Total</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>{formatCurrency(selectedOrder.totalAmount || 0)}</TableCell>
+                    <TableCell sx={labelCellSx}>Total</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(selectedOrder.totalAmount || 0)}</TableCell>
                   </TableRow>
                   <TableRow>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>Paid</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>{formatCurrency(selectedOrder.paidAmount || 0)}</TableCell>
+                    <TableCell sx={labelCellSx}>Paid</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(selectedOrder.paidAmount || 0)}</TableCell>
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>Balance</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>{formatCurrency(Math.max(0, (selectedOrder.totalAmount || 0) - (selectedOrder.paidAmount || 0)))}</TableCell>
+                    <TableCell sx={labelCellSx}>Balance</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(Math.max(0, (selectedOrder.totalAmount || 0) - (selectedOrder.paidAmount || 0)))}</TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell colSpan={2} sx={{ textAlign: 'center' }}>
@@ -211,7 +246,7 @@ const PurchaseOrderDetailsPanel: React.FC<PurchaseOrderDetailsPanelProps> = ({
                           {hasPayment ? 'Unpay' : 'Pay'}
                         </Button>
                         {isReceived ? (
-                          <Button variant="contained" size="small" color="warning" sx={{ minWidth: 110 }} onClick={onReturn} disabled={!selectedOrder?.items || selectedOrder.items.length === 0 || isLoading}>
+                          <Button variant="contained" size="small" color="warning" sx={{ minWidth: 110 }} onClick={onReturn} disabled={!selectedOrder.items || selectedOrder.items.length === 0 || isLoading}>
                             Return
                           </Button>
                         ) : (
@@ -222,7 +257,7 @@ const PurchaseOrderDetailsPanel: React.FC<PurchaseOrderDetailsPanelProps> = ({
                             sx={{ minWidth: 110 }}
                             onClick={onReceive}
                             disabled={
-                              !selectedOrder?.items ||
+                              !selectedOrder.items ||
                               selectedOrder.items.length === 0 ||
                               isLoading ||
                               !((selectedOrder.paidAmount || 0) >= (selectedOrder.totalAmount || 0) && (selectedOrder.paidAmount || 0) > 0)
@@ -238,72 +273,10 @@ const PurchaseOrderDetailsPanel: React.FC<PurchaseOrderDetailsPanelProps> = ({
               </Table>
             </TableContainer>
           </Grid>
-
-          <Grid item xs={12}>
-            <Box sx={{ borderTop: '2px solid', borderColor: 'divider', my: 1 }} />
-            <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-              <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px', mb: 1 }}>
-                PO Items
-              </Typography>
-              {selectedOrder.items && selectedOrder.items.length > 0 ? (
-                <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
-                  <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': { borderBottom: TABLE_STYLES.cell.border, py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px } }}>
-                    <TableHead>
-                      <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50', color: 'text.primary', fontSize: '0.8rem' } }}>
-                        <TableCell sx={{ width: '35%' }}>Product</TableCell>
-                        <TableCell align="center" sx={{ width: '13%' }}>Quantity</TableCell>
-                        <TableCell align="center" sx={{ width: '13%' }}>Price</TableCell>
-                        <TableCell align="center" sx={{ width: '13%' }}>Discount</TableCell>
-                        <TableCell align="center" sx={{ width: '13%' }}>Sub-total</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {selectedOrder.items.map((item: any, index: number) => (
-                        <TableRow key={item.id || index} hover sx={{ '&:hover': { backgroundColor: 'action.hover' }, transition: 'background-color 0.2s ease', height: TABLE_STYLES.row.height }}>
-                          <TableCell sx={{ fontSize: '0.8rem' }}>{item.product?.name || item.description || 'N/A'}</TableCell>
-                          <TableCell align="center" sx={{ fontSize: '0.8rem' }}>{item.quantity}</TableCell>
-                          <TableCell align="center" sx={{ fontSize: '0.8rem' }}>{formatCurrency(item.unitPrice || item.unitCost || 0)}</TableCell>
-                          <TableCell align="center" sx={{ fontSize: '0.8rem' }}>
-                            {item.discountAmount ? (
-                              <Box component="span">
-                                {`-${formatCurrency(item.discountAmount)}`}
-                                {item.discountPercent > 0 && (
-                                  <Typography component="span" sx={{ fontSize: '0.7rem', color: 'text.secondary', ml: 0.5 }}>
-                                    ({item.discountPercent}%)
-                                  </Typography>
-                                )}
-                              </Box>
-                            ) : '-'}
-                          </TableCell>
-                          <TableCell align="center" sx={{ fontSize: '0.8rem' }}>{formatCurrency(item.totalAmount || item.total || item.quantity * (item.unitPrice || item.unitCost || 0))}</TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </TableContainer>
-              ) : (
-                <Alert severity="info">No items in this order</Alert>
-              )}
-            </Box>
-          </Grid>
-
-          {selectedOrder.notes && (
-            <Grid item xs={12}>
-              <Box sx={{ borderTop: '2px solid', borderColor: 'divider', my: 1 }} />
-              <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-                <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px', mb: 1 }}>
-                  Notes
-                </Typography>
-                <Box sx={{ p: 2, backgroundColor: 'grey.50', borderRadius: 1, fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
-                  {selectedOrder.notes}
-                </Box>
-              </Box>
-            </Grid>
-          )}
         </Grid>
       </Box>
     </Paper>
   )
 }
 
-export default PurchaseOrderDetailsPanel
+export default PurchaseOrderContextHeader

--- a/frontend/src/pages/purchasing/components/PurchaseOrderWorkspaceCard.tsx
+++ b/frontend/src/pages/purchasing/components/PurchaseOrderWorkspaceCard.tsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import {
+  Alert,
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { PurchaseOrder } from '@/types'
+import { formatCurrency } from '@/utils/formatters'
+
+interface PurchaseOrderWorkspaceCardProps {
+  selectedOrder: PurchaseOrder | null
+}
+
+const PurchaseOrderWorkspaceCard: React.FC<PurchaseOrderWorkspaceCardProps> = ({ selectedOrder }) => {
+  if (!selectedOrder) {
+    return <Paper sx={{ flex: 1 }} />
+  }
+
+  return (
+    <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
+        <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+          PO Items
+        </Typography>
+      </Box>
+
+      <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', p: TABLE_STYLES.cell.padding.px }}>
+        <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          {selectedOrder.items && selectedOrder.items.length > 0 ? (
+            <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
+              <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': { borderBottom: TABLE_STYLES.cell.border, py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px } }}>
+                <TableHead>
+                  <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50', color: 'text.primary', fontSize: '0.8rem' } }}>
+                    <TableCell sx={{ width: '35%' }}>Product</TableCell>
+                    <TableCell align="center" sx={{ width: '13%' }}>Quantity</TableCell>
+                    <TableCell align="center" sx={{ width: '13%' }}>Price</TableCell>
+                    <TableCell align="center" sx={{ width: '13%' }}>Discount</TableCell>
+                    <TableCell align="center" sx={{ width: '13%' }}>Sub-total</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {selectedOrder.items.map((item: any, index: number) => (
+                    <TableRow key={item.id || index} hover sx={{ '&:hover': { backgroundColor: 'action.hover' }, transition: 'background-color 0.2s ease', height: TABLE_STYLES.row.height }}>
+                      <TableCell sx={{ fontSize: '0.8rem' }}>{item.product?.name || item.description || 'N/A'}</TableCell>
+                      <TableCell align="center" sx={{ fontSize: '0.8rem' }}>{item.quantity}</TableCell>
+                      <TableCell align="center" sx={{ fontSize: '0.8rem' }}>{formatCurrency(item.unitPrice || item.unitCost || 0)}</TableCell>
+                      <TableCell align="center" sx={{ fontSize: '0.8rem' }}>
+                        {item.discountAmount ? (
+                          <Box component="span">
+                            {`-${formatCurrency(item.discountAmount)}`}
+                            {item.discountPercent > 0 && (
+                              <Typography component="span" sx={{ fontSize: '0.7rem', color: 'text.secondary', ml: 0.5 }}>
+                                ({item.discountPercent}%)
+                              </Typography>
+                            )}
+                          </Box>
+                        ) : '-'}
+                      </TableCell>
+                      <TableCell align="center" sx={{ fontSize: '0.8rem' }}>{formatCurrency(item.totalAmount || item.total || item.quantity * (item.unitPrice || item.unitCost || 0))}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          ) : (
+            <Alert severity="info">No items in this order</Alert>
+          )}
+        </Box>
+
+        {selectedOrder.notes && (
+          <Box sx={{ mt: 1 }}>
+            <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px', mb: 1 }}>
+              Notes
+            </Typography>
+            <Box sx={{ p: 2, backgroundColor: 'grey.50', borderRadius: 1, fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+              {selectedOrder.notes}
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </Paper>
+  )
+}
+
+export default PurchaseOrderWorkspaceCard

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -1,14 +1,15 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { ArrowDownward as ArrowDownIcon, ArrowUpward as ArrowUpIcon, Sort as SortIcon } from '@mui/icons-material'
 import { Alert, Box, Button, Stack, useMediaQuery, useTheme } from '@mui/material'
-import Grid from '@mui/material/GridLegacy'
 import { useStore } from 'react-redux'
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 
+import MasterDetailWorkspace from '@/components/common/MasterDetailWorkspace'
 import PageHeader from '@/components/common/PageHeader'
 import { FilterBar } from '@/components/filters'
+import OrderContextHeader from './components/OrderContextHeader'
 import OrdersDialogs from './components/OrdersDialogs'
-import OrderDetailsPanel from './components/OrderDetailsPanel'
+import OrderWorkspaceCard from './components/OrderWorkspaceCard'
 import OrdersTable from './components/OrdersTable'
 import { useOrdersActions } from './hooks/useOrdersActions'
 import { useOrdersPageState } from './hooks/useOrdersPageState'
@@ -233,8 +234,9 @@ export const OrdersPage: React.FC = () => {
         </Alert>
       )}
 
-      <Grid container spacing={3}>
-        <Grid item xs={12} md={3}>
+      <MasterDetailWorkspace
+        isMobile={isMobile}
+        listSlot={(
           <OrdersTable
             orders={orders}
             loading={loading}
@@ -244,9 +246,9 @@ export const OrdersPage: React.FC = () => {
             onOrderSelect={selection.handleOrderSelect}
             orderListRef={pageState.orderListRef}
           />
-        </Grid>
-        <Grid item xs={12} md={9}>
-          <OrderDetailsPanel
+        )}
+        headerSlot={(
+          <OrderContextHeader
             selectedOrder={selectedOrder}
             isLoading={pageState.isLoading}
             journalEntryRef={pageState.journalEntryRef}
@@ -263,8 +265,9 @@ export const OrdersPage: React.FC = () => {
             onFulfillOrder={actions.handleFulfillOrder}
             onUnfulfillOrder={actions.handleUnfulfillOrder}
           />
-        </Grid>
-      </Grid>
+        )}
+        workspaceSlot={<OrderWorkspaceCard selectedOrder={selectedOrder} />}
+      />
 
       <OrdersDialogs
         selectedOrder={selectedOrder}

--- a/frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
+++ b/frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
@@ -24,8 +24,19 @@ vi.mock('@/store/api/salesApi', () => ({
   useDeleteSalesOrderMutation: vi.fn(() => [vi.fn()]),
 }))
 
+vi.mock('@/components/common/MasterDetailWorkspace', () => ({
+  default: ({ listSlot, headerSlot, workspaceSlot }: any) => (
+    <div>
+      <div>MasterDetailWorkspace</div>
+      <div>{listSlot}</div>
+      <div>{headerSlot}</div>
+      <div>{workspaceSlot}</div>
+    </div>
+  ),
+}))
 vi.mock('../components/OrdersTable', () => ({ default: () => <div>OrdersTable</div> }))
-vi.mock('../components/OrderDetailsPanel', () => ({ default: () => <div>OrderDetailsPanel</div> }))
+vi.mock('../components/OrderContextHeader', () => ({ default: () => <div>OrderContextHeader</div> }))
+vi.mock('../components/OrderWorkspaceCard', () => ({ default: () => <div>OrderWorkspaceCard</div> }))
 vi.mock('../components/OrdersDialogs', () => ({ default: () => <div>OrdersDialogs</div> }))
 vi.mock('../hooks/useOrdersActions', () => ({
   useOrdersActions: () => ({
@@ -87,6 +98,15 @@ describe('OrdersPage FilterBar integration', () => {
   it('renders the shared filter search input', () => {
     renderPage()
     expect(screen.getByPlaceholderText(/search orders/i)).toBeInTheDocument()
+  })
+
+  it('renders the master-detail workspace with split sales detail cards', () => {
+    renderPage()
+
+    expect(screen.getByText('MasterDetailWorkspace')).toBeInTheDocument()
+    expect(screen.getByText('OrdersTable')).toBeInTheDocument()
+    expect(screen.getByText('OrderContextHeader')).toBeInTheDocument()
+    expect(screen.getByText('OrderWorkspaceCard')).toBeInTheDocument()
   })
 
   it('restores filters from URL into the sales orders query', () => {

--- a/frontend/src/pages/sales/components/OrderContextHeader.tsx
+++ b/frontend/src/pages/sales/components/OrderContextHeader.tsx
@@ -5,7 +5,6 @@ import {
   Print as PrintIcon,
 } from '@mui/icons-material'
 import {
-  Alert,
   Box,
   Button,
   IconButton,
@@ -15,7 +14,6 @@ import {
   TableBody,
   TableCell,
   TableContainer,
-  TableHead,
   TableRow,
   Typography,
 } from '@mui/material'
@@ -30,7 +28,7 @@ interface JournalEntryRef {
   referenceNumber: string
 }
 
-interface OrderDetailsPanelProps {
+interface OrderContextHeaderProps {
   selectedOrder: SalesOrder | null
   isLoading: boolean
   journalEntryRef: JournalEntryRef | null
@@ -56,7 +54,28 @@ const actionIconSx = {
   p: 0.125,
 }
 
-const OrderDetailsPanel: React.FC<OrderDetailsPanelProps> = ({
+const detailTableSx = {
+  tableLayout: 'fixed',
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const labelCellSx = {
+  fontWeight: 600,
+  color: 'text.secondary',
+  fontSize: '0.8rem',
+}
+
+const valueCellSx = {
+  fontSize: '0.8rem',
+}
+
+const OrderContextHeader: React.FC<OrderContextHeaderProps> = ({
   selectedOrder,
   isLoading,
   journalEntryRef,
@@ -75,7 +94,7 @@ const OrderDetailsPanel: React.FC<OrderDetailsPanelProps> = ({
 }) => {
   if (!selectedOrder) {
     return (
-      <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
         <Typography variant="h6" color="text.secondary">
           Select an order to view details
         </Typography>
@@ -96,8 +115,16 @@ const OrderDetailsPanel: React.FC<OrderDetailsPanelProps> = ({
   const isOverpaid = (selectedOrder.paidAmount || 0) > (selectedOrder.totalAmount || 0)
 
   return (
-    <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', flexDirection: 'column' }}>
-      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+    <Paper sx={{ overflow: 'hidden' }}>
+      <Box
+        sx={{
+          p: TABLE_STYLES.cell.padding.px,
+          borderBottom: TABLE_STYLES.cell.border,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
         <Typography
           variant="tableHeader"
           sx={{
@@ -122,23 +149,11 @@ const OrderDetailsPanel: React.FC<OrderDetailsPanelProps> = ({
         </Box>
       </Box>
 
-      <Box sx={{ flex: 1, overflow: 'auto', p: TABLE_STYLES.cell.padding.px }}>
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
         <Grid container spacing={3}>
           <Grid item xs={12} md={6}>
             <TableContainer>
-              <Table
-                size={TABLE_STYLES.size}
-                sx={{
-                  tableLayout: 'fixed',
-                  '& .MuiTableCell-root': {
-                    border: 'none',
-                    py: TABLE_STYLES.cell.padding.py,
-                    px: TABLE_STYLES.cell.padding.px,
-                    '&:nth-of-type(1)': { width: '40%' },
-                    '&:nth-of-type(2)': { width: '60%' },
-                  },
-                }}
-              >
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
                 <TableBody>
                   <TableRow>
                     <TableCell colSpan={2} sx={{ pb: TABLE_STYLES.cell.padding.py * 0.67, py: TABLE_STYLES.cell.padding.py * 0.67, borderTop: TABLE_STYLES.cell.border }}>
@@ -148,20 +163,16 @@ const OrderDetailsPanel: React.FC<OrderDetailsPanelProps> = ({
                     </TableCell>
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                      Customer Name
-                    </TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>
-                      {selectedOrder.customer?.name || 'Unknown Customer'}
-                    </TableCell>
+                    <TableCell sx={labelCellSx}>Customer Name</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedOrder.customer?.name || 'Unknown Customer'}</TableCell>
                   </TableRow>
                   <TableRow>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>SO Date</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>{formatDate(selectedOrder.orderDate)}</TableCell>
+                    <TableCell sx={labelCellSx}>SO Date</TableCell>
+                    <TableCell sx={valueCellSx}>{formatDate(selectedOrder.orderDate)}</TableCell>
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>Invoice No</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>
+                    <TableCell sx={labelCellSx}>Invoice No</TableCell>
+                    <TableCell sx={valueCellSx}>
                       {selectedOrder.invoices && selectedOrder.invoices.length > 0 ? (
                         selectedOrder.invoices.map((invoice: any, index: number) => (
                           <Box key={invoice.id} component="span">
@@ -179,8 +190,8 @@ const OrderDetailsPanel: React.FC<OrderDetailsPanelProps> = ({
                     </TableCell>
                   </TableRow>
                   <TableRow>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>Payment No</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>
+                    <TableCell sx={labelCellSx}>Payment No</TableCell>
+                    <TableCell sx={valueCellSx}>
                       {allPayments.length === 0 ? (
                         <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}>
                           No payments
@@ -199,8 +210,8 @@ const OrderDetailsPanel: React.FC<OrderDetailsPanelProps> = ({
                     </TableCell>
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>Journal Entry No</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>
+                    <TableCell sx={labelCellSx}>Journal Entry No</TableCell>
+                    <TableCell sx={valueCellSx}>
                       {!selectedOrder.isFulfilled ? (
                         <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}>Not fulfilled</Typography>
                       ) : journalEntryRefLoading ? (
@@ -221,19 +232,7 @@ const OrderDetailsPanel: React.FC<OrderDetailsPanelProps> = ({
 
           <Grid item xs={12} md={6}>
             <TableContainer>
-              <Table
-                size={TABLE_STYLES.size}
-                sx={{
-                  tableLayout: 'fixed',
-                  '& .MuiTableCell-root': {
-                    border: 'none',
-                    py: TABLE_STYLES.cell.padding.py,
-                    px: TABLE_STYLES.cell.padding.px,
-                    '&:nth-of-type(1)': { width: '40%' },
-                    '&:nth-of-type(2)': { width: '60%' },
-                  },
-                }}
-              >
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
                 <TableBody>
                   <TableRow>
                     <TableCell colSpan={2} sx={{ pb: TABLE_STYLES.cell.padding.py * 0.67, py: TABLE_STYLES.cell.padding.py * 0.67, borderTop: TABLE_STYLES.cell.border }}>
@@ -243,26 +242,26 @@ const OrderDetailsPanel: React.FC<OrderDetailsPanelProps> = ({
                     </TableCell>
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>Sub-total</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>
+                    <TableCell sx={labelCellSx}>Sub-total</TableCell>
+                    <TableCell sx={valueCellSx}>
                       {formatCurrency(selectedOrder.items?.reduce((sum: number, item: any) => sum + (Number(item.totalAmount) || 0), 0) || 0)}
                     </TableCell>
                   </TableRow>
                   <TableRow>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>Shipping</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>{formatCurrency((selectedOrder as any).shippingAmount || 0)}</TableCell>
+                    <TableCell sx={labelCellSx}>Shipping</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency((selectedOrder as any).shippingAmount || 0)}</TableCell>
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>Total</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>{formatCurrency(selectedOrder.totalAmount || 0)}</TableCell>
+                    <TableCell sx={labelCellSx}>Total</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(selectedOrder.totalAmount || 0)}</TableCell>
                   </TableRow>
                   <TableRow>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>Paid</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>{formatCurrency(selectedOrder.paidAmount || 0)}</TableCell>
+                    <TableCell sx={labelCellSx}>Paid</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(selectedOrder.paidAmount || 0)}</TableCell>
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                    <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>Balance</TableCell>
-                    <TableCell sx={{ fontSize: '0.8rem' }}>{balance < 0 ? `-${formatCurrency(Math.abs(balance))}` : formatCurrency(balance)}</TableCell>
+                    <TableCell sx={labelCellSx}>Balance</TableCell>
+                    <TableCell sx={valueCellSx}>{balance < 0 ? `-${formatCurrency(Math.abs(balance))}` : formatCurrency(balance)}</TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell colSpan={2} sx={{ textAlign: 'center' }}>
@@ -295,84 +294,9 @@ const OrderDetailsPanel: React.FC<OrderDetailsPanelProps> = ({
             </TableContainer>
           </Grid>
         </Grid>
-
-        <Box sx={{ borderTop: '2px solid', borderColor: 'divider', pageBreakBefore: 'always', '@media print': { pageBreakBefore: 'always' } }} />
-
-        <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-          <TableContainer>
-            <Table size={TABLE_STYLES.size} sx={{ tableLayout: 'fixed', '& .MuiTableCell-root': { border: 'none', py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px } }}>
-              <TableBody>
-                <TableRow>
-                  <TableCell colSpan={3} sx={{ pb: TABLE_STYLES.cell.padding.py * 0.67, py: TABLE_STYLES.cell.padding.py * 0.67, borderTop: TABLE_STYLES.cell.border }}>
-                    <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
-                      SO Items
-                    </Typography>
-                  </TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
-          </TableContainer>
-
-          <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-            {selectedOrder.items && selectedOrder.items.length > 0 ? (
-              <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
-                <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': { borderBottom: TABLE_STYLES.cell.border, py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px } }}>
-                  <TableHead>
-                    <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50', color: 'text.primary', fontSize: '0.8rem' } }}>
-                      <TableCell sx={{ width: '40%' }}>Product</TableCell>
-                      <TableCell align="center" sx={{ width: '12%' }}>Quantity</TableCell>
-                      <TableCell align="right" sx={{ width: '16%' }}>Unit Price</TableCell>
-                      <TableCell align="right" sx={{ width: '16%' }}>Discount</TableCell>
-                      <TableCell align="right" sx={{ width: '16%' }}>Total</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {selectedOrder.items.map((item: any, index: number) => (
-                      <TableRow key={index} hover sx={{ '&:hover': { backgroundColor: 'action.hover' }, transition: 'background-color 0.2s ease', height: TABLE_STYLES.row.height }}>
-                        <TableCell sx={{ fontSize: '0.8rem', lineHeight: 1.2 }}>
-                          {item.product?.name || 'Unknown Product'}
-                          {item.description && (
-                            <Typography sx={{ fontSize: '0.7rem', color: 'text.secondary', display: 'block' }}>
-                              {item.description}
-                            </Typography>
-                          )}
-                        </TableCell>
-                        <TableCell align="center" sx={{ fontSize: '0.8rem', fontWeight: 400, lineHeight: 1.2 }}>
-                          {item.quantity || 0}
-                        </TableCell>
-                        <TableCell align="right" sx={{ fontSize: '0.8rem', fontWeight: 400, lineHeight: 1.2 }}>
-                          {formatCurrency(item.unitPrice || 0)}
-                        </TableCell>
-                        <TableCell align="right" sx={{ fontSize: '0.8rem', fontWeight: 400, lineHeight: 1.2 }}>
-                          {item.discountType === 'percentage' && item.discountPercent ? `${item.discountPercent}%` : item.discountAmount ? `-${formatCurrency(item.discountAmount)}` : '-'}
-                        </TableCell>
-                        <TableCell align="right" sx={{ fontSize: '0.8rem', lineHeight: 1.2 }}>
-                          {formatCurrency(item.totalAmount || item.quantity * item.unitPrice || 0)}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </TableContainer>
-            ) : (
-              <Alert severity="info">No items in this order</Alert>
-            )}
-          </Box>
-        </Box>
-
-        {selectedOrder.notes && (
-          <Box sx={{ mt: 1 }}>
-            <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px', mb: 1 }}>
-              NOTES
-            </Typography>
-            <Box sx={{ p: 2, backgroundColor: 'grey.50', borderRadius: 1, fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
-              {selectedOrder.notes}
-            </Box>
-          </Box>
-        )}
       </Box>
     </Paper>
   )
 }
 
-export default OrderDetailsPanel
+export default OrderContextHeader

--- a/frontend/src/pages/sales/components/OrderWorkspaceCard.tsx
+++ b/frontend/src/pages/sales/components/OrderWorkspaceCard.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import {
+  Alert,
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { SalesOrder } from '@/types'
+import { formatCurrency } from '@/utils/formatters'
+
+interface OrderWorkspaceCardProps {
+  selectedOrder: SalesOrder | null
+}
+
+const OrderWorkspaceCard: React.FC<OrderWorkspaceCardProps> = ({ selectedOrder }) => {
+  if (!selectedOrder) {
+    return <Paper sx={{ flex: 1 }} />
+  }
+
+  return (
+    <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+      <TableContainer>
+        <Table size={TABLE_STYLES.size} sx={{ tableLayout: 'fixed', '& .MuiTableCell-root': { border: 'none', py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px } }}>
+          <TableBody>
+            <TableRow>
+              <TableCell colSpan={3} sx={{ pb: TABLE_STYLES.cell.padding.py * 0.67, py: TABLE_STYLES.cell.padding.py * 0.67, borderTop: TABLE_STYLES.cell.border }}>
+                <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+                  SO Items
+                </Typography>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', p: TABLE_STYLES.cell.padding.px }}>
+        <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          {selectedOrder.items && selectedOrder.items.length > 0 ? (
+            <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
+              <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': { borderBottom: TABLE_STYLES.cell.border, py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px } }}>
+                <TableHead>
+                  <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50', color: 'text.primary', fontSize: '0.8rem' } }}>
+                    <TableCell sx={{ width: '40%' }}>Product</TableCell>
+                    <TableCell align="center" sx={{ width: '12%' }}>Quantity</TableCell>
+                    <TableCell align="right" sx={{ width: '16%' }}>Unit Price</TableCell>
+                    <TableCell align="right" sx={{ width: '16%' }}>Discount</TableCell>
+                    <TableCell align="right" sx={{ width: '16%' }}>Total</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {selectedOrder.items.map((item: any, index: number) => (
+                    <TableRow key={index} hover sx={{ '&:hover': { backgroundColor: 'action.hover' }, transition: 'background-color 0.2s ease', height: TABLE_STYLES.row.height }}>
+                      <TableCell sx={{ fontSize: '0.8rem', lineHeight: 1.2 }}>
+                        {item.product?.name || 'Unknown Product'}
+                        {item.description && (
+                          <Typography sx={{ fontSize: '0.7rem', color: 'text.secondary', display: 'block' }}>
+                            {item.description}
+                          </Typography>
+                        )}
+                      </TableCell>
+                      <TableCell align="center" sx={{ fontSize: '0.8rem', fontWeight: 400, lineHeight: 1.2 }}>
+                        {item.quantity || 0}
+                      </TableCell>
+                      <TableCell align="right" sx={{ fontSize: '0.8rem', fontWeight: 400, lineHeight: 1.2 }}>
+                        {formatCurrency(item.unitPrice || 0)}
+                      </TableCell>
+                      <TableCell align="right" sx={{ fontSize: '0.8rem', fontWeight: 400, lineHeight: 1.2 }}>
+                        {item.discountType === 'percentage' && item.discountPercent ? `${item.discountPercent}%` : item.discountAmount ? `-${formatCurrency(item.discountAmount)}` : '-'}
+                      </TableCell>
+                      <TableCell align="right" sx={{ fontSize: '0.8rem', lineHeight: 1.2 }}>
+                        {formatCurrency(item.totalAmount || item.quantity * item.unitPrice || 0)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          ) : (
+            <Alert severity="info">No items in this order</Alert>
+          )}
+        </Box>
+
+        {selectedOrder.notes && (
+          <Box sx={{ mt: 1 }}>
+            <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px', mb: 1 }}>
+              NOTES
+            </Typography>
+            <Box sx={{ p: 2, backgroundColor: 'grey.50', borderRadius: 1, fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+              {selectedOrder.notes}
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </Paper>
+  )
+}
+
+export default OrderWorkspaceCard


### PR DESCRIPTION
## Summary
- Add `MasterDetailWorkspace` reusable layout shell (3 named slots: list, header, workspace)
- Split `OrderDetailsPanel` → `OrderContextHeader` + `OrderWorkspaceCard` (sales)
- Split `PurchaseOrderDetailsPanel` → `PurchaseOrderContextHeader` + `PurchaseOrderWorkspaceCard` (purchasing)
- Wire both pages to show order list, metadata, and items simultaneously on desktop
- Mobile: stacked fallback preserving existing behavior

## Test plan
- [x] Sales Orders: list (25%), context header (top right), items workspace (bottom right) all visible simultaneously on desktop
- [x] Purchase Orders: same layout
- [x] Items table scrolls independently of context header
- [x] Selecting an order: context header shows metadata, workspace shows items
- [x] No order selected: context header shows "Select an order to view details", workspace is blank
- [x] Mobile width: layout stacks vertically
- [x] `npm run type-check` passes
- [x] Layout + filterbar tests pass

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)