### PR TITLE
fix(ui): auto-expand master-detail workspace to fill available height

### DIFF
--- a/frontend/src/components/common/MainLayout.tsx
+++ b/frontend/src/components/common/MainLayout.tsx
@@ -83,6 +83,8 @@ const MainLayout: React.FC = () => {
         component="main"
         sx={{
           flexGrow: 1,
+          display: 'flex',
+          flexDirection: 'column',
           pt: 8,
           px: { xs: 2, sm: 3 },
           pb: 3,
@@ -92,7 +94,9 @@ const MainLayout: React.FC = () => {
           maxWidth: '100%',
         }}
       >
-        <Outlet />
+        <Box sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+          <Outlet />
+        </Box>
       </Box>
     </Box>
   )

--- a/frontend/src/components/common/MasterDetailWorkspace.test.tsx
+++ b/frontend/src/components/common/MasterDetailWorkspace.test.tsx
@@ -5,11 +5,11 @@ import MasterDetailWorkspace from './MasterDetailWorkspace'
 
 describe('MasterDetailWorkspace', () => {
   it('renders the three slots in desktop mode', () => {
-    render(
+    const { container } = render(
       <MasterDetailWorkspace
-        listSlot={<div>List Slot</div>}
-        headerSlot={<div>Header Slot</div>}
-        workspaceSlot={<div>Workspace Slot</div>}
+        listSlot={<div data-testid="list-slot">List Slot</div>}
+        headerSlot={<div data-testid="header-slot">Header Slot</div>}
+        workspaceSlot={<div data-testid="workspace-slot">Workspace Slot</div>}
         isMobile={false}
       />,
     )
@@ -17,10 +17,31 @@ describe('MasterDetailWorkspace', () => {
     expect(screen.getByText('List Slot')).toBeInTheDocument()
     expect(screen.getByText('Header Slot')).toBeInTheDocument()
     expect(screen.getByText('Workspace Slot')).toBeInTheDocument()
+
+    const desktopRoot = container.firstElementChild as HTMLElement
+    const rightColumn = screen.getByTestId('header-slot').parentElement as HTMLElement
+    const workspaceWrapper = screen.getByTestId('workspace-slot').parentElement as HTMLElement
+
+    const desktopRootStyles = window.getComputedStyle(desktopRoot)
+    const rightColumnStyles = window.getComputedStyle(rightColumn)
+    const workspaceWrapperStyles = window.getComputedStyle(workspaceWrapper)
+
+    expect(desktopRootStyles.display).toBe('flex')
+    expect(desktopRootStyles.flexDirection).toBe('row')
+    expect(desktopRootStyles.flexGrow).toBe('1')
+    expect(desktopRootStyles.minHeight).toBe('0px')
+    expect(rightColumnStyles.display).toBe('flex')
+    expect(rightColumnStyles.flexDirection).toBe('column')
+    expect(rightColumnStyles.overflow).toBe('hidden')
+    expect(rightColumnStyles.minHeight).toBe('0px')
+    expect(workspaceWrapperStyles.display).toBe('flex')
+    expect(workspaceWrapperStyles.flexDirection).toBe('column')
+    expect(workspaceWrapperStyles.overflow).toBe('hidden')
+    expect(workspaceWrapperStyles.minHeight).toBe('0px')
   })
 
   it('renders the same three slots in mobile mode', () => {
-    render(
+    const { container } = render(
       <MasterDetailWorkspace
         listSlot={<div>List Slot</div>}
         headerSlot={<div>Header Slot</div>}
@@ -32,5 +53,9 @@ describe('MasterDetailWorkspace', () => {
     expect(screen.getByText('List Slot')).toBeInTheDocument()
     expect(screen.getByText('Header Slot')).toBeInTheDocument()
     expect(screen.getByText('Workspace Slot')).toBeInTheDocument()
+
+    const mobileRootStyles = window.getComputedStyle(container.firstElementChild as HTMLElement)
+    expect(mobileRootStyles.display).toBe('flex')
+    expect(mobileRootStyles.flexDirection).toBe('column')
   })
 })

--- a/frontend/src/components/common/MasterDetailWorkspace.tsx
+++ b/frontend/src/components/common/MasterDetailWorkspace.tsx
@@ -25,7 +25,7 @@ const MasterDetailWorkspace: React.FC<MasterDetailWorkspaceProps> = ({
   }
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'row', height: 'calc(100vh - 300px)', gap: 3 }}>
+    <Box sx={{ display: 'flex', flexDirection: 'row', flex: 1, minHeight: 0, gap: 3 }}>
       <Box
         sx={{
           width: '25%',
@@ -33,13 +33,14 @@ const MasterDetailWorkspace: React.FC<MasterDetailWorkspaceProps> = ({
           overflow: 'hidden',
           display: 'flex',
           flexDirection: 'column',
+          minHeight: 0,
         }}
       >
         {listSlot}
       </Box>
-      <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2, overflow: 'hidden' }}>
+      <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2, overflow: 'hidden', minHeight: 0 }}>
         {headerSlot}
-        <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+        <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
           {workspaceSlot}
         </Box>
       </Box>

--- a/frontend/src/components/common/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/common/__tests__/MainLayout.test.tsx
@@ -1,13 +1,20 @@
 import { render } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
-import { describe, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 
 import MainLayout from '../MainLayout'
 
 vi.mock('../Sidebar', () => ({ default: () => <div data-testid="sidebar" /> }))
 vi.mock('../TopBar', () => ({ default: () => <div data-testid="topbar" /> }))
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    Outlet: () => <div data-testid="outlet-content">Outlet Content</div>,
+  }
+})
 
 function makeStore() {
   return configureStore({
@@ -26,5 +33,32 @@ describe('MainLayout', () => {
         </MemoryRouter>
       </Provider>
     )
+  })
+
+  it('renders the routed content inside a shrinkable flex wrapper', () => {
+    const { container } = render(
+      <Provider store={makeStore()}>
+        <MemoryRouter>
+          <MainLayout />
+        </MemoryRouter>
+      </Provider>
+    )
+
+    const main = container.querySelector('main')
+    const outlet = container.querySelector('[data-testid="outlet-content"]')
+    const outletWrapper = outlet?.parentElement
+
+    expect(main).not.toBeNull()
+    expect(outletWrapper).not.toBeNull()
+    const mainStyles = window.getComputedStyle(main as HTMLElement)
+    const outletWrapperStyles = window.getComputedStyle(outletWrapper as HTMLElement)
+
+    expect(mainStyles.display).toBe('flex')
+    expect(mainStyles.flexDirection).toBe('column')
+    expect(mainStyles.overflow).toBe('hidden')
+    expect(outletWrapperStyles.display).toBe('flex')
+    expect(outletWrapperStyles.flexDirection).toBe('column')
+    expect(outletWrapperStyles.flexGrow).toBe('1')
+    expect(outletWrapperStyles.minHeight).toBe('0px')
   })
 })

--- a/frontend/src/pages/inventory/ProductsPage.tsx
+++ b/frontend/src/pages/inventory/ProductsPage.tsx
@@ -125,7 +125,7 @@ export const ProductsPage: React.FC = () => {
   const contentMarginRight = pageState.calculatorPanelOpen ? { xs: '0px', md: '320px' } : '0px'
 
   return (
-    <Box sx={{ p: 3, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+    <Box data-testid="products-page-root" sx={{ p: 0, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
       <Box sx={{ mb: 3, transition: 'margin-right 0.3s ease-in-out', marginRight: contentMarginRight }}>
         <PageHeader
           title="Products"

--- a/frontend/src/pages/inventory/ProductsPage.tsx
+++ b/frontend/src/pages/inventory/ProductsPage.tsx
@@ -125,7 +125,7 @@ export const ProductsPage: React.FC = () => {
   const contentMarginRight = pageState.calculatorPanelOpen ? { xs: '0px', md: '320px' } : '0px'
 
   return (
-    <Box sx={{ p: 3 }}>
+    <Box sx={{ p: 3, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
       <Box sx={{ mb: 3, transition: 'margin-right 0.3s ease-in-out', marginRight: contentMarginRight }}>
         <PageHeader
           title="Products"
@@ -152,9 +152,19 @@ export const ProductsPage: React.FC = () => {
         </Box>
       </Stack>
 
-      <Box sx={{ transition: 'margin-right 0.3s ease-in-out', marginRight: contentMarginRight }}>
-        <Grid container spacing={3}>
-          <Grid item xs={12} md={3}>
+      <Box
+        data-testid="products-content-region"
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          transition: 'margin-right 0.3s ease-in-out',
+          marginRight: contentMarginRight,
+        }}
+      >
+        <Grid container spacing={3} sx={{ flex: 1, minHeight: 0 }}>
+          <Grid item xs={12} md={3} sx={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}>
             <ProductsTable
               products={products}
               loading={isProductsFetching}
@@ -165,7 +175,7 @@ export const ProductsPage: React.FC = () => {
               onProductSelect={selection.handleProductSelect}
             />
           </Grid>
-          <Grid item xs={12} md={9}>
+          <Grid item xs={12} md={9} sx={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}>
             <ProductDetailsPanel
               products={products}
               selectedProduct={selectedProduct}

--- a/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
@@ -443,7 +443,7 @@ const StockAdjustmentsPage: React.FC = () => {
   })
 
   return (
-    <Box sx={{ p: 3 }}>
+    <Box sx={{ p: 3, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
       {/* Header */}
       <PageHeader
         title="Stock Adjustments"
@@ -487,14 +487,20 @@ const StockAdjustmentsPage: React.FC = () => {
         </Alert>
       )}
       {/* Split Layout */}
-      <Grid container spacing={3}>
+      <Box
+        data-testid="stock-adjustments-content-region"
+        sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}
+      >
+        <Grid container spacing={3} sx={{ flex: 1, minHeight: 0 }}>
         {/* Left Side - Adjustment List */}
         <Grid
           size={{
             xs: 12,
             md: 3
-          }}>
-          <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', flexDirection: 'column' }}>
+          }}
+          sx={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}
+        >
+          <Paper sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
             <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
               <Typography variant="tableHeader" sx={{
                 fontWeight: 600,
@@ -506,11 +512,11 @@ const StockAdjustmentsPage: React.FC = () => {
               </Typography>
             </Box>
 
-            <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }} ref={adjustmentListRef}>
+            <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }} ref={adjustmentListRef}>
               {(isLoading || (isFetching && !adjustmentsResponse)) ? (
                 <ListSkeleton rows={8} columns={1} />
               ) : (
-                <Box sx={{ flex: 1, opacity: isFetching ? 0.6 : 1, position: 'relative' }}>
+                <Box sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', opacity: isFetching ? 0.6 : 1, position: 'relative' }}>
                   {isFetching ? (
                     <CircularProgress size={16} sx={{ position: 'absolute', top: 8, right: 8, zIndex: 1 }} />
                   ) : null}
@@ -550,9 +556,11 @@ const StockAdjustmentsPage: React.FC = () => {
           size={{
             xs: 12,
             md: 9
-          }}>
+          }}
+          sx={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}
+        >
           {selectedAdjustment ? (
-            <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', flexDirection: 'column' }}>
+            <Paper sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
               <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                   <Typography variant="tableHeader" sx={{
@@ -629,7 +637,7 @@ const StockAdjustmentsPage: React.FC = () => {
                 </Box>
               </Box>
 
-            <Box sx={{ flex: 1, overflow: 'auto', p: TABLE_STYLES.cell.padding.px }}>
+            <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', p: TABLE_STYLES.cell.padding.px }}>
               {/* SA Details Section */}
               <Box>
                 <Grid container spacing={3}>
@@ -856,7 +864,7 @@ const StockAdjustmentsPage: React.FC = () => {
                 </TableContainer>
 
                 {/* SA Items Table */}
-                <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+                <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
                   {selectedAdjustment.items && selectedAdjustment.items.length > 0 ? (
                     <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
                       <Table
@@ -984,14 +992,15 @@ const StockAdjustmentsPage: React.FC = () => {
             </Box>
             </Paper>
           ) : (
-            <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Paper sx={{ flex: 1, minHeight: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
               <Typography variant="h6" color="text.secondary">
                 Select an adjustment to view details
               </Typography>
             </Paper>
           )}
         </Grid>
-      </Grid>
+        </Grid>
+      </Box>
       {/* Deleted Stock Adjustments Dialog */}
       <DeletedStockAdjustmentsDialog
         open={showDeletedDialog}

--- a/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
@@ -443,7 +443,7 @@ const StockAdjustmentsPage: React.FC = () => {
   })
 
   return (
-    <Box sx={{ p: 3, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+    <Box data-testid="stock-adjustments-page-root" sx={{ p: 0, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
       {/* Header */}
       <PageHeader
         title="Stock Adjustments"

--- a/frontend/src/pages/inventory/__tests__/ProductsPage.filterbar.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/ProductsPage.filterbar.test.tsx
@@ -100,6 +100,14 @@ describe('ProductsPage FilterBar integration', () => {
     expect(window.getComputedStyle(contentRegion).minHeight).toBe('0px')
   })
 
+  it('does not add extra page-root bottom padding beyond MainLayout', () => {
+    renderPage()
+
+    const pageRoot = screen.getByTestId('products-page-root')
+
+    expect(window.getComputedStyle(pageRoot).paddingBottom).toBe('0px')
+  })
+
   it('restores filters from URL into the products query', () => {
     renderPage('/?search=gundam&status=inactive')
     expect(useGetProductsQuery).toHaveBeenLastCalledWith(

--- a/frontend/src/pages/inventory/__tests__/ProductsPage.filterbar.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/ProductsPage.filterbar.test.tsx
@@ -91,6 +91,15 @@ describe('ProductsPage FilterBar integration', () => {
     expect(window.getComputedStyle(filterWrapper as HTMLElement).marginBottom).toBe('16px')
   })
 
+  it('renders the products content region as a shrinkable flex container', () => {
+    renderPage()
+
+    const contentRegion = screen.getByTestId('products-content-region')
+
+    expect(window.getComputedStyle(contentRegion).flexGrow).toBe('1')
+    expect(window.getComputedStyle(contentRegion).minHeight).toBe('0px')
+  })
+
   it('restores filters from URL into the products query', () => {
     renderPage('/?search=gundam&status=inactive')
     expect(useGetProductsQuery).toHaveBeenLastCalledWith(

--- a/frontend/src/pages/inventory/__tests__/StockAdjustmentsPage.filterbar.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/StockAdjustmentsPage.filterbar.test.tsx
@@ -72,4 +72,13 @@ describe('StockAdjustmentsPage FilterBar', () => {
       expect.not.objectContaining({ status: expect.anything() }),
     )
   })
+
+  it('renders the stock adjustments content region as a shrinkable flex container', () => {
+    renderPage()
+
+    const contentRegion = screen.getByTestId('stock-adjustments-content-region')
+
+    expect(window.getComputedStyle(contentRegion).flexGrow).toBe('1')
+    expect(window.getComputedStyle(contentRegion).minHeight).toBe('0px')
+  })
 })

--- a/frontend/src/pages/inventory/__tests__/StockAdjustmentsPage.filterbar.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/StockAdjustmentsPage.filterbar.test.tsx
@@ -81,4 +81,12 @@ describe('StockAdjustmentsPage FilterBar', () => {
     expect(window.getComputedStyle(contentRegion).flexGrow).toBe('1')
     expect(window.getComputedStyle(contentRegion).minHeight).toBe('0px')
   })
+
+  it('does not add extra page-root bottom padding beyond MainLayout', () => {
+    renderPage()
+
+    const pageRoot = screen.getByTestId('stock-adjustments-page-root')
+
+    expect(window.getComputedStyle(pageRoot).paddingBottom).toBe('0px')
+  })
 })

--- a/frontend/src/pages/inventory/components/ProductDetailsPanel.tsx
+++ b/frontend/src/pages/inventory/components/ProductDetailsPanel.tsx
@@ -26,7 +26,7 @@ const ProductDetailsPanel: React.FC<ProductDetailsPanelProps> = ({
   onDeleteProduct,
 }) => {
   return (
-    <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', flexDirection: 'column' }}>
+    <Paper sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
       {products.length === 0 ? (
         <Box sx={{ flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
           <Typography variant="body1" color="text.secondary" textAlign="center">
@@ -114,7 +114,7 @@ const ProductDetailsPanel: React.FC<ProductDetailsPanelProps> = ({
             </Box>
           </Box>
 
-          <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
             {currentTab === 0 && (
               <Box sx={{ flex: 1, overflow: 'auto', p: TABLE_STYLES.cell.padding.px }}>
                 <ProductDetailsTab product={selectedProduct} />

--- a/frontend/src/pages/inventory/components/ProductsTable.tsx
+++ b/frontend/src/pages/inventory/components/ProductsTable.tsx
@@ -35,7 +35,7 @@ const ProductsTable: React.FC<ProductsTableProps> = ({
   onProductSelect,
 }) => {
   return (
-    <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', flexDirection: 'column' }}>
+    <Paper sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
       <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <Typography
@@ -55,6 +55,7 @@ const ProductsTable: React.FC<ProductsTableProps> = ({
       <Box
         sx={{
           flex: 1,
+          minHeight: 0,
           overflow: 'hidden',
           display: 'flex',
           flexDirection: 'column',
@@ -79,7 +80,7 @@ const ProductsTable: React.FC<ProductsTableProps> = ({
             </Typography>
           </Box>
         ) : (
-          <TableContainer sx={{ flex: 1, overflowX: 'auto' }}>
+          <TableContainer sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
             <Table
               size={TABLE_STYLES.size}
               stickyHeader

--- a/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
@@ -175,7 +175,7 @@ export const PurchaseOrdersPage: React.FC = () => {
   }, [navigate, pageState.journalEntryRef])
 
   return (
-    <Box sx={{ p: 3 }}>
+    <Box sx={{ p: 3, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
       <PageHeader
         title="Purchase Orders"
         subtitle="Manage supplier purchase orders and procurement"
@@ -205,39 +205,41 @@ export const PurchaseOrdersPage: React.FC = () => {
         </Alert>
       )}
 
-      <MasterDetailWorkspace
-        isMobile={isMobile}
-        listSlot={(
-          <PurchaseOrdersTable
-            purchaseOrders={purchaseOrders}
-            loading={loading}
-            total={pagination?.total || 0}
-            selectedOrderId={selectedOrder?.id}
-            focusedOrderIndex={pageState.focusedOrderIndex}
-            onOrderSelect={selection.handleOrderSelect}
-            orderListRef={pageState.orderListRef}
-          />
-        )}
-        headerSlot={(
-          <PurchaseOrderContextHeader
-            selectedOrder={selectedOrder}
-            isLoading={pageState.isLoading}
-            journalEntryRef={pageState.journalEntryRef}
-            journalEntryRefLoading={pageState.journalEntryRefLoading}
-            onEditClick={actions.handleEditClick}
-            onDeleteClick={actions.handleDeleteClick}
-            onPrint={() => pageState.setPrintDialogOpen(true)}
-            onNavigateToGoodsReceived={navigateToGoodsReceived}
-            onNavigateToVendorPayment={navigateToVendorPayment}
-            onNavigateToJournalEntry={navigateToJournalEntry}
-            onUnpay={actions.handleUnpay}
-            onOpenPaymentDialog={actions.handleOpenPaymentDialog}
-            onReturn={actions.handleReturn}
-            onReceive={actions.handleReceive}
-          />
-        )}
-        workspaceSlot={<PurchaseOrderWorkspaceCard selectedOrder={selectedOrder} />}
-      />
+      <Box sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+        <MasterDetailWorkspace
+          isMobile={isMobile}
+          listSlot={(
+            <PurchaseOrdersTable
+              purchaseOrders={purchaseOrders}
+              loading={loading}
+              total={pagination?.total || 0}
+              selectedOrderId={selectedOrder?.id}
+              focusedOrderIndex={pageState.focusedOrderIndex}
+              onOrderSelect={selection.handleOrderSelect}
+              orderListRef={pageState.orderListRef}
+            />
+          )}
+          headerSlot={(
+            <PurchaseOrderContextHeader
+              selectedOrder={selectedOrder}
+              isLoading={pageState.isLoading}
+              journalEntryRef={pageState.journalEntryRef}
+              journalEntryRefLoading={pageState.journalEntryRefLoading}
+              onEditClick={actions.handleEditClick}
+              onDeleteClick={actions.handleDeleteClick}
+              onPrint={() => pageState.setPrintDialogOpen(true)}
+              onNavigateToGoodsReceived={navigateToGoodsReceived}
+              onNavigateToVendorPayment={navigateToVendorPayment}
+              onNavigateToJournalEntry={navigateToJournalEntry}
+              onUnpay={actions.handleUnpay}
+              onOpenPaymentDialog={actions.handleOpenPaymentDialog}
+              onReturn={actions.handleReturn}
+              onReceive={actions.handleReceive}
+            />
+          )}
+          workspaceSlot={<PurchaseOrderWorkspaceCard selectedOrder={selectedOrder} />}
+        />
+      </Box>
 
       <PurchaseOrdersDialogs
         selectedOrder={selectedOrder}

--- a/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
@@ -175,7 +175,7 @@ export const PurchaseOrdersPage: React.FC = () => {
   }, [navigate, pageState.journalEntryRef])
 
   return (
-    <Box sx={{ p: 3, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+    <Box data-testid="purchase-orders-page-root" sx={{ p: 0, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
       <PageHeader
         title="Purchase Orders"
         subtitle="Manage supplier purchase orders and procurement"

--- a/frontend/src/pages/purchasing/__tests__/PurchaseOrdersPage.filterbar.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/PurchaseOrdersPage.filterbar.test.tsx
@@ -127,6 +127,14 @@ describe('PurchaseOrdersPage FilterBar integration', () => {
     expect(window.getComputedStyle(workspaceWrapper as HTMLElement).minHeight).toBe('0px')
   })
 
+  it('does not add extra page-root bottom padding beyond MainLayout', () => {
+    renderPage()
+
+    const pageRoot = screen.getByTestId('purchase-orders-page-root')
+
+    expect(window.getComputedStyle(pageRoot).paddingBottom).toBe('0px')
+  })
+
   it('restores new URL params into the purchase orders query', () => {
     renderPage('/?search=gundam&supplierId=sup-1')
     expect(useGetPurchaseOrdersQuery).toHaveBeenLastCalledWith(

--- a/frontend/src/pages/purchasing/__tests__/PurchaseOrdersPage.filterbar.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/PurchaseOrdersPage.filterbar.test.tsx
@@ -116,6 +116,17 @@ describe('PurchaseOrdersPage FilterBar integration', () => {
     expect(screen.getByText('PurchaseOrderWorkspaceCard')).toBeInTheDocument()
   })
 
+  it('renders the workspace inside a shrinkable flex wrapper', () => {
+    renderPage()
+
+    const workspaceMarker = screen.getByText('MasterDetailWorkspace')
+    const workspaceWrapper = workspaceMarker.parentElement?.parentElement
+
+    expect(workspaceWrapper).not.toBeNull()
+    expect(window.getComputedStyle(workspaceWrapper as HTMLElement).flexGrow).toBe('1')
+    expect(window.getComputedStyle(workspaceWrapper as HTMLElement).minHeight).toBe('0px')
+  })
+
   it('restores new URL params into the purchase orders query', () => {
     renderPage('/?search=gundam&supplierId=sup-1')
     expect(useGetPurchaseOrdersQuery).toHaveBeenLastCalledWith(

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -235,7 +235,7 @@ export const OrdersPage: React.FC = () => {
   }, [navigate, selectedOrder])
 
   return (
-    <Box sx={{ p: 3, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+    <Box data-testid="orders-page-root" sx={{ p: 0, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
       <PageHeader
         title="Sales Orders"
         subtitle="Track sales orders and delivery status"

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -235,7 +235,7 @@ export const OrdersPage: React.FC = () => {
   }, [navigate, selectedOrder])
 
   return (
-    <Box sx={{ p: 3 }}>
+    <Box sx={{ p: 3, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
       <PageHeader
         title="Sales Orders"
         subtitle="Track sales orders and delivery status"
@@ -260,40 +260,42 @@ export const OrdersPage: React.FC = () => {
         </Alert>
       )}
 
-      <MasterDetailWorkspace
-        isMobile={isMobile}
-        listSlot={(
-          <OrdersTable
-            orders={orders}
-            loading={loading}
-            total={pagination?.total || 0}
-            selectedOrderId={selectedOrder?.id}
-            focusedOrderIndex={pageState.focusedOrderIndex}
-            onOrderSelect={selection.handleOrderSelect}
-            orderListRef={pageState.orderListRef}
-          />
-        )}
-        headerSlot={(
-          <OrderContextHeader
-            selectedOrder={selectedOrder}
-            isLoading={pageState.isLoading}
-            journalEntryRef={pageState.journalEntryRef}
-            journalEntryRefLoading={pageState.journalEntryRefLoading}
-            onEditOrder={actions.handleEditOrder}
-            onDeleteOrder={() => selectedOrder && void actions.handleOrderAction('delete', selectedOrder.id)}
-            onPrintOrder={() => pageState.setPrintDialogOpen(true)}
-            onNavigateToInvoice={selection.handleNavigateToInvoice}
-            onNavigateToPayment={selection.handleNavigateToPayment}
-            onNavigateToJournalEntry={navigateToJournalEntry}
-            onRefundOrder={actions.handleRefundOrder}
-            onUnpayOrder={actions.handleUnpayOrder}
-            onOpenPaymentDialog={actions.openPaymentDialog}
-            onFulfillOrder={actions.handleFulfillOrder}
-            onUnfulfillOrder={actions.handleUnfulfillOrder}
-          />
-        )}
-        workspaceSlot={<OrderWorkspaceCard selectedOrder={selectedOrder} />}
-      />
+      <Box sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+        <MasterDetailWorkspace
+          isMobile={isMobile}
+          listSlot={(
+            <OrdersTable
+              orders={orders}
+              loading={loading}
+              total={pagination?.total || 0}
+              selectedOrderId={selectedOrder?.id}
+              focusedOrderIndex={pageState.focusedOrderIndex}
+              onOrderSelect={selection.handleOrderSelect}
+              orderListRef={pageState.orderListRef}
+            />
+          )}
+          headerSlot={(
+            <OrderContextHeader
+              selectedOrder={selectedOrder}
+              isLoading={pageState.isLoading}
+              journalEntryRef={pageState.journalEntryRef}
+              journalEntryRefLoading={pageState.journalEntryRefLoading}
+              onEditOrder={actions.handleEditOrder}
+              onDeleteOrder={() => selectedOrder && void actions.handleOrderAction('delete', selectedOrder.id)}
+              onPrintOrder={() => pageState.setPrintDialogOpen(true)}
+              onNavigateToInvoice={selection.handleNavigateToInvoice}
+              onNavigateToPayment={selection.handleNavigateToPayment}
+              onNavigateToJournalEntry={navigateToJournalEntry}
+              onRefundOrder={actions.handleRefundOrder}
+              onUnpayOrder={actions.handleUnpayOrder}
+              onOpenPaymentDialog={actions.openPaymentDialog}
+              onFulfillOrder={actions.handleFulfillOrder}
+              onUnfulfillOrder={actions.handleUnfulfillOrder}
+            />
+          )}
+          workspaceSlot={<OrderWorkspaceCard selectedOrder={selectedOrder} />}
+        />
+      </Box>
 
       <OrdersDialogs
         selectedOrder={selectedOrder}

--- a/frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
+++ b/frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
@@ -129,6 +129,14 @@ describe('OrdersPage FilterBar integration', () => {
     expect(window.getComputedStyle(workspaceWrapper as HTMLElement).minHeight).toBe('0px')
   })
 
+  it('does not add extra page-root bottom padding beyond MainLayout', () => {
+    renderPage()
+
+    const pageRoot = screen.getByTestId('orders-page-root')
+
+    expect(window.getComputedStyle(pageRoot).paddingBottom).toBe('0px')
+  })
+
   it('restores filters from URL into the sales orders query', () => {
     renderPage('/?search=gundam&customerId=cust-1&paymentStatus=paid')
     expect(useGetSalesOrdersQuery).toHaveBeenLastCalledWith(

--- a/frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
+++ b/frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
@@ -118,6 +118,17 @@ describe('OrdersPage FilterBar integration', () => {
     expect(screen.getByText('OrderWorkspaceCard')).toBeInTheDocument()
   })
 
+  it('renders the workspace inside a shrinkable flex wrapper', () => {
+    renderPage()
+
+    const workspaceMarker = screen.getByText('MasterDetailWorkspace')
+    const workspaceWrapper = workspaceMarker.parentElement?.parentElement
+
+    expect(workspaceWrapper).not.toBeNull()
+    expect(window.getComputedStyle(workspaceWrapper as HTMLElement).flexGrow).toBe('1')
+    expect(window.getComputedStyle(workspaceWrapper as HTMLElement).minHeight).toBe('0px')
+  })
+
   it('restores filters from URL into the sales orders query', () => {
     renderPage('/?search=gundam&customerId=cust-1&paymentStatus=paid')
     expect(useGetSalesOrdersQuery).toHaveBeenLastCalledWith(


### PR DESCRIPTION
## Summary
- replace the `calc(100vh - 300px)` master-detail sizing with a flex height chain through `MainLayout`, `MasterDetailWorkspace`, and the four issue #276 pages
- migrate Sales Orders, Purchase Orders, Products, and Stock Adjustments to shrinkable page shells with `flex: 1` and `minHeight: 0`, including inventory detail cards
- remove duplicate page-root padding on the four target pages so the workspace ends at the standard `MainLayout` bottom padding

## Verification
- [x] `cd frontend && npx vitest run src/components/common/__tests__/MainLayout.test.tsx src/components/common/MasterDetailWorkspace.test.tsx --no-coverage`
- [x] `cd frontend && npx vitest run src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx src/pages/purchasing/__tests__/PurchaseOrdersPage.filterbar.test.tsx --no-coverage`
- [x] `cd frontend && npx vitest run src/pages/inventory/__tests__/ProductsPage.filterbar.test.tsx src/pages/inventory/__tests__/StockAdjustmentsPage.filterbar.test.tsx --no-coverage`
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run type-check`
- [ ] `cd frontend && npm run test` (did not terminate within the observed window on this branch; not marked as passed)

Closes #276
