### PR TITLE
chore(deps): update nginx to 1.29.7-alpine-slim

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -28,7 +28,7 @@ ENV VITE_APP_VERSION=$VITE_APP_VERSION
 RUN npm run build
 
 # Production stage
-FROM nginx:1.28.3-alpine3.23 AS production
+FROM nginx:1.29.7-alpine-slim AS production
 
 # Update Alpine packages and install curl for health checks
 RUN apk update && \

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,2 +1,2 @@
-FROM nginx:1.28.3-alpine3.23
+FROM nginx:1.29.7-alpine-slim
 COPY nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
## Summary

- Updates `nginx/Dockerfile` and `frontend/Dockerfile` base image from `nginx:1.28.3-alpine3.23` to `nginx:1.29.7-alpine-slim`
- ~80% image size reduction (59.2 MB → 12.1 MB)
- All compiled modules identical — no config changes required
- `apk` is available in the slim image, so `curl` install in `frontend/Dockerfile` continues to work

## Test plan

- [x] `docker compose build nginx frontend`
- [x] `docker compose up -d nginx frontend`
- [x] Check logs: `docker compose logs nginx frontend`
- [x] Verify health: `curl -f http://localhost/health`

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)