### PR TITLE
feat(sales): Customers page UI modernization to match Sales Orders patterns

### DIFF
--- a/frontend/src/pages/sales/CustomersPage.tsx
+++ b/frontend/src/pages/sales/CustomersPage.tsx
@@ -1,12 +1,10 @@
-import React, { useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Alert, Box, useMediaQuery, useTheme } from '@mui/material'
 import { useNavigate } from 'react-router-dom'
 
-import ConfirmationDialog from '@/components/common/ConfirmationDialog'
 import MasterDetailWorkspace from '@/components/common/MasterDetailWorkspace'
 import PageHeader from '@/components/common/PageHeader'
 import { FilterBar } from '@/components/filters'
-import DeletedCustomersDialog from '@/components/sales/DeletedCustomersDialog'
 import { useFilterBar } from '@/hooks/useFilterBar'
 import { useNotification } from '@/hooks/useNotification'
 import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
@@ -15,6 +13,7 @@ import { useGetCustomersQuery } from '@/store/api/salesApi'
 import { selectSelectedCustomer } from '@/store/slices/salesSlice'
 import type { FilterBarConfig } from '@/types/filterBar.types'
 import CustomerContextHeader from './components/CustomerContextHeader'
+import CustomersDialogs from './components/CustomersDialogs'
 import CustomerList from './components/CustomerList'
 import CustomerWorkspaceCard from './components/CustomerWorkspaceCard'
 import { useCustomersActions } from './hooks/useCustomersActions'
