### PR TITLE
feat(purchasing): refactor Suppliers page to MasterDetailWorkspace pattern

### DIFF
--- a/backend/src/modules/purchasing/controllers/supplier.controller.ts
+++ b/backend/src/modules/purchasing/controllers/supplier.controller.ts
@@ -146,6 +146,33 @@ export class SupplierController {
     return await this.supplierService.findDeleted(query);
   }
 
+  @Get(':id/purchase-orders')
+  @ApiOperation({ summary: 'Get purchase orders for a supplier' })
+  @ApiResponse({ status: 200, description: 'Purchase orders retrieved successfully' })
+  async getSupplierPurchaseOrders(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<{ data: any[]; total: number }> {
+    return await this.supplierService.getSupplierPurchaseOrders(id);
+  }
+
+  @Get(':id/grns')
+  @ApiOperation({ summary: 'Get goods received notes for a supplier' })
+  @ApiResponse({ status: 200, description: 'GRNs retrieved successfully' })
+  async getSupplierGRNs(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<{ data: any[]; total: number }> {
+    return await this.supplierService.getSupplierGRNs(id);
+  }
+
+  @Get(':id/payments')
+  @ApiOperation({ summary: 'Get vendor payments for a supplier' })
+  @ApiResponse({ status: 200, description: 'Payments retrieved successfully' })
+  async getSupplierPayments(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<{ data: any[]; total: number }> {
+    return await this.supplierService.getSupplierPayments(id);
+  }
+
   @Get(':id')
   @ApiOperation({
     summary: 'Get supplier by ID',

--- a/backend/src/modules/purchasing/dto/supplier.dto.ts
+++ b/backend/src/modules/purchasing/dto/supplier.dto.ts
@@ -124,6 +124,9 @@ export class SupplierResponseDto {
   @ApiProperty({ description: 'Company name' })
   companyName!: string;
 
+  @ApiProperty({ description: 'Whether the supplier is active' })
+  isActive!: boolean;
+
   @ApiProperty({ description: 'Contact person name' })
   contactPerson?: string;
 

--- a/backend/src/modules/purchasing/services/supplier.service.spec.ts
+++ b/backend/src/modules/purchasing/services/supplier.service.spec.ts
@@ -3,6 +3,9 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { SupplierService } from './supplier.service';
 import { Supplier, SupplierType } from '../../../database/entities/supplier.entity';
+import { PurchaseOrder } from '../../../database/entities/purchase-order.entity';
+import { GoodsReceivedNote } from '../../../database/entities/goods-received-note.entity';
+import { VendorPayment } from '../../../database/entities/vendor-payment.entity';
 import { AuditLogService } from '../../audit-logs/services';
 import { UserRole } from '../../../database/entities/user.entity';
 
@@ -43,6 +46,24 @@ describe('SupplierService', () => {
           provide: getRepositoryToken(Supplier),
           useValue: {
             createQueryBuilder: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(PurchaseOrder),
+          useValue: {
+            findAndCount: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(GoodsReceivedNote),
+          useValue: {
+            findAndCount: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(VendorPayment),
+          useValue: {
+            findAndCount: jest.fn(),
           },
         },
         {

--- a/backend/src/modules/purchasing/services/supplier.service.ts
+++ b/backend/src/modules/purchasing/services/supplier.service.ts
@@ -5,6 +5,9 @@ import {
   Supplier,
   SupplierType,
 } from '../../../database/entities/supplier.entity';
+import { PurchaseOrder } from '../../../database/entities/purchase-order.entity';
+import { GoodsReceivedNote } from '../../../database/entities/goods-received-note.entity';
+import { VendorPayment } from '../../../database/entities/vendor-payment.entity';
 import {
   CreateSupplierDto,
   UpdateSupplierDto,
@@ -34,6 +37,12 @@ export class SupplierService {
   constructor(
     @InjectRepository(Supplier)
     private readonly supplierRepository: Repository<Supplier>,
+    @InjectRepository(PurchaseOrder)
+    private readonly purchaseOrderRepository: Repository<PurchaseOrder>,
+    @InjectRepository(GoodsReceivedNote)
+    private readonly grnRepository: Repository<GoodsReceivedNote>,
+    @InjectRepository(VendorPayment)
+    private readonly vendorPaymentRepository: Repository<VendorPayment>,
     private readonly auditLogService: AuditLogService,
   ) {}
 
@@ -758,6 +767,38 @@ export class SupplierService {
 
     this.logger.log(`Bulk permanent delete completed: ${deletedCount} deleted, ${failedIds.length} failed`);
     return { deletedCount, failedIds };
+  }
+
+  async getSupplierPurchaseOrders(supplierId: string): Promise<{ data: PurchaseOrder[]; total: number }> {
+    const [data, total] = await this.purchaseOrderRepository.findAndCount({
+      where: { supplierId },
+      order: { orderDate: 'DESC' },
+      take: 50,
+    });
+
+    return { data, total };
+  }
+
+  async getSupplierGRNs(supplierId: string): Promise<{ data: GoodsReceivedNote[]; total: number }> {
+    const [data, total] = await this.grnRepository.findAndCount({
+      where: { supplierId },
+      relations: ['purchaseOrder'],
+      order: { receivedDate: 'DESC' },
+      take: 50,
+    });
+
+    return { data, total };
+  }
+
+  async getSupplierPayments(supplierId: string): Promise<{ data: VendorPayment[]; total: number }> {
+    const [data, total] = await this.vendorPaymentRepository.findAndCount({
+      where: { supplierId },
+      relations: ['paymentMethodEntity'],
+      order: { paymentDate: 'DESC' },
+      take: 50,
+    });
+
+    return { data, total };
   }
 
   /**

--- a/backend/src/modules/purchasing/services/supplier.service.ts
+++ b/backend/src/modules/purchasing/services/supplier.service.ts
@@ -809,6 +809,7 @@ export class SupplierService {
       id: supplier.id,
       type: supplier.type,
       companyName: supplier.companyName,
+      isActive: supplier.isActive,
       contactPerson: supplier.contactPerson,
       phone: supplier.phone,
       streetAddress: supplier.streetAddress,

--- a/frontend/src/pages/purchasing/SupplierFormPage.tsx
+++ b/frontend/src/pages/purchasing/SupplierFormPage.tsx
@@ -1,0 +1,403 @@
+import React, { useEffect, useState } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material'
+import { useNavigate, useParams } from 'react-router-dom'
+import { useForm, Controller } from 'react-hook-form'
+import { yupResolver } from '@hookform/resolvers/yup'
+import * as yup from 'yup'
+
+import PageHeader from '@/components/common/PageHeader'
+import { useNotification } from '@/hooks/useNotification'
+import api from '@/services/api'
+import {
+  useCreateSupplierMutation,
+  useLazyCheckDuplicateCompanyNameQuery,
+  useUpdateSupplierMutation,
+} from '@/store/api/purchasingApi'
+import type { Supplier } from '@/types'
+import { SupplierType } from '@/types'
+
+const supplierSchema = yup.object({
+  companyName: yup.string().required('Company name is required').max(200, 'Name must be less than 200 characters'),
+  type: yup.string().oneOf(['local', 'international']).required('Type is required'),
+  contactPerson: yup.string().optional().nullable().transform((value) => value?.trim() || null).max(200, 'Name must be less than 200 characters'),
+  phone: yup.string().optional().nullable().transform((value) => value?.trim() || null).max(20, 'Phone must be less than 20 characters'),
+  streetAddress: yup.string().optional().nullable().transform((value) => value?.trim() || null).max(255, 'Street address must be less than 255 characters'),
+  city: yup.string().optional().nullable().transform((value) => value?.trim() || null).max(100, 'City must be less than 100 characters'),
+  state: yup.string().optional().nullable().transform((value) => value?.trim() || null).max(100, 'State must be less than 100 characters'),
+  postalCode: yup.string().optional().nullable().transform((value) => value?.trim() || null).max(20, 'Postal code must be less than 20 characters'),
+  country: yup.string().optional().nullable().transform((value) => value?.trim() || null).max(100, 'Country must be less than 100 characters'),
+  notes: yup.string().optional().nullable().transform((value) => value?.trim() || null),
+})
+
+interface SupplierFormData {
+  companyName: string
+  type: SupplierType
+  contactPerson?: string | null
+  phone?: string | null
+  streetAddress?: string | null
+  city?: string | null
+  state?: string | null
+  postalCode?: string | null
+  country?: string | null
+  notes?: string | null
+}
+
+const SupplierFormPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { showSuccess, showError } = useNotification()
+  const isEdit = !!id
+
+  const [supplier, setSupplier] = useState<Supplier | null>(null)
+  const [loadingSupplier, setLoadingSupplier] = useState(isEdit)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [companyNameError, setCompanyNameError] = useState<string | null>(null)
+  const [isCheckingDuplicate, setIsCheckingDuplicate] = useState(false)
+
+  const [createSupplier, { isLoading: isCreating }] = useCreateSupplierMutation()
+  const [updateSupplier, { isLoading: isUpdating }] = useUpdateSupplierMutation()
+  const [checkDuplicateCompanyName] = useLazyCheckDuplicateCompanyNameQuery()
+  const isSaving = isCreating || isUpdating
+
+  const { control, handleSubmit, reset, watch, formState: { errors } } = useForm<SupplierFormData>({
+    resolver: yupResolver(supplierSchema) as any,
+    defaultValues: {
+      companyName: '',
+      type: SupplierType.LOCAL,
+      contactPerson: null,
+      phone: null,
+      streetAddress: null,
+      city: null,
+      state: null,
+      postalCode: null,
+      country: null,
+      notes: null,
+    },
+  })
+
+  const companyName = watch('companyName')
+
+  useEffect(() => {
+    if (!id) return
+
+    setLoadingSupplier(true)
+    api.get(`/purchasing/suppliers/${id}`)
+      .then((res) => {
+        const currentSupplier: Supplier = res.data?.data ?? res.data
+        setSupplier(currentSupplier)
+        reset({
+          companyName: currentSupplier.companyName,
+          type: currentSupplier.type,
+          contactPerson: currentSupplier.contactPerson || null,
+          phone: currentSupplier.phone || null,
+          streetAddress: currentSupplier.streetAddress || null,
+          city: currentSupplier.city || null,
+          state: currentSupplier.state || null,
+          postalCode: currentSupplier.postalCode || null,
+          country: currentSupplier.country || null,
+          notes: currentSupplier.notes || null,
+        })
+      })
+      .catch(() => setLoadError('Supplier not found.'))
+      .finally(() => setLoadingSupplier(false))
+  }, [id, reset])
+
+  useEffect(() => {
+    if (supplier && companyName === supplier.companyName) {
+      setCompanyNameError(null)
+      setIsCheckingDuplicate(false)
+      return
+    }
+
+    const check = async () => {
+      if (!companyName || companyName.trim().length < 2) {
+        setCompanyNameError(null)
+        return
+      }
+
+      setIsCheckingDuplicate(true)
+      try {
+        const result = await checkDuplicateCompanyName({
+          companyName: companyName.trim(),
+          excludeId: supplier?.id,
+        }).unwrap()
+        setCompanyNameError(result?.exists ? (result.message || 'This company name already exists') : null)
+      } catch {
+        setCompanyNameError(null)
+      } finally {
+        setIsCheckingDuplicate(false)
+      }
+    }
+
+    const timer = setTimeout(check, 500)
+    return () => clearTimeout(timer)
+  }, [companyName, supplier, checkDuplicateCompanyName])
+
+  const handleFormSubmit = async (data: SupplierFormData) => {
+    if (companyNameError) {
+      showError(companyNameError)
+      return
+    }
+
+    const cleanedData = {
+      ...data,
+      contactPerson: data.contactPerson?.trim() || null,
+      phone: data.phone?.trim() || null,
+      streetAddress: data.streetAddress?.trim() || null,
+      city: data.city?.trim() || null,
+      state: data.state?.trim() || null,
+      postalCode: data.postalCode?.trim() || null,
+      country: data.country?.trim() || null,
+      notes: data.notes?.trim() || null,
+    }
+
+    try {
+      if (isEdit && id) {
+        await updateSupplier({ id, data: cleanedData }).unwrap()
+        showSuccess('Supplier updated successfully')
+      } else {
+        await createSupplier(cleanedData).unwrap()
+        showSuccess('Supplier created successfully')
+      }
+      navigate('/purchasing/suppliers')
+    } catch (error: any) {
+      showError(`Failed to ${isEdit ? 'update' : 'create'} supplier: ${error?.message ?? error}`)
+    }
+  }
+
+  if (loadingSupplier) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', pt: 10 }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  if (loadError) {
+    return <Alert severity="error">{loadError}</Alert>
+  }
+
+  return (
+    <>
+      <PageHeader
+        title={isEdit ? 'Edit Supplier' : 'New Supplier'}
+        subtitle={isEdit ? `Editing ${supplier?.companyName ?? ''}` : 'Add a new supplier to your account'}
+        variant="standard"
+      />
+      <Paper sx={{ p: 3, maxWidth: 800 }}>
+        <form onSubmit={handleSubmit(handleFormSubmit)}>
+          <Grid container spacing={2}>
+            <Grid size={12}>
+              <Typography variant="h6" gutterBottom>Basic Information</Typography>
+            </Grid>
+
+            <Grid size={{ xs: 12, md: 6 }}>
+              <Controller
+                name="type"
+                control={control}
+                render={({ field }) => (
+                  <FormControl fullWidth error={!!errors.type}>
+                    <InputLabel>Supplier Type</InputLabel>
+                    <Select {...field} label="Supplier Type">
+                      <MenuItem value={SupplierType.LOCAL}>Local</MenuItem>
+                      <MenuItem value={SupplierType.INTERNATIONAL}>International</MenuItem>
+                    </Select>
+                  </FormControl>
+                )}
+              />
+            </Grid>
+
+            <Grid size={12}>
+              <Controller
+                name="companyName"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    fullWidth
+                    label="Company Name"
+                    error={!!errors.companyName || !!companyNameError}
+                    helperText={errors.companyName?.message || companyNameError || (isCheckingDuplicate ? 'Checking availability...' : '')}
+                    InputProps={{
+                      endAdornment: isCheckingDuplicate ? <CircularProgress size={20} /> : null,
+                    }}
+                  />
+                )}
+              />
+            </Grid>
+
+            <Grid size={{ xs: 12, md: 6 }}>
+              <Controller
+                name="contactPerson"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    value={field.value || ''}
+                    fullWidth
+                    label="Contact Person"
+                    error={!!errors.contactPerson}
+                    helperText={errors.contactPerson?.message}
+                  />
+                )}
+              />
+            </Grid>
+
+            <Grid size={{ xs: 12, md: 6 }}>
+              <Controller
+                name="phone"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    value={field.value || ''}
+                    fullWidth
+                    label="Phone"
+                    error={!!errors.phone}
+                    helperText={errors.phone?.message}
+                  />
+                )}
+              />
+            </Grid>
+
+            <Grid size={12}>
+              <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>Address Information</Typography>
+            </Grid>
+
+            <Grid size={12}>
+              <Controller
+                name="streetAddress"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    value={field.value || ''}
+                    fullWidth
+                    label="Street Address"
+                    error={!!errors.streetAddress}
+                    helperText={errors.streetAddress?.message}
+                  />
+                )}
+              />
+            </Grid>
+
+            <Grid size={{ xs: 12, md: 6 }}>
+              <Controller
+                name="city"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    value={field.value || ''}
+                    fullWidth
+                    label="City"
+                    error={!!errors.city}
+                    helperText={errors.city?.message}
+                  />
+                )}
+              />
+            </Grid>
+
+            <Grid size={{ xs: 12, md: 6 }}>
+              <Controller
+                name="state"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    value={field.value || ''}
+                    fullWidth
+                    label="State"
+                    error={!!errors.state}
+                    helperText={errors.state?.message}
+                  />
+                )}
+              />
+            </Grid>
+
+            <Grid size={{ xs: 12, md: 6 }}>
+              <Controller
+                name="postalCode"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    value={field.value || ''}
+                    fullWidth
+                    label="Postal Code"
+                    error={!!errors.postalCode}
+                    helperText={errors.postalCode?.message}
+                  />
+                )}
+              />
+            </Grid>
+
+            <Grid size={{ xs: 12, md: 6 }}>
+              <Controller
+                name="country"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    value={field.value || ''}
+                    fullWidth
+                    label="Country"
+                    error={!!errors.country}
+                    helperText={errors.country?.message}
+                  />
+                )}
+              />
+            </Grid>
+
+            <Grid size={12}>
+              <Controller
+                name="notes"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    value={field.value || ''}
+                    fullWidth
+                    multiline
+                    rows={3}
+                    label="Notes"
+                    error={!!errors.notes}
+                    helperText={errors.notes?.message}
+                  />
+                )}
+              />
+            </Grid>
+
+            <Grid size={12}>
+              <Box sx={{ display: 'flex', gap: 2, justifyContent: 'flex-end', pt: 1 }}>
+                <Button onClick={() => navigate('/purchasing/suppliers')}>Cancel</Button>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  disabled={isSaving || isCheckingDuplicate || !!companyNameError}
+                >
+                  {isSaving ? <CircularProgress size={20} /> : (isEdit ? 'Update' : 'Create')}
+                </Button>
+              </Box>
+            </Grid>
+          </Grid>
+        </form>
+      </Paper>
+    </>
+  )
+}
+
+export default SupplierFormPage

--- a/frontend/src/pages/purchasing/SuppliersPage.tsx
+++ b/frontend/src/pages/purchasing/SuppliersPage.tsx
@@ -1,92 +1,25 @@
-import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react'
-import {
-  Box,
-  Typography,
-  Paper,
-  Button,
-  TextField,
-  Grid,
-  Chip,
-  IconButton,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Alert,
-  CircularProgress,
-  useTheme,
-  useMediaQuery,
-  Tooltip,
-  Stack,
-} from '@mui/material'
-import {
-  Edit as EditIcon,
-  Delete as DeleteIcon,
-  Visibility as ViewIcon,
-  Phone as PhoneIcon,
-  LocationOn as LocationIcon,
-} from '@mui/icons-material'
-import { useForm, Controller } from 'react-hook-form'
-import { yupResolver } from '@hookform/resolvers/yup'
-import * as yup from 'yup'
-import { ListSkeleton } from '@/components/common/ListSkeleton'
+import React, { useEffect, useMemo, useState } from 'react'
+import { Alert, Box, useMediaQuery, useTheme } from '@mui/material'
+import { useNavigate } from 'react-router-dom'
+
+import MasterDetailWorkspace from '@/components/common/MasterDetailWorkspace'
 import PageHeader from '@/components/common/PageHeader'
 import { FilterBar } from '@/components/filters'
 import { useFilterBar } from '@/hooks/useFilterBar'
 import { useNotification } from '@/hooks/useNotification'
 import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
-import {
-  useCreateSupplierMutation,
-  useDeleteSupplierMutation,
-  useGetSuppliersQuery,
-  useLazyCheckDuplicateCompanyNameQuery,
-  useUpdateSupplierMutation,
-} from '@/store/api/purchasingApi'
-import type { Supplier } from '@/types'
-import { SupplierType } from '@/types'
-import { formatCurrency } from '@/utils/currency'
-import { formatDate } from '@/utils/formatters'
-import DeletedSuppliersDialog from '@/components/purchasing/DeletedSuppliersDialog'
-import ConfirmationDialog from '@/components/common/ConfirmationDialog'
-import { TABLE_STYLES } from '@/constants/tableStyles'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
+import { useGetSuppliersQuery } from '@/store/api/purchasingApi'
+import { selectSelectedSupplier } from '@/store/slices/purchasingSlice'
 import type { FilterBarConfig } from '@/types/filterBar.types'
 
-// Form validation schema
-const supplierSchema = yup.object({
-  companyName: yup.string().required('Company name is required').max(200, 'Name must be less than 200 characters'),
-  type: yup.string().oneOf(['local', 'international']).required('Type is required'),
-  contactPerson: yup.string().optional().nullable().transform((value) => value?.trim() || null).max(200, 'Name must be less than 200 characters'),
-  phone: yup.string().optional().nullable().transform((value) => value?.trim() || null).max(20, 'Phone must be less than 20 characters'),
-  streetAddress: yup.string().optional().nullable().transform((value) => value?.trim() || null).max(255, 'Street address must be less than 255 characters'),
-  city: yup.string().optional().nullable().transform((value) => value?.trim() || null).max(100, 'City must be less than 100 characters'),
-  state: yup.string().optional().nullable().transform((value) => value?.trim() || null).max(100, 'State must be less than 100 characters'),
-  postalCode: yup.string().optional().nullable().transform((value) => value?.trim() || null).max(20, 'Postal code must be less than 20 characters'),
-  country: yup.string().optional().nullable().transform((value) => value?.trim() || null).max(100, 'Country must be less than 100 characters'),
-  notes: yup.string().optional().nullable().transform((value) => value?.trim() || null),
-})
-
-interface SupplierFormData {
-  companyName: string
-  type: SupplierType
-  contactPerson?: string | null
-  phone?: string | null
-  streetAddress?: string | null
-  city?: string | null
-  state?: string | null
-  postalCode?: string | null
-  country?: string | null
-  notes?: string | null
-}
+import SupplierContextHeader from './components/SupplierContextHeader'
+import SuppliersDialogs from './components/SuppliersDialogs'
+import SupplierList from './components/SupplierList'
+import SupplierWorkspaceCard from './components/SupplierWorkspaceCard'
+import { useSuppliersActions } from './hooks/useSuppliersActions'
+import { useSuppliersPageState } from './hooks/useSuppliersPageState'
+import { useSuppliersSelection } from './hooks/useSuppliersSelection'
 
 interface SupplierFilters {
   search: string
@@ -96,8 +29,13 @@ interface SupplierFilters {
 const SuppliersPage: React.FC = () => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('md'))
+  const navigate = useNavigate()
+  const dispatch = useAppDispatch()
   const { showSuccess, showError } = useNotification()
-  const searchInputRef = useRef<HTMLInputElement | null>(null)
+  const selectedSupplier = useAppSelector(selectSelectedSupplier)
+  const [pageError, setPageError] = useState<string | null>(null)
+
+  const pageState = useSuppliersPageState()
 
   const filterConfig = useMemo<FilterBarConfig<SupplierFilters>>(
     () => ({
@@ -120,6 +58,14 @@ const SuppliersPage: React.FC = () => {
 
   const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
 
+  const filterHandlers = useMemo(() => ({
+    ...handlers,
+    onSearchChange: (value: string) => {
+      pageState.setShouldPreserveSearchFocus(true)
+      handlers.onSearchChange(value)
+    },
+  }), [handlers, pageState])
+
   const supplierQueryParams = useMemo(
     () => ({
       search: appliedFilters.search || undefined,
@@ -133,905 +79,125 @@ const SuppliersPage: React.FC = () => {
     [appliedFilters],
   )
 
-  const {
-    data: suppliersResponse,
-    isLoading: isSuppliersLoading,
-    isFetching: isSuppliersFetching,
-    error: suppliersQueryError,
-    refetch: refetchSuppliers,
-  } = useGetSuppliersQuery(supplierQueryParams)
-  const [createSupplier, { isLoading: isCreatingSupplier }] = useCreateSupplierMutation()
-  const [updateSupplier, { isLoading: isUpdatingSupplier }] = useUpdateSupplierMutation()
-  const [deleteSupplier, { isLoading: isDeletingSupplier }] = useDeleteSupplierMutation()
-  const [checkDuplicateCompanyName] = useLazyCheckDuplicateCompanyNameQuery()
-  const suppliers = suppliersResponse?.data || []
-  const isMutatingSupplier = isCreatingSupplier || isUpdatingSupplier || isDeletingSupplier
-  const error =
-    suppliersQueryError && typeof suppliersQueryError === 'object'
-      ? ((suppliersQueryError as any).data?.message || (suppliersQueryError as any).data || 'Failed to load suppliers')
-      : null
+  const { data: suppliersResponse, isLoading, isFetching, error, refetch } = useGetSuppliersQuery(supplierQueryParams)
+  const suppliers = suppliersResponse?.data ?? []
+  const loading = isLoading || isFetching
 
-  // Local state
-  const [selectedSupplier, setSelectedSupplier] = useState<Supplier | null>(null)
-  const [isFormOpen, setIsFormOpen] = useState(false)
-  const [isViewOpen, setIsViewOpen] = useState(false)
-  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false)
-  const [isDeletedDialogOpen, setIsDeletedDialogOpen] = useState(false)
-  const [companyNameError, setCompanyNameError] = useState<string | null>(null)
-  const [isCheckingDuplicate, setIsCheckingDuplicate] = useState(false)
-
-  // Form setup
-  const { control, handleSubmit, reset, formState: { errors }, watch } = useForm<SupplierFormData>({
-    resolver: yupResolver(supplierSchema) as any,
-    defaultValues: {
-      companyName: '',
-      type: SupplierType.LOCAL,
-      contactPerson: null,
-      phone: null,
-      streetAddress: null,
-      city: null,
-      state: null,
-      postalCode: null,
-      country: null,
-      notes: null,
+  useEffect(() => {
+    if (
+      pageState.shouldPreserveSearchFocus &&
+      pageState.searchInputRef.current &&
+      document.activeElement !== pageState.searchInputRef.current
+    ) {
+      const timer = setTimeout(() => {
+        pageState.searchInputRef.current?.focus()
+        pageState.setShouldPreserveSearchFocus(false)
+      }, 0)
+      return () => clearTimeout(timer)
     }
+
+    if (pageState.shouldPreserveSearchFocus) {
+      pageState.setShouldPreserveSearchFocus(false)
+    }
+  }, [loading, pageState])
+
+  const selection = useSuppliersSelection({
+    dispatch,
+    suppliers,
+    selectedSupplier,
+    focusedSupplierIndex: pageState.focusedSupplierIndex,
+    setFocusedSupplierIndex: pageState.setFocusedSupplierIndex,
+    navigate,
+    supplierListRef: pageState.supplierListRef,
+    setDeleteConfirmOpen: pageState.setDeleteConfirmOpen,
+    setDeletedSuppliersDialogOpen: pageState.setDeletedSuppliersDialogOpen,
   })
 
-  // Watch company name for real-time validation
-  const companyName = watch('companyName')
+  const actions = useSuppliersActions({
+    dispatch,
+    selectedSupplier,
+    refetchSuppliers: () => {
+      void refetch()
+    },
+    showSuccess,
+    showError,
+    setDeleteConfirmOpen: pageState.setDeleteConfirmOpen,
+    setPageError,
+  })
 
-  // Keyboard shortcuts - only search
   useKeyboardShortcuts({
     onSearch: () => {
-      searchInputRef.current?.focus()
-      searchInputRef.current?.select()
+      pageState.searchInputRef.current?.focus()
+      pageState.searchInputRef.current?.select()
     },
+    onArrowUp: selection.handleNavigateUp,
+    onArrowDown: selection.handleNavigateDown,
+    onEnter: selection.handleEnterAction,
+    onPageUp: selection.handlePageUpNavigation,
+    onPageDown: selection.handlePageDownNavigation,
+    onHome: selection.handleNavigateToFirst,
+    onEnd: selection.handleNavigateToLast,
+    onEscape: selection.handleEscapeAction,
   })
 
-  // Load suppliers on mount and when filters change
-  // Debounced duplicate check for company name
-  useEffect(() => {
-    // Skip check if dialog is not open
-    if (!isFormOpen) {
-      return
-    }
-
-    // Skip check if company name hasn't changed from original (when editing)
-    if (selectedSupplier && companyName === selectedSupplier.companyName) {
-      setCompanyNameError(null)
-      setIsCheckingDuplicate(false)
-      return
-    }
-
-    const checkDuplicate = async () => {
-      if (!companyName || companyName.trim().length < 2) {
-        setCompanyNameError(null)
-        return
-      }
-
-      setIsCheckingDuplicate(true)
-      try {
-        const result = await checkDuplicateCompanyName({
-          companyName: companyName.trim(),
-          excludeId: selectedSupplier?.id,
-        }).unwrap()
-
-        if (result?.exists) {
-          const errorMsg = result.message || 'This company name already exists'
-          setCompanyNameError(errorMsg)
-        } else {
-          setCompanyNameError(null)
-        }
-      } catch (error) {
-        setCompanyNameError(null)
-      } finally {
-        setIsCheckingDuplicate(false)
-      }
-    }
-
-    const timer = setTimeout(checkDuplicate, 500)
-    return () => {
-      clearTimeout(timer)
-    }
-  }, [companyName, selectedSupplier?.id, isFormOpen, checkDuplicateCompanyName])
-
-  // Handle form submit
-  const handleFormSubmit = async (data: SupplierFormData) => {
-    // Prevent submission if duplicate exists
-    if (companyNameError) {
-      showError(companyNameError)
-      return
-    }
-
-    try {
-      const cleanedData = {
-        ...data,
-        contactPerson: data.contactPerson?.trim() || null,
-        phone: data.phone?.trim() || null,
-        streetAddress: data.streetAddress?.trim() || null,
-        city: data.city?.trim() || null,
-        state: data.state?.trim() || null,
-        postalCode: data.postalCode?.trim() || null,
-        country: data.country?.trim() || null,
-        notes: data.notes?.trim() || null,
-      }
-
-      if (selectedSupplier) {
-        await updateSupplier({ id: selectedSupplier.id, data: cleanedData }).unwrap()
-        showSuccess('Supplier updated successfully')
-      } else {
-        await createSupplier(cleanedData).unwrap()
-        showSuccess('Supplier created successfully')
-      }
-      handleCloseForm()
-      void refetchSuppliers()
-    } catch (error: any) {
-      // Extract error message from the response
-      let errorMessage = `Failed to ${selectedSupplier ? 'update' : 'create'} supplier`
-
-      if (error?.message) {
-        errorMessage = error.message
-      } else if (typeof error === 'string') {
-        errorMessage = error
-      }
-
-      showError(errorMessage)
-    }
-  }
-
-  // Handle delete
-  const handleDelete = async () => {
-    if (!selectedSupplier) return
-    try {
-      await deleteSupplier(selectedSupplier.id).unwrap()
-      showSuccess(`Supplier "${selectedSupplier.companyName}" deleted successfully`)
-      setIsDeleteConfirmOpen(false)
-      setSelectedSupplier(null)
-    } catch (error: any) {
-      console.error('Delete failed:', error)
-      let errorMessage = 'An unexpected error occurred. Please try again.'
-      const actualError = error
-      if (actualError?.response?.data) {
-        const backendError = actualError.response.data
-        if (backendError.message) {
-          errorMessage = backendError.message
-          if (backendError.suggestions && Array.isArray(backendError.suggestions) && backendError.suggestions.length > 0) {
-            errorMessage += `\n\nSuggestion: ${backendError.suggestions[0]}`
-          }
-        }
-      } else if (actualError?.message && actualError.message !== 'Request failed with status code 400') {
-        errorMessage = actualError.message
-      }
-      showError(errorMessage)
-    } finally {
-      await refetchSuppliers()
-    }
-  }
-
-  // Form helpers
-  const handleOpenForm = (supplier?: Supplier) => {
-    setCompanyNameError(null)
-    setIsCheckingDuplicate(false)
-
-    if (supplier) {
-      setSelectedSupplier(supplier)
-      reset({
-        companyName: supplier.companyName,
-        type: supplier.type,
-        contactPerson: supplier.contactPerson || null,
-        phone: supplier.phone || null,
-        streetAddress: (supplier as any).streetAddress || null,
-        city: (supplier as any).city || null,
-        state: (supplier as any).state || null,
-        postalCode: (supplier as any).postalCode || null,
-        country: (supplier as any).country || null,
-        notes: supplier.notes || null,
-      })
-    } else {
-      setSelectedSupplier(null)
-      reset({
-        companyName: '',
-        type: SupplierType.LOCAL,
-        contactPerson: null,
-        phone: null,
-        streetAddress: null,
-        city: null,
-        state: null,
-        postalCode: null,
-        country: null,
-        notes: null,
-      })
-    }
-    setIsFormOpen(true)
-  }
-
-  const handleCloseForm = () => {
-    setIsFormOpen(false)
-    setSelectedSupplier(null)
-    setCompanyNameError(null)
-    setIsCheckingDuplicate(false)
-    reset()
-  }
-
-  const handleViewSupplier = (supplier: Supplier) => {
-    setSelectedSupplier(supplier)
-    setIsViewOpen(true)
-  }
-
-
   return (
-    <>
-      {/* Header */}
+    <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
       <PageHeader
         title="Suppliers"
         subtitle="Manage your suppliers and vendor relationships"
         variant="workflow"
-        secondaryAction={{ label: 'View Deleted', onClick: () => setIsDeletedDialogOpen(true) }}
-        primaryAction={{ label: 'Add Supplier', onClick: () => handleOpenForm() }}
+        secondaryAction={{ label: 'View Deleted', onClick: () => pageState.setDeletedSuppliersDialogOpen(true) }}
+        primaryAction={{ label: 'New Supplier', onClick: () => navigate('/purchasing/suppliers/create') }}
         toolbar={(
           <FilterBar
             config={filterConfig}
             draftFilters={draftFilters}
-            handlers={handlers}
+            handlers={filterHandlers}
             hasActiveFilters={hasActiveFilters}
-            searchInputRef={searchInputRef}
+            searchInputRef={pageState.searchInputRef}
           />
         )}
       />
-      {/* Error Alert */}
-      {error && (
-        <Alert severity="error" sx={{ mb: 3 }}>
-          {error}
+
+      {(pageError || error) && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setPageError(null)}>
+          {pageError || 'Failed to load suppliers.'}
         </Alert>
       )}
-      {/* Supplier Table */}
-      <Paper sx={{ borderRadius: 2, overflow: 'hidden' }}>
-        {(isSuppliersLoading || (isSuppliersFetching && !suppliersResponse)) ? (
-          <ListSkeleton rows={8} columns={4} />
-        ) : (
-          <Box sx={{ opacity: isSuppliersFetching ? 0.6 : 1, position: 'relative' }}>
-            {isSuppliersFetching && (
-              <CircularProgress size={16} sx={{ position: 'absolute', top: 8, right: 8 }} />
-            )}
-            <TableContainer sx={{ overflowX: 'auto' }}>
-              <Table
-                size={TABLE_STYLES.size}
-                sx={{
-                  minWidth: isMobile ? 650 : 800,
-                  '& .MuiTableCell-root': {
-                    borderBottom: TABLE_STYLES.cell.border,
-                    py: TABLE_STYLES.cell.padding.py,
-                    px: TABLE_STYLES.cell.padding.px,
-                  },
-                }}
-              >
-                <TableHead>
-                  <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50', py: 1 } }}>
-                    <TableCell sx={{ width: isMobile ? '35%' : '25%' }}>
-                      <Typography variant="tableHeader" sx={{
-                        fontWeight: 600,
-                        color: 'text.primary',
-                        fontSize: '0.8rem',
-                      }}>
-                        Supplier
-                      </Typography>
-                    </TableCell>
-                    {!isMobile && (
-                      <TableCell sx={{ width: '10%' }}>
-                        <Typography variant="tableHeader" sx={{
-                          fontWeight: 600,
-                          color: 'text.primary',
-                          fontSize: '0.8rem',
-                        }}>
-                          Type
-                        </Typography>
-                      </TableCell>
-                    )}
-                    <TableCell sx={{ width: isMobile ? '25%' : '15%' }}>
-                      <Typography variant="tableHeader" sx={{
-                        fontWeight: 600,
-                        color: 'text.primary',
-                        fontSize: '0.8rem',
-                      }}>
-                        Contact
-                      </Typography>
-                    </TableCell>
-                    {!isMobile && (
-                      <TableCell sx={{ width: '12%' }}>
-                        <Typography variant="tableHeader" sx={{
-                          fontWeight: 600,
-                          color: 'text.primary',
-                          fontSize: '0.8rem',
-                        }}>
-                          Phone
-                        </Typography>
-                      </TableCell>
-                    )}
-                    <TableCell align="right" sx={{ width: isMobile ? '40%' : '15%' }}>
-                      <Typography variant="tableHeader" sx={{
-                        fontWeight: 600,
-                        color: 'text.primary',
-                        fontSize: '0.8rem',
-                      }}>
-                        Actions
-                      </Typography>
-                    </TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {suppliers.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={5} align="center">
-                        <Typography variant="body2" color="text.secondary">
-                          No suppliers found
-                        </Typography>
-                      </TableCell>
-                    </TableRow>
-                  ) : (
-                    suppliers.map((supplier) => (
-                      <TableRow
-                        key={supplier.id}
-                        hover
-                        tabIndex={0}
-                        sx={{
-                          '&:hover, &:focus-within': {
-                            backgroundColor: 'action.hover',
-                            '& .supplier-actions': {
-                              opacity: 1,
-                            },
-                          },
-                          transition: 'background-color 0.2s ease',
-                          cursor: 'default',
-                          height: TABLE_STYLES.row.height,
-                        }}
-                      >
-                        <TableCell>
-                          <Box>
-                            <Typography variant="body2" sx={{
-                              fontWeight: 400,
-                              fontSize: '0.8rem',
-                              lineHeight: 1.2,
-                            }}>
-                              {supplier.companyName}
-                            </Typography>
-                          </Box>
-                          {isMobile && (
-                            <Box sx={{ mt: 0.5, display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
-                              <Chip
-                                label={supplier.type === SupplierType.LOCAL ? 'Local' : 'International'}
-                                size="small"
-                                color={supplier.type === SupplierType.LOCAL ? 'primary' : 'secondary'}
-                                sx={{ fontSize: '0.65rem' }}
-                              />
-                            </Box>
-                          )}
-                        </TableCell>
-                        {!isMobile && (
-                          <TableCell>
-                            <Chip
-                              label={supplier.type === SupplierType.LOCAL ? 'Local' : 'International'}
-                              size="small"
-                              color={supplier.type === SupplierType.LOCAL ? 'primary' : 'secondary'}
-                              sx={{
-                                fontSize: '0.7rem',
-                                fontWeight: 500,
-                                height: `${TABLE_STYLES.row.height * 0.65}px`,
-                                '& .MuiChip-label': {
-                                  fontSize: `${Math.max(10, TABLE_STYLES.row.height * 0.35)}px`,
-                                  lineHeight: 1,
-                                },
-                              }}
-                            />
-                          </TableCell>
-                        )}
-                        <TableCell>
-                          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
-                            {supplier.contactPerson && (
-                              <Typography variant="body2" sx={{ fontSize: '0.8rem' }}>
-                                {supplier.contactPerson}
-                              </Typography>
-                            )}
-                            {isMobile && supplier.phone && (
-                              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                                <PhoneIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
-                                <Typography variant="tableCaption" sx={{ fontSize: '0.7rem' }}>{supplier.phone}</Typography>
-                              </Box>
-                            )}
-                          </Box>
-                        </TableCell>
-                        {!isMobile && (
-                          <TableCell>
-                            {supplier.phone && (
-                              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                                <PhoneIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
-                                <Typography variant="body2" sx={{ fontSize: '0.8rem' }}>{supplier.phone}</Typography>
-                              </Box>
-                            )}
-                          </TableCell>
-                        )}
-                        <TableCell align="right">
-                          <Box
-                            className="supplier-actions"
-                            sx={{
-                              display: 'flex',
-                              justifyContent: 'flex-end',
-                              alignItems: 'center',
-                              height: '100%',
-                              gap: 0.25,
-                              opacity: isMobile ? 1 : 0.7,
-                              transition: 'opacity 0.2s ease',
-                            }}
-                          >
-                            <IconButton
-                              size="small"
-                              title={`Edit ${supplier.companyName}`}
-                              aria-label={`Edit supplier ${supplier.companyName}`}
-                              onClick={() => handleOpenForm(supplier)}
-                              sx={{
-                                height: `${TABLE_STYLES.row.height * 0.75}px`,
-                                width: `${TABLE_STYLES.row.height * 0.75}px`,
-                                minHeight: 20,
-                                minWidth: 20,
-                                p: 0.125,
-                                color: 'primary.main',
-                                '&:hover': {
-                                  backgroundColor: 'primary.light',
-                                  color: 'primary.dark',
-                                },
-                              }}
-                            >
-                              <EditIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
-                            </IconButton>
-                            <IconButton
-                              size="small"
-                              title={`Delete ${supplier.companyName}`}
-                              aria-label={`Delete supplier ${supplier.companyName}`}
-                              onClick={() => {
-                                setSelectedSupplier(supplier)
-                                setIsDeleteConfirmOpen(true)
-                              }}
-                              sx={{
-                                height: `${TABLE_STYLES.row.height * 0.75}px`,
-                                width: `${TABLE_STYLES.row.height * 0.75}px`,
-                                minHeight: 20,
-                                minWidth: 20,
-                                p: 0.125,
-                                color: 'error.main',
-                                '&:hover': {
-                                  backgroundColor: 'error.light',
-                                  color: 'error.dark',
-                                },
-                              }}
-                            >
-                              <DeleteIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
-                            </IconButton>
-                            <IconButton
-                              size="small"
-                              title={`View ${supplier.companyName} details`}
-                              aria-label={`View supplier ${supplier.companyName} details`}
-                              onClick={() => handleViewSupplier(supplier)}
-                              sx={{
-                                height: `${TABLE_STYLES.row.height * 0.75}px`,
-                                width: `${TABLE_STYLES.row.height * 0.75}px`,
-                                minHeight: 20,
-                                minWidth: 20,
-                                p: 0.125,
-                                color: 'info.main',
-                                '&:hover': {
-                                  backgroundColor: 'info.light',
-                                  color: 'info.dark',
-                                },
-                              }}
-                            >
-                              <ViewIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
-                            </IconButton>
-                          </Box>
-                          {isMobile && (
-                            <Box sx={{ mt: 0.25, textAlign: 'right' }}>
-                              <Typography variant="tableCaption" color="text.secondary" sx={{ fontSize: '0.65rem' }}>
-                                {supplier.totalOrders} orders • {formatCurrency(supplier.totalPurchases)}
-                              </Typography>
-                            </Box>
-                          )}
-                        </TableCell>
-                      </TableRow>
-                    ))
-                  )}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          </Box>
+
+      <MasterDetailWorkspace
+        isMobile={isMobile}
+        listSlot={(
+          <SupplierList
+            suppliers={suppliers}
+            loading={loading}
+            total={suppliers.length}
+            selectedSupplierId={selectedSupplier?.id}
+            focusedIndex={pageState.focusedSupplierIndex}
+            onSelect={selection.handleSupplierSelect}
+            supplierListRef={pageState.supplierListRef}
+          />
         )}
-      </Paper>
-      {/* Supplier Form Dialog */}
-      <Dialog
-        open={isFormOpen}
-        onClose={handleCloseForm}
-        maxWidth="md"
-        fullWidth
-        fullScreen={isMobile}
-      >
-        <DialogTitle>
-          {selectedSupplier ? 'Edit Supplier' : 'Add New Supplier'}
-        </DialogTitle>
-        <form onSubmit={handleSubmit(handleFormSubmit)}>
-          <DialogContent dividers>
-            <Grid container spacing={2}>
-              <Grid size={12}>
-                <Typography variant="h6" gutterBottom>
-                  Basic Information
-                </Typography>
-              </Grid>
-
-              <Grid size={12}>
-                <Controller
-                  name="type"
-                  control={control}
-                  render={({ field }) => (
-                    <FormControl fullWidth error={!!errors.type}>
-                      <InputLabel>Supplier Type</InputLabel>
-                      <Select {...field} label="Supplier Type">
-                        <MenuItem value={SupplierType.LOCAL}>Local</MenuItem>
-                        <MenuItem value={SupplierType.INTERNATIONAL}>International</MenuItem>
-                      </Select>
-                    </FormControl>
-                  )}
-                />
-              </Grid>
-
-              <Grid size={12}>
-                <Controller
-                  name="companyName"
-                  control={control}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      fullWidth
-                      label="Company Name"
-                      error={!!errors.companyName || !!companyNameError}
-                      helperText={errors.companyName?.message || companyNameError || (isCheckingDuplicate ? 'Checking availability...' : '')}
-                      InputProps={{
-                        endAdornment: isCheckingDuplicate ? (
-                          <CircularProgress size={20} />
-                        ) : null,
-                      }}
-                    />
-                  )}
-                />
-              </Grid>
-
-              <Grid
-                size={{
-                  xs: 12,
-                  md: 6
-                }}>
-                <Controller
-                  name="contactPerson"
-                  control={control}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      value={field.value || ''}
-                      fullWidth
-                      label="Contact Person"
-                      error={!!errors.contactPerson}
-                      helperText={errors.contactPerson?.message}
-                    />
-                  )}
-                />
-              </Grid>
-
-              <Grid
-                size={{
-                  xs: 12,
-                  md: 6
-                }}>
-                <Controller
-                  name="phone"
-                  control={control}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      value={field.value || ''}
-                      fullWidth
-                      label="Phone"
-                      error={!!errors.phone}
-                      helperText={errors.phone?.message}
-                    />
-                  )}
-                />
-              </Grid>
-
-              {/* Address Information */}
-              <Grid size={12}>
-                <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>
-                  Address Information
-                </Typography>
-              </Grid>
-
-              <Grid size={12}>
-                <Controller
-                  name="streetAddress"
-                  control={control}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      value={field.value || ''}
-                      fullWidth
-                      label="Street Address"
-                      error={!!errors.streetAddress}
-                      helperText={errors.streetAddress?.message}
-                    />
-                  )}
-                />
-              </Grid>
-
-              <Grid
-                size={{
-                  xs: 12,
-                  md: 6
-                }}>
-                <Controller
-                  name="city"
-                  control={control}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      value={field.value || ''}
-                      fullWidth
-                      label="City"
-                      error={!!errors.city}
-                      helperText={errors.city?.message}
-                    />
-                  )}
-                />
-              </Grid>
-
-              <Grid
-                size={{
-                  xs: 12,
-                  md: 6
-                }}>
-                <Controller
-                  name="state"
-                  control={control}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      value={field.value || ''}
-                      fullWidth
-                      label="State"
-                      error={!!errors.state}
-                      helperText={errors.state?.message}
-                    />
-                  )}
-                />
-              </Grid>
-
-              <Grid
-                size={{
-                  xs: 12,
-                  md: 6
-                }}>
-                <Controller
-                  name="postalCode"
-                  control={control}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      value={field.value || ''}
-                      fullWidth
-                      label="Postal Code"
-                      error={!!errors.postalCode}
-                      helperText={errors.postalCode?.message}
-                    />
-                  )}
-                />
-              </Grid>
-
-              <Grid
-                size={{
-                  xs: 12,
-                  md: 6
-                }}>
-                <Controller
-                  name="country"
-                  control={control}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      value={field.value || ''}
-                      fullWidth
-                      label="Country"
-                      error={!!errors.country}
-                      helperText={errors.country?.message}
-                    />
-                  )}
-                />
-              </Grid>
-
-              {/* Notes */}
-              <Grid size={12}>
-                <Controller
-                  name="notes"
-                  control={control}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      value={field.value || ''}
-                      fullWidth
-                      multiline
-                      rows={3}
-                      label="Notes"
-                      error={!!errors.notes}
-                      helperText={errors.notes?.message}
-                    />
-                  )}
-                />
-              </Grid>
-            </Grid>
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={handleCloseForm}>
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              variant="contained"
-              disabled={isMutatingSupplier || isCheckingDuplicate || !!companyNameError}
-            >
-              {isMutatingSupplier ? <CircularProgress size={20} /> : (selectedSupplier ? 'Update' : 'Create')}
-            </Button>
-          </DialogActions>
-        </form>
-      </Dialog>
-      {/* Supplier Details Dialog */}
-      <Dialog
-        open={isViewOpen}
-        onClose={() => setIsViewOpen(false)}
-        maxWidth="md"
-        fullWidth
-      >
-        <DialogTitle>Supplier Details</DialogTitle>
-        <DialogContent dividers>
-          {selectedSupplier && (
-            <Grid container spacing={2}>
-              <Grid size={12}>
-                <Box sx={{ mb: 2 }}>
-                  <Typography variant="h5" fontWeight={600} sx={{ mb: 1 }}>
-                    {selectedSupplier.companyName}
-                  </Typography>
-                </Box>
-              </Grid>
-
-              <Grid
-                size={{
-                  xs: 12,
-                  md: 6
-                }}>
-                <Typography variant="h6" gutterBottom>Contact Information</Typography>
-                <Stack spacing={1}>
-                  {selectedSupplier.contactPerson && (
-                    <Box>
-                      <Typography color="text.secondary" variant="caption">Contact Person</Typography>
-                      <Typography>{selectedSupplier.contactPerson}</Typography>
-                    </Box>
-                  )}
-                  {selectedSupplier.phone && (
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                      <PhoneIcon sx={{ fontSize: 18, color: 'text.secondary' }} />
-                      <Typography>{selectedSupplier.phone}</Typography>
-                    </Box>
-                  )}
-                </Stack>
-              </Grid>
-
-              <Grid
-                size={{
-                  xs: 12,
-                  md: 6
-                }}>
-                <Typography variant="h6" gutterBottom>Address</Typography>
-                <Stack spacing={1}>
-                  {((selectedSupplier as any).streetAddress || (selectedSupplier as any).city || (selectedSupplier as any).state || (selectedSupplier as any).postalCode || (selectedSupplier as any).country) ? (
-                    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
-                      <LocationIcon sx={{ fontSize: 18, color: 'text.secondary', mt: 0.25 }} />
-                      <Box>
-                        {(selectedSupplier as any).streetAddress && (
-                          <Typography>{(selectedSupplier as any).streetAddress}</Typography>
-                        )}
-                        {((selectedSupplier as any).city || (selectedSupplier as any).state || (selectedSupplier as any).postalCode) && (
-                          <Typography>
-                            {[(selectedSupplier as any).city, (selectedSupplier as any).state, (selectedSupplier as any).postalCode]
-                              .filter(Boolean)
-                              .join(', ')}
-                          </Typography>
-                        )}
-                        {(selectedSupplier as any).country && (
-                          <Typography>{(selectedSupplier as any).country}</Typography>
-                        )}
-                      </Box>
-                    </Box>
-                  ) : (
-                    <Typography color="text.secondary" variant="body2">No address provided</Typography>
-                  )}
-                </Stack>
-              </Grid>
-
-              <Grid
-                size={{
-                  xs: 12,
-                  md: 6
-                }}>
-                <Typography variant="h6" gutterBottom>Purchase Statistics</Typography>
-                <Stack spacing={1}>
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                    <Typography color="text.secondary">Total Orders:</Typography>
-                    <Typography fontWeight={600}>{selectedSupplier.totalOrders}</Typography>
-                  </Box>
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                    <Typography color="text.secondary">Total Purchases:</Typography>
-                    <Typography fontWeight={600}>{formatCurrency(selectedSupplier.totalPurchases)}</Typography>
-                  </Box>
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                    <Typography color="text.secondary">Average Order:</Typography>
-                    <Typography fontWeight={600}>{formatCurrency(selectedSupplier.averageOrderValue || 0)}</Typography>
-                  </Box>
-                  {selectedSupplier.lastPurchaseDate && (
-                    <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                      <Typography color="text.secondary">Last Purchase:</Typography>
-                      <Typography fontWeight={600}>
-                        {formatDate(selectedSupplier.lastPurchaseDate)}
-                      </Typography>
-                    </Box>
-                  )}
-                </Stack>
-              </Grid>
-
-              {selectedSupplier.notes && (
-                <Grid size={12}>
-                  <Typography variant="h6" gutterBottom>Notes</Typography>
-                  <Typography>{selectedSupplier.notes}</Typography>
-                </Grid>
-              )}
-            </Grid>
-          )}
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setIsViewOpen(false)}>
-            Close
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={<EditIcon />}
-            onClick={() => {
-              setIsViewOpen(false)
-              selectedSupplier && handleOpenForm(selectedSupplier)
-            }}
-          >
-            Edit
-          </Button>
-        </DialogActions>
-      </Dialog>
-      {/* Delete Confirmation Dialog */}
-      <ConfirmationDialog
-        open={isDeleteConfirmOpen}
-        title="Confirm Delete"
-        message={`Are you sure you want to delete "${selectedSupplier?.companyName}"? This will move it to deleted items.`}
-        confirmText="Delete Supplier"
-        cancelText="Cancel"
-        onConfirm={handleDelete}
-        onCancel={() => setIsDeleteConfirmOpen(false)}
-        severity="warning"
-        loading={isMutatingSupplier}
+        headerSlot={(
+          <SupplierContextHeader
+            selectedSupplier={selectedSupplier}
+            onEdit={() => navigate(`/purchasing/suppliers/${selectedSupplier!.id}/edit`)}
+            onDelete={() => pageState.setDeleteConfirmOpen(true)}
+          />
+        )}
+        workspaceSlot={<SupplierWorkspaceCard selectedSupplier={selectedSupplier} />}
       />
