### PR TITLE
fix: reduce PageHeader bottom margin from 32px to 16px

### DIFF
--- a/frontend/src/components/common/PageHeader.tsx
+++ b/frontend/src/components/common/PageHeader.tsx
@@ -42,7 +42,7 @@ export default function PageHeader({
     <Box
       data-testid={showDivider ? 'page-header-divider' : undefined}
       sx={{
-        mb: 4,
+        mb: 2,
         pb: 2,
         ...(showDivider && {
           borderBottom: `1px solid ${theme.palette.divider}`,

--- a/frontend/src/components/common/__tests__/PageHeader.test.tsx
+++ b/frontend/src/components/common/__tests__/PageHeader.test.tsx
@@ -88,6 +88,11 @@ describe('PageHeader', () => {
     expect(screen.getByTestId('page-header-divider')).toBeInTheDocument()
   })
 
+  it('uses 16px bottom spacing below the header', () => {
+    renderWithTheme(<PageHeader title="Sales Orders" />)
+    expect(getComputedStyle(screen.getByTestId('page-header-divider')).marginBottom).toBe('16px')
+  })
+
   it('hides divider when showDivider is false', () => {
     renderWithTheme(<PageHeader title="Create Sales Order" showDivider={false} />)
     expect(screen.queryByTestId('page-header-divider')).not.toBeInTheDocument()


### PR DESCRIPTION
## Summary
- Changes `mb: 4` → `mb: 2` in `PageHeader.tsx`, reducing the gap between the page title and the content below it from 32px to 16px
- Applies uniformly to all ~75 pages using `PageHeader` (list pages, dashboard pages, form pages)
- Adds a regression test asserting the 16px spacing

## Test Plan
- [x] Run `cd frontend && npx vitest run src/components/common/__tests__/PageHeader.test.tsx` — 25 passed
- [x] Smoke test a list page (Sales Orders, Products, Customers) to confirm tighter header gap
- [x] Verify dashboard overview pages (SalesPage, PurchasingPage, InventoryPage) look correct

Closes #271