### PR TITLE
fix: remove hardcoded timezone, add tz-aware date range resolver

### DIFF
--- a/backend/src/common/utils/date-range.util.spec.ts
+++ b/backend/src/common/utils/date-range.util.spec.ts
@@ -1,0 +1,130 @@
+import { DateTime } from 'luxon';
+import { DateRange } from '@/common/dto/analytics.dto';
+import { resolveDateRange } from './date-range.util';
+
+describe('resolveDateRange', () => {
+  const TZ = 'Asia/Kuala_Lumpur';
+  const fixedUtcNow = new Date('2026-04-09T23:30:00.000Z');
+
+  function kl(
+    year: number,
+    month: number,
+    day: number,
+    hour = 0,
+    minute = 0,
+    second = 0,
+    ms = 0,
+  ): Date {
+    return DateTime.fromObject(
+      { year, month, day, hour, minute, second, millisecond: ms },
+      { zone: TZ },
+    ).toJSDate();
+  }
+
+  describe('custom date range', () => {
+    it('returns normalized custom dates regardless of dateRange param', () => {
+      const start = new Date('2026-03-01T00:00:00.000Z');
+      const end = new Date('2026-03-31T00:00:00.000Z');
+      const { startDate, endDate } = resolveDateRange(TZ, undefined, start, end, fixedUtcNow);
+
+      expect(startDate.toISOString()).toBe('2026-03-01T00:00:00.000Z');
+      expect(endDate.toISOString()).toBe('2026-03-31T23:59:59.999Z');
+    });
+  });
+
+  describe('TODAY', () => {
+    it('returns start and end of the current day in the configured timezone', () => {
+      const { startDate, endDate } = resolveDateRange(TZ, DateRange.TODAY, undefined, undefined, fixedUtcNow);
+
+      expect(startDate.toISOString()).toBe(kl(2026, 4, 10, 0, 0, 0, 0).toISOString());
+      expect(endDate.toISOString()).toBe(kl(2026, 4, 10, 23, 59, 59, 999).toISOString());
+    });
+  });
+
+  describe('THIS_WEEK', () => {
+    it('returns start of Sunday of the current week in the configured timezone', () => {
+      const { startDate, endDate } = resolveDateRange(TZ, DateRange.THIS_WEEK, undefined, undefined, fixedUtcNow);
+
+      expect(startDate.toISOString()).toBe(kl(2026, 4, 5, 0, 0, 0, 0).toISOString());
+      expect(endDate.toISOString()).toBe(kl(2026, 4, 10, 23, 59, 59, 999).toISOString());
+    });
+  });
+
+  describe('THIS_MONTH', () => {
+    it('returns first day of current month in the configured timezone', () => {
+      const { startDate, endDate } = resolveDateRange(TZ, DateRange.THIS_MONTH, undefined, undefined, fixedUtcNow);
+
+      expect(startDate.toISOString()).toBe(kl(2026, 4, 1, 0, 0, 0, 0).toISOString());
+      expect(endDate.toISOString()).toBe(kl(2026, 4, 10, 23, 59, 59, 999).toISOString());
+    });
+  });
+
+  describe('THIS_QUARTER', () => {
+    it('returns first day of Q2 (Apr) for April date', () => {
+      const { startDate } = resolveDateRange(TZ, DateRange.THIS_QUARTER, undefined, undefined, fixedUtcNow);
+
+      expect(startDate.toISOString()).toBe(kl(2026, 4, 1, 0, 0, 0, 0).toISOString());
+    });
+  });
+
+  describe('THIS_YEAR', () => {
+    it('returns Jan 1 of current year in the configured timezone', () => {
+      const { startDate } = resolveDateRange(TZ, DateRange.THIS_YEAR, undefined, undefined, fixedUtcNow);
+
+      expect(startDate.toISOString()).toBe(kl(2026, 1, 1, 0, 0, 0, 0).toISOString());
+    });
+  });
+
+  describe('LAST_WEEK', () => {
+    it('returns the full previous week (Sun-Sat) in the configured timezone', () => {
+      const { startDate, endDate } = resolveDateRange(TZ, DateRange.LAST_WEEK, undefined, undefined, fixedUtcNow);
+
+      expect(startDate.toISOString()).toBe(kl(2026, 3, 29, 0, 0, 0, 0).toISOString());
+      expect(endDate.toISOString()).toBe(kl(2026, 4, 4, 23, 59, 59, 999).toISOString());
+    });
+  });
+
+  describe('LAST_MONTH', () => {
+    it('returns the full previous calendar month in the configured timezone', () => {
+      const { startDate, endDate } = resolveDateRange(TZ, DateRange.LAST_MONTH, undefined, undefined, fixedUtcNow);
+
+      expect(startDate.toISOString()).toBe(kl(2026, 3, 1, 0, 0, 0, 0).toISOString());
+      expect(endDate.toISOString()).toBe(kl(2026, 3, 31, 23, 59, 59, 999).toISOString());
+    });
+  });
+
+  describe('LAST_QUARTER', () => {
+    it('returns Q1 (Jan-Mar) when current month is April', () => {
+      const { startDate, endDate } = resolveDateRange(TZ, DateRange.LAST_QUARTER, undefined, undefined, fixedUtcNow);
+
+      expect(startDate.toISOString()).toBe(kl(2026, 1, 1, 0, 0, 0, 0).toISOString());
+      expect(endDate.toISOString()).toBe(kl(2026, 3, 31, 23, 59, 59, 999).toISOString());
+    });
+  });
+
+  describe('LAST_YEAR', () => {
+    it('returns the full previous calendar year in the configured timezone', () => {
+      const { startDate, endDate } = resolveDateRange(TZ, DateRange.LAST_YEAR, undefined, undefined, fixedUtcNow);
+
+      expect(startDate.toISOString()).toBe(kl(2025, 1, 1, 0, 0, 0, 0).toISOString());
+      expect(endDate.toISOString()).toBe(kl(2025, 12, 31, 23, 59, 59, 999).toISOString());
+    });
+  });
+
+  describe('default (no dateRange)', () => {
+    it('defaults to THIS_MONTH when dateRange is undefined', () => {
+      const { startDate } = resolveDateRange(TZ, undefined, undefined, undefined, fixedUtcNow);
+
+      expect(startDate.toISOString()).toBe(kl(2026, 4, 1, 0, 0, 0, 0).toISOString());
+    });
+  });
+
+  describe('UTC boundary correctness', () => {
+    it('midnight KL is 16:00 previous day UTC (not 00:00 UTC)', () => {
+      const { startDate } = resolveDateRange(TZ, DateRange.TODAY, undefined, undefined, fixedUtcNow);
+
+      expect(startDate.getUTCHours()).toBe(16);
+      expect(startDate.getUTCDate()).toBe(9);
+    });
+  });
+});

