### PR TITLE
refactor: remove pagination limit from supplier and customer endpoints

### DIFF
--- a/backend/src/modules/purchasing/controllers/supplier.controller.ts
+++ b/backend/src/modules/purchasing/controllers/supplier.controller.ts
@@ -62,17 +62,15 @@ export class SupplierController {
   }
 
   @Get()
-  @ApiOperation({ 
+  @ApiOperation({
     summary: 'Get all suppliers',
-    description: 'Retrieve suppliers with advanced filtering, searching, and pagination capabilities.'
+    description: 'Retrieve suppliers with advanced filtering and searching capabilities.'
   })
   @ApiResponse({
     status: 200,
     description: 'Suppliers retrieved successfully',
     type: SupplierListResponseDto,
   })
-  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number (default: 1)' })
-  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Items per page (default: 10, max: 100)' })
   @ApiQuery({ name: 'search', required: false, type: String, description: 'Search by company name, code, contact person, or email' })
   @ApiQuery({ name: 'type', required: false, enum: ['local', 'international'], description: 'Filter by supplier type' })
   @ApiQuery({ name: 'status', required: false, enum: ['active', 'inactive', 'suspended', 'blacklisted'], description: 'Filter by status' })

--- a/backend/src/modules/purchasing/dto/supplier.dto.ts
+++ b/backend/src/modules/purchasing/dto/supplier.dto.ts
@@ -10,11 +10,10 @@ import {
   MaxLength,
   MinLength,
   Min,
-  Max,
   IsDateString,
   IsUUID,
 } from 'class-validator';
-import { Type, Transform } from 'class-transformer';
+import { Transform } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional, PartialType } from '@nestjs/swagger';
 import { SupplierType } from '../../../database/entities/supplier.entity';
 
@@ -85,21 +84,6 @@ export class UpdateSupplierDto extends PartialType(CreateSupplierDto) {
 }
 
 export class SupplierQueryDto {
-  @ApiPropertyOptional({ description: 'Page number', default: 1 })
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  page?: number = 1;
-
-  @ApiPropertyOptional({ description: 'Items per page', default: 10 })
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  @Max(1000)
-  limit?: number = 10;
-
   @ApiPropertyOptional({ description: 'Search term' })
   @IsOptional()
   @IsString()
@@ -210,21 +194,6 @@ export class SupplierListResponseDto {
 
   @ApiProperty({ description: 'Total count' })
   total!: number;
-
-  @ApiProperty({ description: 'Current page' })
-  page!: number;
-
-  @ApiProperty({ description: 'Items per page' })
-  limit!: number;
-
-  @ApiProperty({ description: 'Total pages' })
-  totalPages!: number;
-
-  @ApiProperty({ description: 'Has next page' })
-  hasNext!: boolean;
-
-  @ApiProperty({ description: 'Has previous page' })
-  hasPrev!: boolean;
 }
 
 class SupplierAnalyticsDto {

--- a/backend/src/modules/purchasing/services/supplier.service.spec.ts
+++ b/backend/src/modules/purchasing/services/supplier.service.spec.ts
@@ -2,13 +2,38 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { SupplierService } from './supplier.service';
-import { Supplier } from '../../../database/entities/supplier.entity';
+import { Supplier, SupplierType } from '../../../database/entities/supplier.entity';
 import { AuditLogService } from '../../audit-logs/services';
 import { UserRole } from '../../../database/entities/user.entity';
 
-describe('SupplierService.searchGlobal', () => {
+describe('SupplierService', () => {
   let service: SupplierService;
   let supplierRepository: jest.Mocked<Repository<Supplier>>;
+
+  const createSupplier = (id: string, overrides: Partial<Supplier> = {}): Supplier =>
+    ({
+      id,
+      type: SupplierType.LOCAL,
+      companyName: `Supplier ${id}`,
+      contactPerson: `Contact ${id}`,
+      phone: '0123456789',
+      streetAddress: null,
+      city: null,
+      state: null,
+      postalCode: null,
+      country: null,
+      totalPurchases: 125.5,
+      totalOrders: 4,
+      averageOrderValue: 31.375,
+      lastPurchaseDate: null,
+      firstPurchaseDate: null,
+      notes: null,
+      isActive: true,
+      createdAt: new Date('2026-04-05T00:00:00.000Z'),
+      updatedAt: new Date('2026-04-05T00:00:00.000Z'),
+      deletedAt: null,
+      ...overrides,
+    }) as Supplier;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -31,34 +56,85 @@ describe('SupplierService.searchGlobal', () => {
     supplierRepository = module.get(getRepositoryToken(Supplier));
   });
 
-  it('exact supplier name match scores SCORE_EXACT_NAME + BOOST_SUPPLIER + BOOST_EXACT_MATCH', async () => {
-    supplierRepository.createQueryBuilder.mockReturnValue({
-      addSelect: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      orderBy: jest.fn().mockReturnThis(),
-      setParameter: jest.fn().mockReturnThis(),
-      take: jest.fn().mockReturnThis(),
-      getMany: jest.fn().mockResolvedValue([
-        {
-          id: 'sup-1',
-          companyName: 'Acme Supplies',
-          phone: '0123456789',
-        },
-      ]),
-    } as any);
+  describe('pagination removal', () => {
+    it('findAll returns all matching suppliers with total-only metadata', async () => {
+      const qb = {
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([createSupplier('1'), createSupplier('2')]),
+      };
+      supplierRepository.createQueryBuilder.mockReturnValue(qb as any);
 
-    const results = await service.searchGlobal('Acme Supplies', {
-      role: UserRole.ADMIN,
-    } as any);
+      const result = await service.findAll({ search: 'Supplier' });
 
-    expect(results[0]).toMatchObject({
-      type: 'supplier',
-      id: 'sup-1',
-      label: 'Acme Supplies',
-      description: '0123456789',
-      route: '/purchasing/suppliers/sup-1',
+      expect(qb.getMany).toHaveBeenCalled();
+      expect(result).toEqual({
+        suppliers: expect.arrayContaining([
+          expect.objectContaining({ id: '1', companyName: 'Supplier 1' }),
+          expect.objectContaining({ id: '2', companyName: 'Supplier 2' }),
+        ]),
+        total: 2,
+      });
     });
-    expect(results[0].score).toBe(122);
+
+    it('findDeleted returns all deleted suppliers without skip/take pagination', async () => {
+      const qb = {
+        withDeleted: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([
+          createSupplier('deleted-1', { deletedAt: new Date('2026-04-05T00:00:00.000Z') }),
+        ]),
+      };
+      supplierRepository.createQueryBuilder.mockReturnValue(qb as any);
+
+      const result = await service.findDeleted({});
+
+      expect(qb.skip).not.toHaveBeenCalled();
+      expect(qb.take).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        suppliers: [
+          expect.objectContaining({ id: 'deleted-1', companyName: 'Supplier deleted-1' }),
+        ],
+        total: 1,
+      });
+    });
+  });
+
+  describe('searchGlobal', () => {
+    it('exact supplier name match scores SCORE_EXACT_NAME + BOOST_SUPPLIER + BOOST_EXACT_MATCH', async () => {
+      supplierRepository.createQueryBuilder.mockReturnValue({
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([
+          {
+            id: 'sup-1',
+            companyName: 'Acme Supplies',
+            phone: '0123456789',
+          },
+        ]),
+      } as any);
+
+      const results = await service.searchGlobal('Acme Supplies', {
+        role: UserRole.ADMIN,
+      } as any);
+
+      expect(results[0]).toMatchObject({
+        type: 'supplier',
+        id: 'sup-1',
+        label: 'Acme Supplies',
+        description: '0123456789',
+        route: '/purchasing/suppliers/sup-1',
+      });
+      expect(results[0].score).toBe(122);
+    });
   });
 });

--- a/backend/src/modules/purchasing/services/supplier.service.ts
+++ b/backend/src/modules/purchasing/services/supplier.service.ts
@@ -157,11 +157,6 @@ export class SupplierService {
     return {
       suppliers: supplierDtos,
       total,
-      page: 1,
-      limit: total,
-      totalPages: 1,
-      hasNext: false,
-      hasPrev: false,
     };
   }
 
@@ -567,16 +562,11 @@ export class SupplierService {
     this.logger.log('Finding deleted suppliers');
 
     const {
-      page = 1,
-      limit = 10,
       search,
       type,
       sortBy = 'companyName',
       sortOrder = 'ASC',
     } = query;
-
-    const skip = (page - 1) * Math.min(limit, 100);
-    const take = Math.min(limit, 100);
 
     const queryBuilder = this.supplierRepository
       .createQueryBuilder('supplier')
@@ -595,27 +585,15 @@ export class SupplierService {
       queryBuilder.andWhere('supplier.type = :type', { type });
     }
 
-    // Count total
-    const total = await queryBuilder.getCount();
-
-    // Apply sorting and pagination
     const validSortFields = ['companyName', 'type', 'createdAt', 'deletedAt'];
     const sortField = validSortFields.includes(sortBy) ? sortBy : 'companyName';
     queryBuilder.orderBy(`supplier.${sortField}`, sortOrder as 'ASC' | 'DESC');
-    queryBuilder.skip(skip).take(take);
 
     const suppliers = await queryBuilder.getMany();
 
-    const totalPages = Math.ceil(total / take);
-
     return {
       suppliers: suppliers.map(supplier => this.mapToResponseDto(supplier)),
-      total,
-      page,
-      limit: take,
-      totalPages,
-      hasNext: page < totalPages,
-      hasPrev: page > 1,
+      total: suppliers.length,
     };
   }
 

--- a/backend/src/modules/sales/controllers/customer.controller.ts
+++ b/backend/src/modules/sales/controllers/customer.controller.ts
@@ -65,8 +65,6 @@ export class CustomerController {
   @ApiQuery({ name: 'isActive', required: false, type: Boolean, description: 'Filter by active status' })
   @ApiQuery({ name: 'sortBy', required: false, description: 'Sort field' })
   @ApiQuery({ name: 'sortOrder', required: false, enum: ['ASC', 'DESC'], description: 'Sort order' })
-  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number' })
-  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Items per page' })
   async getAllCustomers(@Query() query: QueryCustomersDto) {
     return this.customerService.findAll(query);
   }
@@ -90,8 +88,6 @@ export class CustomerController {
     type: [CustomerResponseDto],
   })
   @ApiQuery({ name: 'search', required: false, description: 'Search customers by name, email, or phone' })
-  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number' })
-  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Items per page' })
   async getDeletedCustomers(@Query() query: QueryCustomersDto) {
     return this.customerService.findDeleted(query);
   }

--- a/backend/src/modules/sales/dto/customer.dto.ts
+++ b/backend/src/modules/sales/dto/customer.dto.ts
@@ -4,8 +4,6 @@ import {
   IsOptional,
   IsEnum,
   MaxLength,
-  IsInt,
-  Min,
   Matches,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
@@ -250,26 +248,6 @@ export class QueryCustomersDto {
   @Transform(({ value }) => value?.toUpperCase())
   @IsEnum(['ASC', 'DESC'])
   sortOrder?: 'ASC' | 'DESC';
-
-  @ApiPropertyOptional({
-    description: 'Page number',
-    example: 1,
-  })
-  @IsOptional()
-  @IsInt()
-  @Min(1)
-  @Transform(({ value }) => parseInt(value))
-  page?: number;
-
-  @ApiPropertyOptional({
-    description: 'Items per page',
-    example: 20,
-  })
-  @IsOptional()
-  @IsInt()
-  @Min(1)
-  @Transform(({ value }) => parseInt(value))
-  limit?: number;
 }
 
 export class CustomerResponseDto {

--- a/backend/src/modules/sales/services/customer.service.spec.ts
+++ b/backend/src/modules/sales/services/customer.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CustomerService } from './customer.service';
-import { Customer } from '../../../database/entities/customer.entity';
+import { Customer, CustomerType } from '../../../database/entities/customer.entity';
 import { SalesOrder } from '../../../database/entities/sales-order.entity';
 import { Invoice } from '../../../database/entities/invoice.entity';
 import { AuditLogService } from '../../audit-logs/services';
@@ -13,6 +13,30 @@ describe('CustomerService', () => {
   let service: CustomerService;
   let customerRepository: jest.Mocked<Repository<Customer>>;
   const adminUser = { role: UserRole.ADMIN } as any;
+  const createCustomer = (id: string, overrides: Partial<Customer> = {}): Customer =>
+    ({
+      id,
+      type: CustomerType.BUSINESS,
+      name: `Customer ${id}`,
+      phone: '0123456789',
+      streetAddress: null,
+      city: null,
+      state: null,
+      postalCode: null,
+      country: null,
+      isActive: true,
+      priceListId: null,
+      priceList: null,
+      totalSales: 500,
+      totalOrders: 3,
+      lastPurchaseDate: null,
+      firstPurchaseDate: null,
+      notes: null,
+      createdAt: new Date('2026-04-05T00:00:00.000Z'),
+      updatedAt: new Date('2026-04-05T00:00:00.000Z'),
+      deletedAt: null,
+      ...overrides,
+    }) as Customer;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -48,6 +72,56 @@ describe('CustomerService', () => {
 
     service = module.get<CustomerService>(CustomerService);
     customerRepository = module.get(getRepositoryToken(Customer));
+  });
+
+  describe('pagination removal', () => {
+    it('findAll returns all matching customers with total-only metadata', async () => {
+      const qb = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([createCustomer('1'), createCustomer('2')]),
+      };
+      customerRepository.createQueryBuilder.mockReturnValue(qb as any);
+
+      const result = await service.findAll({ search: 'Customer' });
+
+      expect(qb.skip).not.toHaveBeenCalled();
+      expect(qb.take).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        data: expect.arrayContaining([
+          expect.objectContaining({ id: '1', name: 'Customer 1' }),
+          expect.objectContaining({ id: '2', name: 'Customer 2' }),
+        ]),
+        total: 2,
+      });
+    });
+
+    it('findDeleted returns all deleted customers without offset/limit pagination', async () => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        withDeleted: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        offset: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([
+          createCustomer('deleted-1', { deletedAt: new Date('2026-04-05T00:00:00.000Z') }),
+        ]),
+      };
+      customerRepository.createQueryBuilder.mockReturnValue(qb as any);
+
+      const result = await service.findDeleted({});
+
+      expect(qb.offset).not.toHaveBeenCalled();
+      expect(qb.limit).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        data: [expect.objectContaining({ id: 'deleted-1', name: 'Customer deleted-1' })],
+        total: 1,
+      });
+    });
   });
 
   describe('searchGlobal', () => {

--- a/backend/src/modules/sales/services/customer.service.ts
+++ b/backend/src/modules/sales/services/customer.service.ts
@@ -91,8 +91,6 @@ export class CustomerService {
       isActive,
       sortBy = 'name',
       sortOrder = 'ASC',
-      page = 1,
-      limit = 20,
     } = query;
 
     const where: FindOptionsWhere<Customer> = {};
@@ -126,17 +124,11 @@ export class CustomerService {
       queryBuilder.orderBy(`customer.${sortBy}`, sortOrder);
     }
 
-    // Apply pagination
-    queryBuilder.skip((page - 1) * limit).take(limit);
-
-    const [customers, total] = await queryBuilder.getManyAndCount();
+    const customers = await queryBuilder.getMany();
 
     return {
       data: customers.map(customer => this.mapToResponseDto(customer)),
-      total,
-      page,
-      limit,
-      totalPages: Math.ceil(total / limit),
+      total: customers.length,
     };
   }
 
@@ -217,8 +209,6 @@ export class CustomerService {
       search,
       sortBy = 'name',
       sortOrder = 'ASC',
-      page = 1,
-      limit = 20,
     } = query;
 
     const queryBuilder = this.customerRepository
@@ -241,17 +231,11 @@ export class CustomerService {
       queryBuilder.orderBy(`customer.${sortBy}`, sortOrder);
     }
 
-    // Add pagination
-    queryBuilder.offset((page - 1) * limit).limit(limit);
-
-    const [customers, total] = await queryBuilder.getManyAndCount();
+    const customers = await queryBuilder.getMany();
 
     return {
       data: customers.map(customer => this.mapToResponseDto(customer)),
-      total,
-      page,
-      limit,
-      totalPages: Math.ceil(total / limit),
+      total: customers.length,
     };
   }
 

--- a/frontend/src/components/filters/FilterCustomer.tsx
+++ b/frontend/src/components/filters/FilterCustomer.tsx
@@ -11,7 +11,7 @@ interface Props {
 export function FilterCustomer({ value, onChange }: Props) {
   const uid = useId()
   // isLoading kept intentionally — options will be empty until data arrives (acceptable UX)
-  const { data } = useGetCustomersQuery({ limit: 999999 })
+  const { data } = useGetCustomersQuery({})
   const options = (data?.data ?? []).map((customer) => ({
     value: customer.id,
     label: customer.name,

--- a/frontend/src/components/filters/FilterSupplier.tsx
+++ b/frontend/src/components/filters/FilterSupplier.tsx
@@ -11,7 +11,7 @@ interface Props {
 export function FilterSupplier({ value, onChange }: Props) {
   const uid = useId()
   // isLoading kept intentionally — options will be empty until data arrives (acceptable UX)
-  const { data } = useGetSuppliersQuery({ limit: 999999 })
+  const { data } = useGetSuppliersQuery({})
   const options = (data?.data ?? []).map((supplier) => ({
     value: supplier.id,
     label: supplier.companyName,

--- a/frontend/src/components/filters/__tests__/FilterCustomer.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterCustomer.test.tsx
@@ -7,7 +7,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { FilterCustomer } from '../FilterCustomer'
 
-vi.mock('@/store/api/salesApi', () => ({
+const { useGetCustomersQuery } = vi.hoisted(() => ({
   useGetCustomersQuery: vi.fn(() => ({
     data: {
       data: [
@@ -16,6 +16,10 @@ vi.mock('@/store/api/salesApi', () => ({
       ],
     },
   })),
+}))
+
+vi.mock('@/store/api/salesApi', () => ({
+  useGetCustomersQuery,
 }))
 
 function renderWithStore(ui: ReactElement) {
@@ -34,5 +38,10 @@ describe('FilterCustomer', () => {
     await userEvent.click(screen.getByRole('combobox'))
     expect(await screen.findByText('Amuro Ray')).toBeInTheDocument()
     expect(await screen.findByText('Char Aznable')).toBeInTheDocument()
+  })
+
+  it('requests customers without a limit override', () => {
+    renderWithStore(<FilterCustomer value={null} onChange={vi.fn()} />)
+    expect(useGetCustomersQuery).toHaveBeenCalledWith({})
   })
 })

--- a/frontend/src/components/filters/__tests__/FilterSupplier.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterSupplier.test.tsx
@@ -7,7 +7,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { FilterSupplier } from '../FilterSupplier'
 
-vi.mock('@/store/api/purchasingApi', () => ({
+const { useGetSuppliersQuery } = vi.hoisted(() => ({
   useGetSuppliersQuery: vi.fn(() => ({
     data: {
       data: [
@@ -16,6 +16,10 @@ vi.mock('@/store/api/purchasingApi', () => ({
       ],
     },
   })),
+}))
+
+vi.mock('@/store/api/purchasingApi', () => ({
+  useGetSuppliersQuery,
 }))
 
 function renderWithStore(ui: ReactElement) {
@@ -34,5 +38,10 @@ describe('FilterSupplier', () => {
     await userEvent.click(screen.getByRole('combobox'))
     expect(await screen.findByText('Anaheim Electronics')).toBeInTheDocument()
     expect(await screen.findByText('Zeonic')).toBeInTheDocument()
+  })
+
+  it('requests suppliers without a limit override', () => {
+    renderWithStore(<FilterSupplier value={null} onChange={vi.fn()} />)
+    expect(useGetSuppliersQuery).toHaveBeenCalledWith({})
   })
 })

--- a/frontend/src/pages/sales/CustomersPage.tsx
+++ b/frontend/src/pages/sales/CustomersPage.tsx
@@ -158,7 +158,6 @@ const CustomersPage: React.FC = () => {
             : undefined,
       sortBy: sortState.sortBy,
       sortOrder: sortState.sortOrder,
-      limit: 999999,
     }),
     [appliedFilters, sortState],
   )

--- a/frontend/src/pages/sales/PaymentsPage.tsx
+++ b/frontend/src/pages/sales/PaymentsPage.tsx
@@ -187,7 +187,7 @@ const PaymentsPage: React.FC = () => {
   const hasRestoredSelection = useRef(false)
   const selectedPaymentRef = useRef(selectedPayment)
   const previousPathnameRef = useRef(location.pathname)
-  const { data: customersData } = useGetCustomersQuery({ limit: 999999 })
+  const { data: customersData } = useGetCustomersQuery({})
   const customers = customersData?.data ?? []
   const presetCustomerId = (location.state as { customerId?: string } | null)?.customerId ?? null
 

--- a/frontend/src/pages/sales/__tests__/CustomersPage.filterbar.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CustomersPage.filterbar.test.tsx
@@ -69,4 +69,11 @@ describe('CustomersPage FilterBar', () => {
       expect.not.objectContaining({ isActive: expect.anything() }),
     )
   })
+
+  it('does not pass a limit override to the customers query', () => {
+    renderPage('/')
+    expect(useGetCustomersQuery).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ limit: expect.anything() }),
+    )
+  })
 })


### PR DESCRIPTION
## Summary

- remove `page`/`limit` from supplier and customer query DTOs and drop supplier pagination metadata from the backend response contract
- remove pagination logic from supplier deleted queries and customer active/deleted queries, with regression specs covering the new all-record behavior
- remove frontend `limit: 999999` query overrides from supplier/customer filters and `CustomersPage`, with tests asserting the hooks no longer send that param

Closes #294

## Verification

Passed:
- `cd backend && npx tsc --noEmit -p tsconfig.build.json`
- `cd backend && npx jest src/modules/purchasing/services/supplier.service.spec.ts --no-coverage`
- `cd backend && npx jest src/modules/purchasing --no-coverage`
- `cd backend && npx jest src/modules/sales/services/customer.service.spec.ts --no-coverage`
- `cd backend && npx jest src/modules/sales --no-coverage`
- `cd frontend && npx vitest run src/components/filters/__tests__/FilterSupplier.test.tsx src/components/filters/__tests__/FilterCustomer.test.tsx src/pages/sales/__tests__/CustomersPage.filterbar.test.tsx --reporter=verbose`
- `cd frontend && npm run type-check`
- `cd frontend && npx vitest run src/components/filters/ src/pages/sales/ --reporter=verbose`
- `cd backend && npm run lint`
- `cd backend && npm run test`
- `cd frontend && npm run lint`
- `cd frontend && npm run type-check`

Incomplete:
- `cd frontend && npm run test` did not finish after an extended run and was terminated manually; no failure output was emitted before termination
