### PR TITLE
feat: modernize Sales Orders filter bar (#265)

### DIFF
--- a/backend/src/modules/sales/services/sales-order-query.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-query.service.spec.ts
@@ -142,5 +142,23 @@ describe('SalesOrderQueryService', () => {
       );
       expect(searchCall).toBeDefined();
     });
+
+    it('uses EXISTS subquery in count so an order with multiple matching items counts as 1', async () => {
+      const mainQb = makeQueryBuilder();
+      const countQb = makeQueryBuilder();
+      let callCount = 0;
+      salesOrderRepository.createQueryBuilder.mockImplementation(() => {
+        callCount++;
+        return callCount === 1 ? mainQb : countQb;
+      });
+
+      await service.findAll({ search: 'Widget' });
+
+      const countAndWhereCalls: string[] = countQb.andWhere.mock.calls.map((c: any[]) => c[0]);
+      const existsCall = countAndWhereCalls.find(
+        (c) => typeof c === 'string' && c.includes('EXISTS'),
+      );
+      expect(existsCall).toBeDefined();
+    });
   });
 });

--- a/backend/src/modules/sales/services/sales-order-query.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-query.service.spec.ts
@@ -99,4 +99,48 @@ describe('SalesOrderQueryService', () => {
       ],
     });
   });
+
+  describe('findAll', () => {
+    function makeQueryBuilder() {
+      const qb: any = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        leftJoin: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+        getRawOne: jest.fn().mockResolvedValue({ count: '0' }),
+      };
+      return qb;
+    }
+
+    it('searches customer name with ILIKE', async () => {
+      const qb = makeQueryBuilder();
+      salesOrderRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.findAll({ search: 'Acme' });
+
+      const andWhereCalls: string[] = qb.andWhere.mock.calls.map((c: any[]) => c[0]);
+      const searchCall = andWhereCalls.find(
+        (c) => typeof c === 'string' && c.includes('customer.name ILIKE'),
+      );
+      expect(searchCall).toBeDefined();
+    });
+
+    it('searches product name with ILIKE in main query', async () => {
+      const qb = makeQueryBuilder();
+      salesOrderRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.findAll({ search: 'Widget' });
+
+      const andWhereCalls: string[] = qb.andWhere.mock.calls.map((c: any[]) => c[0]);
+      const searchCall = andWhereCalls.find(
+        (c) => typeof c === 'string' && c.includes('product.name ILIKE'),
+      );
+      expect(searchCall).toBeDefined();
+    });
+  });
 });

