### PR TITLE
feat: rearrange period filter and set null default on Sales Orders (#266)

### DIFF
--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -55,7 +55,7 @@ function renderQuickField<TFilters extends object>(
         customFrom={periodValue.from}
         customTo={periodValue.to}
         onChange={(key, from, to) =>
-          onChange({ key, from: from ?? null, to: to ?? null } satisfies PeriodValue)
+          onChange({ key, from: from ?? null, to: to ?? null } as PeriodValue)
         }
       />
     )

--- a/frontend/src/components/filters/FilterPeriod.test.tsx
+++ b/frontend/src/components/filters/FilterPeriod.test.tsx
@@ -6,10 +6,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { FilterPeriod } from './FilterPeriod'
 
-function renderFilterPeriod(value = 'today', onChange = vi.fn()) {
+function renderFilterPeriod(
+  value: Parameters<typeof FilterPeriod>[0]['value'] = 'today',
+  onChange = vi.fn(),
+) {
   return render(
     <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <FilterPeriod value={value as any} customFrom={null} customTo={null} onChange={onChange} />
+      <FilterPeriod value={value} customFrom={null} customTo={null} onChange={onChange} />
     </LocalizationProvider>,
   )
 }
@@ -23,6 +26,13 @@ describe('FilterPeriod', () => {
     renderFilterPeriod()
 
     expect(screen.getByLabelText('Period')).toBeInTheDocument()
+  })
+
+  it('shows placeholder label when value is null (no selection)', () => {
+    renderFilterPeriod(null)
+
+    expect(screen.getByRole('combobox').textContent?.replace(/\u200b/g, '').trim()).toBe('')
+    expect(screen.getAllByText('Period').length).toBeGreaterThan(0)
   })
 
   it('renders dividers between groups in the dropdown', async () => {
@@ -70,5 +80,12 @@ describe('FilterPeriod', () => {
 
     expect(screen.getAllByText('From').length).toBeGreaterThan(0)
     expect(screen.getAllByText('To').length).toBeGreaterThan(0)
+  })
+
+  it('does not show date pickers when value is null', () => {
+    renderFilterPeriod(null)
+
+    expect(screen.queryByLabelText(/from/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/to/i)).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/filters/FilterPeriod.tsx
+++ b/frontend/src/components/filters/FilterPeriod.tsx
@@ -68,6 +68,7 @@ export function FilterPeriod({ value, customFrom, customTo, onChange }: FilterPe
           value={value ?? ''}
           label="Period"
           displayEmpty
+          notched={value !== null}
           onChange={(event) => handleKeyChange(event.target.value as PeriodKey)}
         >
           {PERIOD_GROUPS.map((group, groupIndex) => [

--- a/frontend/src/components/filters/FilterPeriod.tsx
+++ b/frontend/src/components/filters/FilterPeriod.tsx
@@ -10,7 +10,7 @@ interface FilterPeriodProps {
   value: PeriodKey | null
   customFrom: string | null
   customTo: string | null
-  onChange: (key: PeriodKey, from?: string, to?: string) => void
+  onChange: (key: PeriodKey | null, from?: string, to?: string) => void
 }
 
 export function FilterPeriod({ value, customFrom, customTo, onChange }: FilterPeriodProps) {
@@ -31,8 +31,8 @@ export function FilterPeriod({ value, customFrom, customTo, onChange }: FilterPe
     setInternalTo(customTo)
   }, [customFrom, customTo])
 
-  const handleKeyChange = (key: PeriodKey) => {
-    if (key !== 'custom') {
+  const handleKeyChange = (key: PeriodKey | null) => {
+    if (key === null || key !== 'custom') {
       setInternalFrom(null)
       setInternalTo(null)
       onChange(key)

--- a/frontend/src/components/filters/FilterPeriod.tsx
+++ b/frontend/src/components/filters/FilterPeriod.tsx
@@ -7,7 +7,7 @@ import { PERIOD_GROUPS, PERIOD_LABELS, type PeriodKey } from '@/constants/period
 import { toMuiDatePickerFormat } from '@/utils/formatters'
 
 interface FilterPeriodProps {
-  value: PeriodKey
+  value: PeriodKey | null
   customFrom: string | null
   customTo: string | null
   onChange: (key: PeriodKey, from?: string, to?: string) => void
@@ -61,12 +61,13 @@ export function FilterPeriod({ value, customFrom, customTo, onChange }: FilterPe
   return (
     <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
       <FormControl size="small" sx={{ minWidth: 150 }}>
-        <InputLabel id={labelId}>Period</InputLabel>
+        <InputLabel id={labelId} shrink={value !== null}>Period</InputLabel>
         <Select
           labelId={labelId}
           id={selectId}
-          value={value}
+          value={value ?? ''}
           label="Period"
+          displayEmpty
           onChange={(event) => handleKeyChange(event.target.value as PeriodKey)}
         >
           {PERIOD_GROUPS.map((group, groupIndex) => [

--- a/frontend/src/hooks/useFilterBar.test.tsx
+++ b/frontend/src/hooks/useFilterBar.test.tsx
@@ -102,4 +102,36 @@ describe('useFilterBar — period field', () => {
 
     expect(result.current.appliedFilters.period).toEqual({ key: 'last_week', from: null, to: null })
   })
+
+  it('hasActiveFilters is false when period key is null (default)', () => {
+    interface PeriodFilters {
+      period: PeriodValue
+    }
+
+    const periodConfig: FilterBarConfig<PeriodFilters> = {
+      fields: [{ field: 'period', label: 'Period', type: 'period' }],
+    }
+
+    const { result } = renderHook(() => useFilterBar(periodConfig), { wrapper: makeWrapper() })
+
+    expect(result.current.hasActiveFilters).toBe(false)
+  })
+
+  it('hasActiveFilters is true after period key is set', () => {
+    interface PeriodFilters {
+      period: PeriodValue
+    }
+
+    const periodConfig: FilterBarConfig<PeriodFilters> = {
+      fields: [{ field: 'period', label: 'Period', type: 'period' }],
+    }
+
+    const { result } = renderHook(() => useFilterBar(periodConfig), { wrapper: makeWrapper() })
+
+    act(() => {
+      result.current.handlers.onQuickFilterChange('period', { key: 'this_week', from: null, to: null })
+    })
+
+    expect(result.current.hasActiveFilters).toBe(true)
+  })
 })

--- a/frontend/src/hooks/useFilterBar.test.tsx
+++ b/frontend/src/hooks/useFilterBar.test.tsx
@@ -71,7 +71,7 @@ describe('useFilterBar', () => {
 })
 
 describe('useFilterBar — period field', () => {
-  it('defaults period to this_month when no default configured', () => {
+  it('defaults period key to null when no default is configured', () => {
     interface PeriodFilters {
       period: PeriodValue
     }
@@ -82,11 +82,7 @@ describe('useFilterBar — period field', () => {
 
     const { result } = renderHook(() => useFilterBar(periodConfig), { wrapper: makeWrapper() })
 
-    expect(result.current.appliedFilters.period).toEqual({
-      key: 'this_month',
-      from: null,
-      to: null,
-    })
+    expect(result.current.appliedFilters.period.key).toBeNull()
   })
 
   it('updates period value via onQuickFilterChange', () => {

--- a/frontend/src/hooks/useFilterBar.ts
+++ b/frontend/src/hooks/useFilterBar.ts
@@ -22,7 +22,7 @@ function getDefaults<TFilters extends object>(
     if (field.type === 'select') defaults[key] = null
     else if (field.type === 'multi-select') defaults[key] = []
     else if (field.type === 'period') {
-      defaults[key] = { key: 'this_month', from: null, to: null } satisfies PeriodValue
+      defaults[key] = { key: null, from: null, to: null } satisfies PeriodValue
     }
   }
 

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -64,6 +64,11 @@ export const OrdersPage: React.FC = () => {
       search: { placeholder: 'Search orders...' },
       fields: [
         {
+          field: 'period',
+          label: 'Period',
+          type: 'period',
+        },
+        {
           field: 'customerId',
           label: 'Customer',
           type: 'select',
@@ -81,11 +86,6 @@ export const OrdersPage: React.FC = () => {
           ],
         },
         {
-          field: 'period',
-          label: 'Period',
-          type: 'period',
-        },
-        {
           field: 'fulfillmentStatus',
           label: 'Fulfillment',
           type: 'select',
@@ -99,7 +99,7 @@ export const OrdersPage: React.FC = () => {
         search: '',
         customerId: null,
         paymentStatus: null,
-        period: { key: 'this_month', from: null, to: null },
+        period: { key: null, from: null, to: null },
         fulfillmentStatus: null,
       },
     }),
@@ -110,8 +110,11 @@ export const OrdersPage: React.FC = () => {
   const weekStartsOn = getStartOfWeek()
   const dateRange = useMemo(() => {
     const period = appliedFilters.period
-    if (!period || period.key === 'custom') {
-      return { fromDate: period?.from ?? undefined, toDate: period?.to ?? undefined }
+    if (!period || period.key === null) {
+      return { fromDate: undefined, toDate: undefined }
+    }
+    if (period.key === 'custom') {
+      return { fromDate: period.from ?? undefined, toDate: period.to ?? undefined }
     }
 
     const range = getPeriodDateRange(period.key, weekStartsOn)

--- a/frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
+++ b/frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
@@ -129,6 +129,28 @@ describe('OrdersPage FilterBar integration', () => {
     )
   })
 
+  it('sends no fromDate or toDate when period is not selected (default)', () => {
+    renderPage()
+
+    expect(useGetSalesOrdersQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        fromDate: undefined,
+        toDate: undefined,
+      }),
+    )
+  })
+
+  it('period filter appears before customer filter in the DOM', () => {
+    renderPage()
+
+    const periodLabel = screen.getAllByText('Period')[0]
+    const customerLabel = screen.getAllByText('Customer')[0]
+
+    expect(
+      periodLabel.compareDocumentPosition(customerLabel) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+  })
+
   it('restores period=this_week from URL and resolves to fromDate/toDate in the query', () => {
     renderPage('/?period=this_week')
     expect(useGetSalesOrdersQuery).toHaveBeenLastCalledWith(

--- a/frontend/src/types/filterBar.types.ts
+++ b/frontend/src/types/filterBar.types.ts
@@ -3,7 +3,7 @@ import type { PeriodKey } from '@/constants/periods'
 export type FilterOption = { value: string; label: string }
 
 export type PeriodValue = {
-  key: PeriodKey
+  key: PeriodKey | null
   from: string | null
   to: string | null
 }

--- a/frontend/src/utils/filterBar.url.ts
+++ b/frontend/src/utils/filterBar.url.ts
@@ -1,4 +1,4 @@
-import { PERIOD_KEYS } from '@/constants/periods'
+import { PERIOD_KEYS, type PeriodKey } from '@/constants/periods'
 import type {
   FilterBarConfig,
   FilterFieldConfig,
@@ -146,7 +146,7 @@ export function parseFilters<TFilters extends object>(
         key: null,
         from: null,
         to: null,
-      }
+      } satisfies PeriodValue
       const raw = searchParams.get(key)
       if (raw === null || !(PERIOD_KEYS as readonly string[]).includes(raw)) {
         result[fieldKey] = defaultPeriod

--- a/frontend/src/utils/filterBar.url.ts
+++ b/frontend/src/utils/filterBar.url.ts
@@ -1,4 +1,4 @@
-import { PERIOD_KEYS, type PeriodKey } from '@/constants/periods'
+import { PERIOD_KEYS } from '@/constants/periods'
 import type {
   FilterBarConfig,
   FilterFieldConfig,
@@ -82,13 +82,14 @@ export function serializeFilters<TFilters extends object>(
     if (field.type === 'period') {
       const period = value as PeriodValue | undefined
       const defaultPeriod = defaultValue as PeriodValue | undefined
-      const defaultKey = defaultPeriod?.key ?? 'this_month'
+      const defaultKey = defaultPeriod?.key ?? null
       const defaultFrom = defaultPeriod?.from ?? null
       const defaultTo = defaultPeriod?.to ?? null
       const isDefault =
         !period ||
         (period.key === defaultKey && period.from === defaultFrom && period.to === defaultTo)
       if (isDefault) continue
+      if (period.key === null) continue
       orderedEntries.push([key, period.key])
       if (period.key === 'custom' && period.from && period.to) {
         orderedEntries.push([`${key}_from`, period.from])
@@ -142,7 +143,7 @@ export function parseFilters<TFilters extends object>(
 
     if (field.type === 'period') {
       const defaultPeriod = (defaultValue as PeriodValue | undefined) ?? {
-        key: 'this_month' as PeriodKey,
+        key: null,
         from: null,
         to: null,
       }


### PR DESCRIPTION
## Summary

- Moves the Period filter to appear immediately after the search box (was 3rd field)
- Defaults to no selection (null) instead of "This Month" — no date filtering applied until user picks a period
- Period dropdown shows a greyed-out placeholder matching Customer/Payment dropdown behaviour
- Fixes outlined border gap when a period is selected (MUI `notched` prop sync)

## Changes

- `filterBar.types.ts` — `PeriodValue.key: PeriodKey | null`
- `FilterPeriod.tsx` — handles null value as unselected placeholder; `onChange` accepts `PeriodKey | null`; `notched` prop synced with label shrink
- `FilterBar.tsx` — propagates null key from `onChange`
- `useFilterBar.ts` — internal period fallback default changed from `this_month` to `null`
- `filterBar.url.ts` — null period serializes to no URL param
- `OrdersPage.tsx` — period first in fields, default `{ key: null }`, `dateRange` returns undefined when null

## Test plan

- [x] `npx vitest run src/components/filters/FilterPeriod.test.tsx src/hooks/useFilterBar.test.tsx src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx src/utils/filterBar.url.test.ts`
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] Manual: period dropdown appears after search, shows placeholder, loads all orders by default
- [x] Manual: selecting a period filters correctly; Reset returns to no selection
- [x] Manual: border outline is complete when a period is selected

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)