### PR TITLE
feat(purchasing): add period, paymentStatus, and status filters to Purchase Orders FilterBar

### DIFF
--- a/backend/src/modules/purchasing/dto/purchase-order.dto.ts
+++ b/backend/src/modules/purchasing/dto/purchase-order.dto.ts
@@ -132,6 +132,16 @@ export class PurchaseOrderQueryDto {
   @IsDateString()
   orderDateTo?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by GRN status', enum: ['draft', 'received'] })
+  @IsOptional()
+  @IsEnum(['draft', 'received'])
+  status?: 'draft' | 'received';
+
+  @ApiPropertyOptional({ description: 'Filter by payment status', enum: ['unpaid', 'partial', 'paid', 'overpaid'] })
+  @IsOptional()
+  @IsEnum(['unpaid', 'partial', 'paid', 'overpaid'])
+  paymentStatus?: 'unpaid' | 'partial' | 'paid' | 'overpaid';
+
   @ApiPropertyOptional({ description: 'Sort by field', default: 'orderDate' })
   @IsOptional()
   @IsString()

--- a/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
@@ -316,6 +316,146 @@ describe('PurchaseOrderService', () => {
     });
   });
 
+  describe('findAll', () => {
+    function createFindAllQueryBuilder(orders: PurchaseOrder[] = []) {
+      return {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getCount: jest.fn().mockResolvedValue(orders.length),
+        getMany: jest.fn().mockResolvedValue(orders),
+      };
+    }
+
+    function createFindAllOrder(overrides: Partial<PurchaseOrder> = {}): PurchaseOrder {
+      return {
+        id: 'po-findall-1',
+        orderNumber: 'PO-000101',
+        orderDate: new Date('2026-04-01'),
+        subtotal: 100,
+        discountPercent: 0,
+        discountAmount: 0,
+        shippingAmount: 0,
+        totalAmount: 100,
+        paidAmount: 0,
+        notes: '',
+        supplier: {
+          id: 'supplier-1',
+          companyName: 'Supplier A',
+        },
+        items: [],
+        goodsReceivedNotes: [],
+        vendorPayments: [],
+        isFullyReceived: jest.fn().mockReturnValue(false),
+        getTotalReceivedQuantity: jest.fn().mockReturnValue(0),
+        getTotalOrderedQuantity: jest.fn().mockReturnValue(0),
+        ...overrides,
+      } as unknown as PurchaseOrder;
+    }
+
+    it('adds unpaid paymentStatus filter', async () => {
+      const queryBuilder = createFindAllQueryBuilder([
+        createFindAllOrder({ paidAmount: 0, totalAmount: 100 }),
+      ]);
+      purchaseOrderRepository.createQueryBuilder.mockReturnValue(queryBuilder as any);
+
+      const result = await service.findAll({ paymentStatus: 'unpaid' });
+
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+        '(po.paidAmount = 0 OR po.paidAmount IS NULL)',
+      );
+      result.orders.forEach((order) => {
+        expect(Number(order.paidAmount)).toBe(0);
+      });
+    });
+
+    it('adds partial paymentStatus filter', async () => {
+      const queryBuilder = createFindAllQueryBuilder([
+        createFindAllOrder({ paidAmount: 40, totalAmount: 100 }),
+      ]);
+      purchaseOrderRepository.createQueryBuilder.mockReturnValue(queryBuilder as any);
+
+      const result = await service.findAll({ paymentStatus: 'partial' });
+
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+        'po.paidAmount > 0 AND po.paidAmount < po.totalAmount',
+      );
+      result.orders.forEach((order) => {
+        expect(Number(order.paidAmount)).toBeGreaterThan(0);
+        expect(Number(order.paidAmount)).toBeLessThan(Number(order.totalAmount));
+      });
+    });
+
+    it('adds paid paymentStatus filter', async () => {
+      const queryBuilder = createFindAllQueryBuilder([
+        createFindAllOrder({ paidAmount: 100, totalAmount: 100 }),
+      ]);
+      purchaseOrderRepository.createQueryBuilder.mockReturnValue(queryBuilder as any);
+
+      const result = await service.findAll({ paymentStatus: 'paid' });
+
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+        'po.paidAmount >= po.totalAmount AND po.paidAmount > 0',
+      );
+      result.orders.forEach((order) => {
+        expect(Number(order.paidAmount)).toBeGreaterThanOrEqual(Number(order.totalAmount));
+      });
+    });
+
+    it('adds overpaid paymentStatus filter', async () => {
+      const queryBuilder = createFindAllQueryBuilder([
+        createFindAllOrder({ paidAmount: 120, totalAmount: 100 }),
+      ]);
+      purchaseOrderRepository.createQueryBuilder.mockReturnValue(queryBuilder as any);
+
+      const result = await service.findAll({ paymentStatus: 'overpaid' });
+
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith('po.paidAmount > po.totalAmount');
+      result.orders.forEach((order) => {
+        expect(Number(order.paidAmount)).toBeGreaterThan(Number(order.totalAmount));
+      });
+    });
+
+    it('adds draft status filter', async () => {
+      const queryBuilder = createFindAllQueryBuilder([
+        createFindAllOrder({
+          goodsReceivedNotes: [{ id: 'grn-1', grnNumber: 'GRN-1', status: GrnStatus.DRAFT, receivedDate: new Date('2026-04-01') }] as any,
+        }),
+      ]);
+      purchaseOrderRepository.createQueryBuilder.mockReturnValue(queryBuilder as any);
+
+      const result = await service.findAll({ status: 'draft' });
+
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith('grns.status = :grnStatus', {
+        grnStatus: 'draft',
+      });
+      result.orders.forEach((order) => {
+        expect(order.goodsReceivedNotes?.[0]?.status).toBe('draft');
+      });
+    });
+
+    it('adds received status filter', async () => {
+      const queryBuilder = createFindAllQueryBuilder([
+        createFindAllOrder({
+          goodsReceivedNotes: [{ id: 'grn-2', grnNumber: 'GRN-2', status: GrnStatus.RECEIVED, receivedDate: new Date('2026-04-02') }] as any,
+        }),
+      ]);
+      purchaseOrderRepository.createQueryBuilder.mockReturnValue(queryBuilder as any);
+
+      const result = await service.findAll({ status: 'received' });
+
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith('grns.status = :grnStatus', {
+        grnStatus: 'received',
+      });
+      result.orders.forEach((order) => {
+        expect(order.goodsReceivedNotes?.[0]?.status).toBe('received');
+      });
+    });
+  });
+
   describe('receiveGoods', () => {
     it('posts accounting entry after receiving goods', async () => {
       grnRepository.findOne

--- a/backend/src/modules/purchasing/services/purchase-order.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.ts
@@ -264,6 +264,8 @@ export class PurchaseOrderService {
       supplierId,
       orderDateFrom,
       orderDateTo,
+      status,
+      paymentStatus,
       sortBy = 'orderDate',
       sortOrder = 'DESC',
     } = query;
@@ -301,6 +303,31 @@ export class PurchaseOrderService {
       queryBuilder.andWhere('po.orderDate <= :orderDateTo', {
         orderDateTo: new Date(orderDateTo)
       });
+    }
+
+    if (paymentStatus) {
+      switch (paymentStatus) {
+        case 'unpaid':
+          queryBuilder.andWhere('(po.paidAmount = 0 OR po.paidAmount IS NULL)');
+          break;
+        case 'partial':
+          queryBuilder.andWhere(
+            'po.paidAmount > 0 AND po.paidAmount < po.totalAmount',
+          );
+          break;
+        case 'paid':
+          queryBuilder.andWhere(
+            'po.paidAmount >= po.totalAmount AND po.paidAmount > 0',
+          );
+          break;
+        case 'overpaid':
+          queryBuilder.andWhere('po.paidAmount > po.totalAmount');
+          break;
+      }
+    }
+
+    if (status) {
+      queryBuilder.andWhere('grns.status = :grnStatus', { grnStatus: status });
     }
 
     // Apply sorting

--- a/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
@@ -27,11 +27,15 @@ import {
   useReturnGoodsMutation,
 } from '@/store/api/purchasingApi'
 import { selectSelectedPurchaseOrder } from '@/store/slices/purchasingSlice'
-import type { FilterBarConfig } from '@/types/filterBar.types'
+import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
+import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
 
 interface PurchaseOrderFilters {
   search: string
   supplierId: string | null
+  paymentStatus: 'unpaid' | 'partial' | 'paid' | 'overpaid' | null
+  period: PeriodValue
+  status: 'draft' | 'received' | null
 }
 
 export const PurchaseOrdersPage: React.FC = () => {
@@ -49,27 +53,62 @@ export const PurchaseOrdersPage: React.FC = () => {
       search: { placeholder: 'Search purchase orders...' },
       fields: [
         {
+          field: 'period',
+          label: 'Period',
+          type: 'period',
+        },
+        {
           field: 'supplierId',
           label: 'Supplier',
           type: 'supplier',
+        },
+        {
+          field: 'paymentStatus',
+          label: 'Payment',
+          type: 'payment-status',
+        },
+        {
+          field: 'status',
+          label: 'Order Status',
+          type: 'purchasing-status',
         },
       ],
       defaults: {
         search: '',
         supplierId: null,
+        paymentStatus: null,
+        period: { key: null, from: null, to: null },
+        status: null,
       },
     }),
     [],
   )
 
   const filterBar = useFilterBar(filterConfig)
+  const weekStartsOn = getStartOfWeek()
+  const dateRange = useMemo(() => {
+    const period = filterBar.appliedFilters.period
+    if (!period || period.key === null) {
+      return { fromDate: undefined, toDate: undefined }
+    }
+    if (period.key === 'custom') {
+      return { fromDate: period.from ?? undefined, toDate: period.to ?? undefined }
+    }
+
+    const range = getPeriodDateRange(period.key, weekStartsOn)
+    return { fromDate: range.from, toDate: range.to }
+  }, [filterBar.appliedFilters.period, weekStartsOn])
 
   const queryParams = useMemo(() => ({
     sortBy: pageState.sorting.sortBy,
     sortOrder: pageState.sorting.sortOrder.toUpperCase(),
     search: filterBar.appliedFilters.search || undefined,
     supplierId: filterBar.appliedFilters.supplierId || undefined,
-  }), [filterBar.appliedFilters, pageState.sorting.sortBy, pageState.sorting.sortOrder])
+    paymentStatus: filterBar.appliedFilters.paymentStatus || undefined,
+    status: filterBar.appliedFilters.status || undefined,
+    orderDateFrom: dateRange.fromDate,
+    orderDateTo: dateRange.toDate,
+  }), [dateRange, filterBar.appliedFilters, pageState.sorting.sortBy, pageState.sorting.sortOrder])
 
   const {
     data: purchaseOrdersResponse,


### PR DESCRIPTION
Closes #299

## Summary
- Extended `PurchaseOrderQueryDto` with optional `status` (`draft`|`received`) and `paymentStatus` (`unpaid`|`partial`|`paid`|`overpaid`) fields
- Added filter clauses in `PurchaseOrderService.findAll` — payment status compares `paidAmount`/`totalAmount`, GRN status matches the already-joined `grns.status`
- Updated `PurchaseOrdersPage` to match the Sales Orders filter bar pattern: `period`, `supplierId`, `paymentStatus`, `status` fields with period-to-date-range mapping
- Updated `FilterPurchasingStatus` options from `pending`/`received` to `draft`/`received` to match `GrnStatus` enum

## Test Plan
- [x] Backend: `npx jest src/modules/purchasing/services/purchase-order.service.spec.ts --no-coverage` passes
- [x] Backend: `npm run test` passes
- [x] Frontend: `npm run type-check` passes
- [x] Frontend: `npx vitest run src/components/filters/__tests__/FilterPurchasingStatus.test.tsx` passes
- [x] Frontend: `npx vitest run src/components/filters/__tests__/FilterBar.test.tsx` passes
- [x] Smoke test: Purchase Orders page shows Period, Supplier, Payment, Order Status filters; each filters correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)