-      {/* Deleted Suppliers Dialog */}
-      <DeletedSuppliersDialog
-        open={isDeletedDialogOpen}
-        onClose={() => setIsDeletedDialogOpen(false)}
+
+      <SuppliersDialogs
+        selectedSupplier={selectedSupplier}
+        deleteConfirmOpen={pageState.deleteConfirmOpen}
+        onConfirmDelete={actions.handleDelete}
+        onCancelDelete={actions.handleCancelDelete}
+        deletedSuppliersDialogOpen={pageState.deletedSuppliersDialogOpen}
+        onCloseDeletedSuppliersDialog={() => pageState.setDeletedSuppliersDialogOpen(false)}
       />
-    </>
-  );
+    </Box>
+  )
 }
 
 export default SuppliersPage

--- a/frontend/src/pages/purchasing/__tests__/SuppliersPage.filterbar.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/SuppliersPage.filterbar.test.tsx
@@ -32,6 +32,84 @@ vi.mock('@/hooks/useNotification', () => ({
   useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
 }))
 
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  }
+})
+
+vi.mock('@/components/common/MasterDetailWorkspace', () => ({
+  default: ({ listSlot, headerSlot, workspaceSlot }: any) => (
+    <div>
+      <div>{listSlot}</div>
+      <div>{headerSlot}</div>
+      <div>{workspaceSlot}</div>
+    </div>
+  ),
+}))
+
+vi.mock('../components/SupplierWorkspaceCard', () => ({
+  default: () => <div data-testid="supplier-workspace-card" />,
+}))
+
+vi.mock('../components/SupplierContextHeader', () => ({
+  default: () => <div data-testid="supplier-context-header" />,
+}))
+
+vi.mock('../components/SupplierList', () => ({
+  default: ({ suppliers, onSelect }: any) => (
+    <div data-testid="supplier-list">
+      {suppliers.map((supplier: any) => (
+        <div key={supplier.id} data-testid={`supplier-item-${supplier.id}`} onClick={() => onSelect(supplier)}>
+          {supplier.companyName}
+        </div>
+      ))}
+    </div>
+  ),
+}))
+
+vi.mock('../components/SuppliersDialogs', () => ({
+  default: () => <div data-testid="suppliers-dialogs" />,
+}))
+
+vi.mock('../hooks/useSuppliersSelection', () => ({
+  useSuppliersSelection: () => ({
+    handleSupplierSelect: vi.fn(),
+    handleNavigateUp: vi.fn(),
+    handleNavigateDown: vi.fn(),
+    handleNavigateToFirst: vi.fn(),
+    handleNavigateToLast: vi.fn(),
+    handlePageUpNavigation: vi.fn(),
+    handlePageDownNavigation: vi.fn(),
+    handleEnterAction: vi.fn(),
+    handleEscapeAction: vi.fn(),
+  }),
+}))
+
+vi.mock('../hooks/useSuppliersActions', () => ({
+  useSuppliersActions: () => ({
+    handleDelete: vi.fn(),
+    handleCancelDelete: vi.fn(),
+  }),
+}))
+
+vi.mock('../hooks/useSuppliersPageState', () => ({
+  useSuppliersPageState: () => ({
+    deleteConfirmOpen: false,
+    setDeleteConfirmOpen: vi.fn(),
+    deletedSuppliersDialogOpen: false,
+    setDeletedSuppliersDialogOpen: vi.fn(),
+    focusedSupplierIndex: -1,
+    setFocusedSupplierIndex: vi.fn(),
+    shouldPreserveSearchFocus: false,
+    setShouldPreserveSearchFocus: vi.fn(),
+    supplierListRef: { current: null },
+    searchInputRef: { current: null },
+  }),
+}))
+
 vi.mock('@/components/purchasing/DeletedSuppliersDialog', () => ({
   default: () => <div>DeletedSuppliersDialog</div>,
 }))

