### PR TITLE
fix: isActive filter no longer coerces null/empty-string to false

### DIFF
--- a/backend/src/modules/purchasing/dto/supplier.dto.spec.ts
+++ b/backend/src/modules/purchasing/dto/supplier.dto.spec.ts
@@ -1,0 +1,40 @@
+import { plainToInstance } from 'class-transformer';
+import { SupplierQueryDto } from './supplier.dto';
+
+describe('SupplierQueryDto', () => {
+  function make(raw: Record<string, unknown> = {}): SupplierQueryDto {
+    return plainToInstance(SupplierQueryDto, raw);
+  }
+
+  describe('isActive transform', () => {
+    it('returns undefined when isActive is not provided', () => {
+      const dto = make({});
+      expect(dto.isActive).toBeUndefined();
+    });
+
+    it('returns true when isActive is the string "true"', () => {
+      const dto = make({ isActive: 'true' });
+      expect(dto.isActive).toBe(true);
+    });
+
+    it('returns false when isActive is the string "false"', () => {
+      const dto = make({ isActive: 'false' });
+      expect(dto.isActive).toBe(false);
+    });
+
+    it('returns true when isActive is the boolean true', () => {
+      const dto = make({ isActive: true });
+      expect(dto.isActive).toBe(true);
+    });
+
+    it('returns undefined when isActive is an empty string', () => {
+      const dto = make({ isActive: '' });
+      expect(dto.isActive).toBeUndefined();
+    });
+
+    it('returns undefined when isActive is null', () => {
+      const dto = make({ isActive: null });
+      expect(dto.isActive).toBeUndefined();
+    });
+  });
+});

--- a/backend/src/modules/purchasing/dto/supplier.dto.ts
+++ b/backend/src/modules/purchasing/dto/supplier.dto.ts
@@ -96,7 +96,10 @@ export class SupplierQueryDto {
 
   @ApiPropertyOptional({ description: 'Filter active suppliers only' })
   @IsOptional()
-  @Transform(({ value }) => value === 'true' || value === true)
+  @Transform(({ value }) => {
+    if (value === undefined || value === null || value === '') return undefined;
+    return value === 'true' || value === true;
+  })
   @IsBoolean()
   isActive?: boolean;
 

--- a/backend/src/modules/sales/dto/customer.dto.spec.ts
+++ b/backend/src/modules/sales/dto/customer.dto.spec.ts
@@ -1,0 +1,40 @@
+import { plainToInstance } from 'class-transformer';
+import { QueryCustomersDto } from './customer.dto';
+
+describe('QueryCustomersDto', () => {
+  function make(raw: Record<string, unknown> = {}): QueryCustomersDto {
+    return plainToInstance(QueryCustomersDto, raw);
+  }
+
+  describe('isActive transform', () => {
+    it('returns undefined when isActive is not provided', () => {
+      const dto = make({});
+      expect(dto.isActive).toBeUndefined();
+    });
+
+    it('returns true when isActive is the string "true"', () => {
+      const dto = make({ isActive: 'true' });
+      expect(dto.isActive).toBe(true);
+    });
+
+    it('returns false when isActive is the string "false"', () => {
+      const dto = make({ isActive: 'false' });
+      expect(dto.isActive).toBe(false);
+    });
+
+    it('returns true when isActive is the boolean true', () => {
+      const dto = make({ isActive: true });
+      expect(dto.isActive).toBe(true);
+    });
+
+    it('returns undefined when isActive is an empty string', () => {
+      const dto = make({ isActive: '' });
+      expect(dto.isActive).toBeUndefined();
+    });
+
+    it('returns undefined when isActive is null', () => {
+      const dto = make({ isActive: null });
+      expect(dto.isActive).toBeUndefined();
+    });
+  });
+});

--- a/backend/src/modules/sales/dto/customer.dto.ts
+++ b/backend/src/modules/sales/dto/customer.dto.ts
@@ -228,7 +228,10 @@ export class QueryCustomersDto {
   })
   @IsOptional()
   @IsBoolean()
-  @Transform(({ value }) => value === 'true' || value === true)
+  @Transform(({ value }) => {
+    if (value === undefined || value === null || value === '') return undefined;
+    return value === 'true' || value === true;
+  })
   isActive?: boolean;
 
   @ApiPropertyOptional({


### PR DESCRIPTION
## Summary
- `SupplierQueryDto` and `QueryCustomersDto` `isActive` transforms now return `undefined` for `null` and empty-string inputs instead of coercing them to `false`
- Adds regression specs for both DTOs covering omitted, `null`, empty-string, `'true'`, `'false'`, and boolean `true` inputs

## Test Plan
- [x] `cd backend && npx jest src/modules/purchasing/dto/supplier.dto.spec.ts --no-coverage` — 6 tests pass
- [x] `cd backend && npx jest src/modules/sales/dto/customer.dto.spec.ts --no-coverage` — 6 tests pass
- [x] `GET /api/purchasing/suppliers` (no params) returns active suppliers
- [x] `GET /api/sales/customers` (no params) returns active customers

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)