### PR TITLE
feat(layout): migrate FilterBar to PageHeader toolbar slot (closes #284)

### DIFF
--- a/frontend/src/pages/inventory/InventoryPage.tsx
+++ b/frontend/src/pages/inventory/InventoryPage.tsx
@@ -270,14 +270,15 @@ const InventoryPage: React.FC = () => {
         subtitle="Monitor stock levels, track movements, and manage inventory health"
         secondaryAction={{ label: 'Manage Categories', onClick: () => navigate('/inventory/categories') }}
         primaryAction={{ label: 'Add Product', onClick: () => navigate('/inventory/products') }}
-      />
-
-      <FilterBar
-        config={inventoryConfig}
-        draftFilters={draftFilters}
-        handlers={handlers}
-        hasActiveFilters={hasActiveFilters}
-        isFetching={isFetching}
+        toolbar={
+          <FilterBar
+            config={inventoryConfig}
+            draftFilters={draftFilters}
+            handlers={handlers}
+            hasActiveFilters={hasActiveFilters}
+            isFetching={isFetching}
+          />
+        }
       />
 
       {error && (

--- a/frontend/src/pages/inventory/ProductsPage.tsx
+++ b/frontend/src/pages/inventory/ProductsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { Box, Stack, useMediaQuery, useTheme } from '@mui/material'
+import { Box } from '@mui/material'
 import Grid from '@mui/material/GridLegacy'
 import { useLocation, useNavigate } from 'react-router-dom'
 
@@ -36,9 +36,6 @@ export const ProductsPage: React.FC = () => {
   const navigate = useNavigate()
   const location = useLocation()
   const { showSuccess, showError } = useNotification()
-  const theme = useTheme()
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
-
   const selectedProduct = useAppSelector(selectSelectedProduct)
   const pageState = useProductsPageState()
   const filterConfig = useMemo<FilterBarConfig<InventoryProductFilters>>(
@@ -130,27 +127,20 @@ export const ProductsPage: React.FC = () => {
         <PageHeader
           title="Products"
           subtitle="Manage your product catalog and inventory"
+          variant="workflow"
           secondaryAction={{ label: 'View Deleted', onClick: () => pageState.setDeletedProductsDialogOpen(true) }}
           primaryAction={{ label: 'Add Product', onClick: actions.handleAddProduct }}
+          toolbar={(
+            <FilterBar
+              config={filterConfig}
+              draftFilters={draftFilters}
+              handlers={handlers}
+              hasActiveFilters={hasActiveFilters}
+              searchInputRef={pageState.searchInputRef}
+            />
+          )}
         />
       </Box>
-
-      <Stack
-        direction={isMobile ? 'column' : 'row'}
-        spacing={1}
-        alignItems={isMobile ? 'stretch' : 'center'}
-        sx={{ mb: 2, transition: 'margin-right 0.3s ease-in-out', marginRight: contentMarginRight }}
-      >
-        <Box sx={{ flex: 1 }}>
-          <FilterBar
-            config={filterConfig}
-            draftFilters={draftFilters}
-            handlers={handlers}
-            hasActiveFilters={hasActiveFilters}
-            searchInputRef={pageState.searchInputRef}
-          />
-        </Box>
-      </Stack>
 
       <Box sx={{ transition: 'margin-right 0.3s ease-in-out', marginRight: contentMarginRight }}>
         <Grid container spacing={3}>

--- a/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
@@ -16,8 +16,6 @@ import {
   Alert,
   Grid,
   IconButton,
-  useTheme,
-  useMediaQuery,
   Stack,
 } from '@mui/material'
 import {
@@ -117,8 +115,6 @@ const AdjustmentRow = memo(({ adjustment, index, selectedAdjustmentId, focusedAd
 AdjustmentRow.displayName = 'AdjustmentRow'
 
 const StockAdjustmentsPage: React.FC = () => {
-  const theme = useTheme()
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
   const navigate = useNavigate()
   const location = useLocation()
   const dispatch = useAppDispatch()
@@ -448,37 +444,35 @@ const StockAdjustmentsPage: React.FC = () => {
       <PageHeader
         title="Stock Adjustments"
         subtitle="View and manage stock adjustment history"
+        variant="workflow"
         secondaryAction={{ label: 'View Deleted', onClick: () => setShowDeletedDialog(true) }}
         primaryAction={{ label: 'New Adjustment', onClick: () => navigate('/inventory/stock-adjustments/create') }}
+        toolbar={(
+          <FilterBar
+            config={filterConfig}
+            draftFilters={draftFilters}
+            handlers={handlers}
+            hasActiveFilters={hasActiveFilters}
+            searchInputRef={searchInputRef}
+          />
+        )}
       />
-      {/* Filters and Search */}
-      <Box sx={{ mb: 3 }}>
-        <Stack direction={isMobile ? 'column' : 'row'} spacing={1} alignItems={isMobile ? 'stretch' : 'flex-start'}>
-          <Box sx={{ flex: 1 }}>
-            <FilterBar
-              config={filterConfig}
-              draftFilters={draftFilters}
-              handlers={handlers}
-              hasActiveFilters={hasActiveFilters}
-              searchInputRef={searchInputRef}
-            />
-          </Box>
-
-          <Button
-            variant={sortState.sortBy === 'adjustmentDate' ? 'contained' : 'outlined'}
-            size="medium"
-            startIcon={sortState.sortBy === 'adjustmentDate' ? (sortState.sortOrder === 'desc' ? <ArrowDownIcon /> : <ArrowUpIcon />) : <SortIcon />}
-            onClick={() => handleSort('adjustmentDate')}
-            sx={{
-              height: '40px',
-              fontSize: '0.875rem',
-              minWidth: 'auto',
-              px: 2,
-            }}
-          >
-            Sort
-          </Button>
-        </Stack>
+      {/* Sort button */}
+      <Box sx={{ mb: 3, display: 'flex', justifyContent: 'flex-end' }}>
+        <Button
+          variant={sortState.sortBy === 'adjustmentDate' ? 'contained' : 'outlined'}
+          size="medium"
+          startIcon={sortState.sortBy === 'adjustmentDate' ? (sortState.sortOrder === 'desc' ? <ArrowDownIcon /> : <ArrowUpIcon />) : <SortIcon />}
+          onClick={() => handleSort('adjustmentDate')}
+          sx={{
+            height: '40px',
+            fontSize: '0.875rem',
+            minWidth: 'auto',
+            px: 2,
+          }}
+        >
+          Sort
+        </Button>
       </Box>
       {/* Error Display */}
       {error && (

--- a/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
@@ -179,25 +179,25 @@ export const PurchaseOrdersPage: React.FC = () => {
       <PageHeader
         title="Purchase Orders"
         subtitle="Manage supplier purchase orders and procurement"
+        variant="workflow"
         secondaryAction={{ label: 'View Deleted', onClick: () => pageState.setDeletedOrdersDialogOpen(true) }}
         primaryAction={{ label: 'Create Order', onClick: () => navigate('/purchasing/orders/create') }}
+        toolbar={(
+          <FilterBar
+            config={filterConfig}
+            draftFilters={filterBar.draftFilters}
+            handlers={filterBar.handlers}
+            hasActiveFilters={filterBar.hasActiveFilters}
+            searchInputRef={pageState.searchInputRef}
+            sort={{
+              field: 'orderNumber',
+              sortBy: pageState.sorting.sortBy,
+              sortOrder: pageState.sorting.sortOrder,
+              onSort: handleSort,
+            }}
+          />
+        )}
       />
-
-      <Box sx={{ mb: 2 }}>
-        <FilterBar
-          config={filterConfig}
-          draftFilters={filterBar.draftFilters}
-          handlers={filterBar.handlers}
-          hasActiveFilters={filterBar.hasActiveFilters}
-          searchInputRef={pageState.searchInputRef}
-          sort={{
-            field: 'orderNumber',
-            sortBy: pageState.sorting.sortBy,
-            sortOrder: pageState.sorting.sortOrder,
-            onSort: handleSort,
-          }}
-        />
-      </Box>
 
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>

--- a/frontend/src/pages/purchasing/PurchasingPage.tsx
+++ b/frontend/src/pages/purchasing/PurchasingPage.tsx
@@ -231,14 +231,15 @@ const PurchasingPage: React.FC = () => {
         title="Purchasing Overview"
         subtitle="Monitor purchasing activities and manage supplier relationships"
         primaryAction={{ label: 'Create Purchase Order', onClick: () => navigate('/purchasing/orders/create') }}
-      />
-
-      <FilterBar
-        config={purchasingConfig}
-        draftFilters={draftFilters}
-        handlers={handlers}
-        hasActiveFilters={hasActiveFilters}
-        isFetching={isFetching}
+        toolbar={
+          <FilterBar
+            config={purchasingConfig}
+            draftFilters={draftFilters}
+            handlers={handlers}
+            hasActiveFilters={hasActiveFilters}
+            isFetching={isFetching}
+          />
+        }
       />
 
       {error && (

--- a/frontend/src/pages/purchasing/SuppliersPage.tsx
+++ b/frontend/src/pages/purchasing/SuppliersPage.tsx
@@ -365,19 +365,19 @@ const SuppliersPage: React.FC = () => {
       <PageHeader
         title="Suppliers"
         subtitle="Manage your suppliers and vendor relationships"
+        variant="workflow"
         secondaryAction={{ label: 'View Deleted', onClick: () => setIsDeletedDialogOpen(true) }}
         primaryAction={{ label: 'Add Supplier', onClick: () => handleOpenForm() }}
+        toolbar={(
+          <FilterBar
+            config={filterConfig}
+            draftFilters={draftFilters}
+            handlers={handlers}
+            hasActiveFilters={hasActiveFilters}
+            searchInputRef={searchInputRef}
+          />
+        )}
       />
-      {/* Filters and Search */}
-      <Box sx={{ mb: 3 }}>
-        <FilterBar
-          config={filterConfig}
-          draftFilters={draftFilters}
-          handlers={handlers}
-          hasActiveFilters={hasActiveFilters}
-          searchInputRef={searchInputRef}
-        />
-      </Box>
       {/* Error Alert */}
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>

--- a/frontend/src/pages/sales/CustomersPage.tsx
+++ b/frontend/src/pages/sales/CustomersPage.tsx
@@ -419,19 +419,19 @@ const CustomersPage: React.FC = () => {
       <PageHeader
         title="Customers"
         subtitle="View customer profiles and client account details"
+        variant="workflow"
         secondaryAction={{ label: 'View Deleted', onClick: () => setIsDeletedDialogOpen(true) }}
         primaryAction={{ label: 'New Customer', onClick: () => handleOpenForm() }}
+        toolbar={(
+          <FilterBar
+            config={filterConfig}
+            draftFilters={draftFilters}
+            handlers={handlers}
+            hasActiveFilters={hasActiveFilters}
+            searchInputRef={searchInputRef}
+          />
+        )}
       />
-      {/* Filters and Search */}
-      <Box sx={{ mb: 2 }}>
-        <FilterBar
-          config={filterConfig}
-          draftFilters={draftFilters}
-          handlers={handlers}
-          hasActiveFilters={hasActiveFilters}
-          searchInputRef={searchInputRef}
-        />
-      </Box>
       {/* Error Alert */}
       {(pageError || error) && (
         <Alert severity="error" sx={{ mb: 3 }} onClose={() => setPageError(null)}>

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -239,20 +239,20 @@ export const OrdersPage: React.FC = () => {
       <PageHeader
         title="Sales Orders"
         subtitle="Track sales orders and delivery status"
+        variant="workflow"
         secondaryAction={{ label: 'View Deleted', onClick: () => pageState.setDeletedOrdersDialogOpen(true) }}
         primaryAction={{ label: 'Create Order', onClick: () => navigate('/sales/orders/create') }}
+        toolbar={(
+          <FilterBar
+            config={filterConfig}
+            draftFilters={draftFilters}
+            handlers={filterHandlers}
+            hasActiveFilters={hasActiveFilters}
+            searchInputRef={pageState.searchInputRef}
+            sort={{ field: 'orderNumber', sortBy, sortOrder, onSort: handleSort }}
+          />
+        )}
       />
-
-      <Box sx={{ mb: 2 }}>
-        <FilterBar
-          config={filterConfig}
-          draftFilters={draftFilters}
-          handlers={filterHandlers}
-          hasActiveFilters={hasActiveFilters}
-          searchInputRef={pageState.searchInputRef}
-          sort={{ field: 'orderNumber', sortBy, sortOrder, onSort: handleSort }}
-        />
-      </Box>
 
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>

--- a/frontend/src/pages/sales/PaymentsPage.tsx
+++ b/frontend/src/pages/sales/PaymentsPage.tsx
@@ -28,8 +28,6 @@ import {
   Divider,
   Link,
   Stack,
-  useTheme,
-  useMediaQuery,
 } from '@mui/material'
 import {
   Edit as EditIcon,
@@ -165,8 +163,6 @@ const PaymentRow = memo(({ payment, index, selectedPaymentId, focusedPaymentInde
 PaymentRow.displayName = 'PaymentRow'
 
 const PaymentsPage: React.FC = () => {
-  const theme = useTheme()
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
   const navigate = useNavigate()
   const location = useLocation()
   const dispatch = useAppDispatch()
@@ -483,46 +479,45 @@ const PaymentsPage: React.FC = () => {
       <PageHeader
         title="Payments"
         subtitle="Review customer payments and transaction history"
+        variant="workflow"
         secondaryAction={{ label: 'View Deleted', onClick: () => setDeletedPaymentsDialogOpen(true) }}
+        toolbar={(
+          <FilterBar
+            config={filterConfig}
+            draftFilters={draftFilters}
+            handlers={filterBarHandlers}
+            hasActiveFilters={hasActiveFilters}
+            searchInputRef={searchInputRef}
+          />
+        )}
       />
-      {/* Filters and Search */}
-      <Box sx={{ mb: 3 }}>
-        <Stack direction={isMobile ? 'column' : 'row'} spacing={1} alignItems={isMobile ? 'stretch' : 'flex-start'}>
-          <Box sx={{ flex: 1 }}>
-            <FilterBar
-              config={filterConfig}
-              draftFilters={draftFilters}
-              handlers={filterBarHandlers}
-              hasActiveFilters={hasActiveFilters}
-              searchInputRef={searchInputRef}
+      {/* Preset customer chip + sort button */}
+      <Box sx={{ mb: 3, display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+        {presetCustomerId ? (
+          <Stack direction="row" sx={{ flex: 1 }}>
+            <Chip
+              label={`Customer: ${customers.find((customer) => customer.id === presetCustomerId)?.name ?? presetCustomerId}`}
+              size="small"
+              variant="filled"
             />
-
-            {presetCustomerId ? (
-              <Stack direction="row" sx={{ mt: '7px' }}>
-                <Chip
-                  label={`Customer: ${customers.find((customer) => customer.id === presetCustomerId)?.name ?? presetCustomerId}`}
-                  size="small"
-                  variant="filled"
-                />
-              </Stack>
-            ) : null}
-          </Box>
-
-          <Button
-            variant={sortState.sortBy === 'paymentNumber' ? 'contained' : 'outlined'}
-            size="medium"
-            startIcon={sortState.sortBy === 'paymentNumber' ? (sortState.sortOrder === 'desc' ? <ArrowDownIcon /> : <ArrowUpIcon />) : <SortIcon />}
-            onClick={() => handleSort('paymentNumber')}
-            sx={{
-              height: '40px',
-              fontSize: '0.875rem',
-              minWidth: 'auto',
-              px: 2,
-            }}
-          >
-            Sort
-          </Button>
-        </Stack>
+          </Stack>
+        ) : (
+          <Box sx={{ flex: 1 }} />
+        )}
+        <Button
+          variant={sortState.sortBy === 'paymentNumber' ? 'contained' : 'outlined'}
+          size="medium"
+          startIcon={sortState.sortBy === 'paymentNumber' ? (sortState.sortOrder === 'desc' ? <ArrowDownIcon /> : <ArrowUpIcon />) : <SortIcon />}
+          onClick={() => handleSort('paymentNumber')}
+          sx={{
+            height: '40px',
+            fontSize: '0.875rem',
+            minWidth: 'auto',
+            px: 2,
+          }}
+        >
+          Sort
+        </Button>
       </Box>
       {/* Error Display */}
       {error && (

--- a/frontend/src/pages/sales/SalesPage.tsx
+++ b/frontend/src/pages/sales/SalesPage.tsx
@@ -197,15 +197,17 @@ const SalesPage: React.FC = () => {
       <PageHeader
         title="Sales Overview"
         subtitle="Monitor sales performance and manage customer relationships"
+        variant="overview"
         primaryAction={{ label: 'Create Order', onClick: () => navigate('/sales/orders/create') }}
-      />
-
-      <FilterBar
-        config={salesConfig}
-        draftFilters={draftFilters}
-        handlers={handlers}
-        hasActiveFilters={hasActiveFilters}
-        isFetching={isFetching}
+        toolbar={
+          <FilterBar
+            config={salesConfig}
+            draftFilters={draftFilters}
+            handlers={handlers}
+            hasActiveFilters={hasActiveFilters}
+            isFetching={isFetching}
+          />
+        }
       />
 
       {error && (

--- a/frontend/src/pages/settings/PriceListsPage.tsx
+++ b/frontend/src/pages/settings/PriceListsPage.tsx
@@ -244,19 +244,18 @@ const PriceListsPage: React.FC = () => {
       <PageHeader
         title="Price Lists"
         subtitle="Manage pricing structures and product prices"
+        variant="workflow"
         secondaryAction={{ label: 'Refresh', onClick: () => refetch() }}
         primaryAction={{ label: 'Add Price List', onClick: handleAddPriceList }}
+        toolbar={(
+          <FilterBar
+            config={filterConfig}
+            draftFilters={draftFilters}
+            handlers={filterHandlers}
+            hasActiveFilters={hasActiveFilters}
+          />
+        )}
       />
-
-      {/* Filters */}
-      <Box sx={{ mb: 3 }}>
-        <FilterBar
-          config={filterConfig}
-          draftFilters={draftFilters}
-          handlers={filterHandlers}
-          hasActiveFilters={hasActiveFilters}
-        />
-      </Box>
 
       {/* Error Alert */}
       {error && <Alert severity="error" sx={{ mb: 2 }}>Failed to load price lists</Alert>}

--- a/frontend/src/pages/settings/UserManagementPage.tsx
+++ b/frontend/src/pages/settings/UserManagementPage.tsx
@@ -286,6 +286,7 @@ const UserManagementPage: React.FC = () => {
       <PageHeader
         title="User Management"
         subtitle="Manage system users and access control"
+        variant="workflow"
         secondaryAction={{
           label: 'Refresh',
           onClick: () => {
@@ -294,6 +295,14 @@ const UserManagementPage: React.FC = () => {
           },
         }}
         primaryAction={{ label: 'Add User', onClick: handleAddUser }}
+        toolbar={(
+          <FilterBar
+            config={filterConfig}
+            draftFilters={draftFilters}
+            handlers={filterHandlers}
+            hasActiveFilters={hasActiveFilters}
+          />
+        )}
       />
 
       {/* Statistics Cards */}
@@ -317,16 +326,6 @@ const UserManagementPage: React.FC = () => {
           </Paper>
         </Box>
       )}
-
-      {/* Filters */}
-      <Box sx={{ mb: 3 }}>
-        <FilterBar
-          config={filterConfig}
-          draftFilters={draftFilters}
-          handlers={filterHandlers}
-          hasActiveFilters={hasActiveFilters}
-        />
-      </Box>
 
       {/* Error Alert */}
       {error && (


### PR DESCRIPTION
## Summary

- Moves `<FilterBar>` from sibling-after-`PageHeader` into the `toolbar` prop on all 12 affected pages
- Removes manual `<Box sx={{ mb: 2/3 }}>` and `<Stack>` wrappers around filter bars
- Adds `variant=\"overview\"` or `variant=\"workflow\"` to `PageHeader` on pages that were missing it
- `PageHeader.tsx` unchanged — the `toolbar` slot with `mt: 1` and outer `mb: 2` already provided the correct gap

**Pages migrated:** SalesPage, PurchasingPage, InventoryPage, OrdersPage, PurchaseOrdersPage, CustomersPage, SuppliersPage, PaymentsPage, StockAdjustmentsPage, ProductsPage, UserManagementPage, PriceListsPage

**Excluded:** DashboardPage, AccountingDashboardPage (no FilterBar), JournalEntriesPage (custom batch-action filter row, not a FilterBar)

## Test plan

- [ ] Visit each migrated page and confirm FilterBar renders inside the header area, not as a separate block below
- [ ] Confirm 16px gap between filter bar and page content on all pages
- [ ] Confirm no double-gap or missing-gap on any page
- [ ] Confirm ProductsPage calculator panel slide still animates correctly
- [ ] Confirm PaymentsPage preset-customer Chip and sort Button still appear correctly
- [ ] Confirm StockAdjustmentsPage sort Button still appears correctly

## Verification

- `cd frontend && npm run type-check`
- `cd frontend && npm run lint`