--- a/backend/src/modules/sales/services/sales-order-query.service.ts
+++ b/backend/src/modules/sales/services/sales-order-query.service.ts
@@ -115,9 +115,10 @@ export class SalesOrderQueryService {
     }
 
     if (search) {
-      queryBuilder = queryBuilder.andWhere('order.orderNumber ILIKE :search', {
-        search: `%${search}%`,
-      });
+      queryBuilder = queryBuilder.andWhere(
+        '(order.orderNumber ILIKE :search OR customer.name ILIKE :search OR product.name ILIKE :search)',
+        { search: `%${search}%` },
+      );
     }
 
     if (paymentStatus && paymentStatus !== 'all') {

--- a/backend/src/modules/sales/services/sales-order-query.service.ts
+++ b/backend/src/modules/sales/services/sales-order-query.service.ts
@@ -161,7 +161,8 @@ export class SalesOrderQueryService {
     const countQuery = this.salesOrderRepository
       .createQueryBuilder('order')
       .where('order.deletedAt IS NULL')
-      .select('COUNT(order.id)', 'count');
+      .select('COUNT(order.id)', 'count')
+      .leftJoin('order.customer', 'customer');
 
     if (customerId) {
       countQuery.andWhere('order.customerId = :customerId', { customerId });
@@ -175,7 +176,17 @@ export class SalesOrderQueryService {
       countQuery.andWhere('order.orderDate <= :toDate', { toDate: endDate });
     }
     if (search) {
-      countQuery.andWhere('order.orderNumber ILIKE :search', { search: `%${search}%` });
+      countQuery.andWhere(
+        `(order.orderNumber ILIKE :search
+          OR customer.name ILIKE :search
+          OR EXISTS (
+            SELECT 1 FROM sales_order_items i
+            JOIN products p ON p.id = i."productId"
+            WHERE i."salesOrderId" = order.id
+            AND p.name ILIKE :search
+          ))`,
+        { search: `%${search}%` },
+      );
     }
 
     if (paymentStatus && paymentStatus !== 'all') {

--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -1,3 +1,8 @@
+import {
+  ArrowDownward as ArrowDownIcon,
+  ArrowUpward as ArrowUpIcon,
+  Sort as SortIcon,
+} from '@mui/icons-material'
 import { Button, Stack } from '@mui/material'
 
 import { FilterPeriod } from './FilterPeriod'
@@ -6,6 +11,7 @@ import { FilterSelect } from './FilterSelect'
 import type {
   FilterBarConfig,
   FilterBarHandlers,
+  FilterBarSortConfig,
   PeriodValue,
 } from '@/types/filterBar.types'
 
@@ -15,6 +21,7 @@ interface Props<TFilters extends object> {
   handlers: FilterBarHandlers<TFilters>
   hasActiveFilters: boolean
   searchInputRef?: React.RefObject<HTMLInputElement | null>
+  sort?: FilterBarSortConfig
 }
 
 function renderQuickField<TFilters extends object>(
@@ -63,6 +70,7 @@ export function FilterBar<TFilters extends object>({
   handlers,
   hasActiveFilters,
   searchInputRef,
+  sort,
 }: Props<TFilters>) {
   return (
     <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
@@ -79,6 +87,23 @@ export function FilterBar<TFilters extends object>({
       {hasActiveFilters ? (
         <Button size="small" variant="outlined" color="inherit" sx={{ ml: 1 }} onClick={handlers.onClearAll}>
           Reset
+        </Button>
+      ) : null}
+      {sort ? (
+        <Button
+          size="small"
+          variant={sort.sortBy === sort.field ? 'contained' : 'outlined'}
+          color={sort.sortBy === sort.field ? 'primary' : 'inherit'}
+          startIcon={
+            sort.sortBy === sort.field
+              ? sort.sortOrder === 'desc'
+                ? <ArrowDownIcon />
+                : <ArrowUpIcon />
+              : <SortIcon />
+          }
+          onClick={() => sort.onSort(sort.field)}
+        >
+          Sort
         </Button>
       ) : null}
     </Stack>

--- a/frontend/src/components/filters/__tests__/FilterBar.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterBar.test.tsx
@@ -41,6 +41,25 @@ describe('FilterBar', () => {
     expect(screen.getByLabelText(/status/i)).toBeInTheDocument()
   })
 
+  it('renders the optional sort button and calls onSort', () => {
+    const onSort = vi.fn()
+
+    render(
+      <FilterBar
+        {...baseProps}
+        sort={{
+          field: 'orderNumber',
+          sortBy: 'orderNumber',
+          sortOrder: 'desc',
+          onSort,
+        }}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /sort/i }))
+    expect(onSort).toHaveBeenCalledWith('orderNumber')
+  })
+
   it('shows reset only with active filters', () => {
     const { rerender } = render(<FilterBar {...baseProps} />)
     expect(screen.queryByRole('button', { name: /reset/i })).not.toBeInTheDocument()

--- a/frontend/src/components/filters/__tests__/FilterBar.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterBar.test.tsx
@@ -60,6 +60,25 @@ describe('FilterBar', () => {
     expect(onSort).toHaveBeenCalledWith('orderNumber')
   })
 
+  it('renders sort button in inactive state when sortBy differs from field', () => {
+    render(
+      <FilterBar
+        {...baseProps}
+        sort={{
+          field: 'orderNumber',
+          sortBy: 'orderDate',
+          sortOrder: 'asc',
+          onSort: vi.fn(),
+        }}
+      />,
+    )
+
+    const btn = screen.getByRole('button', { name: /sort/i })
+    expect(btn).toBeInTheDocument()
+    // inactive: MUI outlined variant has no contained class
+    expect(btn.className).not.toMatch(/MuiButton-contained/)
+  })
+
   it('shows reset only with active filters', () => {
     const { rerender } = render(<FilterBar {...baseProps} />)
     expect(screen.queryByRole('button', { name: /reset/i })).not.toBeInTheDocument()

--- a/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo } from 'react'
-import { ArrowDownward as ArrowDownIcon, ArrowUpward as ArrowUpIcon, Sort as SortIcon } from '@mui/icons-material'
-import { Alert, Box, Button, Stack, useMediaQuery, useTheme } from '@mui/material'
+import { Alert, Box, useMediaQuery, useTheme } from '@mui/material'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import MasterDetailWorkspace from '@/components/common/MasterDetailWorkspace'
@@ -184,29 +183,21 @@ export const PurchaseOrdersPage: React.FC = () => {
         primaryAction={{ label: 'Create Order', onClick: () => navigate('/purchasing/orders/create') }}
       />
 
-      <Stack direction={isMobile ? 'column' : 'row'} spacing={1} alignItems={isMobile ? 'stretch' : 'center'} sx={{ mb: 3 }}>
-        <Box sx={{ flex: 1 }}>
-          <FilterBar
-            config={filterConfig}
-            draftFilters={filterBar.draftFilters}
-            handlers={filterBar.handlers}
-            hasActiveFilters={filterBar.hasActiveFilters}
-            searchInputRef={pageState.searchInputRef}
-          />
-        </Box>
-        <Button
-          variant={pageState.sorting.sortBy === 'orderNumber' ? 'contained' : 'outlined'}
-          size="small"
-          startIcon={pageState.sorting.sortBy === 'orderNumber'
-            ? pageState.sorting.sortOrder === 'desc'
-              ? <ArrowDownIcon />
-              : <ArrowUpIcon />
-            : <SortIcon />}
-          onClick={() => handleSort('orderNumber')}
-        >
-          Sort
-        </Button>
-      </Stack>
+      <Box sx={{ mb: 3 }}>
+        <FilterBar
+          config={filterConfig}
+          draftFilters={filterBar.draftFilters}
+          handlers={filterBar.handlers}
+          hasActiveFilters={filterBar.hasActiveFilters}
+          searchInputRef={pageState.searchInputRef}
+          sort={{
+            field: 'orderNumber',
+            sortBy: pageState.sorting.sortBy,
+            sortOrder: pageState.sorting.sortOrder,
+            onSort: handleSort,
+          }}
+        />
+      </Box>
 
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { ArrowDownward as ArrowDownIcon, ArrowUpward as ArrowUpIcon, Sort as SortIcon } from '@mui/icons-material'
-import { Alert, Box, Button, Stack, useMediaQuery, useTheme } from '@mui/material'
+import { Alert, Box, useMediaQuery, useTheme } from '@mui/material'
 import { useStore } from 'react-redux'
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 
@@ -30,12 +29,15 @@ import {
   selectSalesError,
   selectSelectedOrder,
 } from '@/store/slices/salesSlice'
-import type { FilterBarConfig } from '@/types/filterBar.types'
+import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
+import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
 
 interface SalesOrderFilters {
   search: string
   customerId: string | null
   paymentStatus: 'unpaid' | 'partial' | 'paid' | 'overpaid' | null
+  period: PeriodValue
+  fulfillmentStatus: 'fulfilled' | 'unfulfilled' | null
 }
 
 export const OrdersPage: React.FC = () => {
@@ -78,24 +80,53 @@ export const OrdersPage: React.FC = () => {
             { value: 'overpaid', label: 'Overpaid' },
           ],
         },
+        {
+          field: 'period',
+          label: 'Period',
+          type: 'period',
+        },
+        {
+          field: 'fulfillmentStatus',
+          label: 'Fulfillment',
+          type: 'select',
+          options: [
+            { value: 'unfulfilled', label: 'Unfulfilled' },
+            { value: 'fulfilled', label: 'Fulfilled' },
+          ],
+        },
       ],
       defaults: {
         search: '',
         customerId: null,
         paymentStatus: null,
+        fulfillmentStatus: null,
       },
     }),
     [customers],
   )
 
   const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
+  const weekStartsOn = getStartOfWeek()
+  const dateRange = useMemo(() => {
+    const period = appliedFilters.period
+    if (!period || period.key === 'custom') {
+      return { fromDate: period?.from ?? undefined, toDate: period?.to ?? undefined }
+    }
+
+    const range = getPeriodDateRange(period.key, weekStartsOn)
+    return { fromDate: range.from, toDate: range.to }
+  }, [appliedFilters.period, weekStartsOn])
+
   const orderQueryArgs = useMemo(() => ({
     sortBy,
     sortOrder,
     search: appliedFilters.search || undefined,
     customerId: appliedFilters.customerId || undefined,
     paymentStatus: appliedFilters.paymentStatus || undefined,
-  }), [appliedFilters, sortBy, sortOrder])
+    fulfillmentStatus: appliedFilters.fulfillmentStatus || undefined,
+    fromDate: dateRange.fromDate,
+    toDate: dateRange.toDate,
+  }), [appliedFilters, dateRange, sortBy, sortOrder])
 
   const { data: ordersData, isLoading: loading, refetch: refetchOrders } = useGetSalesOrdersQuery(orderQueryArgs)
   const orders = ordersData?.data ?? []
@@ -208,25 +239,16 @@ export const OrdersPage: React.FC = () => {
         primaryAction={{ label: 'Create Order', onClick: () => navigate('/sales/orders/create') }}
       />
 
-      <Stack direction={isMobile ? 'column' : 'row'} spacing={1} alignItems={isMobile ? 'stretch' : 'center'} sx={{ mb: 3 }}>
-        <Box sx={{ flex: 1 }}>
-          <FilterBar
-            config={filterConfig}
-            draftFilters={draftFilters}
-            handlers={filterHandlers}
-            hasActiveFilters={hasActiveFilters}
-            searchInputRef={pageState.searchInputRef}
-          />
-        </Box>
-        <Button
-          variant={sortBy === 'orderNumber' ? 'contained' : 'outlined'}
-          size="small"
-          startIcon={sortBy === 'orderNumber' ? sortOrder === 'desc' ? <ArrowDownIcon /> : <ArrowUpIcon /> : <SortIcon />}
-          onClick={() => handleSort('orderNumber')}
-        >
-          Sort
-        </Button>
-      </Stack>
+      <Box sx={{ mb: 3 }}>
+        <FilterBar
+          config={filterConfig}
+          draftFilters={draftFilters}
+          handlers={filterHandlers}
+          hasActiveFilters={hasActiveFilters}
+          searchInputRef={pageState.searchInputRef}
+          sort={{ field: 'orderNumber', sortBy, sortOrder, onSort: handleSort }}
+        />
+      </Box>
 
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -99,6 +99,7 @@ export const OrdersPage: React.FC = () => {
         search: '',
         customerId: null,
         paymentStatus: null,
+        period: { key: 'this_month', from: null, to: null },
         fulfillmentStatus: null,
       },
     }),

--- a/frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
+++ b/frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
@@ -119,4 +119,23 @@ describe('OrdersPage FilterBar integration', () => {
       }),
     )
   })
