### PR TITLE
feat(frontend): modernize Customer page — 2-column header, fix scroll, remove stats clutter

### DIFF
--- a/frontend/src/pages/sales/components/CustomerContextHeader.tsx
+++ b/frontend/src/pages/sales/components/CustomerContextHeader.tsx
@@ -5,7 +5,6 @@ import {
 } from '@mui/icons-material'
 import {
   Box,
-  Chip,
   IconButton,
   Paper,
   Table,
@@ -15,10 +14,12 @@ import {
   TableRow,
   Typography,
 } from '@mui/material'
+import Grid from '@mui/material/GridLegacy'
 
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { Customer } from '@/types'
 import { CustomerType } from '@/types'
+import { formatCurrency, formatDate } from '@/utils/formatters'
 
 interface CustomerContextHeaderProps {
   selectedCustomer: Customer | null
@@ -93,67 +94,140 @@ const CustomerContextHeader: React.FC<CustomerContextHeaderProps> = ({
           Customer - {selectedCustomer.name}
         </Typography>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
-          <IconButton size="small" title="Edit Customer" onClick={onEdit} sx={{ ...actionIconSx, color: 'primary.main' }}>
+          <IconButton
+            size="small"
+            title="Edit Customer"
+            onClick={onEdit}
+            sx={{ ...actionIconSx, color: 'primary.main' }}
+          >
             <EditIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
           </IconButton>
-          <IconButton size="small" title="Delete Customer" onClick={onDelete} sx={{ ...actionIconSx, color: 'error.main' }}>
+          <IconButton
+            size="small"
+            title="Delete Customer"
+            onClick={onDelete}
+            sx={{ ...actionIconSx, color: 'error.main' }}
+          >
             <DeleteIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
           </IconButton>
         </Box>
       </Box>
 
       <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
-        <TableContainer>
-          <Table size={TABLE_STYLES.size} sx={detailTableSx}>
-            <TableBody>
-              <TableRow>
-                <TableCell colSpan={2} sx={{ pb: TABLE_STYLES.cell.padding.py * 0.67, py: TABLE_STYLES.cell.padding.py * 0.67, borderTop: TABLE_STYLES.cell.border }}>
-                  <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
-                    Customer Information
-                  </Typography>
-                </TableCell>
-              </TableRow>
-              <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                <TableCell sx={labelCellSx}>Type</TableCell>
-                <TableCell sx={valueCellSx}>
-                  <Chip
-                    label={selectedCustomer.type === CustomerType.BUSINESS ? 'Business' : 'Individual'}
-                    size="small"
-                    variant="outlined"
-                    sx={{ fontSize: '0.75rem' }}
-                  />
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell sx={labelCellSx}>Status</TableCell>
-                <TableCell sx={valueCellSx}>
-                  <Chip
-                    label={selectedCustomer.isActive ? 'Active' : 'Inactive'}
-                    size="small"
-                    color={selectedCustomer.isActive ? 'success' : 'default'}
-                    sx={{ fontSize: '0.75rem' }}
-                  />
-                </TableCell>
-              </TableRow>
-              <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                <TableCell sx={labelCellSx}>Phone</TableCell>
-                <TableCell sx={valueCellSx}>{selectedCustomer.phone || '—'}</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell sx={labelCellSx}>Email</TableCell>
-                <TableCell sx={valueCellSx}>{selectedCustomer.email || '—'}</TableCell>
-              </TableRow>
-              <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                <TableCell sx={labelCellSx}>Price List</TableCell>
-                <TableCell sx={valueCellSx}>
-                  {selectedCustomer.priceList
-                    ? <Chip label={selectedCustomer.priceList.name} size="small" sx={{ fontSize: '0.75rem' }} />
-                    : '—'}
-                </TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
-        </TableContainer>
+        <Grid container spacing={3}>
+          <Grid item xs={12} md={6}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell
+                      colSpan={2}
+                      sx={{
+                        pb: TABLE_STYLES.cell.padding.py * 0.67,
+                        py: TABLE_STYLES.cell.padding.py * 0.67,
+                        borderTop: TABLE_STYLES.cell.border,
+                      }}
+                    >
+                      <Typography
+                        variant="h6"
+                        sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}
+                      >
+                        Customer Information
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Type</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {selectedCustomer.type === CustomerType.BUSINESS ? 'Business' : 'Individual'}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Status</TableCell>
+                    <TableCell
+                      sx={{
+                        ...valueCellSx,
+                        color: selectedCustomer.isActive ? 'success.main' : 'text.disabled',
+                      }}
+                    >
+                      {selectedCustomer.isActive ? 'Active' : 'Inactive'}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Phone</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedCustomer.phone || '—'}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Email</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedCustomer.email || '—'}</TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Price List</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedCustomer.priceList?.name || '—'}</TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell
+                      colSpan={2}
+                      sx={{
+                        pb: TABLE_STYLES.cell.padding.py * 0.67,
+                        py: TABLE_STYLES.cell.padding.py * 0.67,
+                        borderTop: TABLE_STYLES.cell.border,
+                      }}
+                    >
+                      <Typography
+                        variant="h6"
+                        sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}
+                      >
+                        Account Summary
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Total Orders</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedCustomer.totalOrders ?? 0}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Total Sales</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {formatCurrency(selectedCustomer.totalSales ?? 0)}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Avg Order Value</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {formatCurrency(selectedCustomer.averageOrderValue ?? 0)}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>First Purchase</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {selectedCustomer.firstPurchaseDate
+                        ? formatDate(selectedCustomer.firstPurchaseDate)
+                        : '—'}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Last Purchase</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {selectedCustomer.lastPurchaseDate
+                        ? formatDate(selectedCustomer.lastPurchaseDate)
+                        : '—'}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+        </Grid>
       </Box>
     </Paper>
   )