--- a/frontend/src/pages/purchasing/components/SupplierContextHeader.tsx
+++ b/frontend/src/pages/purchasing/components/SupplierContextHeader.tsx
@@ -1,0 +1,210 @@
+import React from 'react'
+import {
+  Delete as DeleteIcon,
+  Edit as EditIcon,
+} from '@mui/icons-material'
+import {
+  Box,
+  IconButton,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+} from '@mui/material'
+import Grid from '@mui/material/GridLegacy'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { Supplier } from '@/types'
+import { SupplierType } from '@/types'
+import { formatCurrency, formatDate } from '@/utils/formatters'
+
+interface SupplierContextHeaderProps {
+  selectedSupplier: Supplier | null
+  onEdit: () => void
+  onDelete: () => void
+}
+
+const actionIconSx = {
+  height: `${TABLE_STYLES.row.height * 0.75}px`,
+  width: `${TABLE_STYLES.row.height * 0.75}px`,
+  minHeight: 20,
+  minWidth: 20,
+  p: 0.125,
+}
+
+const detailTableSx = {
+  tableLayout: 'fixed',
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const labelCellSx = { fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }
+const valueCellSx = { fontSize: '0.8rem' }
+
+const SupplierContextHeader: React.FC<SupplierContextHeaderProps> = ({
+  selectedSupplier,
+  onEdit,
+  onDelete,
+}) => {
+  if (!selectedSupplier) {
+    return (
+      <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
+        <Typography variant="h6" color="text.secondary">
+          Select a supplier to view details
+        </Typography>
+      </Paper>
+    )
+  }
+
+  const addressParts = [
+    selectedSupplier.streetAddress,
+    selectedSupplier.city,
+    selectedSupplier.state,
+    selectedSupplier.postalCode,
+    selectedSupplier.country,
+  ].filter(Boolean)
+
+  return (
+    <Paper sx={{ overflow: 'hidden' }}>
+      <Box
+        sx={{
+          p: TABLE_STYLES.cell.padding.px,
+          borderBottom: TABLE_STYLES.cell.border,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Typography
+          variant="tableHeader"
+          sx={{
+            fontWeight: 600,
+            fontSize: '0.8rem',
+            textTransform: 'uppercase',
+            letterSpacing: '0.5px',
+          }}
+        >
+          Supplier - {selectedSupplier.companyName}
+        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+          <IconButton
+            size="small"
+            title="Edit Supplier"
+            onClick={onEdit}
+            sx={{ ...actionIconSx, color: 'primary.main' }}
+          >
+            <EditIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
+          </IconButton>
+          <IconButton
+            size="small"
+            title="Delete Supplier"
+            onClick={onDelete}
+            sx={{ ...actionIconSx, color: 'error.main' }}
+          >
+            <DeleteIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
+          </IconButton>
+        </Box>
+      </Box>
+
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <Grid container spacing={3}>
+          <Grid item xs={12} md={6}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell
+                      colSpan={2}
+                      sx={{ pb: TABLE_STYLES.cell.padding.py * 0.67, py: TABLE_STYLES.cell.padding.py * 0.67, borderTop: TABLE_STYLES.cell.border }}
+                    >
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Supplier Information
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Type</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {selectedSupplier.type === SupplierType.LOCAL ? 'Local' : 'International'}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Status</TableCell>
+                    <TableCell sx={{ ...valueCellSx, color: selectedSupplier.isActive ? 'success.main' : 'text.disabled' }}>
+                      {selectedSupplier.isActive ? 'Active' : 'Inactive'}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Contact</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedSupplier.contactPerson || '—'}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Phone</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedSupplier.phone || '—'}</TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Address</TableCell>
+                    <TableCell sx={valueCellSx}>{addressParts.length > 0 ? addressParts.join(', ') : '—'}</TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+
+          <Grid item xs={12} md={6}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell
+                      colSpan={2}
+                      sx={{ pb: TABLE_STYLES.cell.padding.py * 0.67, py: TABLE_STYLES.cell.padding.py * 0.67, borderTop: TABLE_STYLES.cell.border }}
+                    >
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Purchase Statistics
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Total Orders</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedSupplier.totalOrders ?? 0}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Total Purchases</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(selectedSupplier.totalPurchases ?? 0)}</TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Avg Order Value</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(selectedSupplier.averageOrderValue ?? 0)}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>First Purchase</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {selectedSupplier.firstPurchaseDate ? formatDate(selectedSupplier.firstPurchaseDate) : '—'}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Last Purchase</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {selectedSupplier.lastPurchaseDate ? formatDate(selectedSupplier.lastPurchaseDate) : '—'}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+        </Grid>
+      </Box>
+    </Paper>
+  )
+}
+
+export default SupplierContextHeader