+
+  it('restores fulfillmentStatus=fulfilled from URL and passes it to the query', () => {
+    renderPage('/?fulfillmentStatus=fulfilled')
+    expect(useGetSalesOrdersQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        fulfillmentStatus: 'fulfilled',
+      }),
+    )
+  })
+
+  it('restores period=this_week from URL and resolves to fromDate/toDate in the query', () => {
+    renderPage('/?period=this_week')
+    expect(useGetSalesOrdersQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        fromDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        toDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      }),
+    )
+  })
 })

--- a/frontend/src/types/filterBar.types.ts
+++ b/frontend/src/types/filterBar.types.ts
@@ -54,3 +54,10 @@ export interface FilterBarHandlers<TFilters> {
   onClearField: (field: keyof TFilters) => void
   onClearAll: () => void
 }
+
+export interface FilterBarSortConfig {
+  field: string
+  sortBy: string
+  sortOrder: 'asc' | 'desc'
+  onSort: (field: string) => void
+}


### PR DESCRIPTION
## Summary

- **Backend**: Extended `SalesOrderQueryService.findAll` search to cover order number, customer name, and product name. Count query uses a `leftJoin` for customer name and an `EXISTS` subquery for product name to prevent row fan-out
- **FilterBar**: Added optional `sort` prop (`FilterBarSortConfig`) — renders a Sort button inside the bar (active: `contained/primary`, inactive: `outlined/inherit`), removing the standalone Sort button duplication across pages
- **OrdersPage**: Added `period` (date range) and `fulfillmentStatus` filter fields; maps `PeriodValue` → `fromDate`/`toDate` via `getPeriodDateRange`; passes `sort` prop to `FilterBar`
- **PurchaseOrdersPage**: Migrated to shared sort button via `FilterBar` sort prop

## Test plan

- [x] Backend: `cd backend && npm run test` — all pass including new customer/product name search + EXISTS count tests
- [x] Frontend type-check: `cd frontend && npm run type-check` — no errors
- [x] Frontend lint: `cd frontend && npm run lint` — no errors
- [x] FilterBar tests: `npx vitest run src/components/filters/__tests__/FilterBar.test.tsx` — 5 tests pass (includes active + inactive sort button cases)
- [x] OrdersPage tests: `npx vitest run src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx` — 5 tests pass (includes fulfillmentStatus + period URL restore)
- [x] PurchaseOrdersPage tests: `npx vitest run src/pages/purchasing/__tests__/PurchaseOrdersPage.filterbar.test.tsx` — all pass
- [x] Manual: verify Sales Orders page shows Period and Fulfillment dropdowns, search finds by customer/product name, Sort button is inside the filter bar
- [x] Manual: verify Purchase Orders page Sort button is inside the filter bar

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)