@@ -36,6 +35,8 @@ const CustomersPage: React.FC = () => {
   const [pageError, setPageError] = useState<string | null>(null)
 
   const pageState = useCustomersPageState()
+  const [sortBy, setSortBy] = useState('name')
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
 
   const filterConfig = useMemo<FilterBarConfig<CustomerFilters>>(
     () => ({
@@ -58,6 +59,19 @@ const CustomersPage: React.FC = () => {
 
   const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
 
+  const handleSort = useCallback((field: string) => {
+    setSortOrder((prev) => (sortBy === field && prev === 'desc' ? 'asc' : 'desc'))
+    setSortBy(field)
+  }, [sortBy])
+
+  const filterHandlers = useMemo(() => ({
+    ...handlers,
+    onSearchChange: (value: string) => {
+      pageState.setShouldPreserveSearchFocus(true)
+      handlers.onSearchChange(value)
+    },
+  }), [handlers, pageState])
+
   const customerQueryParams = useMemo(
     () => ({
       search: appliedFilters.search || undefined,
@@ -67,15 +81,28 @@ const CustomersPage: React.FC = () => {
           : appliedFilters.status === 'inactive'
             ? false
             : undefined,
-      sortBy: 'name',
-      sortOrder: 'ASC' as const,
+      sortBy,
+      sortOrder: sortOrder.toUpperCase() as 'ASC' | 'DESC',
     }),
-    [appliedFilters],
+    [appliedFilters, sortBy, sortOrder],
   )
 
   const { data: customersResponse, isLoading, isFetching, error, refetch } = useGetCustomersQuery(customerQueryParams)
   const customers = customersResponse?.data ?? []
   const loading = isLoading || isFetching
+
+  useEffect(() => {
+    if (pageState.shouldPreserveSearchFocus && pageState.searchInputRef.current && document.activeElement !== pageState.searchInputRef.current) {
+      const timer = setTimeout(() => {
+        pageState.searchInputRef.current?.focus()
+        pageState.setShouldPreserveSearchFocus(false)
+      }, 0)
+      return () => clearTimeout(timer)
+    }
+    if (pageState.shouldPreserveSearchFocus) {
+      pageState.setShouldPreserveSearchFocus(false)
+    }
+  }, [loading, pageState])
 
   const selection = useCustomersSelection({
     dispatch,
@@ -128,9 +155,10 @@ const CustomersPage: React.FC = () => {
           <FilterBar
             config={filterConfig}
             draftFilters={draftFilters}
-            handlers={handlers}
+            handlers={filterHandlers}
             hasActiveFilters={hasActiveFilters}
             searchInputRef={pageState.searchInputRef}
+            sort={{ field: 'name', sortBy, sortOrder, onSort: handleSort }}
           />
         )}
       />
@@ -147,35 +175,30 @@ const CustomersPage: React.FC = () => {
           <CustomerList
             customers={customers}
             loading={loading}
+            total={customers.length}
             selectedCustomerId={selectedCustomer?.id}
             focusedIndex={pageState.focusedCustomerIndex}
             onSelect={selection.handleCustomerSelect}
-            listRef={pageState.customerListRef}
+            customerListRef={pageState.customerListRef}
           />
         )}
         headerSlot={(
           <CustomerContextHeader
             selectedCustomer={selectedCustomer}
+            onEdit={() => navigate(`/sales/customers/${selectedCustomer!.id}/edit`)}
             onDelete={() => pageState.setDeleteConfirmOpen(true)}
           />
         )}
         workspaceSlot={<CustomerWorkspaceCard selectedCustomer={selectedCustomer} />}
       />
 
-      <ConfirmationDialog
-        open={pageState.deleteConfirmOpen}
-        title="Confirm Delete"
-        message={`Are you sure you want to delete "${selectedCustomer?.name}"? This will move it to deleted items.`}
-        confirmText="Delete Customer"
-        cancelText="Cancel"
-        onConfirm={actions.handleDelete}
-        onCancel={actions.handleCancelDelete}
-        severity="warning"
-      />
-
-      <DeletedCustomersDialog
-        open={pageState.deletedCustomersDialogOpen}
-        onClose={() => pageState.setDeletedCustomersDialogOpen(false)}
+      <CustomersDialogs
+        selectedCustomer={selectedCustomer}
+        deleteConfirmOpen={pageState.deleteConfirmOpen}
+        onConfirmDelete={actions.handleDelete}
+        onCancelDelete={actions.handleCancelDelete}
+        deletedCustomersDialogOpen={pageState.deletedCustomersDialogOpen}
+        onCloseDeletedCustomersDialog={() => pageState.setDeletedCustomersDialogOpen(false)}
       />
     </Box>
   )

--- a/frontend/src/pages/sales/__tests__/CustomersPage.filter.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CustomersPage.filter.test.tsx
@@ -54,7 +54,7 @@ vi.mock('../components/CustomerContextHeader', () => ({
 }))
 
 vi.mock('../components/CustomerList', () => ({
-  default: ({ customers, onSelect }: any) => (
+  default: ({ customers, onSelect, total: _total }: any) => (
     <div data-testid="customer-list">
       {customers.map((customer: any) => (
         <div key={customer.id} data-testid={`customer-item-${customer.id}`} onClick={() => onSelect(customer)}>
@@ -94,6 +94,8 @@ vi.mock('../hooks/useCustomersPageState', () => ({
     setDeletedCustomersDialogOpen: vi.fn(),
     focusedCustomerIndex: -1,
     setFocusedCustomerIndex: vi.fn(),
+    shouldPreserveSearchFocus: false,
+    setShouldPreserveSearchFocus: vi.fn(),
     customerListRef: { current: null },
     searchInputRef: { current: null },
   }),

--- a/frontend/src/pages/sales/__tests__/CustomersPage.filterbar.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CustomersPage.filterbar.test.tsx
@@ -62,7 +62,7 @@ vi.mock('../components/CustomerContextHeader', () => ({
 }))
 
 vi.mock('../components/CustomerList', () => ({
-  default: ({ customers, onSelect }: any) => (
+  default: ({ customers, onSelect, total: _total }: any) => (
     <div data-testid="customer-list">
       {customers.map((customer: any) => (
         <div key={customer.id} data-testid={`customer-item-${customer.id}`} onClick={() => onSelect(customer)}>
@@ -102,6 +102,8 @@ vi.mock('../hooks/useCustomersPageState', () => ({
     setDeletedCustomersDialogOpen: vi.fn(),
     focusedCustomerIndex: -1,
     setFocusedCustomerIndex: vi.fn(),
+    shouldPreserveSearchFocus: false,
+    setShouldPreserveSearchFocus: vi.fn(),
     customerListRef: { current: null },
     searchInputRef: { current: null },
   }),

--- a/frontend/src/pages/sales/components/CustomerContextHeader.tsx
+++ b/frontend/src/pages/sales/components/CustomerContextHeader.tsx
@@ -1,65 +1,161 @@
 import React from 'react'
-import { Box, Button, Chip, Typography } from '@mui/material'
 import {
   Delete as DeleteIcon,
   Edit as EditIcon,
 } from '@mui/icons-material'
-import { useNavigate } from 'react-router-dom'
+import {
+  Box,
+  Chip,
+  IconButton,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+} from '@mui/material'
 
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { Customer } from '@/types'
 import { CustomerType } from '@/types'
 
 interface CustomerContextHeaderProps {
   selectedCustomer: Customer | null
+  onEdit: () => void
   onDelete: () => void
+}
+
+const actionIconSx = {
+  height: `${TABLE_STYLES.row.height * 0.75}px`,
+  width: `${TABLE_STYLES.row.height * 0.75}px`,
+  minHeight: 20,
+  minWidth: 20,
+  p: 0.125,
+}
+
+const detailTableSx = {
+  tableLayout: 'fixed',
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const labelCellSx = {
+  fontWeight: 600,
+  color: 'text.secondary',
+  fontSize: '0.8rem',
+}
+
+const valueCellSx = {
+  fontSize: '0.8rem',
 }
 
 const CustomerContextHeader: React.FC<CustomerContextHeaderProps> = ({
   selectedCustomer,
+  onEdit,
   onDelete,
 }) => {
-  const navigate = useNavigate()
-
   if (!selectedCustomer) {
     return (
-      <Box sx={{ p: 2, color: 'text.secondary' }}>
-        <Typography variant="body2">Select a customer from the list</Typography>
-      </Box>
+      <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
+        <Typography variant="h6" color="text.secondary">
+          Select a customer to view details
+        </Typography>
+      </Paper>
     )
   }
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 1 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-        <Typography variant="h6" fontWeight={600} noWrap>
-          {selectedCustomer.name}
+    <Paper sx={{ overflow: 'hidden' }}>
+      <Box
+        sx={{
+          p: TABLE_STYLES.cell.padding.px,
+          borderBottom: TABLE_STYLES.cell.border,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Typography
+          variant="tableHeader"
+          sx={{
+            fontWeight: 600,
+            fontSize: '0.8rem',
+            textTransform: 'uppercase',
+            letterSpacing: '0.5px',
+          }}
+        >
+          Customer - {selectedCustomer.name}
         </Typography>
-        <Chip
-          label={selectedCustomer.type === CustomerType.BUSINESS ? 'Business' : 'Individual'}
-          size="small"
-          variant="outlined"
-        />
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+          <IconButton size="small" title="Edit Customer" onClick={onEdit} sx={{ ...actionIconSx, color: 'primary.main' }}>
+            <EditIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
+          </IconButton>
+          <IconButton size="small" title="Delete Customer" onClick={onDelete} sx={{ ...actionIconSx, color: 'error.main' }}>
+            <DeleteIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
+          </IconButton>
+        </Box>
       </Box>
-      <Box sx={{ display: 'flex', gap: 1 }}>
-        <Button
-          size="small"
-          variant="outlined"
-          startIcon={<EditIcon />}
-          onClick={() => navigate(`/sales/customers/${selectedCustomer.id}/edit`)}
-        >
-          Edit
-        </Button>
-        <Button
-          size="small"
-          variant="outlined"
-          color="error"
-          startIcon={<DeleteIcon />}
-          onClick={onDelete}
-        >
-          Delete
-        </Button>
+
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <TableContainer>
+          <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+            <TableBody>
+              <TableRow>
+                <TableCell colSpan={2} sx={{ pb: TABLE_STYLES.cell.padding.py * 0.67, py: TABLE_STYLES.cell.padding.py * 0.67, borderTop: TABLE_STYLES.cell.border }}>
+                  <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                    Customer Information
+                  </Typography>
+                </TableCell>
+              </TableRow>
+              <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                <TableCell sx={labelCellSx}>Type</TableCell>
+                <TableCell sx={valueCellSx}>
+                  <Chip
+                    label={selectedCustomer.type === CustomerType.BUSINESS ? 'Business' : 'Individual'}
+                    size="small"
+                    variant="outlined"
+                    sx={{ fontSize: '0.75rem' }}
+                  />
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell sx={labelCellSx}>Status</TableCell>
+                <TableCell sx={valueCellSx}>
+                  <Chip
+                    label={selectedCustomer.isActive ? 'Active' : 'Inactive'}
+                    size="small"
+                    color={selectedCustomer.isActive ? 'success' : 'default'}
+                    sx={{ fontSize: '0.75rem' }}
+                  />
+                </TableCell>
+              </TableRow>
+              <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                <TableCell sx={labelCellSx}>Phone</TableCell>
+                <TableCell sx={valueCellSx}>{selectedCustomer.phone || '—'}</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell sx={labelCellSx}>Email</TableCell>
+                <TableCell sx={valueCellSx}>{selectedCustomer.email || '—'}</TableCell>
+              </TableRow>
+              <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                <TableCell sx={labelCellSx}>Price List</TableCell>
+                <TableCell sx={valueCellSx}>
+                  {selectedCustomer.priceList
+                    ? <Chip label={selectedCustomer.priceList.name} size="small" sx={{ fontSize: '0.75rem' }} />
+                    : '—'}
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </TableContainer>
       </Box>
-    </Box>
+    </Paper>
   )
 }
 

--- a/frontend/src/pages/sales/components/CustomerList.tsx
+++ b/frontend/src/pages/sales/components/CustomerList.tsx
@@ -1,70 +1,162 @@
-import React from 'react'
-import { Box, List, ListItemButton, ListItemText, Typography } from '@mui/material'
+import React, { memo } from 'react'
+import {
+  Box,
+  Paper,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+} from '@mui/material'
 
-import { ListSkeleton } from '@/components/common/ListSkeleton'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { Customer } from '@/types'
+
+interface CustomerRowProps {
+  customer: Customer
+  index: number
+  selectedCustomerId: string | undefined
+  focusedIndex: number
+  onSelect: (customer: Customer) => void
+}
+
+const CustomerRow = memo(({ customer, index, selectedCustomerId, focusedIndex, onSelect }: CustomerRowProps) => {
+  const isSelected = selectedCustomerId === customer.id
+  const isFocused = index === focusedIndex
+
+  return (
+    <TableRow
+      hover
+      onClick={() => onSelect(customer)}
+      data-customer-index={index}
+      sx={{
+        cursor: 'pointer',
+        backgroundColor: isSelected ? 'action.selected' : isFocused ? 'action.focus' : 'inherit',
+        '&:hover': {
+          backgroundColor: isSelected ? 'action.selected' : 'action.hover',
+        },
+        transition: 'background-color 0.2s ease',
+        height: TABLE_STYLES.row.height,
+        ...(isFocused && {
+          outline: '2px solid',
+          outlineColor: 'primary.main',
+          outlineOffset: '-2px',
+        }),
+      }}
+    >
+      <TableCell>
+        <Typography
+          variant="body2"
+          sx={{
+            fontWeight: 400,
+            fontSize: '0.8rem',
+            lineHeight: 1.2,
+          }}
+        >
+          {customer.name}
+        </Typography>
+      </TableCell>
+    </TableRow>
+  )
+})
+
+CustomerRow.displayName = 'CustomerRow'
 
 interface CustomerListProps {
   customers: Customer[]
   loading: boolean
+  total: number
   selectedCustomerId: string | undefined
   focusedIndex: number
   onSelect: (customer: Customer) => void
-  listRef: React.RefObject<HTMLDivElement | null>
+  customerListRef: React.RefObject<HTMLDivElement | null>
 }
 
 const CustomerList: React.FC<CustomerListProps> = ({
   customers,
   loading,
+  total,
   selectedCustomerId,
   focusedIndex,
   onSelect,
-  listRef,
+  customerListRef,
 }) => {
-  if (loading) {
-    return <ListSkeleton rows={10} columns={1} />
-  }
-
   return (
-    <Box
-      ref={listRef}
-      sx={{
-        flex: 1,
-        overflow: 'auto',
-        borderRadius: 1,
-        border: '1px solid',
-        borderColor: 'divider',
-        bgcolor: 'background.paper',
-      }}
-    >
-      {customers.length === 0 ? (
-        <Box sx={{ p: 3, textAlign: 'center' }}>
-          <Typography variant="body2" color="text.secondary">No customers found</Typography>
+    <Paper sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Typography
+            variant="tableHeader"
+            sx={{
+              fontWeight: 600,
+              fontSize: '0.8rem',
+              textTransform: 'uppercase',
+              letterSpacing: '0.5px',
+            }}
+          >
+            Customers ({total})
+          </Typography>
+          {loading && customers.length > 0 && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Typography variant="caption" color="text.secondary">
+                Searching...
+              </Typography>
+              <Box sx={{ width: 16, height: 16 }}>
+                <Skeleton variant="circular" width={16} height={16} />
+              </Box>
+            </Box>
+          )}
         </Box>
-      ) : (
-        <List dense disablePadding>
-          {customers.map((customer, index) => (
-            <ListItemButton
-              key={customer.id}
-              data-customer-index={index}
-              selected={customer.id === selectedCustomerId}
-              onClick={() => onSelect(customer)}
-              sx={{
-                borderLeft: index === focusedIndex ? '3px solid' : '3px solid transparent',
-                borderColor: index === focusedIndex ? 'primary.main' : 'transparent',
-                py: 1,
-                px: 1.5,
-              }}
-            >
-              <ListItemText
-                primary={customer.name}
-                primaryTypographyProps={{ variant: 'body2', noWrap: true }}
-              />
-            </ListItemButton>
-          ))}
-        </List>
-      )}
-    </Box>
+      </Box>
+
+      <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }} ref={customerListRef}>
+        <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
+          <Table
+            size={TABLE_STYLES.size}
+            sx={{
+              '& .MuiTableCell-root': {
+                borderBottom: TABLE_STYLES.cell.border,
+                py: TABLE_STYLES.cell.padding.py * 0.75,
+                px: TABLE_STYLES.cell.padding.px * 0.75,
+              },
+            }}
+          >
+            <TableBody>
+              {loading && customers.length === 0
+                ? [...Array(10)].map((_, index) => (
+                    <TableRow key={`skeleton-${index}`}>
+                      <TableCell>
+                        <Skeleton height={40} />
+                      </TableCell>
+                    </TableRow>
+                  ))
+                : customers.length === 0
+                  ? (
+                      <TableRow>
+                        <TableCell>
+                          <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center', py: 2 }}>
+                            No customers found
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  : customers.map((customer, index) => (
+                      <CustomerRow
+                        key={customer.id}
+                        customer={customer}
+                        index={index}
+                        selectedCustomerId={selectedCustomerId}
+                        focusedIndex={focusedIndex}
+                        onSelect={onSelect}
+                      />
+                    ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+    </Paper>
   )
 }
 

--- a/frontend/src/pages/sales/components/CustomerWorkspaceCard.tsx
+++ b/frontend/src/pages/sales/components/CustomerWorkspaceCard.tsx
@@ -155,9 +155,9 @@ const CustomerWorkspaceCard: React.FC<CustomerWorkspaceCardProps> = ({ selectedC
 
   if (loading) {
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', pt: 6 }}>
+      <Paper sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         <CircularProgress />
-      </Box>
+      </Paper>
     )
   }
 

--- a/frontend/src/pages/sales/components/CustomerWorkspaceCard.tsx
+++ b/frontend/src/pages/sales/components/CustomerWorkspaceCard.tsx
@@ -20,7 +20,6 @@ import {
 import {
   AccountBalance as InvoiceIcon,
   LocationOn as LocationIcon,
-  People as CustomersIcon,
   Phone as PhoneIcon,
   ShoppingCart as OrdersIcon,
   Star as StarIcon,
@@ -151,14 +150,7 @@ const CustomerWorkspaceCard: React.FC<CustomerWorkspaceCardProps> = ({ selectedC
   }, [tabValue, invoicesLoaded, selectedCustomer?.id])
 
   if (!selectedCustomer) {
-    return (
-      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', flex: 1, gap: 2, color: 'text.secondary' }}>
-        <CustomersIcon sx={{ fontSize: 64, opacity: 0.3 }} />
-        <Typography variant="h6" color="text.secondary">
-          Select a customer to view details
-        </Typography>
-      </Box>
-    )
+    return <Paper sx={{ flex: 1 }} />
   }
 
   if (loading) {
@@ -207,35 +199,33 @@ const CustomerWorkspaceCard: React.FC<CustomerWorkspaceCardProps> = ({ selectedC
   ]
 
   return (
-    <Box sx={{ overflow: 'auto', flex: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <Paper sx={{ p: 2 }}>
-        <Stack spacing={0.5}>
-          <Stack direction="row" spacing={1} flexWrap="wrap">
-            <Chip
-              label={selectedCustomer.isActive ? 'Active' : 'Inactive'}
-              color={selectedCustomer.isActive ? 'success' : 'default'}
-              size="small"
-            />
-            <Chip
-              label={selectedCustomer.type === CustomerType.BUSINESS ? 'Business' : 'Individual'}
-              size="small"
-              variant="outlined"
-            />
-          </Stack>
-          {selectedCustomer.phone && (
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              <PhoneIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
-              <Typography variant="body2">{selectedCustomer.phone}</Typography>
-            </Box>
-          )}
-          {fullAddress && (
-            <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
-              <LocationIcon sx={{ fontSize: 16, color: 'text.secondary', mt: 0.2 }} />
-              <Typography variant="body2" sx={{ whiteSpace: 'pre-line' }}>{fullAddress}</Typography>
-            </Box>
-          )}
+    <Paper sx={{ overflow: 'auto', flex: 1, display: 'flex', flexDirection: 'column', gap: 2, p: 2 }}>
+      <Stack spacing={0.5}>
+        <Stack direction="row" spacing={1} flexWrap="wrap">
+          <Chip
+            label={selectedCustomer.isActive ? 'Active' : 'Inactive'}
+            color={selectedCustomer.isActive ? 'success' : 'default'}
+            size="small"
+          />
+          <Chip
+            label={selectedCustomer.type === CustomerType.BUSINESS ? 'Business' : 'Individual'}
+            size="small"
+            variant="outlined"
+          />
         </Stack>
-      </Paper>
+        {selectedCustomer.phone && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <PhoneIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+            <Typography variant="body2">{selectedCustomer.phone}</Typography>
+          </Box>
+        )}
+        {fullAddress && (
+          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+            <LocationIcon sx={{ fontSize: 16, color: 'text.secondary', mt: 0.2 }} />
+            <Typography variant="body2" sx={{ whiteSpace: 'pre-line' }}>{fullAddress}</Typography>
+          </Box>
+        )}
+      </Stack>
 
       <SalesStatsCards stats={stats} />
 
@@ -375,7 +365,7 @@ const CustomerWorkspaceCard: React.FC<CustomerWorkspaceCardProps> = ({ selectedC
           </>
         )}
       </TabPanel>
-    </Box>
+    </Paper>
   )
 }
 

--- a/frontend/src/pages/sales/components/CustomersDialogs.tsx
+++ b/frontend/src/pages/sales/components/CustomersDialogs.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+
+import ConfirmationDialog from '@/components/common/ConfirmationDialog'
+import DeletedCustomersDialog from '@/components/sales/DeletedCustomersDialog'
+import type { Customer } from '@/types'
+
+interface CustomersDialogsProps {
+  selectedCustomer: Customer | null
+  deleteConfirmOpen: boolean
+  onConfirmDelete: () => Promise<void> | void
+  onCancelDelete: () => void
+  deletedCustomersDialogOpen: boolean
+  onCloseDeletedCustomersDialog: () => void
+}
+
+const CustomersDialogs: React.FC<CustomersDialogsProps> = ({
+  selectedCustomer,
+  deleteConfirmOpen,
+  onConfirmDelete,
+  onCancelDelete,
+  deletedCustomersDialogOpen,
+  onCloseDeletedCustomersDialog,
+}) => {
+  return (
+    <>
+      <ConfirmationDialog
+        open={deleteConfirmOpen}
+        title="Confirm Delete"
+        message={`Are you sure you want to delete "${selectedCustomer?.name}"? This will move it to deleted items.`}
+        confirmText="Delete Customer"
+        cancelText="Cancel"
+        onConfirm={onConfirmDelete}
+        onCancel={onCancelDelete}
+        severity="warning"
+      />
+
+      <DeletedCustomersDialog
+        open={deletedCustomersDialogOpen}
+        onClose={onCloseDeletedCustomersDialog}
+      />
+    </>
+  )
+}
+
+export default CustomersDialogs

--- a/frontend/src/pages/sales/hooks/useCustomersPageState.ts
+++ b/frontend/src/pages/sales/hooks/useCustomersPageState.ts
@@ -4,6 +4,7 @@ export function useCustomersPageState() {
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
   const [deletedCustomersDialogOpen, setDeletedCustomersDialogOpen] = useState(false)
   const [focusedCustomerIndex, setFocusedCustomerIndex] = useState(-1)
+  const [shouldPreserveSearchFocus, setShouldPreserveSearchFocus] = useState(false)
 
   const customerListRef = useRef<HTMLDivElement>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
@@ -15,6 +16,8 @@ export function useCustomersPageState() {
     setDeletedCustomersDialogOpen,
     focusedCustomerIndex,
     setFocusedCustomerIndex,
+    shouldPreserveSearchFocus,
+    setShouldPreserveSearchFocus,
     customerListRef,
     searchInputRef,
   }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -160,6 +160,7 @@ export interface Customer {
   type: CustomerType;
   name: string;
   phone?: string;
+  email?: string;
   // Address Information
   streetAddress?: string;
   city?: string;


### PR DESCRIPTION
## Summary

- Rewrites `CustomerList` as a `Paper`+`Table` component matching `OrdersTable` style (header bar with count, `TABLE_STYLES`, skeleton loading)
- Rewrites `CustomerContextHeader` as a `Paper` with title bar + icon buttons + detail rows (Type, Status, Phone, Email, Price List)
- Changes `CustomerWorkspaceCard` outer wrapper from `Box` to `Paper`; loading state also wrapped in `Paper`
- Extracts `ConfirmationDialog` + `DeletedCustomersDialog` into a new centralized `CustomersDialogs` component
- Adds sort state + `FilterBar` sort prop (sortable by name) to `CustomersPage`
- Adds `shouldPreserveSearchFocus` focus management matching `OrdersPage` behavior
- Adds `email?: string` to `Customer` type

Closes #305

## Test Plan

- [x] Type-check passes: `cd frontend && npm run type-check`
- [ ] Tests pass: `cd frontend && npx vitest run src/pages/sales/__tests__/CustomersPage.filter.test.tsx src/pages/sales/__tests__/CustomersPage.filterbar.test.tsx src/pages/sales/__tests__/CustomerFormPage.test.tsx`
- [x] Lint passes: `cd frontend && npm run lint -- --max-warnings=0 src/pages/sales/CustomersPage.tsx src/pages/sales/components/CustomerList.tsx src/pages/sales/components/CustomerContextHeader.tsx src/pages/sales/components/CustomerWorkspaceCard.tsx src/pages/sales/components/CustomersDialogs.tsx src/pages/sales/hooks/useCustomersPageState.ts`
- [x] Visually verify Customers page matches Sales Orders page style in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)