### PR TITLE
fix: unified page padding - centralize margins in MainLayout (closes #282)

### DIFF
--- a/frontend/src/components/common/MainLayout.tsx
+++ b/frontend/src/components/common/MainLayout.tsx
@@ -83,6 +83,8 @@ const MainLayout: React.FC = () => {
         component="main"
         sx={{
           flexGrow: 1,
+          display: 'flex',
+          flexDirection: 'column',
           pt: 11,
           px: { xs: 2, sm: 3 },
           pb: 3,

--- a/frontend/src/components/common/MainLayout.tsx
+++ b/frontend/src/components/common/MainLayout.tsx
@@ -83,7 +83,7 @@ const MainLayout: React.FC = () => {
         component="main"
         sx={{
           flexGrow: 1,
-          pt: 8,
+          pt: 11,
           px: { xs: 2, sm: 3 },
           pb: 3,
           bgcolor: 'background.default',

--- a/frontend/src/components/common/MasterDetailWorkspace.tsx
+++ b/frontend/src/components/common/MasterDetailWorkspace.tsx
@@ -25,7 +25,7 @@ const MasterDetailWorkspace: React.FC<MasterDetailWorkspaceProps> = ({
   }
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'row', height: 'calc(100vh - 324px)', gap: 3 }}>
+    <Box sx={{ display: 'flex', flexDirection: 'row', flex: 1, minHeight: 0, gap: 3 }}>
       <Box
         sx={{
           width: '25%',

--- a/frontend/src/components/common/MasterDetailWorkspace.tsx
+++ b/frontend/src/components/common/MasterDetailWorkspace.tsx
@@ -25,7 +25,7 @@ const MasterDetailWorkspace: React.FC<MasterDetailWorkspaceProps> = ({
   }
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'row', height: 'calc(100vh - 300px)', gap: 3 }}>
+    <Box sx={{ display: 'flex', flexDirection: 'row', height: 'calc(100vh - 324px)', gap: 3 }}>
       <Box
         sx={{
           width: '25%',

--- a/frontend/src/components/common/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/common/__tests__/MainLayout.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import { describe, it, vi } from 'vitest'
@@ -26,5 +26,17 @@ describe('MainLayout', () => {
         </MemoryRouter>
       </Provider>
     )
+  })
+
+  it('applies a 24px gap below the app bar', () => {
+    render(
+      <Provider store={makeStore()}>
+        <MemoryRouter>
+          <MainLayout />
+        </MemoryRouter>
+      </Provider>
+    )
+
+    expect(screen.getByRole('main')).toHaveStyle({ paddingTop: '88px' })
   })
 })

--- a/frontend/src/pages/accounting/AccountMappingsPage.tsx
+++ b/frontend/src/pages/accounting/AccountMappingsPage.tsx
@@ -282,7 +282,7 @@ const AccountMappingsPage: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         title="Account Mappings"
         subtitle="Configure default account assignments for transactions"
@@ -562,7 +562,7 @@ const AccountMappingsPage: React.FC = () => {
         severity="warning"
         loading={clearing}
       />
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/accounting/AccountingDashboardPage.tsx
+++ b/frontend/src/pages/accounting/AccountingDashboardPage.tsx
@@ -227,7 +227,7 @@ const AccountingDashboardPage: React.FC = () => {
   });
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="overview"
         title="Accounting Dashboard"
@@ -584,7 +584,7 @@ const AccountingDashboardPage: React.FC = () => {
           </Paper>
         </Grid>
       </Grid>
-    </Box>
+    </>
   );
 };
 

--- a/frontend/src/pages/accounting/BankReconciliationDetailsPage.tsx
+++ b/frontend/src/pages/accounting/BankReconciliationDetailsPage.tsx
@@ -187,15 +187,15 @@ const BankReconciliationDetailsPage: React.FC = () => {
 
   if (!reconciliation) {
     return (
-      <Box sx={{ p: 3 }}>
+      <>
         <Alert severity="error">Bank reconciliation not found</Alert>
         <Button onClick={handleBack} sx={{ mt: 2 }}>Back</Button>
-      </Box>
+      </>
     );
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="workflow"
         title={reconciliation.account ? `${reconciliation.account.code} - ${reconciliation.account.name}` : 'Bank Reconciliation'}
@@ -340,7 +340,7 @@ const BankReconciliationDetailsPage: React.FC = () => {
           </Table>
         </TableContainer>
       </Paper>
-    </Box>
+    </>
   );
 };
 

--- a/frontend/src/pages/accounting/BankReconciliationsPage.tsx
+++ b/frontend/src/pages/accounting/BankReconciliationsPage.tsx
@@ -167,7 +167,7 @@ const BankReconciliationsPage: React.FC = () => {
       : periods.find((period: any) => period.id === periodFilter)?.name || periodFilter;
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="workflow"
         title="Bank Reconciliations"
@@ -291,7 +291,7 @@ const BankReconciliationsPage: React.FC = () => {
         onClose={handleFormClose}
         onSuccess={handleFormSuccess}
       />
-    </Box>
+    </>
   );
 };
 

--- a/frontend/src/pages/accounting/ChartOfAccountsPage.tsx
+++ b/frontend/src/pages/accounting/ChartOfAccountsPage.tsx
@@ -199,7 +199,7 @@ const ChartOfAccountsPage: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       {/* Account Mapping Warning */}
       <AccountMappingWarning context="system" />
 
@@ -734,7 +734,7 @@ const ChartOfAccountsPage: React.FC = () => {
         onClose={() => setDeletedDialogOpen(false)}
         onChanged={() => refetch()}
       />
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/accounting/ExpensesPage.tsx
+++ b/frontend/src/pages/accounting/ExpensesPage.tsx
@@ -268,7 +268,7 @@ const ExpensesPage: React.FC = () => {
   })
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         title="Expenses"
         subtitle="Record and manage business expense transactions"
@@ -469,7 +469,7 @@ const ExpensesPage: React.FC = () => {
           <Button variant="contained" onClick={save}>Save</Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/accounting/FiscalPeriodsPage.tsx
+++ b/frontend/src/pages/accounting/FiscalPeriodsPage.tsx
@@ -273,7 +273,7 @@ const FiscalPeriodsPage: React.FC = () => {
   }, [periods])
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       {/* Account Mapping Warning */}
       <AccountMappingWarning context="system" />
 
@@ -730,7 +730,7 @@ const FiscalPeriodsPage: React.FC = () => {
         onCancel={handleCancelReopen}
         severity="info"
       />
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/accounting/FundTransfersPage.tsx
+++ b/frontend/src/pages/accounting/FundTransfersPage.tsx
@@ -205,7 +205,7 @@ const FundTransfersPage: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         title="Fund Transfers"
         subtitle="Move funds between accounts and review transfer history"
@@ -478,7 +478,7 @@ const FundTransfersPage: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -349,7 +349,7 @@ const JournalEntriesPage: React.FC = () => {
   const someSelected = selectedIds.size > 0 && selectedIds.size < selectableEntries.length
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       {/* Account Mapping Warning */}
       <AccountMappingWarning context="system" />
 
@@ -696,7 +696,7 @@ const JournalEntriesPage: React.FC = () => {
         onCancel={() => setIsBulkDeleteConfirmOpen(false)}
         loading={actionLoading}
       />
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/accounting/JournalEntryDetailsPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntryDetailsPage.tsx
@@ -169,12 +169,12 @@ const JournalEntryDetailsPage: React.FC = () => {
 
   if (!entry) {
     return (
-      <Box sx={{ p: 3 }}>
+      <>
         <Alert severity="error">Journal entry not found</Alert>
         <Button onClick={handleBack} sx={{ mt: 2 }}>
           Back to List
         </Button>
-      </Box>
+      </>
     )
   }
 
@@ -185,7 +185,7 @@ const JournalEntryDetailsPage: React.FC = () => {
   const difference = entry.totalDebits - entry.totalCredits
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="workflow"
         title={entry.referenceNumber}
@@ -512,7 +512,7 @@ const JournalEntryDetailsPage: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/accounting/JournalEntryFormPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntryFormPage.tsx
@@ -354,7 +354,7 @@ const JournalEntryFormPage: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       {/* Header */}
       <PageHeader
         variant="workflow"
@@ -691,7 +691,7 @@ const JournalEntryFormPage: React.FC = () => {
           </Grid>
         </Grid>
       </form>
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/accounting/OwnerEquityPage.tsx
+++ b/frontend/src/pages/accounting/OwnerEquityPage.tsx
@@ -220,7 +220,7 @@ const OwnerEquityPage: React.FC = () => {
   })
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         title="Owner Equity"
         subtitle="Track owner contributions and equity transactions"
@@ -395,7 +395,7 @@ const OwnerEquityPage: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/accounting/SettlementsPage.tsx
+++ b/frontend/src/pages/accounting/SettlementsPage.tsx
@@ -81,7 +81,7 @@ const SettlementsPage: React.FC = () => {
   };
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         title="Settlements"
         subtitle="Settle pending payments by payment method"
@@ -154,7 +154,7 @@ const SettlementsPage: React.FC = () => {
           <Button variant="contained" color="error" onClick={onCancel}>Cancel Settlement</Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   );
 };
 

--- a/frontend/src/pages/accounting/reports/AccountActivityPage.tsx
+++ b/frontend/src/pages/accounting/reports/AccountActivityPage.tsx
@@ -242,7 +242,7 @@ const AccountActivityPage: React.FC = () => {
   };
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title="Account Activity Report"
@@ -714,7 +714,7 @@ const AccountActivityPage: React.FC = () => {
           </Typography>
         </Paper>
       )}
-    </Box>
+    </>
   );
 };
 

--- a/frontend/src/pages/accounting/reports/BalanceSheetPage.tsx
+++ b/frontend/src/pages/accounting/reports/BalanceSheetPage.tsx
@@ -326,7 +326,7 @@ const BalanceSheetPage: React.FC = () => {
       : Math.abs(totalAssets - totalLiabilitiesAndEquity) < 0.01;
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title="Balance Sheet"
@@ -625,7 +625,7 @@ const BalanceSheetPage: React.FC = () => {
           </Typography>
         </Paper>
       )}
-    </Box>
+    </>
   );
 };
 

--- a/frontend/src/pages/accounting/reports/GeneralLedgerPage.tsx
+++ b/frontend/src/pages/accounting/reports/GeneralLedgerPage.tsx
@@ -153,7 +153,7 @@ const GeneralLedgerPage: React.FC = () => {
   };
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title="General Ledger"
@@ -612,7 +612,7 @@ const GeneralLedgerPage: React.FC = () => {
           </Typography>
         </Paper>
       )}
-    </Box>
+    </>
   );
 };
 

--- a/frontend/src/pages/accounting/reports/ProfitAndLossPage.tsx
+++ b/frontend/src/pages/accounting/reports/ProfitAndLossPage.tsx
@@ -243,7 +243,7 @@ const ProfitAndLossPage: React.FC = () => {
   };
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title="Profit & Loss Statement"
@@ -522,7 +522,7 @@ const ProfitAndLossPage: React.FC = () => {
           </Typography>
         </Paper>
       )}
-    </Box>
+    </>
   );
 };
 