--- a/backend/src/common/utils/date-range.util.ts
+++ b/backend/src/common/utils/date-range.util.ts
@@ -1,0 +1,79 @@
+import { DateTime } from 'luxon';
+import { DateRange } from '@/common/dto/analytics.dto';
+
+export function resolveDateRange(
+  timezone: string,
+  dateRange?: DateRange,
+  customStartDate?: Date,
+  customEndDate?: Date,
+  now: Date = new Date(),
+): { startDate: Date; endDate: Date } {
+  if (customStartDate && customEndDate) {
+    const normalizedStart = new Date(customStartDate);
+    normalizedStart.setUTCHours(0, 0, 0, 0);
+
+    const normalizedEnd = new Date(customEndDate);
+    normalizedEnd.setUTCHours(23, 59, 59, 999);
+
+    return { startDate: normalizedStart, endDate: normalizedEnd };
+  }
+
+  const current = DateTime.fromJSDate(now, { zone: timezone });
+  const endOfToday = current.endOf('day');
+  let startDate: Date;
+  let endDate = endOfToday.toJSDate();
+
+  switch (dateRange) {
+    case DateRange.TODAY:
+      startDate = current.startOf('day').toJSDate();
+      break;
+    case DateRange.THIS_WEEK:
+      startDate = current.startOf('day').minus({ days: current.weekday % 7 }).toJSDate();
+      break;
+    case DateRange.THIS_MONTH:
+      startDate = current.startOf('month').toJSDate();
+      break;
+    case DateRange.THIS_QUARTER: {
+      const quarterStartMonth = Math.floor((current.month - 1) / 3) * 3 + 1;
+      startDate = current.set({ month: quarterStartMonth }).startOf('month').toJSDate();
+      break;
+    }
+    case DateRange.THIS_YEAR:
+      startDate = current.startOf('year').toJSDate();
+      break;
+    case DateRange.LAST_WEEK: {
+      const startOfThisWeek = current.startOf('day').minus({ days: current.weekday % 7 });
+      startDate = startOfThisWeek.minus({ weeks: 1 }).toJSDate();
+      endDate = startOfThisWeek.minus({ milliseconds: 1 }).toJSDate();
+      break;
+    }
+    case DateRange.LAST_MONTH: {
+      const lastMonth = current.minus({ months: 1 });
+      startDate = lastMonth.startOf('month').toJSDate();
+      endDate = lastMonth.endOf('month').toJSDate();
+      break;
+    }
+    case DateRange.LAST_QUARTER: {
+      const currentQuarterStartMonth = Math.floor((current.month - 1) / 3) * 3 + 1;
+      const lastQuarterStartMonth = currentQuarterStartMonth - 3;
+      const lastQuarter =
+        lastQuarterStartMonth < 1
+          ? current.set({ year: current.year - 1, month: lastQuarterStartMonth + 12 })
+          : current.set({ month: lastQuarterStartMonth });
+      startDate = lastQuarter.startOf('month').toJSDate();
+      endDate = lastQuarter.plus({ months: 2 }).endOf('month').toJSDate();
+      break;
+    }
+    case DateRange.LAST_YEAR: {
+      const lastYear = current.minus({ years: 1 });
+      startDate = lastYear.startOf('year').toJSDate();
+      endDate = lastYear.endOf('year').toJSDate();
+      break;
+    }
+    default:
+      startDate = current.startOf('month').toJSDate();
+      break;
+  }
+
+  return { startDate, endDate };
+}

