### PR TITLE
chore(deps): upgrade react-router-dom to 7.14.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erp-frontend",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-frontend",
-      "version": "1.42.0",
+      "version": "1.42.1",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -29,7 +29,7 @@
         "react-dom": "^19.2.4",
         "react-hook-form": "^7.71.2",
         "react-redux": "^9.2.0",
-        "react-router-dom": "7.13.2",
+        "react-router-dom": "7.14.0",
         "redux-persist": "^6.0.0",
         "socket.io-client": "^4.7.4",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
@@ -3018,6 +3018,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5209,9 +5218,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
-      "integrity": "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.0.tgz",
+      "integrity": "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -5231,12 +5240,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.2.tgz",
-      "integrity": "sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.0.tgz",
+      "integrity": "sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.2"
+        "react-router": "7.14.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -6356,15 +6365,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.71.2",
     "react-redux": "^9.2.0",
-    "react-router-dom": "7.13.2",
+    "react-router-dom": "7.14.0",
     "redux-persist": "^6.0.0",
     "socket.io-client": "^4.7.4",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",


### PR DESCRIPTION
## Summary
- Bumps `react-router-dom` from `7.13.2` to `7.14.0` in `frontend/package.json`
- Updates `package-lock.json` (lockfile metadata synced from 1.42.0 → 1.42.1 to match existing manifest)
- No code changes required — none of the v7.14.0 breaking changes apply to this app (library mode only, no fetcher/clientLoader/splat routes)

## Test Plan
- [x] `npm list react-router-dom` → `react-router-dom@7.14.0`
- [x] `npm run type-check` → exit 0
- [x] `src/__tests__/router.test.tsx` → 6 passed
- [x] `src/components/errors/RouteErrorBoundary.test.tsx` → 6 passed
- [x] `src/components/auth/__tests__/ProtectedRoute.test.tsx` → 5 passed
- [x] `src/pages/auth/__tests__/LoginPage.test.tsx` → 9 passed

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)