### PR TITLE
fix: standardize filter bar bottom gap to 16px

### DIFF
--- a/frontend/src/components/filters/DashboardFilterBar.tsx
+++ b/frontend/src/components/filters/DashboardFilterBar.tsx
@@ -75,7 +75,7 @@ export function DashboardFilterBar({
   ]
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mb: 3 }}>
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mb: 2 }}>
       <FilterPeriod
         value={period}
         customFrom={customFrom}

--- a/frontend/src/components/filters/__tests__/DashboardFilterBar.test.tsx
+++ b/frontend/src/components/filters/__tests__/DashboardFilterBar.test.tsx
@@ -29,6 +29,12 @@ function wrap(ui: React.ReactElement) {
 }
 
 describe('DashboardFilterBar', () => {
+  it('uses a 16px bottom margin on the root filter row', () => {
+    const { container } = wrap(<DashboardFilterBar {...baseProps()} />)
+
+    expect(window.getComputedStyle(container.firstElementChild as Element).marginBottom).toBe('16px')
+  })
+
   it('does not render Customer select when customers prop is absent', () => {
     wrap(<DashboardFilterBar {...baseProps()} />)
     expect(screen.queryByLabelText('Customer')).toBeNull()

--- a/frontend/src/pages/inventory/ProductsPage.tsx
+++ b/frontend/src/pages/inventory/ProductsPage.tsx
@@ -139,7 +139,7 @@ export const ProductsPage: React.FC = () => {
         direction={isMobile ? 'column' : 'row'}
         spacing={1}
         alignItems={isMobile ? 'stretch' : 'center'}
-        sx={{ mb: 3, transition: 'margin-right 0.3s ease-in-out', marginRight: contentMarginRight }}
+        sx={{ mb: 2, transition: 'margin-right 0.3s ease-in-out', marginRight: contentMarginRight }}
       >
         <Box sx={{ flex: 1 }}>
           <FilterBar

--- a/frontend/src/pages/inventory/__tests__/ProductsPage.filterbar.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/ProductsPage.filterbar.test.tsx
@@ -79,6 +79,16 @@ describe('ProductsPage FilterBar integration', () => {
     expect(screen.getByPlaceholderText(/search by name, barcode, or brand/i)).toBeInTheDocument()
   })
 
+  it('uses a 16px bottom margin below the filter bar wrapper', () => {
+    renderPage()
+
+    const filterRow = screen.getByPlaceholderText(/search by name, barcode, or brand/i).closest('.MuiStack-root')
+    const filterWrapper = filterRow?.parentElement?.closest('.MuiStack-root')
+
+    expect(filterWrapper).not.toBeNull()
+    expect(window.getComputedStyle(filterWrapper as HTMLElement).marginBottom).toBe('16px')
+  })
+
   it('restores filters from URL into the products query', () => {
     renderPage('/?search=gundam&status=inactive')
     expect(useGetProductsQuery).toHaveBeenLastCalledWith(

--- a/frontend/src/pages/inventory/__tests__/ProductsPage.filterbar.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/ProductsPage.filterbar.test.tsx
@@ -82,8 +82,10 @@ describe('ProductsPage FilterBar integration', () => {
   it('uses a 16px bottom margin below the filter bar wrapper', () => {
     renderPage()
 
-    const filterRow = screen.getByPlaceholderText(/search by name, barcode, or brand/i).closest('.MuiStack-root')
-    const filterWrapper = filterRow?.parentElement?.closest('.MuiStack-root')
+    const filterWrapper = screen
+      .getByPlaceholderText(/search by name, barcode, or brand/i)
+      .closest('.MuiBox-root')
+      ?.parentElement
 
     expect(filterWrapper).not.toBeNull()
     expect(window.getComputedStyle(filterWrapper as HTMLElement).marginBottom).toBe('16px')

--- a/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
@@ -183,7 +183,7 @@ export const PurchaseOrdersPage: React.FC = () => {
         primaryAction={{ label: 'Create Order', onClick: () => navigate('/purchasing/orders/create') }}
       />
 
-      <Box sx={{ mb: 3 }}>
+      <Box sx={{ mb: 2 }}>
         <FilterBar
           config={filterConfig}
           draftFilters={filterBar.draftFilters}

--- a/frontend/src/pages/purchasing/__tests__/PurchaseOrdersPage.filterbar.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/PurchaseOrdersPage.filterbar.test.tsx
@@ -98,6 +98,16 @@ describe('PurchaseOrdersPage FilterBar integration', () => {
     expect(screen.getByPlaceholderText(/search purchase orders/i)).toBeInTheDocument()
   })
 
+  it('uses a 16px bottom margin below the filter bar wrapper', () => {
+    renderPage()
+
+    const filterRow = screen.getByPlaceholderText(/search purchase orders/i).closest('.MuiStack-root')
+    const filterWrapper = filterRow?.parentElement
+
+    expect(filterWrapper).not.toBeNull()
+    expect(window.getComputedStyle(filterWrapper as HTMLElement).marginBottom).toBe('16px')
+  })
+
   it('renders the master-detail workspace with split purchasing detail cards', () => {
     renderPage()
 

--- a/frontend/src/pages/sales/CustomersPage.tsx
+++ b/frontend/src/pages/sales/CustomersPage.tsx
@@ -423,7 +423,7 @@ const CustomersPage: React.FC = () => {
         primaryAction={{ label: 'New Customer', onClick: () => handleOpenForm() }}
       />
       {/* Filters and Search */}
-      <Box sx={{ mb: 3 }}>
+      <Box sx={{ mb: 2 }}>
         <FilterBar
           config={filterConfig}
           draftFilters={draftFilters}

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -243,7 +243,7 @@ export const OrdersPage: React.FC = () => {
         primaryAction={{ label: 'Create Order', onClick: () => navigate('/sales/orders/create') }}
       />
 
-      <Box sx={{ mb: 3 }}>
+      <Box sx={{ mb: 2 }}>
         <FilterBar
           config={filterConfig}
           draftFilters={draftFilters}

--- a/frontend/src/pages/sales/__tests__/CustomersPage.filterbar.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CustomersPage.filterbar.test.tsx
@@ -56,6 +56,16 @@ describe('CustomersPage FilterBar', () => {
     expect(screen.getByPlaceholderText(/search by name or phone/i)).toBeInTheDocument()
   })
 
+  it('uses a 16px bottom margin below the filter bar wrapper', () => {
+    renderPage()
+
+    const filterRow = screen.getByPlaceholderText(/search by name or phone/i).closest('.MuiStack-root')
+    const filterWrapper = filterRow?.parentElement
+
+    expect(filterWrapper).not.toBeNull()
+    expect(window.getComputedStyle(filterWrapper as HTMLElement).marginBottom).toBe('16px')
+  })
+
   it('restores filters from URL and passes them to query', () => {
     renderPage('/?search=acme&status=active')
     expect(useGetCustomersQuery).toHaveBeenLastCalledWith(

--- a/frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
+++ b/frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
@@ -100,6 +100,16 @@ describe('OrdersPage FilterBar integration', () => {
     expect(screen.getByPlaceholderText(/search orders/i)).toBeInTheDocument()
   })
 
+  it('uses a 16px bottom margin below the filter bar wrapper', () => {
+    renderPage()
+
+    const filterRow = screen.getByPlaceholderText(/search orders/i).closest('.MuiStack-root')
+    const filterWrapper = filterRow?.parentElement
+
+    expect(filterWrapper).not.toBeNull()
+    expect(window.getComputedStyle(filterWrapper as HTMLElement).marginBottom).toBe('16px')
+  })
+
   it('renders the master-detail workspace with split sales detail cards', () => {
     renderPage()
 


### PR DESCRIPTION
## Summary
- Reduces bottom margin below filter bar from 24px (`mb: 3`) to 16px (`mb: 2`) on all pages
- Fixes `DashboardFilterBar` internally (covers Sales and Purchasing dashboards)
- Fixes wrapping containers on Orders, Purchase Orders, Products, and Customers pages

Closes #272

## Test plan
- [x] Smoke test list pages: Sales Orders, Purchase Orders, Products, Customers
- [x] Check Sales Dashboard and Purchasing Dashboard filter bar spacing
- [x] Verify filter bar -> table transition looks intentional and compact

## Verification
- `cd frontend && npx vitest run src/components/filters/__tests__/DashboardFilterBar.test.tsx`
- `cd frontend && npx vitest run src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx`
- `cd frontend && npx vitest run src/pages/purchasing/__tests__/PurchaseOrdersPage.filterbar.test.tsx`
- `cd frontend && npx vitest run src/pages/inventory/__tests__/ProductsPage.filterbar.test.tsx`
- `cd frontend && npx vitest run src/pages/sales/__tests__/CustomersPage.filterbar.test.tsx`
- `cd frontend && npm run lint`
- `cd frontend && npm run type-check`
- `cd frontend && timeout 300s npm run test` (timed out with exit code 124)