--- a/backend/src/config/database-config.factory.ts
+++ b/backend/src/config/database-config.factory.ts
@@ -126,7 +126,7 @@ export function createDatabaseConfig(configService: ConfigService, allowDefaults
       ),
 
       // Timezone configuration for PostgreSQL
-      timezone: 'Asia/Kuala_Lumpur',
+      timezone: 'UTC',
     },
   };
 }

--- a/backend/src/database/migrations/1775697850409-RemoveHardcodedTimezone.ts
+++ b/backend/src/database/migrations/1775697850409-RemoveHardcodedTimezone.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveHardcodedTimezone1775697850409 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER DATABASE erp_db SET timezone TO 'UTC'`);
+    await queryRunner.query(`
+      COMMENT ON DATABASE erp_db IS 'ERP Database - Timezone: UTC (user timezone managed via RegionalSettings)'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER DATABASE erp_db SET timezone TO 'Asia/Kuala_Lumpur'`);
+    await queryRunner.query(`
+      COMMENT ON DATABASE erp_db IS 'ERP Database - Timezone: Asia/Kuala_Lumpur'
+    `);
+  }
+}

--- a/backend/src/modules/inventory/services/inventory-analytics-dashboard.service.spec.ts
+++ b/backend/src/modules/inventory/services/inventory-analytics-dashboard.service.spec.ts
@@ -47,7 +47,7 @@ describe('InventoryAnalyticsService.getInventoryDashboardAnalytics', () => {
     stockMovementRepo = mockRepo();
     purchaseOrderItemRepo = mockRepo();
     settingsService = {
-      getRegionalSettings: jest.fn().mockResolvedValue({ lowStockThreshold: 10 }),
+      getRegionalSettings: jest.fn().mockResolvedValue({ lowStockThreshold: 10, timezone: 'UTC' }),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/backend/src/modules/inventory/services/inventory-analytics.service.ts
+++ b/backend/src/modules/inventory/services/inventory-analytics.service.ts
@@ -6,6 +6,7 @@ import { PurchaseCostHistory } from '../../../database/entities/purchase-cost-hi
 import { PurchaseOrderItem } from '../../../database/entities/purchase-order-item.entity';
 import { differenceInCalendarDays, subDays, subMonths, subYears } from 'date-fns';
 import { SettingsService } from '../../settings/settings.service';
+import { resolveDateRange } from '@/common/utils/date-range.util';
 import {
   InventoryAnalyticsQueryDto,
   InventoryAnalyticsResponseDto,
@@ -15,7 +16,7 @@ import {
   LowStockAlertDto,
   RecentMovementDto,
 } from '../dto/inventory-analytics.dto';
-import { DateRange, GroupByPeriod } from '@/common/dto/analytics.dto';
+import { GroupByPeriod } from '@/common/dto/analytics.dto';
 
 export interface InventorySummaryQuery {
   productIds?: string[];
@@ -660,7 +661,9 @@ export class InventoryAnalyticsService {
   async getInventoryDashboardAnalytics(
     query: InventoryAnalyticsQueryDto,
   ): Promise<InventoryAnalyticsResponseDto> {
-    const { startDate, endDate } = this.resolveInventoryDateRange(
+    const { timezone } = await this.settingsService.getRegionalSettings();
+    const { startDate, endDate } = resolveDateRange(
+      timezone,
       query.dateRange,
       query.startDate,
       query.endDate,
@@ -954,76 +957,6 @@ export class InventoryAnalyticsService {
   private async getLowStockThreshold(): Promise<number> {
     const settings = await this.settingsService.getRegionalSettings();
     return settings.lowStockThreshold ?? 10;
-  }
-
-  private resolveInventoryDateRange(
-    dateRange?: DateRange,
-    customStartDate?: Date,
-    customEndDate?: Date,
-  ): { startDate: Date; endDate: Date } {
-    const now = new Date();
-    let startDate: Date;
-    let endDate = new Date(new Date().setHours(23, 59, 59, 999));
-
-    if (customStartDate && customEndDate) {
-      const normalizedStart = new Date(customStartDate);
-      normalizedStart.setUTCHours(0, 0, 0, 0);
-      const normalizedEnd = new Date(customEndDate);
-      normalizedEnd.setUTCHours(23, 59, 59, 999);
-      return { startDate: normalizedStart, endDate: normalizedEnd };
-    }
-
-    switch (dateRange) {
-      case DateRange.TODAY:
-        startDate = new Date(now.setHours(0, 0, 0, 0));
-        break;
-      case DateRange.THIS_WEEK:
-        startDate = new Date(now.setDate(now.getDate() - now.getDay()));
-        startDate.setHours(0, 0, 0, 0);
-        break;
-      case DateRange.THIS_MONTH:
-        startDate = new Date(now.getFullYear(), now.getMonth(), 1);
-        break;
-      case DateRange.THIS_QUARTER: {
-        const quarter = Math.floor(now.getMonth() / 3);
-        startDate = new Date(now.getFullYear(), quarter * 3, 1);
-        break;
-      }
-      case DateRange.THIS_YEAR:
-        startDate = new Date(now.getFullYear(), 0, 1);
-        break;
-      case DateRange.LAST_WEEK: {
-        const day = now.getDay();
-        startDate = new Date(now);
-        startDate.setDate(startDate.getDate() - day - 7);
-        startDate.setHours(0, 0, 0, 0);
-        endDate = new Date(now);
-        endDate.setDate(endDate.getDate() - day - 1);
-        endDate.setHours(23, 59, 59, 999);
-        break;
-      }
-      case DateRange.LAST_MONTH:
-        startDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
-        endDate = new Date(now.getFullYear(), now.getMonth(), 0, 23, 59, 59, 999);
-        break;
-      case DateRange.LAST_QUARTER: {
-        const lastQuarter = Math.floor(now.getMonth() / 3) - 1;
-        const year = lastQuarter < 0 ? now.getFullYear() - 1 : now.getFullYear();
-        const quarterStart = lastQuarter < 0 ? 3 : lastQuarter;
-        startDate = new Date(year, quarterStart * 3, 1);
-        endDate = new Date(year, quarterStart * 3 + 3, 0, 23, 59, 59, 999);
-        break;
-      }
-      case DateRange.LAST_YEAR:
-        startDate = new Date(now.getFullYear() - 1, 0, 1);
-        endDate = new Date(now.getFullYear() - 1, 11, 31, 23, 59, 59, 999);
-        break;
-      default:
-        startDate = new Date(now.getFullYear(), now.getMonth(), 1);
-        break;
-    }
-
-    return { startDate, endDate };
   }
 
   private computeInventoryComparePeriod(

--- a/backend/src/modules/purchasing/services/purchasing-analytics.service.spec.ts
+++ b/backend/src/modules/purchasing/services/purchasing-analytics.service.spec.ts
@@ -10,6 +10,7 @@ import {
 import { PurchasingAnalyticsService } from './purchasing-analytics.service';
 import { PurchasingAnalyticsQueryDto } from '../dto/purchasing-analytics.dto';
 import { DateRange } from '@/common/dto/analytics.dto';
+import { SettingsService } from '../../settings/settings.service';
 
 function makeChainableQb(rawManyResult: any[] = [], manyResult: any[] = [], rawOneResult: any = {}) {
   const qb: any = {
@@ -34,9 +35,13 @@ function makeChainableQb(rawManyResult: any[] = [], manyResult: any[] = [], rawO
 describe('PurchasingAnalyticsService', () => {
   let service: PurchasingAnalyticsService;
   let purchaseOrderRepository: { createQueryBuilder: jest.Mock };
+  let settingsService: { getRegionalSettings: jest.Mock };
 
   beforeEach(async () => {
     purchaseOrderRepository = { createQueryBuilder: jest.fn() };
+    settingsService = {
+      getRegionalSettings: jest.fn().mockResolvedValue({ timezone: 'UTC' }),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -46,6 +51,7 @@ describe('PurchasingAnalyticsService', () => {
         { provide: getRepositoryToken(Supplier), useValue: { createQueryBuilder: jest.fn() } },
         { provide: getRepositoryToken(Product), useValue: { createQueryBuilder: jest.fn() } },
         { provide: getRepositoryToken(VendorPayment), useValue: { createQueryBuilder: jest.fn() } },
+        { provide: SettingsService, useValue: settingsService },
       ],
     }).compile();
 

--- a/backend/src/modules/purchasing/services/purchasing-analytics.service.ts
+++ b/backend/src/modules/purchasing/services/purchasing-analytics.service.ts
@@ -9,6 +9,7 @@ import {
   VendorPayment,
 } from '../../../database/entities';
 import { differenceInCalendarDays, subDays, subMonths, subYears } from 'date-fns';
+import { SettingsService } from '../../settings/settings.service';
 import {
   PurchasingAnalyticsQueryDto,
   PurchasingAnalyticsResponseDto,
@@ -18,7 +19,8 @@ import {
   TopSupplierDto,
   RecentPurchaseOrderDto,
 } from '../dto/purchasing-analytics.dto';
-import { DateRange, GroupByPeriod } from '@/common/dto/analytics.dto';
+import { GroupByPeriod } from '@/common/dto/analytics.dto';
+import { resolveDateRange } from '@/common/utils/date-range.util';
 
 interface PurchaseOrderSummaryQuery {
   dateFrom?: Date;
@@ -120,6 +122,7 @@ export class PurchasingAnalyticsService {
     private readonly productRepository: Repository<Product>,
     @InjectRepository(VendorPayment)
     private readonly vendorPaymentRepository: Repository<VendorPayment>,
+    private readonly settingsService: SettingsService,
   ) {}
 
   async getPurchaseOrderSummary(
@@ -578,7 +581,9 @@ export class PurchasingAnalyticsService {
   async getPurchasingAnalytics(
     query: PurchasingAnalyticsQueryDto,
   ): Promise<PurchasingAnalyticsResponseDto> {
-    const { startDate, endDate } = this.parsePurchasingDateRange(
+    const { timezone } = await this.settingsService.getRegionalSettings();
+    const { startDate, endDate } = resolveDateRange(
+      timezone,
       query.dateRange,
       query.startDate,
       query.endDate,
@@ -919,72 +924,6 @@ export class PurchasingAnalyticsService {
       : mapped;
 
     return filtered.slice(0, limit).map(({ computedPaymentStatus: _, ...rest }) => rest);
-  }
-
-  private parsePurchasingDateRange(
-    dateRange?: DateRange,
-    customStartDate?: Date,
-    customEndDate?: Date,
-  ): { startDate: Date; endDate: Date } {
-    const now = new Date();
-    let startDate: Date;
-    let endDate: Date = new Date(new Date().setHours(23, 59, 59, 999));
-
-    if (customStartDate && customEndDate) {
-      const normalizedStartDate = new Date(customStartDate);
-      normalizedStartDate.setUTCHours(0, 0, 0, 0);
-      const normalizedEndDate = new Date(customEndDate);
-      normalizedEndDate.setUTCHours(23, 59, 59, 999);
-      return { startDate: normalizedStartDate, endDate: normalizedEndDate };
-    }
-
-    switch (dateRange) {
-      case DateRange.TODAY:
-        startDate = new Date(now.setHours(0, 0, 0, 0));
-        break;
-      case DateRange.THIS_WEEK:
-        startDate = new Date(now.setDate(now.getDate() - now.getDay()));
-        startDate.setHours(0, 0, 0, 0);
-        break;
-      case DateRange.THIS_MONTH:
-        startDate = new Date(now.getFullYear(), now.getMonth(), 1);
-        break;
-      case DateRange.THIS_QUARTER: {
-        const quarter = Math.floor(now.getMonth() / 3);
-        startDate = new Date(now.getFullYear(), quarter * 3, 1);
-        break;
-      }
-      case DateRange.THIS_YEAR:
-        startDate = new Date(now.getFullYear(), 0, 1);
-        break;
-      case DateRange.LAST_WEEK:
-        startDate = new Date(now.setDate(now.getDate() - now.getDay() - 7));
-        startDate.setHours(0, 0, 0, 0);
-        endDate = new Date(now.setDate(now.getDate() - now.getDay() - 1));
-        endDate.setHours(23, 59, 59, 999);
-        break;
-      case DateRange.LAST_MONTH:
-        startDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
-        endDate = new Date(now.getFullYear(), now.getMonth(), 0, 23, 59, 59, 999);
-        break;
-      case DateRange.LAST_QUARTER: {
-        const lastQuarter = Math.floor(now.getMonth() / 3) - 1;
-        const year = lastQuarter < 0 ? now.getFullYear() - 1 : now.getFullYear();
-        const quarterStart = lastQuarter < 0 ? 3 : lastQuarter;
-        startDate = new Date(year, quarterStart * 3, 1);
-        endDate = new Date(year, quarterStart * 3 + 3, 0, 23, 59, 59, 999);
-        break;
-      }
-      case DateRange.LAST_YEAR:
-        startDate = new Date(now.getFullYear() - 1, 0, 1);
-        endDate = new Date(now.getFullYear() - 1, 11, 31, 23, 59, 59, 999);
-        break;
-      default: // THIS_MONTH
-        startDate = new Date(now.getFullYear(), now.getMonth(), 1);
-        break;
-    }
-
-    return { startDate, endDate };
   }
 
   private computePurchasingComparePeriod(

--- a/backend/src/modules/sales/services/sales-analytics.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-analytics.service.spec.ts
@@ -8,6 +8,7 @@ import { Customer } from '../../../database/entities/customer.entity';
 import { SalesOrderItem } from '../../../database/entities/sales-order-item.entity';
 import { SalesAnalyticsReportService } from './sales-analytics-report.service';
 import { SalesAnalyticsQueryDto } from '../dto/sales-analytics.dto';
+import { SettingsService } from '../../settings/settings.service';
 
 const d = (s: string) => new Date(`${s}T00:00:00.000Z`);
 
@@ -51,8 +52,12 @@ function makeChainableQb(rawOneResult: any = {}) {
 
 describe('SalesAnalyticsService', () => {
   let service: SalesAnalyticsService;
+  const settingsService = {
+    getRegionalSettings: jest.fn().mockResolvedValue({ timezone: 'UTC' }),
+  };
 
   beforeEach(async () => {
+    settingsService.getRegionalSettings.mockResolvedValue({ timezone: 'UTC' });
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SalesAnalyticsService,
@@ -62,34 +67,11 @@ describe('SalesAnalyticsService', () => {
         { provide: getRepositoryToken(Customer), useValue: makeRepoMock() },
         { provide: getRepositoryToken(SalesOrderItem), useValue: makeRepoMock() },
         { provide: SalesAnalyticsReportService, useValue: { getProductSummary: jest.fn() } },
+        { provide: SettingsService, useValue: settingsService },
       ],
     }).compile();
 
     service = module.get<SalesAnalyticsService>(SalesAnalyticsService);
-  });
-
-  describe('parseDateRange', () => {
-    it('uses explicit startDate and endDate when provided without dateRange', () => {
-      const result = (service as any).parseDateRange(
-        undefined,
-        d('2026-03-10'),
-        d('2026-03-16'),
-      );
-
-      expect(result.startDate.toISOString().slice(0, 10)).toBe('2026-03-10');
-      expect(result.endDate.toISOString().slice(0, 10)).toBe('2026-03-16');
-    });
-
-    it('treats explicit endDate as inclusive through the end of that day', () => {
-      const result = (service as any).parseDateRange(
-        undefined,
-        d('2026-03-10'),
-        d('2026-03-16'),
-      );
-
-      expect(result.startDate.toISOString()).toBe('2026-03-10T00:00:00.000Z');
-      expect(result.endDate.toISOString()).toBe('2026-03-16T23:59:59.999Z');
-    });
   });
 
   describe('computeComparePeriod', () => {
@@ -143,10 +125,6 @@ describe('SalesAnalyticsService', () => {
 
   describe('getSalesAnalytics', () => {
     beforeEach(() => {
-      jest.spyOn(service as any, 'parseDateRange').mockReturnValue({
-        startDate: d('2026-03-01'),
-        endDate: d('2026-03-31'),
-      });
       jest.spyOn(service as any, 'calculateSalesMetrics').mockResolvedValue({
         totalRevenue: 100,
         totalOrders: 10,
@@ -189,6 +167,7 @@ describe('SalesAnalyticsService', () => {
       expect(result.comparison).toBeDefined();
       expect(result.topCustomers).toBeDefined();
       expect(result.topProducts).toBeDefined();
+      expect(settingsService.getRegionalSettings).toHaveBeenCalled();
     });
 
     it('omits comparison block when compareWith is not set', async () => {
@@ -364,6 +343,7 @@ describe('SalesAnalyticsService', () => {
           },
           { provide: getRepositoryToken(SalesOrderItem), useValue: makeRepoMock() },
           { provide: SalesAnalyticsReportService, useValue: { getProductSummary: jest.fn() } },
+          { provide: SettingsService, useValue: settingsService },
         ],
       }).compile();
       const svc = module2.get<SalesAnalyticsService>(SalesAnalyticsService);
@@ -411,6 +391,7 @@ describe('SalesAnalyticsService', () => {
           },
           { provide: getRepositoryToken(SalesOrderItem), useValue: makeRepoMock() },
           { provide: SalesAnalyticsReportService, useValue: { getProductSummary: jest.fn() } },
+          { provide: SettingsService, useValue: settingsService },
         ],
       }).compile();
       const svc = module2.get<SalesAnalyticsService>(SalesAnalyticsService);
@@ -460,6 +441,7 @@ describe('SalesAnalyticsService', () => {
           },
           { provide: getRepositoryToken(SalesOrderItem), useValue: makeRepoMock() },
           { provide: SalesAnalyticsReportService, useValue: { getProductSummary: jest.fn() } },
+          { provide: SettingsService, useValue: settingsService },
         ],
       }).compile();
       const svc = module2.get<SalesAnalyticsService>(SalesAnalyticsService);

--- a/backend/src/modules/sales/services/sales-analytics.service.ts
+++ b/backend/src/modules/sales/services/sales-analytics.service.ts
@@ -14,7 +14,6 @@ import {
   PeriodMetricDto,
   TopCustomerDto,
   TopProductDto,
-  DateRange,
   SalesPipelineQueryDto,
   SalesPipelineResponseDto,
   PipelineStageDto,
@@ -27,6 +26,8 @@ import {
   SalesAnalyticsPeriodBlockDto,
 } from '../dto/sales-analytics.dto';
 import { SalesAnalyticsReportService } from './sales-analytics-report.service';
+import { SettingsService } from '../../settings/settings.service';
+import { resolveDateRange } from '@/common/utils/date-range.util';
 
 function translatePaymentStatus(
   status: 'unpaid' | 'partial' | 'paid' | 'overpaid',
@@ -61,10 +62,12 @@ export class SalesAnalyticsService {
     @InjectRepository(SalesOrderItem)
     private readonly salesOrderItemRepository: Repository<SalesOrderItem>,
     private readonly salesAnalyticsReportService: SalesAnalyticsReportService,
+    private readonly settingsService: SettingsService,
   ) {}
 
   async getSalesAnalytics(query: SalesAnalyticsQueryDto): Promise<SalesAnalyticsResponseDto> {
-    const { startDate, endDate } = this.parseDateRange(query.dateRange, query.startDate, query.endDate);
+    const { timezone } = await this.settingsService.getRegionalSettings();
+    const { startDate, endDate } = resolveDateRange(timezone, query.dateRange, query.startDate, query.endDate);
     const groupBy = query.groupBy ?? GroupByPeriod.MONTH;
     const comparePeriod = query.compareWith
       ? this.computeComparePeriod(startDate, endDate, query.compareWith)
@@ -108,7 +111,8 @@ export class SalesAnalyticsService {
   }
 
   async getSalesPipeline(query: SalesPipelineQueryDto): Promise<SalesPipelineResponseDto> {
-    const { startDate, endDate } = this.parseDateRange(query.dateRange, query.startDate, query.endDate);
+    const { timezone } = await this.settingsService.getRegionalSettings();
+    const { startDate, endDate } = resolveDateRange(timezone, query.dateRange, query.startDate, query.endDate);
 
     let queryBuilder = this.salesOrderRepository
       .createQueryBuilder('order')
@@ -168,7 +172,8 @@ export class SalesAnalyticsService {
       throw new Error('Customer ID is required');
     }
 
-    const { startDate, endDate } = this.parseDateRange(query.dateRange, query.startDate, query.endDate);
+    const { timezone } = await this.settingsService.getRegionalSettings();
+    const { startDate, endDate } = resolveDateRange(timezone, query.dateRange, query.startDate, query.endDate);
 
     const customer = await this.customerRepository.findOne({
       where: { id: query.customerId },
@@ -231,7 +236,8 @@ export class SalesAnalyticsService {
   }
 
   async getRevenueReport(query: RevenueReportQueryDto): Promise<RevenueReportResponseDto> {
-    const { startDate, endDate } = this.parseDateRange(query.period, query.startDate, query.endDate);
+    const { timezone } = await this.settingsService.getRegionalSettings();
+    const { startDate, endDate } = resolveDateRange(timezone, query.period, query.startDate, query.endDate);
     const groupBy = query.groupBy || 'month';
 
     // Get current period data
@@ -746,75 +752,6 @@ export class SalesAnalyticsService {
         averageOrderValue: 0,
       },
     );
-  }
-
-  private parseDateRange(
-    dateRange?: DateRange,
-    customStartDate?: Date,
-    customEndDate?: Date,
-  ): { startDate: Date; endDate: Date } {
-    const now = new Date();
-    let startDate: Date;
-    let endDate: Date = new Date(now.setHours(23, 59, 59, 999));
-
-    if (customStartDate && customEndDate) {
-      const normalizedStartDate = new Date(customStartDate);
-      normalizedStartDate.setUTCHours(0, 0, 0, 0);
-
-      const normalizedEndDate = new Date(customEndDate);
-      normalizedEndDate.setUTCHours(23, 59, 59, 999);
-
-      return {
-        startDate: normalizedStartDate,
-        endDate: normalizedEndDate,
-      };
-    }
-
-    switch (dateRange) {
-      case DateRange.TODAY:
-        startDate = new Date(now.setHours(0, 0, 0, 0));
-        break;
-      case DateRange.THIS_WEEK:
-        startDate = new Date(now.setDate(now.getDate() - now.getDay()));
-        startDate.setHours(0, 0, 0, 0);
-        break;
-      case DateRange.THIS_MONTH:
-        startDate = new Date(now.getFullYear(), now.getMonth(), 1);
-        break;
-      case DateRange.THIS_QUARTER:
-        const quarter = Math.floor(now.getMonth() / 3);
-        startDate = new Date(now.getFullYear(), quarter * 3, 1);
-        break;
-      case DateRange.THIS_YEAR:
-        startDate = new Date(now.getFullYear(), 0, 1);
-        break;
-      case DateRange.LAST_WEEK:
-        startDate = new Date(now.setDate(now.getDate() - now.getDay() - 7));
-        startDate.setHours(0, 0, 0, 0);
-        endDate = new Date(now.setDate(now.getDate() - now.getDay() - 1));
-        endDate.setHours(23, 59, 59, 999);
-        break;
-      case DateRange.LAST_MONTH:
-        startDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
-        endDate = new Date(now.getFullYear(), now.getMonth(), 0, 23, 59, 59, 999);
-        break;
-      case DateRange.LAST_QUARTER:
-        const lastQuarter = Math.floor(now.getMonth() / 3) - 1;
-        const year = lastQuarter < 0 ? now.getFullYear() - 1 : now.getFullYear();
-        const quarterStart = lastQuarter < 0 ? 3 : lastQuarter;
-        startDate = new Date(year, quarterStart * 3, 1);
-        endDate = new Date(year, quarterStart * 3 + 3, 0, 23, 59, 59, 999);
-        break;
-      case DateRange.LAST_YEAR:
-        startDate = new Date(now.getFullYear() - 1, 0, 1);
-        endDate = new Date(now.getFullYear() - 1, 11, 31, 23, 59, 59, 999);
-        break;
-      default: // THIS_MONTH
-        startDate = new Date(now.getFullYear(), now.getMonth(), 1);
-        break;
-    }
-
-    return { startDate, endDate };
   }
 
   private computeComparePeriod(

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,7 +10,6 @@ services:
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
       POSTGRES_INITDB_ARGS: "--encoding=UTF8 --locale=C"
       PGDATA: /var/lib/postgresql/data/pgdata
-      TZ: Asia/Kuala_Lumpur
     volumes:
       - ./data/postgres:/var/lib/postgresql/data/pgdata
     networks:
@@ -42,8 +41,6 @@ services:
     image: redis:8.6.1-alpine3.23
     container_name: erp_redis
     restart: unless-stopped
-    environment:
-      TZ: Asia/Kuala_Lumpur
     command: >
       redis-server
       --requirepass ${REDIS_PASSWORD}
@@ -131,8 +128,6 @@ services:
       - ENABLE_SWAGGER=${ENABLE_SWAGGER:-false}
       - DEBUG_MODE=false
 
-      # Timezone
-      - TZ=Asia/Kuala_Lumpur
     ports:
       - "${PORT:-3001}:${PORT:-3001}"
     depends_on:
@@ -174,8 +169,6 @@ services:
     image: blur88/all:erp-frontend
     container_name: erp_frontend
     restart: unless-stopped
-    environment:
-      - TZ=Asia/Kuala_Lumpur
     ports:
       - "3000:80"
     depends_on:
@@ -214,8 +207,6 @@ services:
     image: blur88/all:erp-nginx
     container_name: erp_nginx
     restart: unless-stopped
-    environment:
-      TZ: Asia/Kuala_Lumpur
     ports:
       - "80:80"
       - "443:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
       POSTGRES_INITDB_ARGS: "--encoding=UTF8 --locale=C"
       PGDATA: /var/lib/postgresql/data/pgdata
-      TZ: Asia/Kuala_Lumpur
     volumes:
       - ./data/postgres:/var/lib/postgresql/data/pgdata
       - ./database/init:/docker-entrypoint-initdb.d:ro
@@ -43,8 +42,6 @@ services:
     image: redis:8.6.1-alpine3.23
     container_name: erp_redis
     restart: unless-stopped
-    environment:
-      TZ: Asia/Kuala_Lumpur
     command: >
       redis-server
       --requirepass ${REDIS_PASSWORD}
@@ -137,8 +134,6 @@ services:
       - ENABLE_SWAGGER=${ENABLE_SWAGGER:-true}
       - DEBUG_MODE=${DEBUG_MODE:-false}
 
-      # Timezone
-      - TZ=Asia/Kuala_Lumpur
     ports:
       - "${PORT:-3001}:${PORT:-3001}"
     depends_on:
@@ -186,8 +181,6 @@ services:
     image: erp-frontend:latest
     container_name: erp_frontend
     restart: unless-stopped
-    environment:
-      - TZ=Asia/Kuala_Lumpur
     ports:
       - "3000:80"
     depends_on:
@@ -229,8 +222,6 @@ services:
     image: erp-nginx:latest
     container_name: erp_nginx
     restart: unless-stopped
-    environment:
-      TZ: Asia/Kuala_Lumpur
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
Closes #318

## Summary
- Remove `TZ: Asia/Kuala_Lumpur` from all Docker Compose services (both `docker-compose.yml` and `docker-compose.prod.yml`) — containers now default to UTC
- Change pg driver `timezone` to `'UTC'` in `database-config.factory.ts` and add migration to reset PostgreSQL database timezone to UTC
- Introduce shared `resolveDateRange` utility (`luxon`) that computes date-range boundaries in the user's configured timezone from `RegionalSettings`
- Refactor inventory, purchasing, and sales analytics services to use the shared resolver instead of local `new Date()` math

## Test Plan
- [x] `npx jest src/common/utils/date-range.util.spec.ts` — unit tests for shared resolver (timezone boundary correctness)
- [x] `npx jest src/modules/inventory/services/inventory-analytics-dashboard.service.spec.ts` — inventory analytics
- [x] `npx jest src/modules/purchasing/` — purchasing analytics
- [x] `npx jest src/modules/sales/` — sales analytics
- [x] `npm run test` — full backend suite
- [x] `npm run lint` — no errors
- [x] `npm run test:e2e` — passed
- [x] Migration applied cleanly on running Docker stack