### PR TITLE
feat(filters): standalone filter components and backend alignment (#277)

### DIFF
--- a/backend/src/modules/purchasing/dto/purchasing-analytics.dto.ts
+++ b/backend/src/modules/purchasing/dto/purchasing-analytics.dto.ts
@@ -44,10 +44,10 @@ export class PurchasingAnalyticsQueryDto {
   @IsIn(['received', 'pending'])
   status?: 'received' | 'pending';
 
-  @ApiPropertyOptional({ enum: ['paid', 'partial', 'unpaid'] })
+  @ApiPropertyOptional({ enum: ['unpaid', 'partial', 'paid', 'overpaid'] })
   @IsOptional()
-  @IsIn(['paid', 'partial', 'unpaid'])
-  paymentStatus?: 'paid' | 'partial' | 'unpaid';
+  @IsIn(['unpaid', 'partial', 'paid', 'overpaid'])
+  paymentStatus?: 'unpaid' | 'partial' | 'paid' | 'overpaid';
 }
 
 export class PurchasingMetricsDto {

--- a/backend/src/modules/purchasing/services/purchasing-analytics.service.spec.ts
+++ b/backend/src/modules/purchasing/services/purchasing-analytics.service.spec.ts
@@ -105,6 +105,42 @@ describe('PurchasingAnalyticsService', () => {
   });
 
   describe('getRecentPurchaseOrders — paymentStatus post-query filtering', () => {
+    it('filters to orders where paidAmount > totalAmount when paymentStatus=overpaid', async () => {
+      const orders = [
+        {
+          orderNumber: 'PO-0001',
+          orderDate: new Date('2026-03-01'),
+          supplier: { companyName: 'Acme' },
+          totalAmount: '1000',
+          vendorPayments: [{ amount: '1100' }],
+          isFullyReceived: true,
+          shippingAmount: '0',
+        },
+        {
+          orderNumber: 'PO-0002',
+          orderDate: new Date('2026-03-02'),
+          supplier: { companyName: 'Beta' },
+          totalAmount: '500',
+          vendorPayments: [{ amount: '500' }],
+          isFullyReceived: false,
+          shippingAmount: '0',
+        },
+      ];
+      const qb = makeChainableQb([], orders, {
+        totalSpent: '1500',
+        totalOrders: '2',
+        averageOrderValue: '750',
+        activeSuppliers: '2',
+      });
+      purchaseOrderRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const query = { ...baseQuery(), paymentStatus: 'overpaid' as const };
+      const result = await service.getPurchasingAnalytics(query);
+
+      expect(result.recentOrders).toHaveLength(1);
+      expect(result.recentOrders[0].orderNumber).toBe('PO-0001');
+    });
+
     it('returns only paid orders when paymentStatus=paid filter is active', async () => {
       const mockOrders = [
         {

--- a/backend/src/modules/purchasing/services/purchasing-analytics.service.ts
+++ b/backend/src/modules/purchasing/services/purchasing-analytics.service.ts
@@ -33,7 +33,18 @@ interface PurchaseOrderSummaryQuery {
 interface PurchasingAnalyticsFilters {
   supplierId?: string;
   status?: 'received' | 'pending';
-  paymentStatus?: 'paid' | 'partial' | 'unpaid';
+  paymentStatus?: 'unpaid' | 'partial' | 'paid' | 'overpaid';
+}
+
+function derivePaymentStatus(
+  paidAmount: number,
+  totalAmount: number,
+): 'unpaid' | 'partial' | 'paid' | 'overpaid' {
+  if (totalAmount <= 0) return 'unpaid';
+  if (paidAmount > totalAmount) return 'overpaid';
+  if (paidAmount === totalAmount) return 'paid';
+  if (paidAmount > 0) return 'partial';
+  return 'unpaid';
 }
 
 export interface PurchaseOrderSummaryItem {
@@ -170,12 +181,7 @@ export class PurchasingAnalyticsService {
           0,
         );
 
-        let paymentStatus = 'unpaid';
-        if (paidAmount >= totalAmount && totalAmount > 0) {
-          paymentStatus = 'paid';
-        } else if (paidAmount > 0) {
-          paymentStatus = 'partial';
-        }
+        const paymentStatus = derivePaymentStatus(paidAmount, totalAmount);
 
         return paymentStatus === query.paymentStatus;
       });
@@ -194,12 +200,7 @@ export class PurchasingAnalyticsService {
       const balance = totalAmount - paidAmount;
 
       // Determine payment status
-      let paymentStatus = 'unpaid';
-      if (paidAmount >= totalAmount && totalAmount > 0) {
-        paymentStatus = 'paid';
-      } else if (paidAmount > 0) {
-        paymentStatus = 'partial';
-      }
+      const paymentStatus = derivePaymentStatus(paidAmount, totalAmount);
 
       // Safely handle orderDate conversion
       let orderDateStr = '';
@@ -301,12 +302,7 @@ export class PurchasingAnalyticsService {
         0,
       );
 
-      let paymentStatus = 'unpaid';
-      if (paidAmount >= totalAmount && totalAmount > 0) {
-        paymentStatus = 'paid';
-      } else if (paidAmount > 0) {
-        paymentStatus = 'partial';
-      }
+      const paymentStatus = derivePaymentStatus(paidAmount, totalAmount);
 
       // Check payment status filter
       if (query.paymentStatus && query.paymentStatus !== 'all' && paymentStatus !== query.paymentStatus) {
@@ -496,12 +492,7 @@ export class PurchasingAnalyticsService {
         const totalAmount = parseFloat(item.purchaseOrder?.totalAmount?.toString() || '0');
         const paidAmount = parseFloat(item.purchaseOrder?.paidAmount?.toString() || '0');
 
-        let paymentStatus = 'unpaid';
-        if (paidAmount >= totalAmount && totalAmount > 0) {
-          paymentStatus = 'paid';
-        } else if (paidAmount > 0) {
-          paymentStatus = 'partial';
-        }
+        const paymentStatus = derivePaymentStatus(paidAmount, totalAmount);
 
         return paymentStatus === query.paymentStatus;
       });
@@ -531,12 +522,7 @@ export class PurchasingAnalyticsService {
         // Calculate payment status for the PO
         const totalAmount = parseFloat(item.purchaseOrder?.totalAmount?.toString() || '0');
         const paidAmount = parseFloat(item.purchaseOrder?.paidAmount?.toString() || '0');
-        let poPaymentStatus = 'unpaid';
-        if (paidAmount >= totalAmount && totalAmount > 0) {
-          poPaymentStatus = 'paid';
-        } else if (paidAmount > 0) {
-          poPaymentStatus = 'partial';
-        }
+        const poPaymentStatus = derivePaymentStatus(paidAmount, totalAmount);
 
         // Note: Product pricing has been migrated to PriceList system
         // Setting pricing fields to 0 as they are no longer stored on Product entity
@@ -758,14 +744,7 @@ export class PurchasingAnalyticsService {
           0,
         );
         const total = parseFloat(po.totalAmount?.toString() || '0');
-        let computedStatus: 'paid' | 'partial' | 'unpaid';
-        if (paidAmount >= total && total > 0) {
-          computedStatus = 'paid';
-        } else if (paidAmount > 0) {
-          computedStatus = 'partial';
-        } else {
-          computedStatus = 'unpaid';
-        }
+        const computedStatus = derivePaymentStatus(paidAmount, total);
 
         if (computedStatus !== filters.paymentStatus) continue;
 
@@ -920,20 +899,17 @@ export class PurchasingAnalyticsService {
         0,
       );
       const total = parseFloat(po.totalAmount?.toString() || '0');
-      let computedPaymentStatus: 'paid' | 'partial' | 'unpaid';
-      if (paidAmount >= total && total > 0) {
-        computedPaymentStatus = 'paid';
-      } else if (paidAmount > 0) {
-        computedPaymentStatus = 'partial';
-      } else {
-        computedPaymentStatus = 'unpaid';
-      }
+      const computedPaymentStatus = derivePaymentStatus(paidAmount, total);
+      const isReceived =
+        typeof po.isFullyReceived === 'function'
+          ? po.isFullyReceived()
+          : Boolean(po.isFullyReceived);
       return {
         orderNumber: po.orderNumber,
         orderDate: date.toISOString().split('T')[0],
         supplierName: po.supplier?.companyName || 'N/A',
         totalAmount: total,
-        status: (po.isFullyReceived() ? 'received' : 'pending') as 'received' | 'pending',
+        status: (isReceived ? 'received' : 'pending') as 'received' | 'pending',
         computedPaymentStatus,
       };
     });

--- a/backend/src/modules/sales/dto/sales-analytics.dto.ts
+++ b/backend/src/modules/sales/dto/sales-analytics.dto.ts
@@ -7,14 +7,11 @@ import {
   IsInt,
   Min,
   IsString,
-  IsBoolean,
 } from 'class-validator';
 import { ApiPropertyOptional, ApiProperty } from '@nestjs/swagger';
 import { format } from 'date-fns';
 import { Transform, Type } from 'class-transformer';
 import { DateRange, GroupByPeriod } from '@/common/dto/analytics.dto';
-import { InvoiceStatus } from '../../../database/entities/invoice.entity';
-
 // Re-export for backward compatibility
 export { DateRange, GroupByPeriod } from '@/common/dto/analytics.dto';
 
@@ -88,24 +85,19 @@ export class SalesAnalyticsQueryDto {
 
   @ApiPropertyOptional({
     description: 'Filter by fulfillment status',
-    example: true,
+    enum: ['fulfilled', 'unfulfilled'],
   })
   @IsOptional()
-  @IsBoolean()
-  @Transform(({ value }) => {
-    if (value === 'true' || value === true) return true;
-    if (value === 'false' || value === false) return false;
-    return undefined;
-  })
-  isFulfilled?: boolean;
+  @IsIn(['fulfilled', 'unfulfilled'])
+  fulfillmentStatus?: 'fulfilled' | 'unfulfilled';
 
   @ApiPropertyOptional({
-    description: 'Filter by invoice payment status',
-    enum: InvoiceStatus,
+    description: 'Filter by payment status',
+    enum: ['unpaid', 'partial', 'paid', 'overpaid'],
   })
   @IsOptional()
-  @IsEnum(InvoiceStatus)
-  paymentStatus?: InvoiceStatus;
+  @IsIn(['unpaid', 'partial', 'paid', 'overpaid'])
+  paymentStatus?: 'unpaid' | 'partial' | 'paid' | 'overpaid';
 }
 
 export class SalesMetricsDto {

--- a/backend/src/modules/sales/services/sales-analytics.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-analytics.service.spec.ts
@@ -7,6 +7,7 @@ import { Payment } from '../../../database/entities/payment.entity';
 import { Customer } from '../../../database/entities/customer.entity';
 import { SalesOrderItem } from '../../../database/entities/sales-order-item.entity';
 import { SalesAnalyticsReportService } from './sales-analytics-report.service';
+import { SalesAnalyticsQueryDto } from '../dto/sales-analytics.dto';
 
 const d = (s: string) => new Date(`${s}T00:00:00.000Z`);
 
@@ -17,6 +18,35 @@ function makeRepoMock() {
     findOne: jest.fn().mockResolvedValue(null),
     count: jest.fn().mockResolvedValue(0),
   };
+}
+
+/**
+ * Standalone query-builder mock used by the canonical-params describe blocks.
+ * Simpler than makeChainMock (no rawMany defaults) so each test can configure
+ * exactly what it needs without noise.
+ * Use makeChainMock (in getSalesAnalytics filter propagation) for full-service tests.
+ */
+function makeChainableQb(rawOneResult: any = {}) {
+  const qb: any = {
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    setParameters: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    addGroupBy: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn().mockResolvedValue([]),
+    getRawOne: jest.fn().mockResolvedValue(rawOneResult),
+    getMany: jest.fn().mockResolvedValue([]),
+    getCount: jest.fn().mockResolvedValue(0),
+  };
+  return qb;
 }
 
 describe('SalesAnalyticsService', () => {
@@ -172,21 +202,35 @@ describe('SalesAnalyticsService', () => {
   });
 
   describe('SalesAnalyticsQueryDto validation', () => {
-    it('accepts isFulfilled=true as boolean after transform', async () => {
-      const { plainToInstance } = await import('class-transformer');
-      const { validate } = await import('class-validator');
-      const { SalesAnalyticsQueryDto } = await import('../dto/sales-analytics.dto');
-      const dto = plainToInstance(SalesAnalyticsQueryDto, { isFulfilled: 'true' });
-      const errors = await validate(dto);
+    it('accepts fulfillmentStatus=fulfilled without validation error', () => {
+      const dto = new SalesAnalyticsQueryDto();
+      dto.fulfillmentStatus = 'fulfilled';
 
-      expect(errors.filter((e) => e.property === 'isFulfilled')).toHaveLength(0);
-      expect(dto.isFulfilled).toBe(true);
+      expect(dto.fulfillmentStatus).toBe('fulfilled');
     });
 
-    it('accepts paymentStatus=paid as valid InvoiceStatus', async () => {
+    it('accepts paymentStatus=unpaid without validation error', () => {
+      const dto = new SalesAnalyticsQueryDto();
+      dto.paymentStatus = 'unpaid';
+
+      expect(dto.paymentStatus).toBe('unpaid');
+    });
+
+    it('accepts fulfillmentStatus=fulfilled as valid canonical value', async () => {
       const { plainToInstance } = await import('class-transformer');
       const { validate } = await import('class-validator');
-      const { SalesAnalyticsQueryDto } = await import('../dto/sales-analytics.dto');
+      const dto = plainToInstance(SalesAnalyticsQueryDto, {
+        fulfillmentStatus: 'fulfilled',
+      });
+      const errors = await validate(dto);
+
+      expect(errors.filter((e) => e.property === 'fulfillmentStatus')).toHaveLength(0);
+      expect(dto.fulfillmentStatus).toBe('fulfilled');
+    });
+
+    it('accepts paymentStatus=paid as valid canonical value', async () => {
+      const { plainToInstance } = await import('class-transformer');
+      const { validate } = await import('class-validator');
       const dto = plainToInstance(SalesAnalyticsQueryDto, { paymentStatus: 'paid' });
       const errors = await validate(dto);
 
@@ -253,16 +297,20 @@ describe('SalesAnalyticsService', () => {
       expect(qb.andWhere).toHaveBeenCalledWith('order.createdByUserId = :salesRepId', { salesRepId: 'rep-1' });
     });
 
-    it('applies paymentStatus filter with invoice join when provided', async () => {
+    it('applies paymentStatus filter with translated invoice join when provided', async () => {
       const qb = makeQbChain();
       const customerQb = makeCustomerQbChain();
       (service as any).salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
       (service as any).customerRepository.createQueryBuilder = jest.fn().mockReturnValue(customerQb);
 
-      await (service as any).getPeriodData(start, end, 'month', { paymentStatus: 'paid' as any });
+      await (service as any).getPeriodData(start, end, 'month', {
+        paymentStatus: 'unpaid',
+      } as any);
 
       expect(qb.leftJoin).toHaveBeenCalledWith('order.invoices', 'invoice');
-      expect(qb.andWhere).toHaveBeenCalledWith('invoice.status = :paymentStatus', { paymentStatus: 'paid' });
+      expect(qb.andWhere).toHaveBeenCalledWith('invoice.status = :paymentStatus', {
+        paymentStatus: 'draft',
+      });
     });
 
     it('applies no extra andWhere calls when query has no filters', async () => {
@@ -277,6 +325,151 @@ describe('SalesAnalyticsService', () => {
       expect(andWhereCalls).not.toContain(expect.stringContaining('customerId'));
       expect(andWhereCalls).not.toContain(expect.stringContaining('salesRepId'));
       expect(andWhereCalls).not.toContain(expect.stringContaining('paymentStatus'));
+    });
+  });
+
+  describe('calculateSalesMetrics — fulfillmentStatus translation', () => {
+    it('adds isFulfilled=true WHERE when fulfillmentStatus=fulfilled', async () => {
+      const orderQb = makeChainableQb({
+        totalRevenue: '0',
+        totalOrders: '0',
+        averageOrderValue: '0',
+        completedOrders: '0',
+        confirmedOrders: '0',
+        draftOrders: '0',
+      });
+      const invoiceQb = makeChainableQb({
+        paidInvoicesAmount: '0',
+        pendingInvoicesAmount: '0',
+        overdueInvoicesAmount: '0',
+      });
+      const module2 = await Test.createTestingModule({
+        providers: [
+          SalesAnalyticsService,
+          {
+            provide: getRepositoryToken(SalesOrder),
+            useValue: { createQueryBuilder: jest.fn().mockReturnValue(orderQb) },
+          },
+          {
+            provide: getRepositoryToken(Invoice),
+            useValue: { createQueryBuilder: jest.fn().mockReturnValue(invoiceQb) },
+          },
+          {
+            provide: getRepositoryToken(Payment),
+            useValue: { createQueryBuilder: jest.fn().mockReturnValue(makeChainableQb()) },
+          },
+          {
+            provide: getRepositoryToken(Customer),
+            useValue: { createQueryBuilder: jest.fn().mockReturnValue(makeChainableQb()) },
+          },
+          { provide: getRepositoryToken(SalesOrderItem), useValue: makeRepoMock() },
+          { provide: SalesAnalyticsReportService, useValue: { getProductSummary: jest.fn() } },
+        ],
+      }).compile();
+      const svc = module2.get<SalesAnalyticsService>(SalesAnalyticsService);
+
+      const query = new SalesAnalyticsQueryDto();
+      query.fulfillmentStatus = 'fulfilled';
+      await (svc as any).calculateSalesMetrics(new Date(), new Date(), query);
+
+      const andWhereCalls: string[] = orderQb.andWhere.mock.calls.map((c: any[]) => c[0]);
+      expect(andWhereCalls.some((call) => call.includes('isFulfilled'))).toBe(true);
+    });
+
+    it('adds isFulfilled=false WHERE when fulfillmentStatus=unfulfilled', async () => {
+      const orderQb = makeChainableQb({
+        totalRevenue: '0',
+        totalOrders: '0',
+        averageOrderValue: '0',
+        completedOrders: '0',
+        confirmedOrders: '0',
+        draftOrders: '0',
+      });
+      const invoiceQb = makeChainableQb({
+        paidInvoicesAmount: '0',
+        pendingInvoicesAmount: '0',
+        overdueInvoicesAmount: '0',
+      });
+      const module2 = await Test.createTestingModule({
+        providers: [
+          SalesAnalyticsService,
+          {
+            provide: getRepositoryToken(SalesOrder),
+            useValue: { createQueryBuilder: jest.fn().mockReturnValue(orderQb) },
+          },
+          {
+            provide: getRepositoryToken(Invoice),
+            useValue: { createQueryBuilder: jest.fn().mockReturnValue(invoiceQb) },
+          },
+          {
+            provide: getRepositoryToken(Payment),
+            useValue: { createQueryBuilder: jest.fn().mockReturnValue(makeChainableQb()) },
+          },
+          {
+            provide: getRepositoryToken(Customer),
+            useValue: { createQueryBuilder: jest.fn().mockReturnValue(makeChainableQb()) },
+          },
+          { provide: getRepositoryToken(SalesOrderItem), useValue: makeRepoMock() },
+          { provide: SalesAnalyticsReportService, useValue: { getProductSummary: jest.fn() } },
+        ],
+      }).compile();
+      const svc = module2.get<SalesAnalyticsService>(SalesAnalyticsService);
+
+      const query = new SalesAnalyticsQueryDto();
+      query.fulfillmentStatus = 'unfulfilled';
+      await (svc as any).calculateSalesMetrics(new Date(), new Date(), query);
+
+      const andWhereCalls: string[] = orderQb.andWhere.mock.calls.map((c: any[]) => c[0]);
+      expect(andWhereCalls.some((call) => call.includes('isFulfilled'))).toBe(true);
+    });
+  });
+
+  describe('calculateSalesMetrics — paymentStatus translation', () => {
+    it('maps paymentStatus=unpaid to invoice.status=draft in WHERE clause', async () => {
+      const orderQb = makeChainableQb({
+        totalRevenue: '0',
+        totalOrders: '0',
+        averageOrderValue: '0',
+        completedOrders: '0',
+        confirmedOrders: '0',
+        draftOrders: '0',
+      });
+      const invoiceQb = makeChainableQb({
+        paidInvoicesAmount: '0',
+        pendingInvoicesAmount: '0',
+        overdueInvoicesAmount: '0',
+      });
+      const module2 = await Test.createTestingModule({
+        providers: [
+          SalesAnalyticsService,
+          {
+            provide: getRepositoryToken(SalesOrder),
+            useValue: { createQueryBuilder: jest.fn().mockReturnValue(orderQb) },
+          },
+          {
+            provide: getRepositoryToken(Invoice),
+            useValue: { createQueryBuilder: jest.fn().mockReturnValue(invoiceQb) },
+          },
+          {
+            provide: getRepositoryToken(Payment),
+            useValue: { createQueryBuilder: jest.fn().mockReturnValue(makeChainableQb()) },
+          },
+          {
+            provide: getRepositoryToken(Customer),
+            useValue: { createQueryBuilder: jest.fn().mockReturnValue(makeChainableQb()) },
+          },
+          { provide: getRepositoryToken(SalesOrderItem), useValue: makeRepoMock() },
+          { provide: SalesAnalyticsReportService, useValue: { getProductSummary: jest.fn() } },
+        ],
+      }).compile();
+      const svc = module2.get<SalesAnalyticsService>(SalesAnalyticsService);
+
+      const query = new SalesAnalyticsQueryDto();
+      query.paymentStatus = 'unpaid';
+      await (svc as any).calculateSalesMetrics(new Date(), new Date(), query);
+
+      const andWhereCalls: string[] = invoiceQb.andWhere.mock.calls.map((c: any[]) => c[0]);
+      expect(andWhereCalls.some((call) => call.includes('invoice.status'))).toBe(true);
     });
   });
 
@@ -519,7 +712,7 @@ describe('SalesAnalyticsService', () => {
       return chain;
     }
 
-    it('applies isFulfilled filter to orderQuery in calculateSalesMetrics', async () => {
+    it('applies fulfillmentStatus filter to orderQuery in calculateSalesMetrics', async () => {
       const orderChain = makeChainMock();
       const invoiceChain = makeChainMock();
       const customerChain = makeChainMock();
@@ -532,7 +725,7 @@ describe('SalesAnalyticsService', () => {
       (service as any).salesOrderItemRepository.createQueryBuilder = jest.fn().mockReturnValue(makeChainMock({}, []));
 
       await service.getSalesAnalytics({
-        isFulfilled: true,
+        fulfillmentStatus: 'fulfilled',
         dateRange: undefined,
       } as any);
 
@@ -554,18 +747,15 @@ describe('SalesAnalyticsService', () => {
       (service as any).paymentRepository.createQueryBuilder = jest.fn().mockReturnValue(paymentChain);
       (service as any).salesOrderItemRepository.createQueryBuilder = jest.fn().mockReturnValue(makeChainMock({}, []));
 
-      await service.getSalesAnalytics({
-        paymentStatus: 'paid' as any,
-        dateRange: undefined,
-      } as any);
+      await service.getSalesAnalytics({ paymentStatus: 'unpaid', dateRange: undefined } as any);
 
       expect(invoiceChain.andWhere).toHaveBeenCalledWith(
         'invoice.status = :paymentStatus',
-        { paymentStatus: 'paid' },
+        { paymentStatus: 'draft' },
       );
     });
 
-    it('applies isFulfilled filter to getPeriodData orderQuery', async () => {
+    it('applies fulfillmentStatus filter to getPeriodData orderQuery', async () => {
       const orderChain = makeChainMock({}, []);
       const invoiceChain = makeChainMock();
       const customerChain = makeChainMock({}, []);
@@ -578,7 +768,7 @@ describe('SalesAnalyticsService', () => {
       (service as any).salesOrderItemRepository.createQueryBuilder = jest.fn().mockReturnValue(makeChainMock({}, []));
 
       await service.getSalesAnalytics({
-        isFulfilled: false,
+        fulfillmentStatus: 'unfulfilled',
         dateRange: undefined,
       } as any);
 
@@ -588,7 +778,7 @@ describe('SalesAnalyticsService', () => {
       expect(calls.length).toBeGreaterThanOrEqual(2);
     });
 
-    it('applies isFulfilled filter to getTopCustomers orderQuery', async () => {
+    it('applies fulfillmentStatus filter to getTopCustomers orderQuery', async () => {
       const orderChain = makeChainMock({}, []);
       const invoiceChain = makeChainMock();
       const customerChain = makeChainMock({}, []);
@@ -601,7 +791,7 @@ describe('SalesAnalyticsService', () => {
       (service as any).salesOrderItemRepository.createQueryBuilder = jest.fn().mockReturnValue(makeChainMock({}, []));
 
       await service.getSalesAnalytics({
-        isFulfilled: true,
+        fulfillmentStatus: 'fulfilled',
         dateRange: undefined,
       } as any);
 
@@ -658,6 +848,32 @@ describe('SalesAnalyticsService', () => {
         (args: any[]) => args[0] === 'invoice.status = :paymentStatus',
       );
       expect(invoiceStatusCalls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('adds paidAmount > totalAmount predicate when paymentStatus=overpaid (calculateSalesMetrics)', async () => {
+      const orderChain = makeChainMock();
+      const invoiceChain = makeChainMock();
+      const customerChain = makeChainMock();
+      const paymentChain = makeChainMock();
+
+      (service as any).salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue(orderChain);
+      (service as any).invoiceRepository.createQueryBuilder = jest.fn().mockReturnValue(invoiceChain);
+      (service as any).customerRepository.createQueryBuilder = jest.fn().mockReturnValue(customerChain);
+      (service as any).paymentRepository.createQueryBuilder = jest.fn().mockReturnValue(paymentChain);
+      (service as any).salesOrderItemRepository.createQueryBuilder = jest.fn().mockReturnValue(makeChainMock({}, []));
+
+      await service.getSalesAnalytics({ paymentStatus: 'overpaid' as any, dateRange: undefined } as any);
+
+      // Must set invoice.status = PAID
+      expect(invoiceChain.andWhere).toHaveBeenCalledWith(
+        'invoice.status = :paymentStatus',
+        { paymentStatus: 'paid' },
+      );
+      // AND additionally constrain to invoices where paidAmount exceeds totalAmount
+      const overpaidCalls = invoiceChain.andWhere.mock.calls.filter(
+        (args: any[]) => args[0] === 'invoice.paidAmount > invoice.totalAmount',
+      );
+      expect(overpaidCalls.length).toBeGreaterThanOrEqual(1);
     });
   });
 });

--- a/backend/src/modules/sales/services/sales-analytics.service.ts
+++ b/backend/src/modules/sales/services/sales-analytics.service.ts
@@ -28,6 +28,25 @@ import {
 } from '../dto/sales-analytics.dto';
 import { SalesAnalyticsReportService } from './sales-analytics-report.service';
 
+function translatePaymentStatus(
+  status: 'unpaid' | 'partial' | 'paid' | 'overpaid',
+): InvoiceStatus {
+  switch (status) {
+    case 'unpaid':
+      return InvoiceStatus.DRAFT;
+    case 'partial':
+      return InvoiceStatus.PARTIAL_PAID;
+    case 'paid':
+    case 'overpaid':
+      return InvoiceStatus.PAID;
+  }
+}
+
+/** Returns true when the query requires the extra overpaid predicate (paidAmount > totalAmount). */
+function isOverpaidFilter(status: string | undefined): boolean {
+  return status === 'overpaid';
+}
+
 @Injectable()
 export class SalesAnalyticsService {
   constructor(
@@ -338,12 +357,20 @@ export class SalesAnalyticsService {
       orderQuery = orderQuery.andWhere('order.createdByUserId = :salesRepId', { salesRepId: query.salesRepId });
     }
 
-    if (query?.isFulfilled !== undefined) {
-      orderQuery = orderQuery.andWhere('order.isFulfilled = :isFulfilled', { isFulfilled: query.isFulfilled });
+    if (query?.fulfillmentStatus !== undefined) {
+      orderQuery = orderQuery.andWhere('order.isFulfilled = :isFulfilled', {
+        isFulfilled: query.fulfillmentStatus === 'fulfilled',
+      });
     }
 
     if (query?.paymentStatus) {
-      invoiceQuery = invoiceQuery.andWhere('invoice.status = :paymentStatus', { paymentStatus: query.paymentStatus });
+      const invoiceStatus = translatePaymentStatus(query.paymentStatus);
+      invoiceQuery = invoiceQuery.andWhere('invoice.status = :paymentStatus', {
+        paymentStatus: invoiceStatus,
+      });
+      if (isOverpaidFilter(query.paymentStatus)) {
+        invoiceQuery = invoiceQuery.andWhere('invoice.paidAmount > invoice.totalAmount');
+      }
     }
 
     const [orderStats, invoiceStats, customerStats, paymentStats] = await Promise.all([
@@ -443,8 +470,10 @@ export class SalesAnalyticsService {
       .createQueryBuilder('order')
       .where('order.orderDate BETWEEN :startDate AND :endDate', { startDate, endDate });
 
-    if (query?.isFulfilled !== undefined) {
-      periodQuery = periodQuery.andWhere('order.isFulfilled = :isFulfilled', { isFulfilled: query.isFulfilled });
+    if (query?.fulfillmentStatus !== undefined) {
+      periodQuery = periodQuery.andWhere('order.isFulfilled = :isFulfilled', {
+        isFulfilled: query.fulfillmentStatus === 'fulfilled',
+      });
     }
 
     if (query?.customerId) {
@@ -456,9 +485,13 @@ export class SalesAnalyticsService {
     }
 
     if (query?.paymentStatus) {
+      const invoiceStatus = translatePaymentStatus(query.paymentStatus);
       periodQuery = periodQuery
         .leftJoin('order.invoices', 'invoice')
-        .andWhere('invoice.status = :paymentStatus', { paymentStatus: query.paymentStatus });
+        .andWhere('invoice.status = :paymentStatus', { paymentStatus: invoiceStatus });
+      if (isOverpaidFilter(query.paymentStatus)) {
+        periodQuery = periodQuery.andWhere('invoice.paidAmount > invoice.totalAmount');
+      }
     }
 
     const data = await periodQuery
@@ -508,14 +541,20 @@ export class SalesAnalyticsService {
       .leftJoin('order.customer', 'customer')
       .where('order.orderDate BETWEEN :startDate AND :endDate', { startDate, endDate });
 
-    if (query?.isFulfilled !== undefined) {
-      topCustomersQuery = topCustomersQuery.andWhere('order.isFulfilled = :isFulfilled', { isFulfilled: query.isFulfilled });
+    if (query?.fulfillmentStatus !== undefined) {
+      topCustomersQuery = topCustomersQuery.andWhere('order.isFulfilled = :isFulfilled', {
+        isFulfilled: query.fulfillmentStatus === 'fulfilled',
+      });
     }
 
     if (query?.paymentStatus) {
+      const invoiceStatus = translatePaymentStatus(query.paymentStatus);
       topCustomersQuery = topCustomersQuery
         .leftJoin('order.invoices', 'invoice')
-        .andWhere('invoice.status = :paymentStatus', { paymentStatus: query.paymentStatus });
+        .andWhere('invoice.status = :paymentStatus', { paymentStatus: invoiceStatus });
+      if (isOverpaidFilter(query.paymentStatus)) {
+        topCustomersQuery = topCustomersQuery.andWhere('invoice.paidAmount > invoice.totalAmount');
+      }
     }
 
     if (query?.salesRepId) {
@@ -562,14 +601,20 @@ export class SalesAnalyticsService {
       .leftJoin('item.salesOrder', 'order')
       .where('order.orderDate BETWEEN :startDate AND :endDate', { startDate, endDate });
 
-    if (query?.isFulfilled !== undefined) {
-      topProductsQuery = topProductsQuery.andWhere('order.isFulfilled = :isFulfilled', { isFulfilled: query.isFulfilled });
+    if (query?.fulfillmentStatus !== undefined) {
+      topProductsQuery = topProductsQuery.andWhere('order.isFulfilled = :isFulfilled', {
+        isFulfilled: query.fulfillmentStatus === 'fulfilled',
+      });
     }
 
     if (query?.paymentStatus) {
+      const invoiceStatus = translatePaymentStatus(query.paymentStatus);
       topProductsQuery = topProductsQuery
         .leftJoin('order.invoices', 'invoice')
-        .andWhere('invoice.status = :paymentStatus', { paymentStatus: query.paymentStatus });
+        .andWhere('invoice.status = :paymentStatus', { paymentStatus: invoiceStatus });
+      if (isOverpaidFilter(query.paymentStatus)) {
+        topProductsQuery = topProductsQuery.andWhere('invoice.paidAmount > invoice.totalAmount');
+      }
     }
 
     if (query?.customerId) {

--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -1,5 +1,9 @@
-import { CircularProgress, FormControl, InputLabel, MenuItem, Select, Stack, Tooltip } from '@mui/material'
+import { CircularProgress, Stack } from '@mui/material'
 
+import { FilterCompare } from './FilterCompare'
+import { FilterCustomer } from './FilterCustomer'
+import { FilterOrderStatus } from './FilterOrderStatus'
+import { FilterPaymentStatus } from './FilterPaymentStatus'
 import { FilterPeriod } from './FilterPeriod'
 import { FilterSearch } from './FilterSearch'
 import { FilterSelect } from './FilterSelect'
@@ -62,35 +66,45 @@ function renderQuickField<TFilters extends object>(
   if (field.type === 'compare') {
     const periodField = config.fields.find((configField) => configField.type === 'period')
     const periodValue = periodField ? (draftFilters[periodField.field] as PeriodValue) : null
-    const compareDisabled = periodValue?.key === 'today'
-    const selectId = `${String(field.field)}-select`
-    const labelId = `${String(field.field)}-label`
 
     return (
-      <Tooltip
+      <FilterCompare
         key={String(field.field)}
-        title={compareDisabled ? 'Comparison is not available for Today' : ''}
-        placement="top"
-      >
-        <span>
-          <FormControl size="small" sx={{ minWidth: 210 }} disabled={compareDisabled}>
-            <InputLabel id={labelId}>{field.label}</InputLabel>
-            <Select
-              id={selectId}
-              labelId={labelId}
-              disabled={compareDisabled}
-              value={(value as string | null) ?? ''}
-              label={field.label}
-              onChange={(event) => onChange((event.target.value || null) as string | null)}
-            >
-              <MenuItem value="">No Comparison</MenuItem>
-              <MenuItem value="previous_period">Previous Period</MenuItem>
-              <MenuItem value="last_month">Same Period Last Month</MenuItem>
-              <MenuItem value="last_year">Same Period Last Year</MenuItem>
-            </Select>
-          </FormControl>
-        </span>
-      </Tooltip>
+        value={(value as string | null) ?? null}
+        onChange={onChange}
+        periodValue={periodValue}
+      />
+    )
+  }
+
+  if (field.type === 'customer') {
+    return (
+      <FilterCustomer
+        key={String(field.field)}
+        value={(value as string | null) ?? null}
+        onChange={onChange}
+      />
+    )
+  }
+
+  if (field.type === 'order-status') {
+    return (
+      <FilterOrderStatus
+        key={String(field.field)}
+        value={(value as string | null) ?? null}
+        onChange={onChange}
+      />
+    )
+  }
+
+  if (field.type === 'payment-status') {
+    return (
+      <FilterPaymentStatus
+        key={String(field.field)}
+        value={(value as string | null) ?? null}
+        onChange={onChange}
+        includeOverpaid={field.includeOverpaid}
+      />
     )
   }
 

--- a/frontend/src/components/filters/FilterCompare.tsx
+++ b/frontend/src/components/filters/FilterCompare.tsx
@@ -1,0 +1,46 @@
+import { FormControl, InputLabel, MenuItem, Select, Tooltip } from '@mui/material'
+import { useId } from 'react'
+
+import { COMPARE_OPTIONS } from '@/constants/filterOptions'
+import type { PeriodValue } from '@/types/filterBar.types'
+
+interface Props {
+  value: string | null
+  onChange: (value: string | null) => void
+  periodValue: PeriodValue | null
+}
+
+export function FilterCompare({ value, onChange, periodValue }: Props) {
+  const uid = useId()
+  const selectId = `${uid}-compare`
+  const labelId = `${uid}-compare-label`
+  const compareDisabled = periodValue?.key === 'today'
+
+  return (
+    <Tooltip
+      title={compareDisabled ? 'Comparison is not available for Today' : ''}
+      placement="top"
+    >
+      <span>
+        <FormControl size="small" sx={{ minWidth: 210 }} disabled={compareDisabled}>
+          <InputLabel id={labelId}>Compare</InputLabel>
+          <Select
+            id={selectId}
+            labelId={labelId}
+            disabled={compareDisabled}
+            value={value ?? ''}
+            label="Compare"
+            onChange={(event) => onChange((event.target.value || null) as string | null)}
+          >
+            <MenuItem value="">No Comparison</MenuItem>
+            {COMPARE_OPTIONS.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </span>
+    </Tooltip>
+  )
+}

--- a/frontend/src/components/filters/FilterCustomer.tsx
+++ b/frontend/src/components/filters/FilterCustomer.tsx
@@ -1,0 +1,30 @@
+import { useId } from 'react'
+import { useGetCustomersQuery } from '@/store/api/salesApi'
+
+import { FilterSelect } from './FilterSelect'
+
+interface Props {
+  value: string | null
+  onChange: (value: string | null) => void
+}
+
+export function FilterCustomer({ value, onChange }: Props) {
+  const uid = useId()
+  // isLoading kept intentionally — options will be empty until data arrives (acceptable UX)
+  const { data } = useGetCustomersQuery({ limit: 999999 })
+  const options = (data?.data ?? []).map((customer) => ({
+    value: customer.id,
+    label: customer.name,
+  }))
+
+  return (
+    <FilterSelect
+      field={uid}
+      label="Customer"
+      type="select"
+      value={value}
+      options={options}
+      onChange={onChange as (value: string | null | string[]) => void}
+    />
+  )
+}

--- a/frontend/src/components/filters/FilterOrderStatus.tsx
+++ b/frontend/src/components/filters/FilterOrderStatus.tsx
@@ -1,0 +1,26 @@
+import { useId } from 'react'
+import { FilterSelect } from './FilterSelect'
+
+const ORDER_STATUS_OPTIONS = [
+  { value: 'unfulfilled', label: 'Unfulfilled' },
+  { value: 'fulfilled', label: 'Fulfilled' },
+]
+
+interface Props {
+  value: string | null
+  onChange: (value: string | null) => void
+}
+
+export function FilterOrderStatus({ value, onChange }: Props) {
+  const uid = useId()
+  return (
+    <FilterSelect
+      field={uid}
+      label="Order Status"
+      type="select"
+      value={value}
+      options={ORDER_STATUS_OPTIONS}
+      onChange={onChange as (value: string | null | string[]) => void}
+    />
+  )
+}

--- a/frontend/src/components/filters/FilterPaymentStatus.tsx
+++ b/frontend/src/components/filters/FilterPaymentStatus.tsx
@@ -1,0 +1,33 @@
+import { useId } from 'react'
+import { FilterSelect } from './FilterSelect'
+
+const PAYMENT_STATUS_OPTIONS = [
+  { value: 'unpaid', label: 'Unpaid' },
+  { value: 'partial', label: 'Partial' },
+  { value: 'paid', label: 'Paid' },
+  { value: 'overpaid', label: 'Overpaid' },
+]
+
+interface Props {
+  value: string | null
+  onChange: (value: string | null) => void
+  includeOverpaid?: boolean
+}
+
+export function FilterPaymentStatus({ value, onChange, includeOverpaid = true }: Props) {
+  const uid = useId()
+  const options = includeOverpaid
+    ? PAYMENT_STATUS_OPTIONS
+    : PAYMENT_STATUS_OPTIONS.filter((option) => option.value !== 'overpaid')
+
+  return (
+    <FilterSelect
+      field={uid}
+      label="Payment"
+      type="select"
+      value={value}
+      options={options}
+      onChange={onChange as (value: string | null | string[]) => void}
+    />
+  )
+}

--- a/frontend/src/components/filters/__tests__/FilterBar.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterBar.test.tsx
@@ -1,11 +1,19 @@
 import { LocalizationProvider } from '@mui/x-date-pickers'
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
+import { configureStore } from '@reduxjs/toolkit'
 import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { Provider } from 'react-redux'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { FilterBarConfig, FilterBarHandlers, PeriodValue } from '@/types/filterBar.types'
 import { FilterBar } from '../FilterBar'
+
+vi.mock('@/store/api/salesApi', () => ({
+  useGetCustomersQuery: vi.fn(() => ({
+    data: { data: [{ id: 'c1', name: 'Amuro Ray' }] },
+  })),
+}))
 
 interface Filters {
   search: string
@@ -219,6 +227,91 @@ describe('FilterBar — compare field', () => {
     await userEvent.click(screen.getByLabelText('Compare'))
     await userEvent.click(screen.getByText('No Comparison'))
     expect(onQuickFilterChange).toHaveBeenCalledWith('compareWith', null)
+  })
+})
+
+describe('FilterBar — custom filter field types', () => {
+  it('renders FilterCustomer when type=customer', () => {
+    interface CustomerFilters {
+      customerId: string | null
+    }
+
+    const customerConfig: FilterBarConfig<CustomerFilters> = {
+      fields: [{ field: 'customerId', label: 'Customer', type: 'customer' }],
+    }
+
+    render(
+      <Provider store={configureStore({ reducer: {} })}>
+        <FilterBar
+          config={customerConfig}
+          draftFilters={{ customerId: null }}
+          handlers={{
+            onSearchChange: vi.fn(),
+            onSearchCommit: vi.fn(),
+            onQuickFilterChange: vi.fn(),
+            onClearField: vi.fn(),
+            onClearAll: vi.fn(),
+          }}
+          hasActiveFilters={false}
+        />
+      </Provider>,
+    )
+
+    expect(screen.getByLabelText(/customer/i)).toBeInTheDocument()
+  })
+
+  it('renders FilterOrderStatus when type=order-status', () => {
+    interface StatusFilters {
+      fulfillmentStatus: string | null
+    }
+
+    const statusConfig: FilterBarConfig<StatusFilters> = {
+      fields: [{ field: 'fulfillmentStatus', label: 'Order Status', type: 'order-status' }],
+    }
+
+    render(
+      <FilterBar
+        config={statusConfig}
+        draftFilters={{ fulfillmentStatus: null }}
+        handlers={{
+          onSearchChange: vi.fn(),
+          onSearchCommit: vi.fn(),
+          onQuickFilterChange: vi.fn(),
+          onClearField: vi.fn(),
+          onClearAll: vi.fn(),
+        }}
+        hasActiveFilters={false}
+      />,
+    )
+
+    expect(screen.getByLabelText(/order status/i)).toBeInTheDocument()
+  })
+
+  it('renders FilterPaymentStatus when type=payment-status', () => {
+    interface PaymentFilters {
+      paymentStatus: string | null
+    }
+
+    const paymentConfig: FilterBarConfig<PaymentFilters> = {
+      fields: [{ field: 'paymentStatus', label: 'Payment', type: 'payment-status' }],
+    }
+
+    render(
+      <FilterBar
+        config={paymentConfig}
+        draftFilters={{ paymentStatus: null }}
+        handlers={{
+          onSearchChange: vi.fn(),
+          onSearchCommit: vi.fn(),
+          onQuickFilterChange: vi.fn(),
+          onClearField: vi.fn(),
+          onClearAll: vi.fn(),
+        }}
+        hasActiveFilters={false}
+      />,
+    )
+
+    expect(screen.getByLabelText(/payment/i)).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/filters/__tests__/FilterCompare.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterCompare.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { FilterCompare } from '../FilterCompare'
+
+describe('FilterCompare', () => {
+  it('renders the Compare label', () => {
+    render(<FilterCompare value={null} onChange={vi.fn()} periodValue={null} />)
+    expect(screen.getByLabelText(/compare/i)).toBeInTheDocument()
+  })
+
+  it('shows all three comparison options', async () => {
+    render(<FilterCompare value={null} onChange={vi.fn()} periodValue={null} />)
+    await userEvent.click(screen.getByRole('combobox'))
+    expect(await screen.findByText('Previous Period')).toBeInTheDocument()
+    expect(await screen.findByText('Same Period Last Month')).toBeInTheDocument()
+    expect(await screen.findByText('Same Period Last Year')).toBeInTheDocument()
+  })
+
+  it('is disabled when period key is today', () => {
+    render(
+      <FilterCompare
+        value={null}
+        onChange={vi.fn()}
+        periodValue={{ key: 'today', from: null, to: null }}
+      />,
+    )
+    expect(screen.getByRole('combobox')).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('renders an existing selection without crashing', () => {
+    render(<FilterCompare value="previous_period" onChange={vi.fn()} periodValue={null} />)
+    expect(screen.getByRole('combobox')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/filters/__tests__/FilterCustomer.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterCustomer.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import type { ReactElement } from 'react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { FilterCustomer } from '../FilterCustomer'
+
+vi.mock('@/store/api/salesApi', () => ({
+  useGetCustomersQuery: vi.fn(() => ({
+    data: {
+      data: [
+        { id: 'c1', name: 'Amuro Ray' },
+        { id: 'c2', name: 'Char Aznable' },
+      ],
+    },
+  })),
+}))
+
+function renderWithStore(ui: ReactElement) {
+  const store = configureStore({ reducer: {} })
+  return render(<Provider store={store}>{ui}</Provider>)
+}
+
+describe('FilterCustomer', () => {
+  it('renders with Customer label', () => {
+    renderWithStore(<FilterCustomer value={null} onChange={vi.fn()} />)
+    expect(screen.getByLabelText(/customer/i)).toBeInTheDocument()
+  })
+
+  it('shows customer names as options', async () => {
+    renderWithStore(<FilterCustomer value={null} onChange={vi.fn()} />)
+    await userEvent.click(screen.getByRole('combobox'))
+    expect(await screen.findByText('Amuro Ray')).toBeInTheDocument()
+    expect(await screen.findByText('Char Aznable')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/filters/__tests__/FilterOrderStatus.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterOrderStatus.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { FilterOrderStatus } from '../FilterOrderStatus'
+
+describe('FilterOrderStatus', () => {
+  it('renders with Order Status label', () => {
+    render(<FilterOrderStatus value={null} onChange={vi.fn()} />)
+    expect(screen.getByLabelText(/order status/i)).toBeInTheDocument()
+  })
+
+  it('shows Unfulfilled and Fulfilled options', async () => {
+    render(<FilterOrderStatus value={null} onChange={vi.fn()} />)
+    await userEvent.click(screen.getByRole('combobox'))
+    expect(await screen.findByText('Unfulfilled')).toBeInTheDocument()
+    expect(await screen.findByText('Fulfilled')).toBeInTheDocument()
+  })
+
+  it('displays the selected value', () => {
+    render(<FilterOrderStatus value="fulfilled" onChange={vi.fn()} />)
+    expect(screen.getByRole('combobox')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/filters/__tests__/FilterPaymentStatus.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterPaymentStatus.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { FilterPaymentStatus } from '../FilterPaymentStatus'
+
+describe('FilterPaymentStatus', () => {
+  it('renders with Payment label', () => {
+    render(<FilterPaymentStatus value={null} onChange={vi.fn()} />)
+    expect(screen.getByLabelText(/payment/i)).toBeInTheDocument()
+  })
+
+  it('shows all four options by default', async () => {
+    render(<FilterPaymentStatus value={null} onChange={vi.fn()} />)
+    await userEvent.click(screen.getByRole('combobox'))
+    expect(await screen.findByText('Unpaid')).toBeInTheDocument()
+    expect(await screen.findByText('Partial')).toBeInTheDocument()
+    expect(await screen.findByText('Paid')).toBeInTheDocument()
+    expect(await screen.findByText('Overpaid')).toBeInTheDocument()
+  })
+
+  it('hides Overpaid when includeOverpaid=false', async () => {
+    render(<FilterPaymentStatus value={null} onChange={vi.fn()} includeOverpaid={false} />)
+    await userEvent.click(screen.getByRole('combobox'))
+    expect(await screen.findByText('Paid')).toBeInTheDocument()
+    expect(screen.queryByText('Overpaid')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/filters/index.ts
+++ b/frontend/src/components/filters/index.ts
@@ -1,2 +1,6 @@
 export { FilterBar } from './FilterBar'
+export { FilterCompare } from './FilterCompare'
+export { FilterCustomer } from './FilterCustomer'
+export { FilterOrderStatus } from './FilterOrderStatus'
+export { FilterPaymentStatus } from './FilterPaymentStatus'
 export { FilterPeriod } from './FilterPeriod'

--- a/frontend/src/constants/filterOptions.ts
+++ b/frontend/src/constants/filterOptions.ts
@@ -1,0 +1,5 @@
+export const COMPARE_OPTIONS = [
+  { value: 'previous_period', label: 'Previous Period' },
+  { value: 'last_month', label: 'Same Period Last Month' },
+  { value: 'last_year', label: 'Same Period Last Year' },
+]

--- a/frontend/src/hooks/useFilterBar.ts
+++ b/frontend/src/hooks/useFilterBar.ts
@@ -19,7 +19,14 @@ function getDefaults<TFilters extends object>(
       continue
     }
 
-    if (field.type === 'select') defaults[key] = null
+    if (
+      field.type === 'select' ||
+      field.type === 'customer' ||
+      field.type === 'order-status' ||
+      field.type === 'payment-status'
+    ) {
+      defaults[key] = null
+    }
     else if (field.type === 'multi-select') defaults[key] = []
     else if (field.type === 'period') {
       defaults[key] = { key: null, from: null, to: null } satisfies PeriodValue

--- a/frontend/src/pages/purchasing/PurchasingPage.tsx
+++ b/frontend/src/pages/purchasing/PurchasingPage.tsx
@@ -113,13 +113,8 @@ const PurchasingPage: React.FC = () => {
       {
         field: 'paymentStatus',
         label: 'Payment Status',
-        type: 'select',
+        type: 'payment-status',
         paramKey: 'payment',
-        options: [
-          { value: 'paid', label: 'Paid' },
-          { value: 'partial', label: 'Partially Paid' },
-          { value: 'unpaid', label: 'Unpaid' },
-        ],
       },
     ],
     defaults: {

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -21,7 +21,6 @@ import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import type { RootState } from '@/store'
 import {
   useDeleteSalesOrderMutation,
-  useGetCustomersQuery,
   useGetSalesOrdersQuery,
   useLazyGetSalesOrderQuery,
 } from '@/store/api/salesApi'
@@ -56,8 +55,6 @@ export const OrdersPage: React.FC = () => {
   const pageState = useOrdersPageState()
   const [sortBy, setSortBy] = useState('orderNumber')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
-  const { data: customersData } = useGetCustomersQuery({ limit: 999999 })
-  const customers = customersData?.data ?? []
 
   const filterConfig = useMemo<FilterBarConfig<SalesOrderFilters>>(
     () => ({
@@ -71,28 +68,17 @@ export const OrdersPage: React.FC = () => {
         {
           field: 'customerId',
           label: 'Customer',
-          type: 'select',
-          options: customers.map((customer) => ({ value: customer.id, label: customer.name })),
+          type: 'customer',
         },
         {
           field: 'paymentStatus',
           label: 'Payment',
-          type: 'select',
-          options: [
-            { value: 'unpaid', label: 'Unpaid' },
-            { value: 'partial', label: 'Partial' },
-            { value: 'paid', label: 'Paid' },
-            { value: 'overpaid', label: 'Overpaid' },
-          ],
+          type: 'payment-status',
         },
         {
           field: 'fulfillmentStatus',
-          label: 'Fulfillment',
-          type: 'select',
-          options: [
-            { value: 'unfulfilled', label: 'Unfulfilled' },
-            { value: 'fulfilled', label: 'Fulfilled' },
-          ],
+          label: 'Order Status',
+          type: 'order-status',
         },
       ],
       defaults: {
@@ -103,7 +89,7 @@ export const OrdersPage: React.FC = () => {
         fulfillmentStatus: null,
       },
     }),
-    [customers],
+    [],
   )
 
   const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)

--- a/frontend/src/pages/sales/SalesPage.tsx
+++ b/frontend/src/pages/sales/SalesPage.tsx
@@ -29,7 +29,6 @@ import { FilterBar } from '@/components/filters/FilterBar'
 import { useFilterBar } from '@/hooks/useFilterBar'
 import { useNavigate } from 'react-router-dom'
 import api from '@/services/api'
-import { useGetCustomersQuery } from '@/store/api/salesApi'
 import { SalesStatsCards, SalesTrendChart, TopProductsList, TopCustomersList } from './components'
 import type { StatItem } from './components'
 import { useDashboardAnalytics } from './hooks/useDashboardAnalytics'
@@ -46,16 +45,9 @@ const SalesPage: React.FC = () => {
     period: PeriodValue
     compareWith: DashboardCompare
     customerId: string | null
-    isFulfilled: string | null
+    fulfillmentStatus: string | null
     paymentStatus: string | null
   }
-
-  // Assumes small customer count (<50). If this grows, replace with an autocomplete + search endpoint.
-  const { data: customersData } = useGetCustomersQuery({})
-  const customerOptions = (customersData?.data ?? []).map((customer: { id: string; name: string }) => ({
-    value: customer.id,
-    label: customer.name,
-  }))
 
   const salesConfig: FilterBarConfig<SalesDashboardFilters> = {
     namespace: 'sales',
@@ -73,37 +65,27 @@ const SalesPage: React.FC = () => {
       {
         field: 'customerId',
         label: 'Customer',
-        type: 'select',
+        type: 'customer',
         paramKey: 'customer',
-        options: [{ value: '', label: 'All Customers' }, ...customerOptions],
       },
       {
-        field: 'isFulfilled',
+        field: 'fulfillmentStatus',
         label: 'Order Status',
-        type: 'select',
+        type: 'order-status',
         paramKey: 'fulfilled',
-        options: [
-          { value: 'true', label: 'Fulfilled' },
-          { value: 'false', label: 'Pending' },
-        ],
       },
       {
         field: 'paymentStatus',
         label: 'Payment Status',
-        type: 'select',
+        type: 'payment-status',
         paramKey: 'payment',
-        options: [
-          { value: 'paid', label: 'Paid' },
-          { value: 'partial_paid', label: 'Partially Paid' },
-          { value: 'draft', label: 'Draft' },
-        ],
       },
     ],
     defaults: {
       period: { key: 'this_month', from: null, to: null },
       compareWith: null,
       customerId: null,
-      isFulfilled: null,
+      fulfillmentStatus: null,
       paymentStatus: null,
     },
   }

--- a/frontend/src/pages/sales/__tests__/SalesPage.filters.test.tsx
+++ b/frontend/src/pages/sales/__tests__/SalesPage.filters.test.tsx
@@ -1,0 +1,137 @@
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import SalesPage from '../SalesPage'
+
+const mockUseGetCustomersQuery = vi.fn()
+const mockUseDashboardAnalytics = vi.fn()
+const filterBarSpy = vi.fn()
+
+vi.mock('@/store/api/salesApi', () => ({
+  useGetCustomersQuery: (...args: unknown[]) => mockUseGetCustomersQuery(...args),
+}))
+
+vi.mock('../hooks/useDashboardAnalytics', () => ({
+  useDashboardAnalytics: (...args: unknown[]) => mockUseDashboardAnalytics(...args),
+}))
+
+vi.mock('@/components/filters/FilterBar', () => ({
+  FilterBar: (props: unknown) => {
+    filterBarSpy(props)
+    return <div data-testid="filter-bar" />
+  },
+}))
+
+vi.mock('@/services/api', () => ({
+  default: { get: vi.fn().mockResolvedValue({ data: { data: [] } }) },
+}))
+
+vi.mock('react-chartjs-2', () => ({
+  Line: () => <div data-testid="sales-line-chart" />,
+  Bar: () => <div data-testid="sales-bar-chart" />,
+}))
+
+const emptyAnalyticsData = {
+  current: {
+    metrics: {
+      totalRevenue: 0,
+      totalOrders: 0,
+      newCustomers: 0,
+      averageOrderValue: 0,
+      conversionRate: 0,
+      paidInvoicesAmount: 0,
+      pendingInvoicesAmount: 0,
+      overdueInvoicesAmount: 0,
+      completedOrders: 0,
+      confirmedOrders: 0,
+      draftOrders: 0,
+    },
+    periodData: [],
+    periodStart: '2026-03-01',
+    periodEnd: '2026-03-31',
+  },
+  topCustomers: [],
+  topProducts: [],
+}
+
+describe('SalesPage filters', () => {
+  // URL uses namespace-prefixed keys: sales_fulfilled, sales_payment, sales_customer
+  const initialEntry =
+    '/?sales_fulfilled=fulfilled&sales_payment=paid&sales_customer=550e8400-e29b-41d4-a716-446655440001'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseGetCustomersQuery.mockReturnValue({
+      data: {
+        data: [{ id: '550e8400-e29b-41d4-a716-446655440001', name: 'Amuro Ray' }],
+      },
+    })
+    mockUseDashboardAnalytics.mockReturnValue({
+      data: emptyAnalyticsData,
+      isLoading: false,
+      isFetching: false,
+      error: null,
+    })
+  })
+
+  it('passes canonical fulfillmentStatus and paymentStatus into analytics', () => {
+    render(
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <SalesPage />
+      </MemoryRouter>,
+    )
+
+    expect(mockUseDashboardAnalytics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fulfillmentStatus: 'fulfilled',
+        paymentStatus: 'paid',
+      }),
+    )
+  })
+
+  it('passes customerId into analytics when set via URL', () => {
+    render(
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <SalesPage />
+      </MemoryRouter>,
+    )
+
+    expect(mockUseDashboardAnalytics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customerId: '550e8400-e29b-41d4-a716-446655440001',
+      }),
+    )
+  })
+
+  it('omits fulfillmentStatus and paymentStatus from analytics when not set', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <SalesPage />
+      </MemoryRouter>,
+    )
+
+    const call = mockUseDashboardAnalytics.mock.calls[0][0]
+    expect(call.fulfillmentStatus).toBeUndefined()
+    expect(call.paymentStatus).toBeUndefined()
+  })
+
+  it('renders the FilterBar component', () => {
+    render(
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <SalesPage />
+      </MemoryRouter>,
+    )
+    expect(screen.getByTestId('filter-bar')).toBeInTheDocument()
+  })
+
+  it('renders the sales overview heading', () => {
+    render(
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <SalesPage />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText('Sales Overview')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/types/filterBar.types.ts
+++ b/frontend/src/types/filterBar.types.ts
@@ -13,6 +13,9 @@ export type FilterFieldType =
   | 'multi-select'
   | 'period'
   | 'compare'
+  | 'customer'
+  | 'order-status'
+  | 'payment-status'
 
 interface BaseFilterFieldConfig<TFilters, K extends keyof TFilters> {
   field: K
@@ -38,10 +41,29 @@ export interface CompareFilterFieldConfig<TFilters, K extends keyof TFilters>
   type: 'compare'
 }
 
+export interface CustomerFilterFieldConfig<TFilters, K extends keyof TFilters>
+  extends BaseFilterFieldConfig<TFilters, K> {
+  type: 'customer'
+}
+
+export interface OrderStatusFilterFieldConfig<TFilters, K extends keyof TFilters>
+  extends BaseFilterFieldConfig<TFilters, K> {
+  type: 'order-status'
+}
+
+export interface PaymentStatusFilterFieldConfig<TFilters, K extends keyof TFilters>
+  extends BaseFilterFieldConfig<TFilters, K> {
+  type: 'payment-status'
+  includeOverpaid?: boolean
+}
+
 export type FilterFieldConfig<TFilters> =
   | SelectFilterFieldConfig<TFilters, keyof TFilters>
   | PeriodFilterFieldConfig<TFilters, keyof TFilters>
   | CompareFilterFieldConfig<TFilters, keyof TFilters>
+  | CustomerFilterFieldConfig<TFilters, keyof TFilters>
+  | OrderStatusFilterFieldConfig<TFilters, keyof TFilters>
+  | PaymentStatusFilterFieldConfig<TFilters, keyof TFilters>
 
 export interface FilterBarConfig<TFilters> {
   search?: {

--- a/frontend/src/utils/__tests__/dashboardApiParams.test.ts
+++ b/frontend/src/utils/__tests__/dashboardApiParams.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveApiParams } from '../dashboardApiParams'
+import type { DashboardFilterBase } from '../dashboardApiParams'
+
+const baseFilter = (): DashboardFilterBase => ({
+  period: { key: 'this_month', from: null, to: null },
+  compareWith: null,
+})
+
+describe('resolveApiParams', () => {
+  it('passes fulfillmentStatus=fulfilled as-is (not as isFulfilled boolean)', () => {
+    const result = resolveApiParams({
+      ...baseFilter(),
+      fulfillmentStatus: 'fulfilled',
+    })
+    expect(result.fulfillmentStatus).toBe('fulfilled')
+    expect((result as { isFulfilled?: boolean }).isFulfilled).toBeUndefined()
+  })
+
+  it('passes fulfillmentStatus=unfulfilled as-is', () => {
+    const result = resolveApiParams({
+      ...baseFilter(),
+      fulfillmentStatus: 'unfulfilled',
+    })
+    expect(result.fulfillmentStatus).toBe('unfulfilled')
+  })
+
+  it('omits fulfillmentStatus when null', () => {
+    const result = resolveApiParams({
+      ...baseFilter(),
+      fulfillmentStatus: null,
+    })
+    expect(result.fulfillmentStatus).toBeUndefined()
+  })
+})

--- a/frontend/src/utils/dashboardApiParams.test.ts
+++ b/frontend/src/utils/dashboardApiParams.test.ts
@@ -141,31 +141,31 @@ describe('resolveApiParams', () => {
     expect(result.supplierId).toBe('550e8400-e29b-41d4-a716-446655440001')
   })
 
-  it('passes through isFulfilled=true when set', () => {
+  it('passes through fulfillmentStatus=fulfilled when set', () => {
     const result = resolveApiParams({
       period: { key: 'this_month', from: null, to: null },
       compareWith: null,
-      isFulfilled: 'true',
+      fulfillmentStatus: 'fulfilled',
     })
-    expect(result.isFulfilled).toBe(true)
+    expect(result.fulfillmentStatus).toBe('fulfilled')
   })
 
-  it('passes through isFulfilled=false when set', () => {
+  it('passes through fulfillmentStatus=unfulfilled when set', () => {
     const result = resolveApiParams({
       period: { key: 'this_month', from: null, to: null },
       compareWith: null,
-      isFulfilled: 'false',
+      fulfillmentStatus: 'unfulfilled',
     })
-    expect(result.isFulfilled).toBe(false)
+    expect(result.fulfillmentStatus).toBe('unfulfilled')
   })
 
-  it('omits isFulfilled when null', () => {
+  it('omits fulfillmentStatus when null', () => {
     const result = resolveApiParams({
       period: { key: 'this_month', from: null, to: null },
       compareWith: null,
-      isFulfilled: null,
+      fulfillmentStatus: null,
     })
-    expect(result.isFulfilled).toBeUndefined()
+    expect(result.fulfillmentStatus).toBeUndefined()
   })
 
   it('passes through status when set', () => {

--- a/frontend/src/utils/dashboardApiParams.ts
+++ b/frontend/src/utils/dashboardApiParams.ts
@@ -12,7 +12,7 @@ export interface DashboardResolvedApiParams {
   customerId?: string
   supplierId?: string
   status?: string
-  isFulfilled?: boolean
+  fulfillmentStatus?: string
   paymentStatus?: string
   categoryId?: string
   stockStatus?: string
@@ -23,7 +23,7 @@ export interface DashboardFilterBase {
   compareWith: DashboardCompare
   customerId?: string | null
   supplierId?: string | null
-  isFulfilled?: string | null
+  fulfillmentStatus?: string | null
   status?: string | null
   paymentStatus?: string | null
   categoryId?: string | null
@@ -80,18 +80,10 @@ export function resolveApiParams(filters: DashboardFilterBase): DashboardResolve
     ...base,
     ...(filters.customerId ? { customerId: filters.customerId } : {}),
     ...(filters.supplierId ? { supplierId: filters.supplierId } : {}),
-    ...(filters.isFulfilled !== null && filters.isFulfilled !== undefined
-      ? { isFulfilled: filters.isFulfilled === 'true' }
-      : {}),
-    ...(filters.status !== null && filters.status !== undefined ? { status: filters.status } : {}),
-    ...(filters.paymentStatus !== null && filters.paymentStatus !== undefined
-      ? { paymentStatus: filters.paymentStatus }
-      : {}),
-    ...(filters.categoryId !== null && filters.categoryId !== undefined
-      ? { categoryId: filters.categoryId }
-      : {}),
-    ...(filters.stockStatus !== null && filters.stockStatus !== undefined
-      ? { stockStatus: filters.stockStatus }
-      : {}),
+    ...(filters.fulfillmentStatus != null ? { fulfillmentStatus: filters.fulfillmentStatus } : {}),
+    ...(filters.status != null ? { status: filters.status } : {}),
+    ...(filters.paymentStatus != null ? { paymentStatus: filters.paymentStatus } : {}),
+    ...(filters.categoryId != null ? { categoryId: filters.categoryId } : {}),
+    ...(filters.stockStatus != null ? { stockStatus: filters.stockStatus } : {}),
   }
 }

--- a/frontend/src/utils/filterBar.url.ts
+++ b/frontend/src/utils/filterBar.url.ts
@@ -64,8 +64,13 @@ export function serializeFilters<TFilters extends object>(
     const key = effectiveKey(field, ns)
     const value = filters[field.field]
     const defaultValue = defaults[String(field.field)]
+    const isSingleValueField =
+      field.type === 'select' ||
+      field.type === 'customer' ||
+      field.type === 'order-status' ||
+      field.type === 'payment-status'
 
-    if (field.type === 'select') {
+    if (isSingleValueField) {
       if (value !== null && value !== undefined && value !== defaultValue) {
         orderedEntries.push([key, String(value)])
       }
@@ -130,14 +135,31 @@ export function parseFilters<TFilters extends object>(
     const key = effectiveKey(field, ns)
     const fieldKey = String(field.field)
     const defaultValue = defaults[fieldKey]
+    const isSingleValueField =
+      field.type === 'select' ||
+      field.type === 'customer' ||
+      field.type === 'order-status' ||
+      field.type === 'payment-status'
 
-    if (field.type === 'select') {
+    if (isSingleValueField) {
       const raw = searchParams.get(key)
       if (raw === null) {
         result[fieldKey] = defaultValue ?? null
-      } else {
+      } else if (field.type === 'select') {
+        // Validate against declared options so stale/hand-crafted URLs can't inject unknown values.
         const valid = field.options.find((option) => option.value === raw)
         result[fieldKey] = valid ? raw : (defaultValue ?? null)
+      } else if (field.type === 'order-status') {
+        // Fixed value set — validate to prevent bogus URL values reaching the API.
+        const VALID_ORDER_STATUS = ['fulfilled', 'unfulfilled']
+        result[fieldKey] = VALID_ORDER_STATUS.includes(raw) ? raw : (defaultValue ?? null)
+      } else if (field.type === 'payment-status') {
+        // Fixed value set — validate to prevent bogus URL values reaching the API.
+        const VALID_PAYMENT_STATUS = ['unpaid', 'partial', 'paid', 'overpaid']
+        result[fieldKey] = VALID_PAYMENT_STATUS.includes(raw) ? raw : (defaultValue ?? null)
+      } else {
+        // 'customer' — free-form UUID; no option list to validate against.
+        result[fieldKey] = raw
       }
       continue
     }


### PR DESCRIPTION
## Summary
- Add four standalone filter components (`FilterCustomer`, `FilterOrderStatus`, `FilterPaymentStatus`, `FilterCompare`) as first-class `FilterBarConfig` types, eliminating duplicated inline option arrays across pages
- Align all backend payment status APIs to canonical `unpaid | partial | paid | overpaid` values; Sales Analytics also migrates `isFulfilled: boolean` → `fulfillmentStatus: 'fulfilled' | 'unfulfilled'`
- Refactor `OrdersPage`, `SalesPage`, and `PurchasingPage` to use the new filter types; `FilterCustomer` self-fetches customer data so pages no longer call `useGetCustomersQuery` for filter options

## Test Plan
- [x] Backend: `cd backend && npx jest src/modules/sales/services/sales-analytics.service.spec.ts src/modules/purchasing/services/purchasing-analytics.service.spec.ts --no-coverage`
- [x] Frontend components: `cd frontend && npx vitest run src/components/filters/__tests__/`
- [x] Frontend pages: `cd frontend && npx vitest run src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx src/pages/sales/__tests__/SalesPage.filters.test.tsx src/pages/purchasing/__tests__/PurchasingPage.filters.test.tsx`
- [x] Type check: `cd frontend && npm run type-check`
- [x] Smoke test: filter by Payment=Overpaid on Sales Orders, Sales Overview, and Purchasing Overview — each should return only orders where payment exceeds the total amount

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)