--- a/frontend/src/pages/purchasing/components/SupplierList.tsx
+++ b/frontend/src/pages/purchasing/components/SupplierList.tsx
@@ -1,0 +1,159 @@
+import React, { memo } from 'react'
+import {
+  Box,
+  Paper,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+} from '@mui/material'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { Supplier } from '@/types'
+
+interface SupplierRowProps {
+  supplier: Supplier
+  index: number
+  selectedSupplierId: string | undefined
+  focusedIndex: number
+  onSelect: (supplier: Supplier) => void
+}
+
+const SupplierRow = memo(({ supplier, index, selectedSupplierId, focusedIndex, onSelect }: SupplierRowProps) => {
+  const isSelected = selectedSupplierId === supplier.id
+  const isFocused = index === focusedIndex
+
+  return (
+    <TableRow
+      hover
+      onClick={() => onSelect(supplier)}
+      data-supplier-index={index}
+      sx={{
+        cursor: 'pointer',
+        backgroundColor: isSelected ? 'action.selected' : isFocused ? 'action.focus' : 'inherit',
+        '&:hover': {
+          backgroundColor: isSelected ? 'action.selected' : 'action.hover',
+        },
+        transition: 'background-color 0.2s ease',
+        height: TABLE_STYLES.row.height,
+        ...(isFocused && {
+          outline: '2px solid',
+          outlineColor: 'primary.main',
+          outlineOffset: '-2px',
+        }),
+      }}
+    >
+      <TableCell>
+        <Typography
+          variant="body2"
+          sx={{ fontWeight: 400, fontSize: '0.8rem', lineHeight: 1.2 }}
+        >
+          {supplier.companyName}
+        </Typography>
+      </TableCell>
+    </TableRow>
+  )
+})
+
+SupplierRow.displayName = 'SupplierRow'
+
+interface SupplierListProps {
+  suppliers: Supplier[]
+  loading: boolean
+  total: number
+  selectedSupplierId: string | undefined
+  focusedIndex: number
+  onSelect: (supplier: Supplier) => void
+  supplierListRef: React.RefObject<HTMLDivElement | null>
+}
+
+const SupplierList: React.FC<SupplierListProps> = ({
+  suppliers,
+  loading,
+  total,
+  selectedSupplierId,
+  focusedIndex,
+  onSelect,
+  supplierListRef,
+}) => {
+  return (
+    <Paper sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Typography
+            variant="tableHeader"
+            sx={{
+              fontWeight: 600,
+              fontSize: '0.8rem',
+              textTransform: 'uppercase',
+              letterSpacing: '0.5px',
+            }}
+          >
+            Suppliers ({total})
+          </Typography>
+          {loading && suppliers.length > 0 && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Typography variant="caption" color="text.secondary">
+                Searching...
+              </Typography>
+              <Box sx={{ width: 16, height: 16 }}>
+                <Skeleton variant="circular" width={16} height={16} />
+              </Box>
+            </Box>
+          )}
+        </Box>
+      </Box>
+
+      <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }} ref={supplierListRef}>
+        <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
+          <Table
+            size={TABLE_STYLES.size}
+            sx={{
+              '& .MuiTableCell-root': {
+                borderBottom: TABLE_STYLES.cell.border,
+                py: TABLE_STYLES.cell.padding.py * 0.75,
+                px: TABLE_STYLES.cell.padding.px * 0.75,
+              },
+            }}
+          >
+            <TableBody>
+              {loading && suppliers.length === 0
+                ? [...Array(10)].map((_, index) => (
+                    <TableRow key={`skeleton-${index}`}>
+                      <TableCell>
+                        <Skeleton height={40} />
+                      </TableCell>
+                    </TableRow>
+                  ))
+                : suppliers.length === 0
+                  ? (
+                      <TableRow>
+                        <TableCell>
+                          <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center', py: 2 }}>
+                            No suppliers found
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  : suppliers.map((supplier, index) => (
+                      <SupplierRow
+                        key={supplier.id}
+                        supplier={supplier}
+                        index={index}
+                        selectedSupplierId={selectedSupplierId}
+                        focusedIndex={focusedIndex}
+                        onSelect={onSelect}
+                      />
+                    ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+    </Paper>
+  )
+}
+
+export default SupplierList

--- a/frontend/src/pages/purchasing/components/SupplierWorkspaceCard.tsx
+++ b/frontend/src/pages/purchasing/components/SupplierWorkspaceCard.tsx
@@ -1,0 +1,242 @@
+import React, { useEffect, useState } from 'react'
+import {
+  Box,
+  CircularProgress,
+  Paper,
+  Tab,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tabs,
+  Typography,
+} from '@mui/material'
+import {
+  LocalShipping as GRNIcon,
+  Payment as PaymentIcon,
+  ShoppingCart as OrdersIcon,
+} from '@mui/icons-material'
+import { useNavigate } from 'react-router-dom'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import {
+  useGetSupplierGRNsQuery,
+  useGetSupplierPaymentsQuery,
+  useGetSupplierPurchaseOrdersQuery,
+} from '@/store/api/purchasingApi'
+import type { Supplier } from '@/types'
+import { formatCurrency } from '@/utils/currency'
+import { formatDate } from '@/utils/formatters'
+
+interface TabPanelProps {
+  children?: React.ReactNode
+  index: number
+  value: number
+}
+
+function TabPanel({ children, value, index }: TabPanelProps) {
+  return (
+    <Box
+      role="tabpanel"
+      sx={{
+        flex: 1,
+        overflow: 'auto',
+        display: value === index ? 'flex' : 'none',
+        flexDirection: 'column',
+      }}
+    >
+      {value === index && (
+        <Box sx={{ p: TABLE_STYLES.cell.padding.px, flex: 1 }}>
+          {children}
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+interface SupplierWorkspaceCardProps {
+  selectedSupplier: Supplier | null
+}
+
+const SupplierWorkspaceCard: React.FC<SupplierWorkspaceCardProps> = ({ selectedSupplier }) => {
+  const navigate = useNavigate()
+  const [tabValue, setTabValue] = useState(0)
+
+  const supplierId = selectedSupplier?.id ?? ''
+
+  useEffect(() => {
+    setTabValue(0)
+  }, [supplierId])
+
+  const { data: posData, isLoading: posLoading } = useGetSupplierPurchaseOrdersQuery(supplierId, {
+    skip: !supplierId || tabValue !== 0,
+  })
+  const { data: grnsData, isLoading: grnsLoading } = useGetSupplierGRNsQuery(supplierId, {
+    skip: !supplierId || tabValue !== 1,
+  })
+  const { data: paymentsData, isLoading: paymentsLoading } = useGetSupplierPaymentsQuery(supplierId, {
+    skip: !supplierId || tabValue !== 2,
+  })
+
+  const purchaseOrders = posData?.data ?? []
+  const grns = grnsData?.data ?? []
+  const payments = paymentsData?.data ?? []
+
+  if (!selectedSupplier) {
+    return <Paper sx={{ flex: 1 }} />
+  }
+
+  return (
+    <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs value={tabValue} onChange={(_, value) => setTabValue(value)}>
+          <Tab icon={<OrdersIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="Purchase Orders" />
+          <Tab icon={<GRNIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="GRNs" />
+          <Tab icon={<PaymentIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="Payments" />
+        </Tabs>
+      </Box>
+
+      <TabPanel value={tabValue} index={0}>
+        {posLoading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress />
+          </Box>
+        ) : purchaseOrders.length === 0 ? (
+          <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+            No purchase orders found.
+          </Typography>
+        ) : (
+          <TableContainer component={Paper} variant="outlined">
+            <Table size={TABLE_STYLES.size}>
+              <TableHead>
+                <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50' } }}>
+                  <TableCell>Order #</TableCell>
+                  <TableCell>Date</TableCell>
+                  <TableCell>Status</TableCell>
+                  <TableCell align="right">Total</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {purchaseOrders.map((po) => (
+                  <TableRow
+                    key={po.id}
+                    hover
+                    sx={{ cursor: 'pointer' }}
+                    onClick={() => navigate(`/purchasing/orders/${po.id}/edit`)}
+                  >
+                    <TableCell>
+                      <Typography variant="body2" color="primary" fontWeight={600}>
+                        {po.orderNumber}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>{formatDate(po.orderDate)}</TableCell>
+                    <TableCell>
+                      <Typography variant="body2" color="text.secondary">
+                        {po.receivedDate ? 'Received' : po.paidAmount ? 'Paid' : 'Pending'}
+                      </Typography>
+                    </TableCell>
+                    <TableCell align="right">{formatCurrency(po.total ?? po.totalAmount ?? 0)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </TabPanel>
+
+      <TabPanel value={tabValue} index={1}>
+        {grnsLoading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress />
+          </Box>
+        ) : grns.length === 0 ? (
+          <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+            No GRNs found.
+          </Typography>
+        ) : (
+          <TableContainer component={Paper} variant="outlined">
+            <Table size={TABLE_STYLES.size}>
+              <TableHead>
+                <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50' } }}>
+                  <TableCell>GRN #</TableCell>
+                  <TableCell>Date</TableCell>
+                  <TableCell>PO #</TableCell>
+                  <TableCell>Status</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {grns.map((grn) => (
+                  <TableRow
+                    key={grn.id}
+                    hover
+                    sx={{ cursor: grn.purchaseOrder?.id ? 'pointer' : 'default' }}
+                    onClick={() => grn.purchaseOrder?.id && navigate(`/purchasing/orders/${grn.purchaseOrder.id}/edit`)}
+                  >
+                    <TableCell>
+                      <Typography variant="body2" color="primary" fontWeight={600}>
+                        {grn.grnNumber}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>{formatDate(grn.receivedDate)}</TableCell>
+                    <TableCell>{grn.purchaseOrder?.orderNumber ?? '—'}</TableCell>
+                    <TableCell>
+                      <Typography
+                        variant="body2"
+                        sx={{ color: grn.status === 'received' ? 'success.main' : 'text.secondary' }}
+                      >
+                        {grn.status === 'received' ? 'Received' : 'Draft'}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </TabPanel>
+
+      <TabPanel value={tabValue} index={2}>
+        {paymentsLoading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress />
+          </Box>
+        ) : payments.length === 0 ? (
+          <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+            No payments found.
+          </Typography>
+        ) : (
+          <TableContainer component={Paper} variant="outlined">
+            <Table size={TABLE_STYLES.size}>
+              <TableHead>
+                <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50' } }}>
+                  <TableCell>Payment #</TableCell>
+                  <TableCell>Date</TableCell>
+                  <TableCell>Status</TableCell>
+                  <TableCell align="right">Amount</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {payments.map((payment) => (
+                  <TableRow key={payment.id}>
+                    <TableCell>
+                      <Typography variant="body2" fontWeight={600}>
+                        {payment.paymentNumber}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>{formatDate(payment.paymentDate)}</TableCell>
+                    <TableCell>{payment.status}</TableCell>
+                    <TableCell align="right">{formatCurrency(payment.amount)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </TabPanel>
+    </Paper>
+  )
+}
+
+export default SupplierWorkspaceCard

--- a/frontend/src/pages/purchasing/components/SuppliersDialogs.tsx
+++ b/frontend/src/pages/purchasing/components/SuppliersDialogs.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+
+import ConfirmationDialog from '@/components/common/ConfirmationDialog'
+import DeletedSuppliersDialog from '@/components/purchasing/DeletedSuppliersDialog'
+import type { Supplier } from '@/types'
+
+interface SuppliersDialogsProps {
+  selectedSupplier: Supplier | null
+  deleteConfirmOpen: boolean
+  onConfirmDelete: () => Promise<void> | void
+  onCancelDelete: () => void
+  deletedSuppliersDialogOpen: boolean
+  onCloseDeletedSuppliersDialog: () => void
+}
+
+const SuppliersDialogs: React.FC<SuppliersDialogsProps> = ({
+  selectedSupplier,
+  deleteConfirmOpen,
+  onConfirmDelete,
+  onCancelDelete,
+  deletedSuppliersDialogOpen,
+  onCloseDeletedSuppliersDialog,
+}) => {
+  return (
+    <>
+      <ConfirmationDialog
+        open={deleteConfirmOpen}
+        title="Confirm Delete"
+        message={`Are you sure you want to delete "${selectedSupplier?.companyName}"? This will move it to deleted items.`}
+        confirmText="Delete Supplier"
+        cancelText="Cancel"
+        onConfirm={onConfirmDelete}
+        onCancel={onCancelDelete}
+        severity="warning"
+      />
+
+      <DeletedSuppliersDialog
+        open={deletedSuppliersDialogOpen}
+        onClose={onCloseDeletedSuppliersDialog}
+      />
+    </>
+  )
+}
+
+export default SuppliersDialogs

--- a/frontend/src/pages/purchasing/components/__tests__/SupplierContextHeader.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/SupplierContextHeader.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Supplier } from '@/types'
+import { SupplierType } from '@/types'
+import SupplierContextHeader from '../SupplierContextHeader'
+
+const mockSupplier: Supplier = {
+  id: 'sup-1',
+  companyName: 'Acme Corp',
+  type: SupplierType.LOCAL,
+  isActive: true,
+  contactPerson: 'Jane Doe',
+  phone: '555-1234',
+  streetAddress: '123 Main St',
+  city: 'Springfield',
+  state: 'IL',
+  postalCode: '62701',
+  country: 'USA',
+  totalPurchases: 50000,
+  totalOrders: 10,
+  averageOrderValue: 5000,
+  lastPurchaseDate: new Date('2026-01-15'),
+  firstPurchaseDate: new Date('2025-01-01'),
+  notes: undefined,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+describe('SupplierContextHeader', () => {
+  it('shows empty state when no supplier selected', () => {
+    render(<SupplierContextHeader selectedSupplier={null} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    expect(screen.getByText('Select a supplier to view details')).toBeInTheDocument()
+  })
+
+  it('renders supplier company name in header', () => {
+    render(<SupplierContextHeader selectedSupplier={mockSupplier} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    expect(screen.getByText(/Supplier - Acme Corp/i)).toBeInTheDocument()
+  })
+
+  it('renders contact information', () => {
+    render(<SupplierContextHeader selectedSupplier={mockSupplier} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument()
+    expect(screen.getByText('555-1234')).toBeInTheDocument()
+  })
+
+  it('calls onEdit when edit button clicked', async () => {
+    const onEdit = vi.fn()
+    render(<SupplierContextHeader selectedSupplier={mockSupplier} onEdit={onEdit} onDelete={vi.fn()} />)
+    await userEvent.click(screen.getByTitle('Edit Supplier'))
+    expect(onEdit).toHaveBeenCalledOnce()
+  })
+
+  it('calls onDelete when delete button clicked', async () => {
+    const onDelete = vi.fn()
+    render(<SupplierContextHeader selectedSupplier={mockSupplier} onEdit={vi.fn()} onDelete={onDelete} />)
+    await userEvent.click(screen.getByTitle('Delete Supplier'))
+    expect(onDelete).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/pages/purchasing/components/__tests__/SupplierWorkspaceCard.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/SupplierWorkspaceCard.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Supplier } from '@/types'
+import { SupplierType } from '@/types'
+import SupplierWorkspaceCard from '../SupplierWorkspaceCard'
+
+vi.mock('@/store/api/purchasingApi', () => ({
+  useGetSupplierPurchaseOrdersQuery: vi.fn(() => ({ data: undefined, isLoading: false })),
+  useGetSupplierGRNsQuery: vi.fn(() => ({ data: undefined, isLoading: false })),
+  useGetSupplierPaymentsQuery: vi.fn(() => ({ data: undefined, isLoading: false })),
+}))
+
+const mockSupplier: Supplier = {
+  id: 'sup-1',
+  companyName: 'Acme Corp',
+  type: SupplierType.LOCAL,
+  isActive: true,
+  totalPurchases: 0,
+  totalOrders: 0,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+describe('SupplierWorkspaceCard', () => {
+  it('renders empty Paper when no supplier selected', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <SupplierWorkspaceCard selectedSupplier={null} />
+      </MemoryRouter>,
+    )
+
+    expect(container.querySelector('.MuiPaper-root')).toBeInTheDocument()
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument()
+  })
+
+  it('renders three tabs when supplier selected', () => {
+    render(
+      <MemoryRouter>
+        <SupplierWorkspaceCard selectedSupplier={mockSupplier} />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('tab', { name: /purchase orders/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /grns/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /payments/i })).toBeInTheDocument()
+  })
+
+  it('shows empty state when no purchase orders', () => {
+    render(
+      <MemoryRouter>
+        <SupplierWorkspaceCard selectedSupplier={mockSupplier} />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText(/no purchase orders found/i)).toBeInTheDocument()
+  })
+
+  it('switches to GRNs tab on click', async () => {
+    render(
+      <MemoryRouter>
+        <SupplierWorkspaceCard selectedSupplier={mockSupplier} />
+      </MemoryRouter>,
+    )
+
+    await userEvent.click(screen.getByRole('tab', { name: /grns/i }))
+    expect(screen.getByText(/no grns found/i)).toBeInTheDocument()
+  })
+
+  it('switches to Payments tab on click', async () => {
+    render(
+      <MemoryRouter>
+        <SupplierWorkspaceCard selectedSupplier={mockSupplier} />
+      </MemoryRouter>,
+    )
+
+    await userEvent.click(screen.getByRole('tab', { name: /payments/i }))
+    expect(screen.getByText(/no payments found/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/purchasing/hooks/useSuppliersActions.ts
+++ b/frontend/src/pages/purchasing/hooks/useSuppliersActions.ts
@@ -1,0 +1,66 @@
+import { useCallback } from 'react'
+
+import type { AppDispatch } from '@/store'
+import { useDeleteSupplierMutation } from '@/store/api/purchasingApi'
+import { setSelectedSupplier } from '@/store/slices/purchasingSlice'
+import type { Supplier } from '@/types'
+
+interface UseSuppliersActionsParams {
+  dispatch: AppDispatch
+  selectedSupplier: Supplier | null
+  refetchSuppliers: () => void
+  showSuccess: (message: string) => void
+  showError: (message: string) => void
+  setDeleteConfirmOpen: (open: boolean) => void
+  setPageError: (error: string | null) => void
+}
+
+export function useSuppliersActions({
+  dispatch,
+  selectedSupplier,
+  refetchSuppliers,
+  showSuccess,
+  showError,
+  setDeleteConfirmOpen,
+  setPageError,
+}: UseSuppliersActionsParams) {
+  const [deleteSupplier] = useDeleteSupplierMutation()
+
+  const handleDelete = useCallback(async () => {
+    if (!selectedSupplier) return
+
+    try {
+      await deleteSupplier(selectedSupplier.id).unwrap()
+      showSuccess(`Supplier "${selectedSupplier.companyName}" deleted successfully`)
+      dispatch(setSelectedSupplier(null))
+      setDeleteConfirmOpen(false)
+      setPageError(null)
+      refetchSuppliers()
+    } catch (error: any) {
+      const actualError = error?.payload || error
+      const backendError = actualError?.response?.data
+      let errorMessage = 'An unexpected error occurred. Please try again.'
+
+      if (backendError?.message) {
+        errorMessage = backendError.message
+        if (backendError.suggestions?.length > 0) {
+          errorMessage += `\n\nSuggestion: ${backendError.suggestions[0]}`
+        }
+      } else if (actualError?.message && actualError.message !== 'Request failed with status code 400') {
+        errorMessage = actualError.message
+      }
+
+      setPageError(errorMessage)
+      showError(errorMessage)
+    }
+  }, [deleteSupplier, dispatch, refetchSuppliers, selectedSupplier, setDeleteConfirmOpen, setPageError, showError, showSuccess])
+
+  const handleCancelDelete = useCallback(() => {
+    setDeleteConfirmOpen(false)
+  }, [setDeleteConfirmOpen])
+
+  return {
+    handleDelete,
+    handleCancelDelete,
+  }
+}

--- a/frontend/src/pages/purchasing/hooks/useSuppliersPageState.ts
+++ b/frontend/src/pages/purchasing/hooks/useSuppliersPageState.ts
@@ -1,0 +1,24 @@
+import { useRef, useState } from 'react'
+
+export function useSuppliersPageState() {
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
+  const [deletedSuppliersDialogOpen, setDeletedSuppliersDialogOpen] = useState(false)
+  const [focusedSupplierIndex, setFocusedSupplierIndex] = useState(-1)
+  const [shouldPreserveSearchFocus, setShouldPreserveSearchFocus] = useState(false)
+
+  const supplierListRef = useRef<HTMLDivElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  return {
+    deleteConfirmOpen,
+    setDeleteConfirmOpen,
+    deletedSuppliersDialogOpen,
+    setDeletedSuppliersDialogOpen,
+    focusedSupplierIndex,
+    setFocusedSupplierIndex,
+    shouldPreserveSearchFocus,
+    setShouldPreserveSearchFocus,
+    supplierListRef,
+    searchInputRef,
+  }
+}

--- a/frontend/src/pages/purchasing/hooks/useSuppliersSelection.ts
+++ b/frontend/src/pages/purchasing/hooks/useSuppliersSelection.ts
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useRef, type RefObject } from 'react'
+import type { NavigateFunction } from 'react-router-dom'
+
+import type { AppDispatch } from '@/store'
+import { setSelectedSupplier } from '@/store/slices/purchasingSlice'
+import type { Supplier } from '@/types'
+
+interface UseSuppliersSelectionParams {
+  dispatch: AppDispatch
+  suppliers: Supplier[]
+  selectedSupplier: Supplier | null
+  focusedSupplierIndex: number
+  setFocusedSupplierIndex: (index: number) => void
+  navigate: NavigateFunction
+  supplierListRef: RefObject<HTMLDivElement | null>
+  setDeleteConfirmOpen: (open: boolean) => void
+  setDeletedSuppliersDialogOpen: (open: boolean) => void
+}
+
+export function useSuppliersSelection({
+  dispatch,
+  suppliers,
+  selectedSupplier,
+  focusedSupplierIndex,
+  setFocusedSupplierIndex,
+  navigate,
+  supplierListRef,
+  setDeleteConfirmOpen,
+  setDeletedSuppliersDialogOpen,
+}: UseSuppliersSelectionParams) {
+  const hasAutoSelected = useRef(false)
+
+  useEffect(() => {
+    if (suppliers.length > 0 && !hasAutoSelected.current && focusedSupplierIndex === -1 && !selectedSupplier) {
+      hasAutoSelected.current = true
+      setFocusedSupplierIndex(0)
+      dispatch(setSelectedSupplier(suppliers[0]))
+    } else if (suppliers.length === 0) {
+      dispatch(setSelectedSupplier(null))
+      setFocusedSupplierIndex(-1)
+    }
+  }, [suppliers, dispatch, focusedSupplierIndex, selectedSupplier, setFocusedSupplierIndex])
+
+  useEffect(() => {
+    if (focusedSupplierIndex >= 0 && supplierListRef.current) {
+      const focusedRow = supplierListRef.current.querySelector(`[data-supplier-index="${focusedSupplierIndex}"]`)
+      if (focusedRow) {
+        focusedRow.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      }
+    }
+  }, [focusedSupplierIndex, supplierListRef])
+
+  const handleSupplierSelect = useCallback((supplier: Supplier) => {
+    const index = suppliers.findIndex((candidate) => candidate.id === supplier.id)
+    setFocusedSupplierIndex(index)
+    dispatch(setSelectedSupplier(supplier))
+  }, [suppliers, dispatch, setFocusedSupplierIndex])
+
+  const selectAtIndex = useCallback((index: number) => {
+    setFocusedSupplierIndex(index)
+    dispatch(setSelectedSupplier(suppliers[index]))
+  }, [suppliers, dispatch, setFocusedSupplierIndex])
+
+  const handleNavigateUp = useCallback(() => {
+    if (focusedSupplierIndex > 0) {
+      selectAtIndex(focusedSupplierIndex - 1)
+    }
+  }, [focusedSupplierIndex, selectAtIndex])
+
+  const handleNavigateDown = useCallback(() => {
+    if (focusedSupplierIndex < suppliers.length - 1) {
+      selectAtIndex(focusedSupplierIndex + 1)
+    }
+  }, [focusedSupplierIndex, suppliers.length, selectAtIndex])
+
+  const handleNavigateToFirst = useCallback(() => {
+    if (suppliers.length > 0) {
+      selectAtIndex(0)
+    }
+  }, [suppliers.length, selectAtIndex])
+
+  const handleNavigateToLast = useCallback(() => {
+    if (suppliers.length > 0) {
+      selectAtIndex(suppliers.length - 1)
+    }
+  }, [suppliers.length, selectAtIndex])
+
+  const handlePageUpNavigation = useCallback(() => {
+    const newIndex = Math.max(0, focusedSupplierIndex - 20)
+    if (suppliers[newIndex]) {
+      selectAtIndex(newIndex)
+    }
+  }, [focusedSupplierIndex, suppliers, selectAtIndex])
+
+  const handlePageDownNavigation = useCallback(() => {
+    const newIndex = Math.min(suppliers.length - 1, focusedSupplierIndex + 20)
+    if (suppliers[newIndex]) {
+      selectAtIndex(newIndex)
+    }
+  }, [focusedSupplierIndex, suppliers, selectAtIndex])
+
+  const handleEnterAction = useCallback(() => {
+    if (focusedSupplierIndex >= 0 && suppliers[focusedSupplierIndex]) {
+      navigate(`/purchasing/suppliers/${suppliers[focusedSupplierIndex].id}/edit`)
+    }
+  }, [focusedSupplierIndex, suppliers, navigate])
+
+  const handleEscapeAction = useCallback(() => {
+    setFocusedSupplierIndex(-1)
+    dispatch(setSelectedSupplier(null))
+    setDeleteConfirmOpen(false)
+    setDeletedSuppliersDialogOpen(false)
+  }, [dispatch, setDeleteConfirmOpen, setDeletedSuppliersDialogOpen, setFocusedSupplierIndex])
+
+  return {
+    handleSupplierSelect,
+    handleNavigateUp,
+    handleNavigateDown,
+    handleNavigateToFirst,
+    handleNavigateToLast,
+    handlePageUpNavigation,
+    handlePageDownNavigation,
+    handleEnterAction,
+    handleEscapeAction,
+  }
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -36,6 +36,7 @@ const ProductCustomerReport = React.lazy(() => import('./pages/sales/ProductCust
 
 const PurchasingPage = React.lazy(() => import('./pages/purchasing/PurchasingPage'))
 const SuppliersPage = React.lazy(() => import('./pages/purchasing/SuppliersPage'))
+const SupplierFormPage = React.lazy(() => import('./pages/purchasing/SupplierFormPage'))
 const PurchaseOrdersPage = React.lazy(() => import('./pages/purchasing/PurchaseOrdersPage'))
 const CreatePurchaseOrderPage = React.lazy(() => import('./pages/purchasing/CreatePurchaseOrderPage'))
 const GoodsReceivedPage = React.lazy(() => import('./pages/purchasing/GoodsReceivedPage'))
@@ -153,6 +154,8 @@ export const router = createBrowserRouter([
           { path: '/sales/payments', element: <PaymentsPage />, handle: { title: 'Payments' } },
 
           { path: '/purchasing', element: <PurchasingPage />, handle: { title: 'Purchasing' } },
+          { path: '/purchasing/suppliers/create', element: <SupplierFormPage />, handle: { title: 'New Supplier' } },
+          { path: '/purchasing/suppliers/:id/edit', element: <SupplierFormPage />, handle: { title: 'Edit Supplier' } },
           { path: '/purchasing/suppliers', element: <SuppliersPage />, handle: { title: 'Suppliers' } },
           { path: '/purchasing/orders', element: <PurchaseOrdersPage />, handle: { title: 'Purchase Orders' } },
           { path: '/purchasing/orders/create', element: <CreatePurchaseOrderPage />, handle: { title: 'Create Purchase Order' } },

--- a/frontend/src/store/api/purchasingApi.ts
+++ b/frontend/src/store/api/purchasingApi.ts
@@ -82,6 +82,18 @@ export const purchasingApiSlice = createApi({
       transformResponse: (response: any) => normalizeNamedCollection<Supplier>(response, 'suppliers'),
       providesTags: ['DeletedSupplier'],
     }),
+    getSupplierPurchaseOrders: builder.query<{ data: PurchaseOrder[]; total: number }, string>({
+      query: (id) => ({ url: `/purchasing/suppliers/${id}/purchase-orders` }),
+      providesTags: (_result, _error, id) => [{ type: 'Supplier', id }],
+    }),
+    getSupplierGRNs: builder.query<{ data: GoodsReceivedNote[]; total: number }, string>({
+      query: (id) => ({ url: `/purchasing/suppliers/${id}/grns` }),
+      providesTags: (_result, _error, id) => [{ type: 'Supplier', id }],
+    }),
+    getSupplierPayments: builder.query<{ data: VendorPayment[]; total: number }, string>({
+      query: (id) => ({ url: `/purchasing/suppliers/${id}/payments` }),
+      providesTags: (_result, _error, id) => [{ type: 'Supplier', id }],
+    }),
     restoreSupplier: builder.mutation<Supplier, string>({
       query: (id) => ({ url: `/purchasing/suppliers/${id}/restore`, method: 'POST' }),
       transformResponse: normalizeSingle<Supplier>,
@@ -228,6 +240,9 @@ export const {
   useUpdateSupplierMutation,
   useDeleteSupplierMutation,
   useGetDeletedSuppliersQuery,
+  useGetSupplierPurchaseOrdersQuery,
+  useGetSupplierGRNsQuery,
+  useGetSupplierPaymentsQuery,
   useRestoreSupplierMutation,
   usePermanentDeleteSupplierMutation,
   useBulkRestoreSuppliersMutation,

--- a/frontend/src/store/slices/purchasingSlice.ts
+++ b/frontend/src/store/slices/purchasingSlice.ts
@@ -1,12 +1,13 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 
 import type { RootState } from '@/store'
-import type { GoodsReceivedNote, PurchaseOrder, SupplierType, VendorPayment } from '@/types'
+import type { GoodsReceivedNote, PurchaseOrder, Supplier, SupplierType, VendorPayment } from '@/types'
 
 interface PurchasingState {
   selectedPurchaseOrder: PurchaseOrder | null
   selectedGRN: GoodsReceivedNote | null
   selectedVendorPayment: VendorPayment | null
+  selectedSupplier: Supplier | null
   supplierFilters: {
     search?: string
     type?: SupplierType
@@ -21,6 +22,7 @@ const initialState: PurchasingState = {
   selectedPurchaseOrder: null,
   selectedGRN: null,
   selectedVendorPayment: null,
+  selectedSupplier: null,
   supplierFilters: {
     search: '',
     sortBy: 'companyName',
@@ -42,6 +44,9 @@ const purchasingSlice = createSlice({
     setSelectedVendorPayment: (state, action: PayloadAction<VendorPayment | null>) => {
       state.selectedVendorPayment = action.payload
     },
+    setSelectedSupplier: (state, action: PayloadAction<Supplier | null>) => {
+      state.selectedSupplier = action.payload
+    },
     updatePurchaseOrderInPlace: (state, action: PayloadAction<PurchaseOrder>) => {
       state.selectedPurchaseOrder = action.payload
     },
@@ -55,6 +60,7 @@ export const {
   setSelectedPurchaseOrder,
   setSelectedGRN,
   setSelectedVendorPayment,
+  setSelectedSupplier,
   updatePurchaseOrderInPlace,
   setSupplierFilters,
 } = purchasingSlice.actions
@@ -62,6 +68,7 @@ export const {
 export const selectSelectedPurchaseOrder = (state: RootState) => state.purchasing.selectedPurchaseOrder
 export const selectSelectedGRN = (state: RootState) => state.purchasing.selectedGRN
 export const selectSelectedVendorPayment = (state: RootState) => state.purchasing.selectedVendorPayment
+export const selectSelectedSupplier = (state: RootState) => state.purchasing.selectedSupplier
 export const selectSupplierFilters = (state: RootState) => state.purchasing.supplierFilters
 
 export default purchasingSlice.reducer

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -313,6 +313,12 @@ export interface Supplier {
   companyName: string;
   contactPerson?: string;
   phone?: string;
+  isActive: boolean;
+  streetAddress?: string | null;
+  city?: string | null;
+  state?: string | null;
+  postalCode?: string | null;
+  country?: string | null;
   // Metrics
   totalPurchases: number;
   totalOrders: number;


### PR DESCRIPTION
## Summary

- Refactors `SuppliersPage.tsx` from a flat Table+Dialog pattern to the `MasterDetailWorkspace` layout, matching `CustomersPage.tsx`
- Adds 3 backend per-supplier history endpoints (`GET /purchasing/suppliers/:id/purchase-orders|grns|payments`)
- Extracts hooks (`useSuppliersPageState`, `useSuppliersSelection`, `useSuppliersActions`) and sub-components (`SupplierList`, `SupplierContextHeader`, `SupplierWorkspaceCard`, `SuppliersDialogs`)
- Adds standalone `SupplierFormPage.tsx` route (`/purchasing/suppliers/create` and `/:id/edit`)
- Fixes `isActive` missing from `SupplierResponseDto` and `mapToResponseDto`
- Cleans up `Supplier` type: adds `isActive`, address fields; removes all `as any` casts

Closes #312

## Test plan

- [x] `cd backend && npm run lint` passes
- [x] `cd backend && npm run test` passes
- [x] `cd frontend && npm run lint` passes
- [x] `cd frontend && npm run type-check` passes
- [x] `npx vitest run src/pages/purchasing/components/__tests__/SupplierContextHeader.test.tsx` passes
- [x] `npx vitest run src/pages/purchasing/components/__tests__/SupplierWorkspaceCard.test.tsx` passes
- [x] `npx vitest run src/pages/purchasing/__tests__/SuppliersPage.filterbar.test.tsx` passes
- [x] Suppliers list loads with MasterDetailWorkspace layout
- [x] Keyboard navigation (↑↓ PageUp/Down Home/End Enter Escape) works
- [x] SupplierContextHeader shows correct Active/Inactive status
- [x] WorkspaceCard PO/GRN/Payments tabs load per-supplier data
- [x] Create/Edit/Delete flows work via new form route

🤖 Generated with [Claude Code](https://claude.com/claude-code)