--- a/frontend/src/pages/accounting/reports/TrialBalancePage.tsx
+++ b/frontend/src/pages/accounting/reports/TrialBalancePage.tsx
@@ -105,7 +105,7 @@ const TrialBalancePage: React.FC = () => {
     : calculateTotals();
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title="Trial Balance"
@@ -242,7 +242,7 @@ const TrialBalancePage: React.FC = () => {
           </TableContainer>
         </Paper>
       )}
-    </Box>
+    </>
   );
 };
 

--- a/frontend/src/pages/audit-logs/AuditLogsPage.tsx
+++ b/frontend/src/pages/audit-logs/AuditLogsPage.tsx
@@ -130,7 +130,7 @@ const AuditLogsPage: React.FC = () => {
   const entityTypes = statistics?.byEntityType.map((e) => e.entityType) ?? []
 
   return (
-    <Box sx={{ display: 'flex', height: '100%', gap: 2, p: 3 }}>
+    <Box sx={{ display: 'flex', height: '100%', gap: 2 }}>
       {/* Sidebar */}
       <Box sx={{ flexShrink: 0, width: sidebarCollapsed ? 48 : 260, transition: 'width 0.2s' }}>
         <FilterSidebar entityTypes={entityTypes} onApply={handleApply} />

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -372,7 +372,7 @@ const DashboardPage: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="overview"
         title="Dashboard"
@@ -416,7 +416,7 @@ const DashboardPage: React.FC = () => {
         totalCategories={dashboardData?.inventory.totalCategories || 0}
         outOfStockCount={dashboardData?.inventory.outOfStockCount || 0}
       />
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/inventory/CategoriesPage.tsx
+++ b/frontend/src/pages/inventory/CategoriesPage.tsx
@@ -351,7 +351,7 @@ const CategoriesPage: React.FC = () => {
 
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="structure"
         title="Categories"
@@ -692,7 +692,7 @@ const CategoriesPage: React.FC = () => {
         onCancel={handleCancelDelete}
         severity="warning"
       />
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/inventory/CreateProductPage.tsx
+++ b/frontend/src/pages/inventory/CreateProductPage.tsx
@@ -7,7 +7,6 @@ import {
   TextField,
   Typography,
   Alert,
-  Container,
   Card,
   CardContent,
 
@@ -387,8 +386,7 @@ const CreateProductPage: React.FC = () => {
   }
 
   return (
-    <Container maxWidth="xl">
-      <Box sx={{ py: 3 }}>
+    <>
         {/* Header */}
         <PageHeader
           variant="workflow"
@@ -820,8 +818,7 @@ const CreateProductPage: React.FC = () => {
             </Grid>
           </form>
         )}
-      </Box>
-    </Container>
+    </>
   );
 }
 

--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -16,7 +16,6 @@ import {
   Paper,
   Autocomplete,
   Alert,
-  Container,
   Card,
   CardContent,
   useTheme,
@@ -277,8 +276,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
   }
 
   return (
-    <Container maxWidth="xl">
-      <Box sx={{ py: 3 }}>
+    <>
         {/* Header */}
         <PageHeader
           variant="workflow"
@@ -615,8 +613,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
             </Grid>
           </form>
         )}
-      </Box>
-    </Container>
+    </>
   );
 }
 

--- a/frontend/src/pages/inventory/HistoricalInventoryReport.tsx
+++ b/frontend/src/pages/inventory/HistoricalInventoryReport.tsx
@@ -512,7 +512,7 @@ const HistoricalInventoryReport: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title="Historical Inventory"
@@ -1257,7 +1257,7 @@ const HistoricalInventoryReport: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/inventory/InventoryPage.tsx
+++ b/frontend/src/pages/inventory/InventoryPage.tsx
@@ -263,7 +263,7 @@ const InventoryPage: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="overview"
         title="Inventory Overview"
@@ -614,7 +614,7 @@ const InventoryPage: React.FC = () => {
           </Grid>
         </Grid>
       </Box>
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/inventory/InventorySummaryReport.tsx
+++ b/frontend/src/pages/inventory/InventorySummaryReport.tsx
@@ -670,7 +670,7 @@ const InventorySummaryReport: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title="Inventory Summary"
@@ -1435,7 +1435,7 @@ const InventorySummaryReport: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/inventory/MovementSummaryReport.tsx
+++ b/frontend/src/pages/inventory/MovementSummaryReport.tsx
@@ -506,7 +506,7 @@ const MovementSummaryReport: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title="Inventory Movement Summary"
@@ -1245,7 +1245,7 @@ const MovementSummaryReport: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/inventory/PriceListReport.tsx
+++ b/frontend/src/pages/inventory/PriceListReport.tsx
@@ -522,7 +522,7 @@ const PriceListReport: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title="Product Price List"
@@ -1202,7 +1202,7 @@ const PriceListReport: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/inventory/ProductCostReport.tsx
+++ b/frontend/src/pages/inventory/ProductCostReport.tsx
@@ -536,7 +536,7 @@ const ProductCostReport: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title="Product Cost Report"
@@ -1253,7 +1253,7 @@ const ProductCostReport: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/inventory/ProductsPage.tsx
+++ b/frontend/src/pages/inventory/ProductsPage.tsx
@@ -125,7 +125,7 @@ export const ProductsPage: React.FC = () => {
   const contentMarginRight = pageState.calculatorPanelOpen ? { xs: '0px', md: '320px' } : '0px'
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <Box sx={{ mb: 3, transition: 'margin-right 0.3s ease-in-out', marginRight: contentMarginRight }}>
         <PageHeader
           title="Products"
@@ -201,7 +201,7 @@ export const ProductsPage: React.FC = () => {
         onConfirmDelete={() => void actions.handleConfirmDelete(pageState.productToDelete)}
         onCancelDelete={actions.handleCancelDelete}
       />
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
@@ -443,7 +443,7 @@ const StockAdjustmentsPage: React.FC = () => {
   })
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       {/* Header */}
       <PageHeader
         title="Stock Adjustments"
@@ -1030,7 +1030,7 @@ const StockAdjustmentsPage: React.FC = () => {
         onCancel={handleCancelCancelDialog}
         severity="warning"
       />
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -16,7 +16,6 @@ import {
   Paper,
   Autocomplete,
   Alert,
-  Container,
   Card,
   CardContent,
   MenuItem,
@@ -338,8 +337,7 @@ const CreatePurchaseOrderPage: React.FC = () => {
   }, [JSON.stringify(watchedItems), watchedShipping])
 
   return (
-    <Container maxWidth="xl">
-      <Box sx={{ py: 3 }}>
+    <>
         {/* Header */}
         <PageHeader
           variant="workflow"
@@ -917,8 +915,7 @@ const CreatePurchaseOrderPage: React.FC = () => {
           </Grid>
         </form>
         )}
-      </Box>
-    </Container>
+    </>
   );
 }
 

--- a/frontend/src/pages/purchasing/GoodsReceivedPage.tsx
+++ b/frontend/src/pages/purchasing/GoodsReceivedPage.tsx
@@ -342,7 +342,7 @@ const GoodsReceivedPage: React.FC = () => {
   })
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       {/* Header */}
       <PageHeader
         title="Goods Received Notes"
@@ -910,7 +910,7 @@ const GoodsReceivedPage: React.FC = () => {
           grn={selectedGRN}
         />
       )}
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
@@ -690,7 +690,7 @@ const PurchaseOrderDetailsReport: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title={reportTitle}
@@ -1545,7 +1545,7 @@ const PurchaseOrderDetailsReport: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
@@ -667,7 +667,7 @@ const PurchaseOrderStatusReport: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title={reportTitle}
@@ -1491,7 +1491,7 @@ const PurchaseOrderStatusReport: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
@@ -549,7 +549,7 @@ const PurchaseOrderSummary: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title={reportTitle}
@@ -1091,7 +1091,7 @@ const PurchaseOrderSummary: React.FC = () => {
           )}
         </Grid>
       </Grid>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