--- a/frontend/src/pages/sales/components/CustomerWorkspaceCard.tsx
+++ b/frontend/src/pages/sales/components/CustomerWorkspaceCard.tsx
@@ -1,12 +1,8 @@
 import React, { useEffect, useState } from 'react'
 import {
-  Alert,
   Box,
-  Chip,
   CircularProgress,
-  Divider,
   Paper,
-  Stack,
   Tab,
   Table,
   TableBody,
@@ -19,32 +15,15 @@ import {
 } from '@mui/material'
 import {
   AccountBalance as InvoiceIcon,
-  LocationOn as LocationIcon,
-  Phone as PhoneIcon,
   ShoppingCart as OrdersIcon,
-  Star as StarIcon,
-  TrendingUp as SalesIcon,
 } from '@mui/icons-material'
 import { useNavigate } from 'react-router-dom'
 
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import api from '@/services/api'
 import type { Customer } from '@/types'
-import { CustomerType } from '@/types'
 import { formatCurrency } from '@/utils/currency'
 import { formatDate } from '@/utils/formatters'
-import SalesStatsCards from './SalesStatsCards'
-import type { StatItem } from './SalesStatsCards'
-
-interface CustomerStatistics {
-  orders: {
-    totalOrders: number
-    totalSales: number
-    averageOrderValue: number
-    firstOrderDate: string | null
-    lastOrderDate: string | null
-  }
-}
 
 interface SalesOrderItem {
   id: string
@@ -74,8 +53,21 @@ interface TabPanelProps {
 
 function TabPanel({ children, value, index }: TabPanelProps) {
   return (
-    <Box role="tabpanel" hidden={value !== index} sx={{ pt: 2, overflow: 'auto' }}>
-      {value === index && children}
+    <Box
+      role="tabpanel"
+      hidden={value !== index}
+      sx={{
+        flex: 1,
+        overflow: 'auto',
+        display: value === index ? 'flex' : 'none',
+        flexDirection: 'column',
+      }}
+    >
+      {value === index && (
+        <Box sx={{ p: TABLE_STYLES.cell.padding.px, flex: 1 }}>
+          {children}
+        </Box>
+      )}
     </Box>
   )
 }
@@ -87,49 +79,35 @@ interface CustomerWorkspaceCardProps {
 const CustomerWorkspaceCard: React.FC<CustomerWorkspaceCardProps> = ({ selectedCustomer }) => {
   const navigate = useNavigate()
 
-  const [statistics, setStatistics] = useState<CustomerStatistics | null>(null)
   const [orders, setOrders] = useState<SalesOrderItem[]>([])
   const [invoices, setInvoices] = useState<OutstandingInvoice[]>([])
   const [totalOutstanding, setTotalOutstanding] = useState(0)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
   const [tabValue, setTabValue] = useState(0)
   const [ordersLoaded, setOrdersLoaded] = useState(false)
   const [invoicesLoaded, setInvoicesLoaded] = useState(false)
 
   useEffect(() => {
     if (!selectedCustomer) {
-      setStatistics(null)
       setOrders([])
       setInvoices([])
       setTotalOutstanding(0)
       setTabValue(0)
       setOrdersLoaded(false)
       setInvoicesLoaded(false)
-      setError(null)
       return
     }
 
-    setLoading(true)
-    setStatistics(null)
     setTabValue(0)
     setOrdersLoaded(false)
     setInvoicesLoaded(false)
     setOrders([])
     setInvoices([])
-    setError(null)
-
-    api.get(`/customers/${selectedCustomer.id}/statistics`)
-      .then((res) => {
-        setStatistics(res.data?.data ?? res.data)
-      })
-      .catch(() => setError('Failed to load customer statistics.'))
-      .finally(() => setLoading(false))
   }, [selectedCustomer?.id])
 
   useEffect(() => {
-    if (tabValue === 1 && !ordersLoaded && selectedCustomer?.id) {
-      api.get(`/customers/${selectedCustomer.id}/sales-history`)
+    if (tabValue === 0 && !ordersLoaded && selectedCustomer?.id) {
+      api
+        .get(`/customers/${selectedCustomer.id}/sales-history`)
         .then((res: any) => setOrders(res.data?.orders ?? res.data ?? []))
         .catch(() => {})
         .finally(() => setOrdersLoaded(true))
@@ -137,8 +115,9 @@ const CustomerWorkspaceCard: React.FC<CustomerWorkspaceCardProps> = ({ selectedC
   }, [tabValue, ordersLoaded, selectedCustomer?.id])
 
   useEffect(() => {
-    if (tabValue === 2 && !invoicesLoaded && selectedCustomer?.id) {
-      api.get(`/customers/${selectedCustomer.id}/outstanding-invoices`)
+    if (tabValue === 1 && !invoicesLoaded && selectedCustomer?.id) {
+      api
+        .get(`/customers/${selectedCustomer.id}/outstanding-invoices`)
         .then((res: any) => {
           const data = res.data?.data ?? res.data
           setInvoices(data?.invoices ?? [])
@@ -153,129 +132,24 @@ const CustomerWorkspaceCard: React.FC<CustomerWorkspaceCardProps> = ({ selectedC
     return <Paper sx={{ flex: 1 }} />
   }
 
-  if (loading) {
-    return (
-      <Paper sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <CircularProgress />
-      </Paper>
-    )
-  }
-
-  if (error) {
-    return <Alert severity="error">{error}</Alert>
-  }
-
-  const fullAddress = [
-    selectedCustomer.streetAddress,
-    [selectedCustomer.city, selectedCustomer.state, selectedCustomer.postalCode].filter(Boolean).join(', '),
-    selectedCustomer.country,
-  ].filter(Boolean).join('\n')
-
-  const stats: StatItem[] = [
-    {
-      title: 'Total Orders',
-      value: selectedCustomer.totalOrders ?? 0,
-      icon: OrdersIcon,
-      color: 'primary',
-    },
-    {
-      title: 'Total Sales',
-      value: formatCurrency(selectedCustomer.totalSales ?? 0),
-      icon: SalesIcon,
-      color: 'success',
-    },
-    {
-      title: 'Avg Order Value',
-      value: formatCurrency(statistics?.orders.averageOrderValue ?? 0),
-      icon: StarIcon,
-      color: 'info',
-    },
-    {
-      title: 'Outstanding',
-      value: formatCurrency(totalOutstanding),
-      icon: InvoiceIcon,
-      color: totalOutstanding > 0 ? 'warning' : 'success',
-    },
-  ]
-
   return (
-    <Paper sx={{ overflow: 'auto', flex: 1, display: 'flex', flexDirection: 'column', gap: 2, p: 2 }}>
-      <Stack spacing={0.5}>
-        <Stack direction="row" spacing={1} flexWrap="wrap">
-          <Chip
-            label={selectedCustomer.isActive ? 'Active' : 'Inactive'}
-            color={selectedCustomer.isActive ? 'success' : 'default'}
-            size="small"
-          />
-          <Chip
-            label={selectedCustomer.type === CustomerType.BUSINESS ? 'Business' : 'Individual'}
-            size="small"
-            variant="outlined"
-          />
-        </Stack>
-        {selectedCustomer.phone && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <PhoneIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
-            <Typography variant="body2">{selectedCustomer.phone}</Typography>
-          </Box>
-        )}
-        {fullAddress && (
-          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
-            <LocationIcon sx={{ fontSize: 16, color: 'text.secondary', mt: 0.2 }} />
-            <Typography variant="body2" sx={{ whiteSpace: 'pre-line' }}>{fullAddress}</Typography>
-          </Box>
-        )}
-      </Stack>
-
-      <SalesStatsCards stats={stats} />
-
+    <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
         <Tabs value={tabValue} onChange={(_, value) => setTabValue(value)}>
-          <Tab label="Overview" />
-          <Tab label="Orders" />
-          <Tab label="Invoices" />
+          <Tab icon={<OrdersIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="Orders" />
+          <Tab icon={<InvoiceIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="Invoices" />
         </Tabs>
       </Box>
 
       <TabPanel value={tabValue} index={0}>
-        <Stack spacing={1.5}>
-          {selectedCustomer.priceList && (
-            <Box sx={{ display: 'flex', gap: 2 }}>
-              <Typography color="text.secondary" sx={{ minWidth: 140 }}>Price List:</Typography>
-              <Chip label={selectedCustomer.priceList.name} size="small" />
-            </Box>
-          )}
-          {statistics?.orders.firstOrderDate && (
-            <Box sx={{ display: 'flex', gap: 2 }}>
-              <Typography color="text.secondary" sx={{ minWidth: 140 }}>First Purchase:</Typography>
-              <Typography>{formatDate(statistics.orders.firstOrderDate)}</Typography>
-            </Box>
-          )}
-          {selectedCustomer.lastPurchaseDate && (
-            <Box sx={{ display: 'flex', gap: 2 }}>
-              <Typography color="text.secondary" sx={{ minWidth: 140 }}>Last Purchase:</Typography>
-              <Typography>{formatDate(selectedCustomer.lastPurchaseDate)}</Typography>
-            </Box>
-          )}
-          {selectedCustomer.notes && (
-            <>
-              <Divider />
-              <Box>
-                <Typography color="text.secondary" gutterBottom>Notes:</Typography>
-                <Typography>{selectedCustomer.notes}</Typography>
-              </Box>
-            </>
-          )}
-        </Stack>
-      </TabPanel>
-
-      <TabPanel value={tabValue} index={1}>
         {!ordersLoaded ? (
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
             <CircularProgress />
           </Box>
         ) : orders.length === 0 ? (
-          <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>No orders found.</Typography>
+          <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+            No orders found.
+          </Typography>
         ) : (
           <TableContainer component={Paper} variant="outlined">
             <Table size={TABLE_STYLES.size}>
@@ -296,15 +170,24 @@ const CustomerWorkspaceCard: React.FC<CustomerWorkspaceCardProps> = ({ selectedC
                     onClick={() => navigate(`/sales/orders/${order.id}/edit`)}
                   >
                     <TableCell>
-                      <Typography variant="body2" color="primary" fontWeight={600}>{order.orderNumber}</Typography>
+                      <Typography variant="body2" color="primary" fontWeight={600}>
+                        {order.orderNumber}
+                      </Typography>
                     </TableCell>
                     <TableCell>{formatDate(order.orderDate)}</TableCell>
                     <TableCell>
-                      <Chip
-                        label={order.isFulfilled ? 'Fulfilled' : order.isPaid ? 'Paid' : 'Pending'}
-                        size="small"
-                        color={order.isFulfilled ? 'success' : order.isPaid ? 'primary' : 'default'}
-                      />
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          color: order.isFulfilled
+                            ? 'success.main'
+                            : order.isPaid
+                              ? 'primary.main'
+                              : 'text.secondary',
+                        }}
+                      >
+                        {order.isFulfilled ? 'Fulfilled' : order.isPaid ? 'Paid' : 'Pending'}
+                      </Typography>
                     </TableCell>
                     <TableCell align="right">{formatCurrency(order.totalAmount)}</TableCell>
                   </TableRow>
@@ -315,13 +198,15 @@ const CustomerWorkspaceCard: React.FC<CustomerWorkspaceCardProps> = ({ selectedC
         )}
       </TabPanel>
 
-      <TabPanel value={tabValue} index={2}>
+      <TabPanel value={tabValue} index={1}>
         {!invoicesLoaded ? (
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
             <CircularProgress />
           </Box>
         ) : invoices.length === 0 ? (
-          <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>No outstanding invoices.</Typography>
+          <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+            No outstanding invoices.
+          </Typography>
         ) : (
           <>
             <Box sx={{ mb: 2, display: 'flex', justifyContent: 'flex-end' }}>
@@ -348,14 +233,20 @@ const CustomerWorkspaceCard: React.FC<CustomerWorkspaceCardProps> = ({ selectedC
                       onClick={() => invoice.salesOrderId && navigate(`/sales/orders/${invoice.salesOrderId}/edit`)}
                     >
                       <TableCell>
-                        <Typography variant="body2" color={invoice.salesOrderId ? 'primary' : 'text.primary'} fontWeight={600}>
+                        <Typography
+                          variant="body2"
+                          color={invoice.salesOrderId ? 'primary' : 'text.primary'}
+                          fontWeight={600}
+                        >
                           {invoice.invoiceNumber}
                         </Typography>
                       </TableCell>
                       <TableCell>{formatDate(invoice.invoiceDate)}</TableCell>
                       <TableCell align="right">{formatCurrency(invoice.totalAmount)}</TableCell>
                       <TableCell align="right">
-                        <Typography fontWeight={600} color="error.main">{formatCurrency(invoice.balanceDue)}</Typography>
+                        <Typography fontWeight={600} color="error.main">
+                          {formatCurrency(invoice.balanceDue)}
+                        </Typography>
                       </TableCell>
                     </TableRow>
                   ))}

--- a/frontend/src/pages/sales/components/CustomerWorkspaceCard.tsx
+++ b/frontend/src/pages/sales/components/CustomerWorkspaceCard.tsx
@@ -55,7 +55,6 @@ function TabPanel({ children, value, index }: TabPanelProps) {
   return (
     <Box
       role="tabpanel"
-      hidden={value !== index}
       sx={{
         flex: 1,
         overflow: 'auto',

--- a/frontend/src/pages/sales/components/__tests__/CustomerContextHeader.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/CustomerContextHeader.test.tsx
@@ -5,25 +5,27 @@ import CustomerContextHeader from '../CustomerContextHeader'
 import { CustomerType } from '@/types'
 import { formatCurrency } from '@/utils/formatters'
 
+const baseCustomer = {
+  id: 'customer-1',
+  type: CustomerType.BUSINESS,
+  name: 'Acme Supplies',
+  phone: '555-0100',
+  email: 'billing@acme.test',
+  isActive: true,
+  totalSales: 12500,
+  totalOrders: 18,
+  averageOrderValue: 694.44,
+  firstPurchaseDate: new Date('2026-01-10T00:00:00.000Z'),
+  lastPurchaseDate: new Date('2026-04-01T00:00:00.000Z'),
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-04-01T00:00:00.000Z'),
+}
+
 describe('CustomerContextHeader', () => {
   it('renders a two-column customer summary layout', () => {
     render(
       <CustomerContextHeader
-        selectedCustomer={{
-          id: 'customer-1',
-          type: CustomerType.BUSINESS,
-          name: 'Acme Supplies',
-          phone: '555-0100',
-          email: 'billing@acme.test',
-          isActive: true,
-          totalSales: 12500,
-          totalOrders: 18,
-          averageOrderValue: 694.44,
-          firstPurchaseDate: new Date('2026-01-10T00:00:00.000Z'),
-          lastPurchaseDate: new Date('2026-04-01T00:00:00.000Z'),
-          createdAt: new Date('2026-01-01T00:00:00.000Z'),
-          updatedAt: new Date('2026-04-01T00:00:00.000Z'),
-        }}
+        selectedCustomer={baseCustomer}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />,
@@ -36,5 +38,51 @@ describe('CustomerContextHeader', () => {
     expect(screen.getByText('Active')).toBeInTheDocument()
     expect(screen.getByText(formatCurrency(12500))).toBeInTheDocument()
     expect(screen.getAllByRole('table')).toHaveLength(2)
+  })
+
+  it('renders Individual type and Inactive status as plain text', () => {
+    render(
+      <CustomerContextHeader
+        selectedCustomer={{ ...baseCustomer, type: CustomerType.INDIVIDUAL, isActive: false }}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Individual')).toBeInTheDocument()
+    expect(screen.getByText('Inactive')).toBeInTheDocument()
+    expect(screen.queryByText('Active')).not.toBeInTheDocument()
+  })
+
+  it('shows — for missing priceList', () => {
+    render(
+      <CustomerContextHeader
+        selectedCustomer={{ ...baseCustomer, priceList: undefined, priceListId: undefined }}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    )
+
+    // Price List row label is present and its value is —
+    const rows = screen.getAllByRole('row')
+    const priceListRow = rows.find(r => r.textContent?.includes('Price List'))
+    expect(priceListRow).toBeTruthy()
+    expect(priceListRow!.textContent).toContain('—')
+  })
+
+  it('shows — for missing first and last purchase dates', () => {
+    render(
+      <CustomerContextHeader
+        selectedCustomer={{ ...baseCustomer, firstPurchaseDate: undefined, lastPurchaseDate: undefined }}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    )
+
+    const rows = screen.getAllByRole('row')
+    const firstRow = rows.find(r => r.textContent?.includes('First Purchase'))
+    const lastRow = rows.find(r => r.textContent?.includes('Last Purchase'))
+    expect(firstRow!.textContent).toContain('—')
+    expect(lastRow!.textContent).toContain('—')
   })
 })

--- a/frontend/src/pages/sales/components/__tests__/CustomerContextHeader.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/CustomerContextHeader.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import CustomerContextHeader from '../CustomerContextHeader'
+import { CustomerType } from '@/types'
+import { formatCurrency } from '@/utils/formatters'
+
+describe('CustomerContextHeader', () => {
+  it('renders a two-column customer summary layout', () => {
+    render(
+      <CustomerContextHeader
+        selectedCustomer={{
+          id: 'customer-1',
+          type: CustomerType.BUSINESS,
+          name: 'Acme Supplies',
+          phone: '555-0100',
+          email: 'billing@acme.test',
+          isActive: true,
+          totalSales: 12500,
+          totalOrders: 18,
+          averageOrderValue: 694.44,
+          firstPurchaseDate: new Date('2026-01-10T00:00:00.000Z'),
+          lastPurchaseDate: new Date('2026-04-01T00:00:00.000Z'),
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+          updatedAt: new Date('2026-04-01T00:00:00.000Z'),
+        }}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Customer - Acme Supplies')).toBeInTheDocument()
+    expect(screen.getByText('Customer Information')).toBeInTheDocument()
+    expect(screen.getByText('Account Summary')).toBeInTheDocument()
+    expect(screen.getByText('Business')).toBeInTheDocument()
+    expect(screen.getByText('Active')).toBeInTheDocument()
+    expect(screen.getByText(formatCurrency(12500))).toBeInTheDocument()
+    expect(screen.getAllByRole('table')).toHaveLength(2)
+  })
+})

--- a/frontend/src/pages/sales/components/__tests__/CustomerWorkspaceCard.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/CustomerWorkspaceCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import CustomerWorkspaceCard from '../CustomerWorkspaceCard'
 import { CustomerType } from '@/types'
@@ -22,6 +22,7 @@ vi.mock('react-router-dom', async (importOriginal) => {
 
 describe('CustomerWorkspaceCard', () => {
   beforeEach(() => {
+    mockedApi.get.mockReset()
     mockedApi.get.mockImplementation((url: string) => {
       if (url.includes('/sales-history')) {
         return Promise.resolve({ data: { orders: [] } })
@@ -38,7 +39,7 @@ describe('CustomerWorkspaceCard', () => {
     })
   })
 
-  it('renders only the orders and invoices tabs', async () => {
+  it('renders only the orders and invoices tabs and lazy-loads each tab once', async () => {
     render(
       <CustomerWorkspaceCard
         selectedCustomer={{
@@ -62,5 +63,22 @@ describe('CustomerWorkspaceCard', () => {
     expect(screen.getByRole('tab', { name: /invoices/i })).toBeInTheDocument()
     expect(screen.queryByRole('tab', { name: /overview/i })).not.toBeInTheDocument()
     expect(screen.getAllByRole('tab')).toHaveLength(2)
+    expect(mockedApi.get).toHaveBeenCalledWith('/customers/customer-1/sales-history')
+    expect(mockedApi.get).not.toHaveBeenCalledWith('/customers/customer-1/outstanding-invoices')
+
+    fireEvent.click(screen.getByRole('tab', { name: /invoices/i }))
+
+    await waitFor(() => {
+      expect(mockedApi.get).toHaveBeenCalledWith('/customers/customer-1/outstanding-invoices')
+    })
+
+    fireEvent.click(screen.getByRole('tab', { name: /orders/i }))
+    fireEvent.click(screen.getByRole('tab', { name: /invoices/i }))
+
+    expect(
+      mockedApi.get.mock.calls.filter(
+        ([url]) => url === '/customers/customer-1/outstanding-invoices',
+      ),
+    ).toHaveLength(1)
   })
 })

--- a/frontend/src/pages/sales/components/__tests__/CustomerWorkspaceCard.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/CustomerWorkspaceCard.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+import CustomerWorkspaceCard from '../CustomerWorkspaceCard'
+import { CustomerType } from '@/types'
+
+const mockedApi = vi.hoisted(() => ({
+  get: vi.fn(),
+}))
+
+vi.mock('@/services/api', () => ({
+  default: mockedApi,
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  }
+})
+
+describe('CustomerWorkspaceCard', () => {
+  beforeEach(() => {
+    mockedApi.get.mockImplementation((url: string) => {
+      if (url.includes('/sales-history')) {
+        return Promise.resolve({ data: { orders: [] } })
+      }
+
+      return Promise.resolve({
+        data: {
+          data: {
+            invoices: [],
+            totalOutstanding: 0,
+          },
+        },
+      })
+    })
+  })
+
+  it('renders only the orders and invoices tabs', async () => {
+    render(
+      <CustomerWorkspaceCard
+        selectedCustomer={{
+          id: 'customer-1',
+          type: CustomerType.BUSINESS,
+          name: 'Acme Supplies',
+          isActive: true,
+          totalSales: 0,
+          totalOrders: 0,
+          averageOrderValue: 0,
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+          updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+        }}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /orders/i })).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('tab', { name: /invoices/i })).toBeInTheDocument()
+    expect(screen.queryByRole('tab', { name: /overview/i })).not.toBeInTheDocument()
+    expect(screen.getAllByRole('tab')).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## Summary

- Redesigns `CustomerContextHeader` to a 2-column `GridLegacy` layout matching `OrderContextHeader` — plain text for Type/Status (no chips), Account Summary in right column sourced directly from the `Customer` object (no extra API calls)
- Refactors `CustomerWorkspaceCard` — removes `SalesStatsCards`, Overview tab, and statistics API call; fixes scroll bug so tabs stay pinned while content scrolls; tabs shift to Orders=0, Invoices=1
- Adds regression tests for both components covering key edge cases (null price list, null purchase dates, Individual/Inactive rendering)

## Test plan

- [x] `CustomerContextHeader.test.tsx` — 4 tests pass
- [x] `CustomerWorkspaceCard.test.tsx` — tab lazy-load behavior passes
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] Visually verify: select a customer, confirm header shows 2-column layout, tabs stay pinned when orders list is long

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)