@@ -175,7 +175,7 @@ export const PurchaseOrdersPage: React.FC = () => {
   }, [navigate, pageState.journalEntryRef])
 
   return (
-    <>
+    <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
       <PageHeader
         title="Purchase Orders"
         subtitle="Manage supplier purchase orders and procurement"
@@ -267,7 +267,7 @@ export const PurchaseOrdersPage: React.FC = () => {
         onClosePaymentDialog={() => pageState.setPaymentDialogOpen(false)}
         onSubmitPayments={actions.handleRecordPayments}
       />
-    </>
+    </Box>
   )
 }
 

--- a/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
@@ -175,7 +175,7 @@ export const PurchaseOrdersPage: React.FC = () => {
   }, [navigate, pageState.journalEntryRef])
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         title="Purchase Orders"
         subtitle="Manage supplier purchase orders and procurement"
@@ -267,7 +267,7 @@ export const PurchaseOrdersPage: React.FC = () => {
         onClosePaymentDialog={() => pageState.setPaymentDialogOpen(false)}
         onSubmitPayments={actions.handleRecordPayments}
       />
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/purchasing/PurchasingPage.tsx
+++ b/frontend/src/pages/purchasing/PurchasingPage.tsx
@@ -225,7 +225,7 @@ const PurchasingPage: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="overview"
         title="Purchasing Overview"
@@ -510,7 +510,7 @@ const PurchasingPage: React.FC = () => {
           </Grid>
         </Grid>
       </Box>
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/purchasing/SuppliersPage.tsx
+++ b/frontend/src/pages/purchasing/SuppliersPage.tsx
@@ -360,7 +360,7 @@ const SuppliersPage: React.FC = () => {
 
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       {/* Header */}
       <PageHeader
         title="Suppliers"
@@ -1030,7 +1030,7 @@ const SuppliersPage: React.FC = () => {
         open={isDeletedDialogOpen}
         onClose={() => setIsDeletedDialogOpen(false)}
       />
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/purchasing/VendorPaymentDetailsReport.tsx
+++ b/frontend/src/pages/purchasing/VendorPaymentDetailsReport.tsx
@@ -446,7 +446,7 @@ const VendorPaymentDetailsReport: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title={reportTitle}
@@ -877,7 +877,7 @@ const VendorPaymentDetailsReport: React.FC = () => {
           )}
         </Grid>
       </Grid>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/purchasing/VendorPaymentsPage.tsx
+++ b/frontend/src/pages/purchasing/VendorPaymentsPage.tsx
@@ -338,7 +338,7 @@ const VendorPaymentsPage: React.FC = () => {
   })
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       {/* Header */}
       <PageHeader
         title="Vendor Payments"
@@ -992,7 +992,7 @@ const VendorPaymentsPage: React.FC = () => {
           payment={selectedPayment}
         />
       )}
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/purchasing/VendorProductListReport.tsx
+++ b/frontend/src/pages/purchasing/VendorProductListReport.tsx
@@ -621,7 +621,7 @@ const VendorProductListReport: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title={reportTitle}
@@ -1321,7 +1321,7 @@ const VendorProductListReport: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -17,7 +17,6 @@ import {
   Paper,
   Autocomplete,
   Alert,
-  Container,
   Card,
   CardContent,
   MenuItem,
@@ -414,8 +413,7 @@ const CreateSalesOrderPage: React.FC = () => {
   }, [JSON.stringify(watchedItems), watchedShipping])
 
   return (
-    <Container maxWidth="xl">
-      <Box sx={{ py: 3 }}>
+    <>
         {/* Header */}
         <PageHeader
           variant="workflow"
@@ -1000,8 +998,7 @@ const CreateSalesOrderPage: React.FC = () => {
             </Grid>
           </form>
         )}
-      </Box>
-    </Container>
+    </>
   );
 }
 

--- a/frontend/src/pages/sales/CustomerOrderHistory.tsx
+++ b/frontend/src/pages/sales/CustomerOrderHistory.tsx
@@ -795,7 +795,7 @@ const CustomerOrderHistory: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title={reportTitle}
@@ -1672,7 +1672,7 @@ const CustomerOrderHistory: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
@@ -559,7 +559,7 @@ const CustomerPaymentByOrder: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title={reportTitle}
@@ -1110,7 +1110,7 @@ const CustomerPaymentByOrder: React.FC = () => {
           )}
         </Grid>
       </Grid>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/sales/CustomerPaymentDetails.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentDetails.tsx
@@ -524,7 +524,7 @@ const CustomerPaymentDetails: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title={reportTitle}
@@ -963,7 +963,7 @@ const CustomerPaymentDetails: React.FC = () => {
           )}
         </Grid>
       </Grid>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/sales/CustomerPaymentSummary.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentSummary.tsx
@@ -470,7 +470,7 @@ const CustomerPaymentSummary: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title={reportTitle}
@@ -876,7 +876,7 @@ const CustomerPaymentSummary: React.FC = () => {
           )}
         </Grid>
       </Grid>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/sales/CustomerProfilePage.tsx
+++ b/frontend/src/pages/sales/CustomerProfilePage.tsx
@@ -166,7 +166,7 @@ const CustomerProfilePage: React.FC = () => {
 
   if (loading) {
     return (
-      <Box sx={{ p: 3, display: 'flex', justifyContent: 'center', pt: 10 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'center', pt: 10 }}>
         <CircularProgress />
       </Box>
     )
@@ -174,14 +174,14 @@ const CustomerProfilePage: React.FC = () => {
 
   if (error || !customer) {
     return (
-      <Box sx={{ p: 3 }}>
+      <>
         <Alert severity="error" sx={{ mb: 2 }}>
           {error ?? 'Customer not found.'}
         </Alert>
         <Button startIcon={<BackIcon />} onClick={() => navigate('/sales/customers')}>
           Back to Customers
         </Button>
-      </Box>
+      </>
     )
   }
 
@@ -194,7 +194,7 @@ const CustomerProfilePage: React.FC = () => {
     .join('\n')
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Button startIcon={<BackIcon />} onClick={() => navigate('/sales/customers')}>
           Back to Customers
@@ -426,7 +426,7 @@ const CustomerProfilePage: React.FC = () => {
         severity="warning"
         loading={deleteLoading}
       />
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/sales/CustomersPage.tsx
+++ b/frontend/src/pages/sales/CustomersPage.tsx
@@ -415,7 +415,7 @@ const CustomersPage: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         title="Customers"
         subtitle="View customer profiles and client account details"
@@ -1065,7 +1065,7 @@ const CustomersPage: React.FC = () => {
         open={isDeletedDialogOpen}
         onClose={() => setIsDeletedDialogOpen(false)}
       />
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/sales/InvoicesPage.tsx
+++ b/frontend/src/pages/sales/InvoicesPage.tsx
@@ -179,7 +179,7 @@ const InvoicesPage: React.FC = () => {
   }, [navigate, pageState.journalEntryRef])
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>
           Failed to load invoices.
@@ -222,7 +222,7 @@ const InvoicesPage: React.FC = () => {
         onCloseDeletedInvoicesDialog={() => pageState.setDeletedInvoicesDialogOpen(false)}
         onClosePrintDialog={() => pageState.setPrintDialogOpen(false)}
       />
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -235,7 +235,7 @@ export const OrdersPage: React.FC = () => {
   }, [navigate, selectedOrder])
 
   return (
-    <>
+    <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
       <PageHeader
         title="Sales Orders"
         subtitle="Track sales orders and delivery status"
@@ -320,7 +320,7 @@ export const OrdersPage: React.FC = () => {
         onSubmitPayments={actions.handleRecordPayments}
         isLoading={pageState.isLoading}
       />
-    </>
+    </Box>
   )
 }
 

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -235,7 +235,7 @@ export const OrdersPage: React.FC = () => {
   }, [navigate, selectedOrder])
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         title="Sales Orders"
         subtitle="Track sales orders and delivery status"
@@ -320,7 +320,7 @@ export const OrdersPage: React.FC = () => {
         onSubmitPayments={actions.handleRecordPayments}
         isLoading={pageState.isLoading}
       />
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/sales/PaymentsPage.tsx
+++ b/frontend/src/pages/sales/PaymentsPage.tsx
@@ -478,7 +478,7 @@ const PaymentsPage: React.FC = () => {
 
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       {/* Header */}
       <PageHeader
         title="Payments"
@@ -992,7 +992,7 @@ const PaymentsPage: React.FC = () => {
           payment={selectedPayment}
         />
       )}
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/sales/ProductCustomerReport.tsx
+++ b/frontend/src/pages/sales/ProductCustomerReport.tsx
@@ -760,7 +760,7 @@ const ProductCustomerReport: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title={reportTitle}
@@ -1618,7 +1618,7 @@ const ProductCustomerReport: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/sales/SalesByProductDetails.tsx
+++ b/frontend/src/pages/sales/SalesByProductDetails.tsx
@@ -814,7 +814,7 @@ const SalesByProductDetails: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title={reportTitle}
@@ -1669,7 +1669,7 @@ const SalesByProductDetails: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/sales/SalesByProductSummary.tsx
+++ b/frontend/src/pages/sales/SalesByProductSummary.tsx
@@ -771,7 +771,7 @@ const SalesByProductSummary: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3, width: '100%' }}>
+    <>
       <PageHeader
         variant="report"
         title={reportTitle}
@@ -1671,7 +1671,7 @@ const SalesByProductSummary: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/sales/SalesOrderProfitReport.tsx
+++ b/frontend/src/pages/sales/SalesOrderProfitReport.tsx
@@ -565,7 +565,7 @@ const SalesOrderProfitReport: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title={reportTitle}
@@ -1123,7 +1123,7 @@ const SalesOrderProfitReport: React.FC = () => {
           )}
         </Grid>
       </Grid>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/sales/SalesOrderSummary.tsx
+++ b/frontend/src/pages/sales/SalesOrderSummary.tsx
@@ -621,7 +621,7 @@ const SalesOrderSummary: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="report"
         title={reportTitle}
@@ -1142,7 +1142,7 @@ const SalesOrderSummary: React.FC = () => {
           )}
         </Grid>
       </Grid>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/sales/SalesPage.tsx
+++ b/frontend/src/pages/sales/SalesPage.tsx
@@ -193,7 +193,7 @@ const SalesPage: React.FC = () => {
   ]
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         title="Sales Overview"
         subtitle="Monitor sales performance and manage customer relationships"
@@ -429,7 +429,7 @@ const SalesPage: React.FC = () => {
           <TopCustomersList customers={topCustomers as any[]} loading={isLoading} />
         </Grid>
       </Grid>
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/settings/BackupManagement.tsx
+++ b/frontend/src/pages/settings/BackupManagement.tsx
@@ -79,7 +79,7 @@ const BackupManagement: React.FC = () => {
   };
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         variant="system"
         title="Backup & Restore Management"
@@ -182,7 +182,7 @@ const BackupManagement: React.FC = () => {
           {error}
         </Alert>
       </Snackbar>
-    </Box>
+    </>
   );
 };
 

--- a/frontend/src/pages/settings/CompanySettingsPage.tsx
+++ b/frontend/src/pages/settings/CompanySettingsPage.tsx
@@ -195,7 +195,7 @@ const CompanySettingsPage: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       {/* Page Header */}
       <PageHeader title="Company Settings" subtitle="Configure your company profile and business information" />
       {/* Error Alert */}
@@ -565,7 +565,7 @@ const CompanySettingsPage: React.FC = () => {
           </Grid>
         </form>
       </Paper>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/settings/DocumentNumbersPage.tsx
+++ b/frontend/src/pages/settings/DocumentNumbersPage.tsx
@@ -110,7 +110,7 @@ const DocumentNumbersPage: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       {/* Page Header */}
       <PageHeader title="Document Numbers Settings" subtitle="Configure automatic numbering sequences for orders, invoices, and other documents" />
       {/* Error Alert */}
@@ -232,7 +232,7 @@ const DocumentNumbersPage: React.FC = () => {
           </Button>
         </Box>
       </Paper>
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/pages/settings/InventoryCostingPage.tsx
+++ b/frontend/src/pages/settings/InventoryCostingPage.tsx
@@ -141,7 +141,7 @@ const InventoryCostingPage: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader title="Inventory Costing Settings" subtitle="Configure costing method and pricing rules for inventory valuation" />
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>
@@ -227,7 +227,7 @@ const InventoryCostingPage: React.FC = () => {
           </Grid>
         </form>
       </Paper>
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/settings/PaymentMethodsPage.tsx
+++ b/frontend/src/pages/settings/PaymentMethodsPage.tsx
@@ -90,7 +90,7 @@ const PaymentMethodsPage: React.FC = () => {
   };
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         title={title}
         subtitle="Manage payment methods and configurations"
@@ -205,7 +205,7 @@ const PaymentMethodsPage: React.FC = () => {
       </Dialog>
 
       <DeletedPaymentMethodsDialog open={deletedOpen} onClose={() => setDeletedOpen(false)} />
-    </Box>
+    </>
   );
 };
 

--- a/frontend/src/pages/settings/PriceListDetailsPage.tsx
+++ b/frontend/src/pages/settings/PriceListDetailsPage.tsx
@@ -189,7 +189,7 @@ const PriceListDetailsPage: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       {/* Header */}
       <Box sx={{ mb: 3 }}>
         <Button startIcon={<BackIcon />} onClick={() => navigate('/settings/price-lists')} sx={{ mb: 2 }}>
@@ -564,7 +564,7 @@ const PriceListDetailsPage: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/settings/PriceListsPage.tsx
+++ b/frontend/src/pages/settings/PriceListsPage.tsx
@@ -239,7 +239,7 @@ const PriceListsPage: React.FC = () => {
 
   // Format date
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       {/* Header */}
       <PageHeader
         title="Price Lists"
@@ -634,7 +634,7 @@ const PriceListsPage: React.FC = () => {
         onConfirm={handleConfirmAction}
         onCancel={handleConfirmClose}
       />
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/settings/PrintSettingsPage.tsx
+++ b/frontend/src/pages/settings/PrintSettingsPage.tsx
@@ -75,14 +75,14 @@ const PrintSettingsPage: React.FC = () => {
 
   if (error) {
     return (
-      <Box sx={{ p: 3 }}>
+      <>
         <Alert severity="error">{error}</Alert>
-      </Box>
+      </>
     )
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       {/* Header */}
       <PageHeader
         title="Print Settings"
@@ -112,7 +112,7 @@ const PrintSettingsPage: React.FC = () => {
           />
         </TabPanel>
       </Paper>
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/settings/RegionalSettingsPage.tsx
+++ b/frontend/src/pages/settings/RegionalSettingsPage.tsx
@@ -219,7 +219,7 @@ const RegionalSettingsPage: React.FC = () => {
   )
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader title="Regional Settings" subtitle="Configure locale, currency, date format, and timezone preferences" />
 
       {error && (
@@ -424,7 +424,7 @@ const RegionalSettingsPage: React.FC = () => {
           </Grid>
         </form>
       </Paper>
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/settings/RoleManagementPage.tsx
+++ b/frontend/src/pages/settings/RoleManagementPage.tsx
@@ -94,7 +94,7 @@ const roles: RoleInfo[] = [
 
 const RoleManagementPage: React.FC = () => {
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       {/* Header */}
       <PageHeader
         title="Roles & Permissions"
@@ -180,7 +180,7 @@ const RoleManagementPage: React.FC = () => {
           administrators can manage user accounts and assign roles.
         </Typography>
       </Paper>
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/settings/SecuritySettingsPage.tsx
+++ b/frontend/src/pages/settings/SecuritySettingsPage.tsx
@@ -11,7 +11,7 @@ import PageHeader from '@/components/common/PageHeader'
 
 const SecuritySettingsPage: React.FC = () => {
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       {/* Header */}
       <PageHeader
         title="Security Settings"
@@ -304,7 +304,7 @@ const SecuritySettingsPage: React.FC = () => {
           </Box>
         </Box>
       </Paper>
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/settings/StockLevelSettingsPage.tsx
+++ b/frontend/src/pages/settings/StockLevelSettingsPage.tsx
@@ -86,7 +86,7 @@ const StockLevelSettingsPage: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       <PageHeader
         title="Stock Level Settings"
         subtitle="Configure thresholds for low stock classification across all products"
@@ -151,7 +151,7 @@ const StockLevelSettingsPage: React.FC = () => {
           </Grid>
         </form>
       </Paper>
-    </Box>
+    </>
   )
 }
 

--- a/frontend/src/pages/settings/UserManagementPage.tsx
+++ b/frontend/src/pages/settings/UserManagementPage.tsx
@@ -281,7 +281,7 @@ const UserManagementPage: React.FC = () => {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
+    <>
       {/* Header */}
       <PageHeader
         title="User Management"
@@ -671,7 +671,7 @@ const UserManagementPage: React.FC = () => {
         onConfirm={handleConfirmAction}
         onCancel={handleConfirmClose}
       />
-    </Box>
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary
- Sets `pt: 11` in `MainLayout.tsx` to provide a consistent 24px gap between the AppBar and page content
- Strips redundant `<Box sx={{ p: 3 }}>` root wrappers from all ~60 pages inside MainLayout
- Removes `<Container maxWidth="xl">` + inner `<Box sx={{ py: 3 }}>` from 4 create/edit pages

## Test Plan
- [ ] Verify no double padding (48px) on any page — all pages should have 24px from edges
- [ ] Verify 24px gap between AppBar and page content top
- [ ] Verify create/edit form pages (Create Product, Create Sales Order, etc.) match list page margins
- [ ] `npm run test` passes (104 files, 696 tests)
- [ ] `npm run type-check` passes
- [ ] `npm run lint` passes

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)