### PR TITLE
fix: migrate FilterSelect to dedicated filter components (#320)

### DIFF
--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -1,16 +1,19 @@
 import { CircularProgress, Stack } from '@mui/material'
 
-import { FilterCompare } from './FilterCompare'
 import { FilterCategory } from './FilterCategory'
+import { FilterCompare } from './FilterCompare'
 import { FilterCustomer } from './FilterCustomer'
+import { FilterCustomerType } from './FilterCustomerType'
 import { FilterOrderStatus } from './FilterOrderStatus'
 import { FilterPaymentStatus } from './FilterPaymentStatus'
 import { FilterPeriod } from './FilterPeriod'
 import { FilterPriceList } from './FilterPriceList'
 import { FilterProductType } from './FilterProductType'
 import { FilterPurchasingStatus } from './FilterPurchasingStatus'
+import { FilterRole } from './FilterRole'
 import { FilterSearch } from './FilterSearch'
-import { FilterSelect } from './FilterSelect'
+import { FilterStatus } from './FilterStatus'
+import { FilterStockAdjustmentStatus } from './FilterStockAdjustmentStatus'
 import { FilterStockStatus } from './FilterStockStatus'
 import { FilterSupplier } from './FilterSupplier'
 import { AppButton } from '@/components/common/AppButton'
@@ -39,16 +42,47 @@ function renderQuickField<TFilters extends object>(
 ) {
   const value = draftFilters[field.field]
   const onChange = (nextValue: unknown) => handlers.onQuickFilterChange(field.field, nextValue)
+  const fieldKey = String(field.field)
 
-  if (field.type === 'select' || field.type === 'multi-select') {
+  if (field.type === 'status') {
     return (
-      <FilterSelect
-        key={String(field.field)}
-        field={String(field.field)}
-        label={field.label}
-        type={field.type}
-        value={value as string | null | string[]}
-        options={field.options}
+      <FilterStatus
+        key={fieldKey}
+        field={fieldKey}
+        value={(value as string | null) ?? null}
+        onChange={onChange}
+      />
+    )
+  }
+
+  if (field.type === 'customer-type') {
+    return (
+      <FilterCustomerType
+        key={fieldKey}
+        field={fieldKey}
+        value={(value as string | null) ?? null}
+        onChange={onChange}
+      />
+    )
+  }
+
+  if (field.type === 'role') {
+    return (
+      <FilterRole
+        key={fieldKey}
+        field={fieldKey}
+        value={(value as string | null) ?? null}
+        onChange={onChange}
+      />
+    )
+  }
+
+  if (field.type === 'stock-adjustment-status') {
+    return (
+      <FilterStockAdjustmentStatus
+        key={fieldKey}
+        field={fieldKey}
+        value={(value as string | null) ?? null}
         onChange={onChange}
       />
     )
@@ -58,7 +92,7 @@ function renderQuickField<TFilters extends object>(
     const periodValue = value as PeriodValue
     return (
       <FilterPeriod
-        key={String(field.field)}
+        key={fieldKey}
         value={periodValue.key}
         customFrom={periodValue.from}
         customTo={periodValue.to}
@@ -75,7 +109,7 @@ function renderQuickField<TFilters extends object>(
 
     return (
       <FilterCompare
-        key={String(field.field)}
+        key={fieldKey}
         value={(value as string | null) ?? null}
         onChange={onChange}
         periodValue={periodValue}
@@ -86,7 +120,8 @@ function renderQuickField<TFilters extends object>(
   if (field.type === 'customer') {
     return (
       <FilterCustomer
-        key={String(field.field)}
+        key={fieldKey}
+        field={fieldKey}
         value={(value as string | null) ?? null}
         onChange={onChange}
       />
@@ -96,7 +131,8 @@ function renderQuickField<TFilters extends object>(
   if (field.type === 'order-status') {
     return (
       <FilterOrderStatus
-        key={String(field.field)}
+        key={fieldKey}
+        field={fieldKey}
         value={(value as string | null) ?? null}
         onChange={onChange}
       />
@@ -106,7 +142,8 @@ function renderQuickField<TFilters extends object>(
   if (field.type === 'payment-status') {
     return (
       <FilterPaymentStatus
-        key={String(field.field)}
+        key={fieldKey}
+        field={fieldKey}
         value={(value as string | null) ?? null}
         onChange={onChange}
         includeOverpaid={field.includeOverpaid}
@@ -117,7 +154,8 @@ function renderQuickField<TFilters extends object>(
   if (field.type === 'supplier') {
     return (
       <FilterSupplier
-        key={String(field.field)}
+        key={fieldKey}
+        field={fieldKey}
         value={(value as string | null) ?? null}
         onChange={onChange}
       />
@@ -127,7 +165,8 @@ function renderQuickField<TFilters extends object>(
   if (field.type === 'price-list') {
     return (
       <FilterPriceList
-        key={String(field.field)}
+        key={fieldKey}
+        field={fieldKey}
         value={(value as string | null) ?? null}
         onChange={onChange as (value: string | null) => void}
       />
@@ -137,7 +176,8 @@ function renderQuickField<TFilters extends object>(
   if (field.type === 'purchasing-status') {
     return (
       <FilterPurchasingStatus
-        key={String(field.field)}
+        key={fieldKey}
+        field={fieldKey}
         value={(value as string | null) ?? null}
         onChange={onChange}
       />
@@ -147,7 +187,8 @@ function renderQuickField<TFilters extends object>(
   if (field.type === 'category') {
     return (
       <FilterCategory
-        key={String(field.field)}
+        key={fieldKey}
+        field={fieldKey}
         value={(value as string | null) ?? null}
         onChange={onChange}
       />
@@ -157,7 +198,8 @@ function renderQuickField<TFilters extends object>(
   if (field.type === 'product-type') {
     return (
       <FilterProductType
-        key={String(field.field)}
+        key={fieldKey}
+        field={fieldKey}
         value={(value as string | null) ?? null}
         onChange={onChange}
       />
@@ -167,7 +209,8 @@ function renderQuickField<TFilters extends object>(
   if (field.type === 'stock-status') {
     return (
       <FilterStockStatus
-        key={String(field.field)}
+        key={fieldKey}
+        field={fieldKey}
         value={(value as string | null) ?? null}
         onChange={onChange}
       />

--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -16,6 +16,7 @@ import { FilterStatus } from './FilterStatus'
 import { FilterStockAdjustmentStatus } from './FilterStockAdjustmentStatus'
 import { FilterStockStatus } from './FilterStockStatus'
 import { FilterSupplier } from './FilterSupplier'
+import { FilterUserStatus } from './FilterUserStatus'
 import { AppButton } from '@/components/common/AppButton'
 import type {
   FilterBarConfig,
@@ -58,6 +59,17 @@ function renderQuickField<TFilters extends object>(
   if (field.type === 'customer-type') {
     return (
       <FilterCustomerType
+        key={fieldKey}
+        field={fieldKey}
+        value={(value as string | null) ?? null}
+        onChange={onChange}
+      />
+    )
+  }
+
+  if (field.type === 'user-status') {
+    return (
+      <FilterUserStatus
         key={fieldKey}
         field={fieldKey}
         value={(value as string | null) ?? null}

--- a/frontend/src/components/filters/FilterCategory.tsx
+++ b/frontend/src/components/filters/FilterCategory.tsx
@@ -1,16 +1,14 @@
-import { useId } from 'react'
-
 import { useGetCategoriesQuery } from '@/store/api/inventoryApi'
 
 import { FilterSelect } from './FilterSelect'
 
 interface Props {
+  field: string
   value: string | null
   onChange: (value: string | null) => void
 }
 
-export function FilterCategory({ value, onChange }: Props) {
-  const uid = useId()
+export function FilterCategory({ field, value, onChange }: Props) {
   const { data } = useGetCategoriesQuery({})
   const options = [...(data ?? [])]
     .sort((left, right) => left.name.localeCompare(right.name))
@@ -18,12 +16,11 @@ export function FilterCategory({ value, onChange }: Props) {
 
   return (
     <FilterSelect
-      field={uid}
+      field={field}
       label="Category"
-      type="select"
       value={value}
       options={options}
-      onChange={onChange as (value: string | null | string[]) => void}
+      onChange={onChange}
     />
   )
 }

--- a/frontend/src/components/filters/FilterCustomer.tsx
+++ b/frontend/src/components/filters/FilterCustomer.tsx
@@ -1,15 +1,14 @@
-import { useId } from 'react'
 import { useGetCustomersQuery } from '@/store/api/salesApi'
 
 import { FilterSelect } from './FilterSelect'
 
 interface Props {
+  field: string
   value: string | null
   onChange: (value: string | null) => void
 }
 
-export function FilterCustomer({ value, onChange }: Props) {
-  const uid = useId()
+export function FilterCustomer({ field, value, onChange }: Props) {
   // isLoading kept intentionally — options will be empty until data arrives (acceptable UX)
   const { data } = useGetCustomersQuery({})
   const options = (data?.data ?? []).map((customer) => ({
@@ -19,12 +18,11 @@ export function FilterCustomer({ value, onChange }: Props) {
 
   return (
     <FilterSelect
-      field={uid}
+      field={field}
       label="Customer"
-      type="select"
       value={value}
       options={options}
-      onChange={onChange as (value: string | null | string[]) => void}
+      onChange={onChange}
     />
   )
 }

--- a/frontend/src/components/filters/FilterCustomerType.tsx
+++ b/frontend/src/components/filters/FilterCustomerType.tsx
@@ -1,0 +1,24 @@
+import { FilterSelect } from './FilterSelect'
+
+const CUSTOMER_TYPE_OPTIONS = [
+  { value: 'individual', label: 'Individual' },
+  { value: 'business', label: 'Business' },
+]
+
+interface Props {
+  field: string
+  value: string | null
+  onChange: (value: string | null) => void
+}
+
+export function FilterCustomerType({ field, value, onChange }: Props) {
+  return (
+    <FilterSelect
+      field={field}
+      label="Customer Type"
+      value={value}
+      options={CUSTOMER_TYPE_OPTIONS}
+      onChange={onChange}
+    />
+  )
+}

--- a/frontend/src/components/filters/FilterOrderStatus.tsx
+++ b/frontend/src/components/filters/FilterOrderStatus.tsx
@@ -1,4 +1,3 @@
-import { useId } from 'react'
 import { FilterSelect } from './FilterSelect'
 
 const ORDER_STATUS_OPTIONS = [
@@ -7,20 +6,19 @@ const ORDER_STATUS_OPTIONS = [
 ]
 
 interface Props {
+  field: string
   value: string | null
   onChange: (value: string | null) => void
 }
 
-export function FilterOrderStatus({ value, onChange }: Props) {
-  const uid = useId()
+export function FilterOrderStatus({ field, value, onChange }: Props) {
   return (
     <FilterSelect
-      field={uid}
+      field={field}
       label="Order Status"
-      type="select"
       value={value}
       options={ORDER_STATUS_OPTIONS}
-      onChange={onChange as (value: string | null | string[]) => void}
+      onChange={onChange}
     />
   )
 }

--- a/frontend/src/components/filters/FilterPaymentStatus.tsx
+++ b/frontend/src/components/filters/FilterPaymentStatus.tsx
@@ -1,4 +1,3 @@
-import { useId } from 'react'
 import { FilterSelect } from './FilterSelect'
 
 const PAYMENT_STATUS_OPTIONS = [
@@ -9,25 +8,24 @@ const PAYMENT_STATUS_OPTIONS = [
 ]
 
 interface Props {
+  field: string
   value: string | null
   onChange: (value: string | null) => void
   includeOverpaid?: boolean
 }
 
-export function FilterPaymentStatus({ value, onChange, includeOverpaid = true }: Props) {
-  const uid = useId()
+export function FilterPaymentStatus({ field, value, onChange, includeOverpaid = true }: Props) {
   const options = includeOverpaid
     ? PAYMENT_STATUS_OPTIONS
     : PAYMENT_STATUS_OPTIONS.filter((option) => option.value !== 'overpaid')
 
   return (
     <FilterSelect
-      field={uid}
+      field={field}
       label="Payment"
-      type="select"
       value={value}
       options={options}
-      onChange={onChange as (value: string | null | string[]) => void}
+      onChange={onChange}
     />
   )
 }

--- a/frontend/src/components/filters/FilterPriceList.tsx
+++ b/frontend/src/components/filters/FilterPriceList.tsx
@@ -1,15 +1,14 @@
-import { useId } from 'react'
 import { useGetPriceListsQuery } from '@/store/api/priceListApi'
 
 import { FilterSelect } from './FilterSelect'
 
 interface Props {
+  field: string
   value: string | null
   onChange: (value: string | null) => void
 }
 
-export function FilterPriceList({ value, onChange }: Props) {
-  const uid = useId()
+export function FilterPriceList({ field, value, onChange }: Props) {
   const { data } = useGetPriceListsQuery({ page: 1, limit: 200, isActive: true })
   const options = (data?.data ?? []).map((pl) => ({
     value: pl.id,
@@ -18,12 +17,11 @@ export function FilterPriceList({ value, onChange }: Props) {
 
   return (
     <FilterSelect
-      field={uid}
+      field={field}
       label="Price List"
-      type="select"
       value={value}
       options={options}
-      onChange={onChange as (value: string | null | string[]) => void}
+      onChange={onChange}
     />
   )
 }

--- a/frontend/src/components/filters/FilterProductType.tsx
+++ b/frontend/src/components/filters/FilterProductType.tsx
@@ -1,5 +1,3 @@
-import { useId } from 'react'
-
 import { FilterSelect } from './FilterSelect'
 
 const PRODUCT_TYPE_OPTIONS = [
@@ -8,21 +6,19 @@ const PRODUCT_TYPE_OPTIONS = [
 ]
 
 interface Props {
+  field: string
   value: string | null
   onChange: (value: string | null) => void
 }
 
-export function FilterProductType({ value, onChange }: Props) {
-  const uid = useId()
-
+export function FilterProductType({ field, value, onChange }: Props) {
   return (
     <FilterSelect
-      field={uid}
+      field={field}
       label="Product Type"
-      type="select"
       value={value}
       options={PRODUCT_TYPE_OPTIONS}
-      onChange={onChange as (value: string | null | string[]) => void}
+      onChange={onChange}
     />
   )
 }

--- a/frontend/src/components/filters/FilterPurchasingStatus.tsx
+++ b/frontend/src/components/filters/FilterPurchasingStatus.tsx
@@ -1,5 +1,3 @@
-import { useId } from 'react'
-
 import { FilterSelect } from './FilterSelect'
 
 const PURCHASING_STATUS_OPTIONS = [
@@ -8,21 +6,19 @@ const PURCHASING_STATUS_OPTIONS = [
 ]
 
 interface Props {
+  field: string
   value: string | null
   onChange: (value: string | null) => void
 }
 
-export function FilterPurchasingStatus({ value, onChange }: Props) {
-  const uid = useId()
-
+export function FilterPurchasingStatus({ field, value, onChange }: Props) {
   return (
     <FilterSelect
-      field={uid}
+      field={field}
       label="Order Status"
-      type="select"
       value={value}
       options={PURCHASING_STATUS_OPTIONS}
-      onChange={onChange as (value: string | null | string[]) => void}
+      onChange={onChange}
     />
   )
 }

--- a/frontend/src/components/filters/FilterRole.tsx
+++ b/frontend/src/components/filters/FilterRole.tsx
@@ -1,0 +1,27 @@
+import { FilterSelect } from './FilterSelect'
+
+const ROLE_OPTIONS = [
+  { value: 'admin', label: 'Admin' },
+  { value: 'manager', label: 'Manager' },
+  { value: 'sales_staff', label: 'Sales Staff' },
+  { value: 'inventory_staff', label: 'Inventory Staff' },
+  { value: 'procurement_staff', label: 'Procurement Staff' },
+]
+
+interface Props {
+  field: string
+  value: string | null
+  onChange: (value: string | null) => void
+}
+
+export function FilterRole({ field, value, onChange }: Props) {
+  return (
+    <FilterSelect
+      field={field}
+      label="Role"
+      value={value}
+      options={ROLE_OPTIONS}
+      onChange={onChange}
+    />
+  )
+}

--- a/frontend/src/components/filters/FilterSelect.tsx
+++ b/frontend/src/components/filters/FilterSelect.tsx
@@ -1,8 +1,6 @@
 import {
-  Checkbox,
   FormControl,
   InputLabel,
-  ListItemText,
   MenuItem,
   OutlinedInput,
   Select,
@@ -13,49 +11,24 @@ import type { FilterOption } from '@/types/filterBar.types'
 interface Props {
   field: string
   label: string
-  type: 'select' | 'multi-select'
-  value: string | null | string[]
+  value: string | null
   options: FilterOption[]
-  onChange: (value: string | null | string[]) => void
-  /** Only applies to type="select" — has no effect on multi-select */
+  onChange: (value: string | null) => void
   emptyLabel?: string
   minWidth?: number
 }
 
-export function FilterSelect({ field, label, type, value, options, onChange, emptyLabel, minWidth }: Props) {
+export function FilterSelect({ field, label, value, options, onChange, emptyLabel, minWidth }: Props) {
   const labelId = `filter-${field}-label`
 
-  if (type === 'multi-select') {
-    const selected = (value as string[]) ?? []
-    return (
-      <FormControl size="small" sx={{ minWidth: minWidth ?? 140 }}>
-        <InputLabel id={labelId}>{label}</InputLabel>
-        <Select
-          labelId={labelId}
-          multiple
-          value={selected}
-          input={<OutlinedInput label={label} />}
-          renderValue={(selectedValues) => `${label}: ${selectedValues.length}`}
-          onChange={(event) => onChange(event.target.value as string[])}
-        >
-          {options.map((option) => (
-            <MenuItem key={option.value} value={option.value}>
-              <Checkbox checked={selected.includes(option.value)} />
-              <ListItemText primary={option.label} />
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
-    )
-  }
-
   return (
-    <FormControl size="small" sx={{ minWidth: minWidth ?? 140 }}>
-      <InputLabel id={labelId}>{label}</InputLabel>
+    <FormControl size="small" sx={{ minWidth: minWidth ?? 160 }}>
+      <InputLabel id={labelId} shrink>{label}</InputLabel>
       <Select
         labelId={labelId}
         value={value ?? ''}
-        label={label}
+        displayEmpty
+        input={<OutlinedInput label={label} notched />}
         onChange={(event) => onChange(event.target.value === '' ? null : event.target.value)}
       >
         <MenuItem value="">{emptyLabel ?? 'All'}</MenuItem>

--- a/frontend/src/components/filters/FilterStatus.tsx
+++ b/frontend/src/components/filters/FilterStatus.tsx
@@ -1,0 +1,24 @@
+import { FilterSelect } from './FilterSelect'
+
+const STATUS_OPTIONS = [
+  { value: 'active', label: 'Active' },
+  { value: 'inactive', label: 'Inactive' },
+]
+
+interface Props {
+  field: string
+  value: string | null
+  onChange: (value: string | null) => void
+}
+
+export function FilterStatus({ field, value, onChange }: Props) {
+  return (
+    <FilterSelect
+      field={field}
+      label="Status"
+      value={value}
+      options={STATUS_OPTIONS}
+      onChange={onChange}
+    />
+  )
+}

--- a/frontend/src/components/filters/FilterStockAdjustmentStatus.tsx
+++ b/frontend/src/components/filters/FilterStockAdjustmentStatus.tsx
@@ -1,0 +1,24 @@
+import { FilterSelect } from './FilterSelect'
+
+const STOCK_ADJUSTMENT_STATUS_OPTIONS = [
+  { value: 'draft', label: 'Draft' },
+  { value: 'completed', label: 'Completed' },
+]
+
+interface Props {
+  field: string
+  value: string | null
+  onChange: (value: string | null) => void
+}
+
+export function FilterStockAdjustmentStatus({ field, value, onChange }: Props) {
+  return (
+    <FilterSelect
+      field={field}
+      label="Status"
+      value={value}
+      options={STOCK_ADJUSTMENT_STATUS_OPTIONS}
+      onChange={onChange}
+    />
+  )
+}

--- a/frontend/src/components/filters/FilterStockAdjustmentStatus.tsx
+++ b/frontend/src/components/filters/FilterStockAdjustmentStatus.tsx
@@ -3,6 +3,7 @@ import { FilterSelect } from './FilterSelect'
 const STOCK_ADJUSTMENT_STATUS_OPTIONS = [
   { value: 'draft', label: 'Draft' },
   { value: 'completed', label: 'Completed' },
+  { value: 'cancelled', label: 'Cancelled' },
 ]
 
 interface Props {

--- a/frontend/src/components/filters/FilterStockStatus.tsx
+++ b/frontend/src/components/filters/FilterStockStatus.tsx
@@ -1,5 +1,3 @@
-import { useId } from 'react'
-
 import { FilterSelect } from './FilterSelect'
 
 const STOCK_STATUS_OPTIONS = [
@@ -8,21 +6,19 @@ const STOCK_STATUS_OPTIONS = [
 ]
 
 interface Props {
+  field: string
   value: string | null
   onChange: (value: string | null) => void
 }
 
-export function FilterStockStatus({ value, onChange }: Props) {
-  const uid = useId()
-
+export function FilterStockStatus({ field, value, onChange }: Props) {
   return (
     <FilterSelect
-      field={uid}
+      field={field}
       label="Stock Status"
-      type="select"
       value={value}
       options={STOCK_STATUS_OPTIONS}
-      onChange={onChange as (value: string | null | string[]) => void}
+      onChange={onChange}
     />
   )
 }

--- a/frontend/src/components/filters/FilterStockStatus.tsx
+++ b/frontend/src/components/filters/FilterStockStatus.tsx
@@ -1,6 +1,7 @@
 import { FilterSelect } from './FilterSelect'
 
 const STOCK_STATUS_OPTIONS = [
+  { value: 'in_stock', label: 'In Stock' },
   { value: 'low_stock', label: 'Low Stock' },
   { value: 'out_of_stock', label: 'Out of Stock' },
 ]

--- a/frontend/src/components/filters/FilterSupplier.tsx
+++ b/frontend/src/components/filters/FilterSupplier.tsx
@@ -1,15 +1,14 @@
-import { useId } from 'react'
 import { useGetSuppliersQuery } from '@/store/api/purchasingApi'
 
 import { FilterSelect } from './FilterSelect'
 
 interface Props {
+  field: string
   value: string | null
   onChange: (value: string | null) => void
 }
 
-export function FilterSupplier({ value, onChange }: Props) {
-  const uid = useId()
+export function FilterSupplier({ field, value, onChange }: Props) {
   // isLoading kept intentionally — options will be empty until data arrives (acceptable UX)
   const { data } = useGetSuppliersQuery({})
   const options = (data?.data ?? []).map((supplier) => ({
@@ -19,12 +18,11 @@ export function FilterSupplier({ value, onChange }: Props) {
 
   return (
     <FilterSelect
-      field={uid}
+      field={field}
       label="Supplier"
-      type="select"
       value={value}
       options={options}
-      onChange={onChange as (value: string | null | string[]) => void}
+      onChange={onChange}
     />
   )
 }

--- a/frontend/src/components/filters/FilterUserStatus.tsx
+++ b/frontend/src/components/filters/FilterUserStatus.tsx
@@ -1,0 +1,25 @@
+import { FilterSelect } from './FilterSelect'
+
+const USER_STATUS_OPTIONS = [
+  { value: 'active', label: 'Active' },
+  { value: 'inactive', label: 'Inactive' },
+  { value: 'suspended', label: 'Suspended' },
+]
+
+interface Props {
+  field: string
+  value: string | null
+  onChange: (value: string | null) => void
+}
+
+export function FilterUserStatus({ field, value, onChange }: Props) {
+  return (
+    <FilterSelect
+      field={field}
+      label="Status"
+      value={value}
+      options={USER_STATUS_OPTIONS}
+      onChange={onChange}
+    />
+  )
+}

--- a/frontend/src/components/filters/__tests__/FilterBar.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterBar.test.tsx
@@ -29,7 +29,7 @@ interface Filters {
 const config: FilterBarConfig<Filters> = {
   search: { placeholder: 'Search...' },
   fields: [
-    { field: 'status', label: 'Status', type: 'select', options: [{ value: 'active', label: 'Active' }] },
+    { field: 'status', label: 'Status', type: 'status' },
   ],
   defaults: { search: '', status: null },
 }

--- a/frontend/src/components/filters/__tests__/FilterCategory.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterCategory.test.tsx
@@ -16,7 +16,7 @@ describe('FilterCategory', () => {
   it('renders a Category select with no options while loading', () => {
     useGetCategoriesQuery.mockReturnValue({ data: undefined })
 
-    render(<FilterCategory value={null} onChange={vi.fn()} />)
+    render(<FilterCategory field="category" value={null} onChange={vi.fn()} />)
 
     expect(screen.getByLabelText('Category')).toBeInTheDocument()
   })
@@ -31,7 +31,7 @@ describe('FilterCategory', () => {
     })
     const user = userEvent.setup()
 
-    render(<FilterCategory value={null} onChange={vi.fn()} />)
+    render(<FilterCategory field="category" value={null} onChange={vi.fn()} />)
 
     await user.click(screen.getByLabelText('Category'))
 
@@ -46,7 +46,7 @@ describe('FilterCategory', () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
 
-    render(<FilterCategory value={null} onChange={onChange} />)
+    render(<FilterCategory field="category" value={null} onChange={onChange} />)
 
     await user.click(screen.getByLabelText('Category'))
     await user.click(screen.getByRole('option', { name: 'Electronics' }))
@@ -61,7 +61,7 @@ describe('FilterCategory', () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
 
-    render(<FilterCategory value="abc-123" onChange={onChange} />)
+    render(<FilterCategory field="category" value="abc-123" onChange={onChange} />)
 
     await user.click(screen.getByLabelText('Category'))
     await user.click(screen.getByRole('option', { name: 'All' }))

--- a/frontend/src/components/filters/__tests__/FilterCustomer.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterCustomer.test.tsx
@@ -29,19 +29,19 @@ function renderWithStore(ui: ReactElement) {
 
 describe('FilterCustomer', () => {
   it('renders with Customer label', () => {
-    renderWithStore(<FilterCustomer value={null} onChange={vi.fn()} />)
+    renderWithStore(<FilterCustomer field="customerId" value={null} onChange={vi.fn()} />)
     expect(screen.getByLabelText(/customer/i)).toBeInTheDocument()
   })
 
   it('shows customer names as options', async () => {
-    renderWithStore(<FilterCustomer value={null} onChange={vi.fn()} />)
+    renderWithStore(<FilterCustomer field="customerId" value={null} onChange={vi.fn()} />)
     await userEvent.click(screen.getByRole('combobox'))
     expect(await screen.findByText('Amuro Ray')).toBeInTheDocument()
     expect(await screen.findByText('Char Aznable')).toBeInTheDocument()
   })
 
   it('requests customers without a limit override', () => {
-    renderWithStore(<FilterCustomer value={null} onChange={vi.fn()} />)
+    renderWithStore(<FilterCustomer field="customerId" value={null} onChange={vi.fn()} />)
     expect(useGetCustomersQuery).toHaveBeenCalledWith({})
   })
 })

--- a/frontend/src/components/filters/__tests__/FilterOrderStatus.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterOrderStatus.test.tsx
@@ -6,19 +6,19 @@ import { FilterOrderStatus } from '../FilterOrderStatus'
 
 describe('FilterOrderStatus', () => {
   it('renders with Order Status label', () => {
-    render(<FilterOrderStatus value={null} onChange={vi.fn()} />)
+    render(<FilterOrderStatus field="orderStatus" value={null} onChange={vi.fn()} />)
     expect(screen.getByLabelText(/order status/i)).toBeInTheDocument()
   })
 
   it('shows Unfulfilled and Fulfilled options', async () => {
-    render(<FilterOrderStatus value={null} onChange={vi.fn()} />)
+    render(<FilterOrderStatus field="orderStatus" value={null} onChange={vi.fn()} />)
     await userEvent.click(screen.getByRole('combobox'))
     expect(await screen.findByText('Unfulfilled')).toBeInTheDocument()
     expect(await screen.findByText('Fulfilled')).toBeInTheDocument()
   })
 
   it('displays the selected value', () => {
-    render(<FilterOrderStatus value="fulfilled" onChange={vi.fn()} />)
+    render(<FilterOrderStatus field="orderStatus" value="fulfilled" onChange={vi.fn()} />)
     expect(screen.getByRole('combobox')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/filters/__tests__/FilterPaymentStatus.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterPaymentStatus.test.tsx
@@ -6,12 +6,12 @@ import { FilterPaymentStatus } from '../FilterPaymentStatus'
 
 describe('FilterPaymentStatus', () => {
   it('renders with Payment label', () => {
-    render(<FilterPaymentStatus value={null} onChange={vi.fn()} />)
+    render(<FilterPaymentStatus field="paymentStatus" value={null} onChange={vi.fn()} />)
     expect(screen.getByLabelText(/payment/i)).toBeInTheDocument()
   })
 
   it('shows all four options by default', async () => {
-    render(<FilterPaymentStatus value={null} onChange={vi.fn()} />)
+    render(<FilterPaymentStatus field="paymentStatus" value={null} onChange={vi.fn()} />)
     await userEvent.click(screen.getByRole('combobox'))
     expect(await screen.findByText('Unpaid')).toBeInTheDocument()
     expect(await screen.findByText('Partial')).toBeInTheDocument()
@@ -20,7 +20,7 @@ describe('FilterPaymentStatus', () => {
   })
 
   it('hides Overpaid when includeOverpaid=false', async () => {
-    render(<FilterPaymentStatus value={null} onChange={vi.fn()} includeOverpaid={false} />)
+    render(<FilterPaymentStatus field="paymentStatus" value={null} onChange={vi.fn()} includeOverpaid={false} />)
     await userEvent.click(screen.getByRole('combobox'))
     expect(await screen.findByText('Paid')).toBeInTheDocument()
     expect(screen.queryByText('Overpaid')).not.toBeInTheDocument()

--- a/frontend/src/components/filters/__tests__/FilterPriceList.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterPriceList.test.tsx
@@ -29,19 +29,19 @@ function renderWithStore(ui: ReactElement) {
 
 describe('FilterPriceList', () => {
   it('renders with Price List label', () => {
-    renderWithStore(<FilterPriceList value={null} onChange={vi.fn()} />)
+    renderWithStore(<FilterPriceList field="priceListId" value={null} onChange={vi.fn()} />)
     expect(screen.getByLabelText(/price list/i)).toBeInTheDocument()
   })
 
   it('shows price list names as options', async () => {
-    renderWithStore(<FilterPriceList value={null} onChange={vi.fn()} />)
+    renderWithStore(<FilterPriceList field="priceListId" value={null} onChange={vi.fn()} />)
     await userEvent.click(screen.getByRole('combobox'))
     expect(await screen.findByText('Retail')).toBeInTheDocument()
     expect(await screen.findByText('Wholesale')).toBeInTheDocument()
   })
 
   it('queries only active price lists', () => {
-    renderWithStore(<FilterPriceList value={null} onChange={vi.fn()} />)
+    renderWithStore(<FilterPriceList field="priceListId" value={null} onChange={vi.fn()} />)
     expect(useGetPriceListsQuery).toHaveBeenCalledWith({ page: 1, limit: 200, isActive: true })
   })
 })

--- a/frontend/src/components/filters/__tests__/FilterProductType.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterProductType.test.tsx
@@ -6,14 +6,14 @@ import { FilterProductType } from '../FilterProductType'
 
 describe('FilterProductType', () => {
   it('renders a Product Type select', () => {
-    render(<FilterProductType value={null} onChange={vi.fn()} />)
+    render(<FilterProductType field="productType" value={null} onChange={vi.fn()} />)
     expect(screen.getByLabelText('Product Type')).toBeInTheDocument()
   })
 
   it('calls onChange with "goods" when Goods is selected', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    render(<FilterProductType value={null} onChange={onChange} />)
+    render(<FilterProductType field="productType" value={null} onChange={onChange} />)
 
     await user.click(screen.getByLabelText('Product Type'))
     await user.click(screen.getByRole('option', { name: 'Goods' }))
@@ -24,7 +24,7 @@ describe('FilterProductType', () => {
   it('calls onChange with "service" when Service is selected', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    render(<FilterProductType value={null} onChange={onChange} />)
+    render(<FilterProductType field="productType" value={null} onChange={onChange} />)
 
     await user.click(screen.getByLabelText('Product Type'))
     await user.click(screen.getByRole('option', { name: 'Service' }))
@@ -35,7 +35,7 @@ describe('FilterProductType', () => {
   it('calls onChange with null when All is selected', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    render(<FilterProductType value="goods" onChange={onChange} />)
+    render(<FilterProductType field="productType" value="goods" onChange={onChange} />)
 
     await user.click(screen.getByLabelText('Product Type'))
     await user.click(screen.getByRole('option', { name: 'All' }))

--- a/frontend/src/components/filters/__tests__/FilterPurchasingStatus.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterPurchasingStatus.test.tsx
@@ -6,12 +6,12 @@ import { FilterPurchasingStatus } from '../FilterPurchasingStatus'
 
 describe('FilterPurchasingStatus', () => {
   it('renders with Order Status label', () => {
-    render(<FilterPurchasingStatus value={null} onChange={vi.fn()} />)
+    render(<FilterPurchasingStatus field="purchasingStatus" value={null} onChange={vi.fn()} />)
     expect(screen.getByLabelText(/order status/i)).toBeInTheDocument()
   })
 
   it('shows Draft and Received options', async () => {
-    render(<FilterPurchasingStatus value={null} onChange={vi.fn()} />)
+    render(<FilterPurchasingStatus field="purchasingStatus" value={null} onChange={vi.fn()} />)
     await userEvent.click(screen.getByRole('combobox'))
     expect(await screen.findByText('Draft')).toBeInTheDocument()
     expect(await screen.findByText('Received')).toBeInTheDocument()

--- a/frontend/src/components/filters/__tests__/FilterSelect.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterSelect.test.tsx
@@ -1,18 +1,17 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 import { FilterSelect } from '../FilterSelect'
 
 describe('FilterSelect', () => {
-  it('renders a custom empty label for single-select filters', async () => {
+  it('renders a custom empty label', async () => {
     render(
       <FilterSelect
         field="customer"
         label="Customer"
-        type="select"
         value={null}
         options={[{ value: 'c1', label: 'Acme Corp' }]}
         onChange={vi.fn()}
@@ -22,15 +21,14 @@ describe('FilterSelect', () => {
 
     await userEvent.click(screen.getByLabelText('Customer'))
 
-    expect(screen.getByText('All Customers')).toBeInTheDocument()
+    expect(within(screen.getByRole('listbox')).getByText('All Customers')).toBeInTheDocument()
   })
 
-  it('applies a custom minWidth to single-select filters', () => {
+  it('applies a custom minWidth', () => {
     const { container } = render(
       <FilterSelect
         field="customer"
         label="Customer"
-        type="select"
         value={null}
         options={[{ value: 'c1', label: 'Acme Corp' }]}
         onChange={vi.fn()}
@@ -46,7 +44,6 @@ describe('FilterSelect', () => {
       <FilterSelect
         field="status"
         label="Status"
-        type="select"
         value={null}
         options={[{ value: 'active', label: 'Active' }]}
         onChange={vi.fn()}
@@ -55,52 +52,20 @@ describe('FilterSelect', () => {
 
     await userEvent.click(screen.getByLabelText('Status'))
 
-    expect(screen.getByText('All')).toBeInTheDocument()
+    expect(within(screen.getByRole('listbox')).getByText('All')).toBeInTheDocument()
   })
 
-  it('defaults minWidth to 140 when minWidth is omitted on single-select', () => {
+  it('defaults minWidth to 160 when minWidth is omitted', () => {
     const { container } = render(
       <FilterSelect
         field="status"
         label="Status"
-        type="select"
         value={null}
         options={[{ value: 'active', label: 'Active' }]}
         onChange={vi.fn()}
       />,
     )
 
-    expect(container.querySelector('.MuiFormControl-root')).toHaveStyle({ minWidth: '140px' })
-  })
-
-  it('defaults minWidth to 140 when minWidth is omitted on multi-select', () => {
-    const { container } = render(
-      <FilterSelect
-        field="tags"
-        label="Tags"
-        type="multi-select"
-        value={[]}
-        options={[{ value: 'a', label: 'A' }]}
-        onChange={vi.fn()}
-      />,
-    )
-
-    expect(container.querySelector('.MuiFormControl-root')).toHaveStyle({ minWidth: '140px' })
-  })
-
-  it('applies a custom minWidth to multi-select filters', () => {
-    const { container } = render(
-      <FilterSelect
-        field="tags"
-        label="Tags"
-        type="multi-select"
-        value={[]}
-        options={[{ value: 'a', label: 'A' }]}
-        onChange={vi.fn()}
-        minWidth={200}
-      />,
-    )
-
-    expect(container.querySelector('.MuiFormControl-root')).toHaveStyle({ minWidth: '200px' })
+    expect(container.querySelector('.MuiFormControl-root')).toHaveStyle({ minWidth: '160px' })
   })
 })

--- a/frontend/src/components/filters/__tests__/FilterStockStatus.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterStockStatus.test.tsx
@@ -6,14 +6,14 @@ import { FilterStockStatus } from '../FilterStockStatus'
 
 describe('FilterStockStatus', () => {
   it('renders a Stock Status select', () => {
-    render(<FilterStockStatus value={null} onChange={vi.fn()} />)
+    render(<FilterStockStatus field="stockStatus" value={null} onChange={vi.fn()} />)
     expect(screen.getByLabelText('Stock Status')).toBeInTheDocument()
   })
 
   it('calls onChange with "low_stock" when Low Stock is selected', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    render(<FilterStockStatus value={null} onChange={onChange} />)
+    render(<FilterStockStatus field="stockStatus" value={null} onChange={onChange} />)
 
     await user.click(screen.getByLabelText('Stock Status'))
     await user.click(screen.getByRole('option', { name: 'Low Stock' }))
@@ -24,7 +24,7 @@ describe('FilterStockStatus', () => {
   it('calls onChange with "out_of_stock" when Out of Stock is selected', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    render(<FilterStockStatus value={null} onChange={onChange} />)
+    render(<FilterStockStatus field="stockStatus" value={null} onChange={onChange} />)
 
     await user.click(screen.getByLabelText('Stock Status'))
     await user.click(screen.getByRole('option', { name: 'Out of Stock' }))
@@ -35,7 +35,7 @@ describe('FilterStockStatus', () => {
   it('calls onChange with null when All is selected', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    render(<FilterStockStatus value="low_stock" onChange={onChange} />)
+    render(<FilterStockStatus field="stockStatus" value="low_stock" onChange={onChange} />)
 
     await user.click(screen.getByLabelText('Stock Status'))
     await user.click(screen.getByRole('option', { name: 'All' }))

--- a/frontend/src/components/filters/__tests__/FilterSupplier.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterSupplier.test.tsx
@@ -29,19 +29,19 @@ function renderWithStore(ui: ReactElement) {
 
 describe('FilterSupplier', () => {
   it('renders with Supplier label', () => {
-    renderWithStore(<FilterSupplier value={null} onChange={vi.fn()} />)
+    renderWithStore(<FilterSupplier field="supplierId" value={null} onChange={vi.fn()} />)
     expect(screen.getByLabelText(/supplier/i)).toBeInTheDocument()
   })
 
   it('shows supplier names as options', async () => {
-    renderWithStore(<FilterSupplier value={null} onChange={vi.fn()} />)
+    renderWithStore(<FilterSupplier field="supplierId" value={null} onChange={vi.fn()} />)
     await userEvent.click(screen.getByRole('combobox'))
     expect(await screen.findByText('Anaheim Electronics')).toBeInTheDocument()
     expect(await screen.findByText('Zeonic')).toBeInTheDocument()
   })
 
   it('requests suppliers without a limit override', () => {
-    renderWithStore(<FilterSupplier value={null} onChange={vi.fn()} />)
+    renderWithStore(<FilterSupplier field="supplierId" value={null} onChange={vi.fn()} />)
     expect(useGetSuppliersQuery).toHaveBeenCalledWith({})
   })
 })

--- a/frontend/src/hooks/useFilterBar.test.tsx
+++ b/frontend/src/hooks/useFilterBar.test.tsx
@@ -14,7 +14,7 @@ interface Filters {
 const config: FilterBarConfig<Filters> = {
   search: { placeholder: '', debounceMs: 0 },
   fields: [
-    { field: 'status', label: 'Status', type: 'select', options: [{ value: 'active', label: 'Active' }] },
+    { field: 'status', label: 'Status', type: 'status' },
   ],
   defaults: { search: '', status: null },
 }

--- a/frontend/src/hooks/useFilterBar.ts
+++ b/frontend/src/hooks/useFilterBar.ts
@@ -20,7 +20,11 @@ function getDefaults<TFilters extends object>(
     }
 
     if (
-      field.type === 'select' ||
+      field.type === 'status' ||
+      field.type === 'user-status' ||
+      field.type === 'customer-type' ||
+      field.type === 'role' ||
+      field.type === 'stock-adjustment-status' ||
       field.type === 'customer' ||
       field.type === 'order-status' ||
       field.type === 'payment-status' ||
@@ -28,11 +32,11 @@ function getDefaults<TFilters extends object>(
       field.type === 'purchasing-status' ||
       field.type === 'category' ||
       field.type === 'product-type' ||
-      field.type === 'stock-status'
+      field.type === 'stock-status' ||
+      field.type === 'price-list'
     ) {
       defaults[key] = null
     }
-    else if (field.type === 'multi-select') defaults[key] = []
     else if (field.type === 'period') {
       defaults[key] = { key: null, from: null, to: null } satisfies PeriodValue
     }

--- a/frontend/src/pages/inventory/InventoryPage.tsx
+++ b/frontend/src/pages/inventory/InventoryPage.tsx
@@ -43,8 +43,6 @@ import { useNavigate } from 'react-router-dom'
 import PageHeader from '@/components/common/PageHeader'
 import { FilterBar } from '@/components/filters/FilterBar'
 import { useFilterBar } from '@/hooks/useFilterBar'
-import { useGetCategoriesQuery } from '@/store/api/inventoryApi'
-import { useGetSuppliersQuery } from '@/store/api/purchasingApi'
 import { useInventoryAnalytics } from './hooks/useInventoryAnalytics'
 import { formatCurrency } from '@/utils/formatters'
 import { TABLE_STYLES } from '@/constants/tableStyles'
@@ -84,18 +82,6 @@ const InventoryPage: React.FC = () => {
     stockStatus: string | null
   }
 
-  const { data: suppliersData } = useGetSuppliersQuery({})
-  const { data: categoriesData } = useGetCategoriesQuery({})
-
-  const supplierOptions = suppliersData?.data?.map((supplier) => ({
-    value: supplier.id,
-    label: supplier.companyName,
-  })) ?? []
-  const categoryOptions = (categoriesData ?? []).map((category) => ({
-    value: category.id,
-    label: category.name,
-  }))
-
   const inventoryConfig: FilterBarConfig<InventoryDashboardFilters> = {
     namespace: 'inventory',
     fields: [
@@ -112,27 +98,20 @@ const InventoryPage: React.FC = () => {
       {
         field: 'supplierId',
         label: 'Supplier',
-        type: 'select',
+        type: 'supplier',
         paramKey: 'supplier',
-        options: [{ value: '', label: 'All Suppliers' }, ...supplierOptions],
       },
       {
         field: 'categoryId',
         label: 'Category',
-        type: 'select',
+        type: 'category',
         paramKey: 'category',
-        options: [{ value: '', label: 'All Categories' }, ...categoryOptions],
       },
       {
         field: 'stockStatus',
         label: 'Stock Status',
-        type: 'select',
+        type: 'stock-status',
         paramKey: 'stock_status',
-        options: [
-          { value: 'in_stock', label: 'In Stock' },
-          { value: 'low_stock', label: 'Low Stock' },
-          { value: 'out_of_stock', label: 'Out of Stock' },
-        ],
       },
     ],
     defaults: {

--- a/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
@@ -133,16 +133,7 @@ const StockAdjustmentsPage: React.FC = () => {
     () => ({
       search: { placeholder: 'Search by adjustment number or notes...' },
       fields: [
-        {
-          field: 'status',
-          label: 'Status',
-          type: 'select',
-          options: [
-            { value: 'draft', label: 'Draft' },
-            { value: 'completed', label: 'Completed' },
-            { value: 'cancelled', label: 'Cancelled' },
-          ],
-        },
+        { field: 'status', label: 'Status', type: 'stock-adjustment-status' },
       ],
       defaults: { search: '', status: null },
     }),

--- a/frontend/src/pages/purchasing/SuppliersPage.tsx
+++ b/frontend/src/pages/purchasing/SuppliersPage.tsx
@@ -41,15 +41,7 @@ const SuppliersPage: React.FC = () => {
     () => ({
       search: { placeholder: 'Search by company name...' },
       fields: [
-        {
-          field: 'status',
-          label: 'Status',
-          type: 'select',
-          options: [
-            { value: 'active', label: 'Active' },
-            { value: 'inactive', label: 'Inactive' },
-          ],
-        },
+        { field: 'status', label: 'Status', type: 'status' },
       ],
       defaults: { search: '', status: null },
     }),

--- a/frontend/src/pages/sales/CustomersPage.tsx
+++ b/frontend/src/pages/sales/CustomersPage.tsx
@@ -44,24 +44,8 @@ const CustomersPage: React.FC = () => {
     () => ({
       search: { placeholder: 'Search by name or phone...' },
       fields: [
-        {
-          field: 'status',
-          label: 'Status',
-          type: 'select',
-          options: [
-            { value: 'active', label: 'Active' },
-            { value: 'inactive', label: 'Inactive' },
-          ],
-        },
-        {
-          field: 'type',
-          label: 'Customer Type',
-          type: 'select',
-          options: [
-            { value: 'individual', label: 'Individual' },
-            { value: 'business', label: 'Business' },
-          ],
-        },
+        { field: 'status', label: 'Status', type: 'status' },
+        { field: 'type', label: 'Customer Type', type: 'customer-type' },
         {
           field: 'priceListId',
           label: 'Price List',

--- a/frontend/src/pages/settings/PriceListsPage.tsx
+++ b/frontend/src/pages/settings/PriceListsPage.tsx
@@ -58,15 +58,7 @@ const PriceListsPage: React.FC = () => {
     () => ({
       search: { placeholder: 'Search by code or name...' },
       fields: [
-        {
-          field: 'status',
-          label: 'Status',
-          type: 'select',
-          options: [
-            { value: 'active', label: 'Active' },
-            { value: 'inactive', label: 'Inactive' },
-          ],
-        },
+        { field: 'status', label: 'Status', type: 'status' },
       ],
       defaults: {
         search: '',

--- a/frontend/src/pages/settings/UserManagementPage.tsx
+++ b/frontend/src/pages/settings/UserManagementPage.tsx
@@ -75,28 +75,8 @@ const UserManagementPage: React.FC = () => {
     () => ({
       search: { placeholder: 'Search by name, email, or username...' },
       fields: [
-        {
-          field: 'role',
-          label: 'Role',
-          type: 'select',
-          options: [
-            { value: 'admin', label: 'Admin' },
-            { value: 'manager', label: 'Manager' },
-            { value: 'sales_staff', label: 'Sales Staff' },
-            { value: 'inventory_staff', label: 'Inventory Staff' },
-            { value: 'procurement_staff', label: 'Procurement Staff' },
-          ],
-        },
-        {
-          field: 'status',
-          label: 'Status',
-          type: 'select',
-          options: [
-            { value: 'active', label: 'Active' },
-            { value: 'inactive', label: 'Inactive' },
-            { value: 'suspended', label: 'Suspended' },
-          ],
-        },
+        { field: 'role', label: 'Role', type: 'role' },
+        { field: 'status', label: 'Status', type: 'user-status' },
       ],
       defaults: { search: '', role: null, status: null },
     }),

--- a/frontend/src/types/filterBar.types.ts
+++ b/frontend/src/types/filterBar.types.ts
@@ -9,8 +9,10 @@ export type PeriodValue = {
 }
 
 export type FilterFieldType =
-  | 'select'
-  | 'multi-select'
+  | 'status'
+  | 'customer-type'
+  | 'role'
+  | 'stock-adjustment-status'
   | 'period'
   | 'compare'
   | 'customer'
@@ -31,10 +33,24 @@ interface BaseFilterFieldConfig<TFilters, K extends keyof TFilters> {
   chipFormatter?: (value: TFilters[K], filters: TFilters) => string
 }
 
-export interface SelectFilterFieldConfig<TFilters, K extends keyof TFilters>
+export interface StatusFilterFieldConfig<TFilters, K extends keyof TFilters>
   extends BaseFilterFieldConfig<TFilters, K> {
-  type: 'select' | 'multi-select'
-  options: FilterOption[]
+  type: 'status'
+}
+
+export interface CustomerTypeFilterFieldConfig<TFilters, K extends keyof TFilters>
+  extends BaseFilterFieldConfig<TFilters, K> {
+  type: 'customer-type'
+}
+
+export interface RoleFilterFieldConfig<TFilters, K extends keyof TFilters>
+  extends BaseFilterFieldConfig<TFilters, K> {
+  type: 'role'
+}
+
+export interface StockAdjustmentStatusFilterFieldConfig<TFilters, K extends keyof TFilters>
+  extends BaseFilterFieldConfig<TFilters, K> {
+  type: 'stock-adjustment-status'
 }
 
 export interface PeriodFilterFieldConfig<TFilters, K extends keyof TFilters>
@@ -94,7 +110,10 @@ export interface PriceListFilterFieldConfig<TFilters, K extends keyof TFilters>
 }
 
 export type FilterFieldConfig<TFilters> =
-  | SelectFilterFieldConfig<TFilters, keyof TFilters>
+  | StatusFilterFieldConfig<TFilters, keyof TFilters>
+  | CustomerTypeFilterFieldConfig<TFilters, keyof TFilters>
+  | RoleFilterFieldConfig<TFilters, keyof TFilters>
+  | StockAdjustmentStatusFilterFieldConfig<TFilters, keyof TFilters>
   | PeriodFilterFieldConfig<TFilters, keyof TFilters>
   | CompareFilterFieldConfig<TFilters, keyof TFilters>
   | CustomerFilterFieldConfig<TFilters, keyof TFilters>

--- a/frontend/src/types/filterBar.types.ts
+++ b/frontend/src/types/filterBar.types.ts
@@ -10,6 +10,7 @@ export type PeriodValue = {
 
 export type FilterFieldType =
   | 'status'
+  | 'user-status'
   | 'customer-type'
   | 'role'
   | 'stock-adjustment-status'
@@ -41,6 +42,11 @@ export interface StatusFilterFieldConfig<TFilters, K extends keyof TFilters>
 export interface CustomerTypeFilterFieldConfig<TFilters, K extends keyof TFilters>
   extends BaseFilterFieldConfig<TFilters, K> {
   type: 'customer-type'
+}
+
+export interface UserStatusFilterFieldConfig<TFilters, K extends keyof TFilters>
+  extends BaseFilterFieldConfig<TFilters, K> {
+  type: 'user-status'
 }
 
 export interface RoleFilterFieldConfig<TFilters, K extends keyof TFilters>
@@ -111,6 +117,7 @@ export interface PriceListFilterFieldConfig<TFilters, K extends keyof TFilters>
 
 export type FilterFieldConfig<TFilters> =
   | StatusFilterFieldConfig<TFilters, keyof TFilters>
+  | UserStatusFilterFieldConfig<TFilters, keyof TFilters>
   | CustomerTypeFilterFieldConfig<TFilters, keyof TFilters>
   | RoleFilterFieldConfig<TFilters, keyof TFilters>
   | StockAdjustmentStatusFilterFieldConfig<TFilters, keyof TFilters>

--- a/frontend/src/utils/filterBar.url.test.ts
+++ b/frontend/src/utils/filterBar.url.test.ts
@@ -6,26 +6,23 @@ import { getManagedParamKeys, parseFilters, serializeFilters } from '@/utils/fil
 interface TestFilters {
   search: string
   status: string | null
-  tags: string[]
 }
 
 const config: FilterBarConfig<TestFilters> = {
   search: { placeholder: 'Search...' },
   fields: [
-    { field: 'status', label: 'Status', type: 'select', options: [{ value: 'active', label: 'Active' }, { value: 'inactive', label: 'Inactive' }] },
-    { field: 'tags', label: 'Tags', type: 'multi-select', options: [{ value: 'a', label: 'A' }, { value: 'b', label: 'B' }] },
+    { field: 'status', label: 'Status', type: 'status' },
   ],
   defaults: {
     search: '',
     status: null,
-    tags: [],
   },
 }
 
 describe('serializeFilters', () => {
   it('omits default values', () => {
     const params = serializeFilters(
-      { search: '', status: null, tags: [] },
+      { search: '', status: null },
       config,
       new URLSearchParams(),
     )
@@ -34,34 +31,25 @@ describe('serializeFilters', () => {
 
   it('serializes search', () => {
     const params = serializeFilters(
-      { search: 'gundam', status: null, tags: [] },
+      { search: 'gundam', status: null },
       config,
       new URLSearchParams(),
     )
     expect(params.get('search')).toBe('gundam')
   })
 
-  it('serializes select value', () => {
+  it('serializes status value', () => {
     const params = serializeFilters(
-      { search: '', status: 'active', tags: [] },
+      { search: '', status: 'active' },
       config,
       new URLSearchParams(),
     )
     expect(params.get('status')).toBe('active')
   })
 
-  it('serializes multi-select as repeated params', () => {
-    const params = serializeFilters(
-      { search: '', status: null, tags: ['a', 'b'] },
-      config,
-      new URLSearchParams(),
-    )
-    expect(params.getAll('tags')).toEqual(['a', 'b'])
-  })
-
   it('preserves unrelated params', () => {
     const params = serializeFilters(
-      { search: 'x', status: null, tags: [] },
+      { search: 'x', status: null },
       config,
       new URLSearchParams('tab=archived&sort=desc'),
     )
@@ -76,23 +64,18 @@ describe('parseFilters', () => {
     expect(parseFilters(new URLSearchParams(), config)).toEqual({
       search: '',
       status: null,
-      tags: [],
     })
   })
 
-  it('drops invalid select values', () => {
+  it('drops invalid status values', () => {
     expect(parseFilters(new URLSearchParams('status=unknown'), config).status).toBeNull()
-  })
-
-  it('parses multi-select repeated params and drops invalid values', () => {
-    expect(parseFilters(new URLSearchParams('tags=a&tags=b&tags=nope'), config).tags).toEqual(['a', 'b'])
   })
 })
 
 describe('getManagedParamKeys', () => {
   it('returns all managed keys', () => {
     expect(getManagedParamKeys(config)).toEqual(
-      expect.arrayContaining(['search', 'status', 'tags']),
+      expect.arrayContaining(['search', 'status']),
     )
   })
 })
@@ -207,7 +190,7 @@ interface NamespacedFilters {
 const namespacedConfig: FilterBarConfig<NamespacedFilters> = {
   search: { placeholder: 'Search...' },
   fields: [
-    { field: 'status', label: 'Status', type: 'select', options: [{ value: 'active', label: 'Active' }] },
+    { field: 'status', label: 'Status', type: 'status' },
   ],
   defaults: { search: '', status: null },
   namespace: 'orders',

--- a/frontend/src/utils/filterBar.url.ts
+++ b/frontend/src/utils/filterBar.url.ts
@@ -65,7 +65,11 @@ export function serializeFilters<TFilters extends object>(
     const value = filters[field.field]
     const defaultValue = defaults[String(field.field)]
     const isSingleValueField =
-      field.type === 'select' ||
+      field.type === 'status' ||
+      field.type === 'user-status' ||
+      field.type === 'customer-type' ||
+      field.type === 'role' ||
+      field.type === 'stock-adjustment-status' ||
       field.type === 'customer' ||
       field.type === 'order-status' ||
       field.type === 'payment-status' ||
@@ -79,13 +83,6 @@ export function serializeFilters<TFilters extends object>(
     if (isSingleValueField) {
       if (value !== null && value !== undefined && value !== defaultValue) {
         orderedEntries.push([key, String(value)])
-      }
-      continue
-    }
-
-    if (field.type === 'multi-select') {
-      for (const item of (value as string[] | undefined) ?? []) {
-        orderedEntries.push([key, item])
       }
       continue
     }
@@ -142,7 +139,11 @@ export function parseFilters<TFilters extends object>(
     const fieldKey = String(field.field)
     const defaultValue = defaults[fieldKey]
     const isSingleValueField =
-      field.type === 'select' ||
+      field.type === 'status' ||
+      field.type === 'user-status' ||
+      field.type === 'customer-type' ||
+      field.type === 'role' ||
+      field.type === 'stock-adjustment-status' ||
       field.type === 'customer' ||
       field.type === 'order-status' ||
       field.type === 'payment-status' ||
@@ -157,31 +158,39 @@ export function parseFilters<TFilters extends object>(
       const raw = searchParams.get(key)
       if (raw === null) {
         result[fieldKey] = defaultValue ?? null
-      } else if (field.type === 'select') {
-        // Validate against declared options so stale/hand-crafted URLs can't inject unknown values.
-        const valid = field.options.find((option) => option.value === raw)
-        result[fieldKey] = valid ? raw : (defaultValue ?? null)
+      } else if (field.type === 'status') {
+        const VALID_STATUS = ['active', 'inactive']
+        result[fieldKey] = VALID_STATUS.includes(raw) ? raw : (defaultValue ?? null)
+      } else if (field.type === 'user-status') {
+        const VALID_USER_STATUS = ['active', 'inactive', 'suspended']
+        result[fieldKey] = VALID_USER_STATUS.includes(raw) ? raw : (defaultValue ?? null)
+      } else if (field.type === 'customer-type') {
+        const VALID_CUSTOMER_TYPE = ['individual', 'business']
+        result[fieldKey] = VALID_CUSTOMER_TYPE.includes(raw) ? raw : (defaultValue ?? null)
+      } else if (field.type === 'role') {
+        const VALID_ROLE = ['admin', 'manager', 'sales_staff', 'inventory_staff', 'procurement_staff']
+        result[fieldKey] = VALID_ROLE.includes(raw) ? raw : (defaultValue ?? null)
+      } else if (field.type === 'stock-adjustment-status') {
+        const VALID_STOCK_ADJUSTMENT_STATUS = ['draft', 'completed', 'cancelled']
+        result[fieldKey] = VALID_STOCK_ADJUSTMENT_STATUS.includes(raw) ? raw : (defaultValue ?? null)
       } else if (field.type === 'order-status') {
-        // Fixed value set — validate to prevent bogus URL values reaching the API.
         const VALID_ORDER_STATUS = ['fulfilled', 'unfulfilled']
         result[fieldKey] = VALID_ORDER_STATUS.includes(raw) ? raw : (defaultValue ?? null)
       } else if (field.type === 'purchasing-status') {
-        const VALID_PURCHASING_STATUS = ['pending', 'received']
+        const VALID_PURCHASING_STATUS = ['draft', 'received']
         result[fieldKey] = VALID_PURCHASING_STATUS.includes(raw) ? raw : (defaultValue ?? null)
       } else if (field.type === 'payment-status') {
-        // Fixed value set — validate to prevent bogus URL values reaching the API.
         const VALID_PAYMENT_STATUS = ['unpaid', 'partial', 'paid', 'overpaid']
         result[fieldKey] = VALID_PAYMENT_STATUS.includes(raw) ? raw : (defaultValue ?? null)
+      } else if (field.type === 'product-type') {
+        const VALID_PRODUCT_TYPE = ['goods', 'service']
+        result[fieldKey] = VALID_PRODUCT_TYPE.includes(raw) ? raw : (defaultValue ?? null)
+      } else if (field.type === 'stock-status') {
+        const VALID_STOCK_STATUS = ['in_stock', 'low_stock', 'out_of_stock']
+        result[fieldKey] = VALID_STOCK_STATUS.includes(raw) ? raw : (defaultValue ?? null)
       } else {
-        // These field types are free-form identifiers or page-level mapped values with no option list to validate against.
         result[fieldKey] = raw
       }
-      continue
-    }
-
-    if (field.type === 'multi-select') {
-      const validOptions = new Set(field.options.map((option) => option.value))
-      result[fieldKey] = searchParams.getAll(key).filter((value) => validOptions.has(value))
       continue
     }
 


### PR DESCRIPTION
## Summary
- Fixes MUI label-clipping bug in `FilterSelect` (issue #320) — adds `displayEmpty`, `OutlinedInput notched`, increases default `minWidth` to 160px
- Creates 4 new dedicated filter components: `FilterStatus`, `FilterCustomerType`, `FilterRole`, `FilterStockAdjustmentStatus` (+ `FilterUserStatus` to preserve `suspended` user status)
- Removes unused `multi-select` branch from `FilterSelect` and the generic `select`/`multi-select` fallback from `FilterBar` — all 10 remaining `type: 'select'` page configs migrated to dedicated types
- Removes `useId()` workaround from all dedicated filter components — `field` is now passed from `FilterBar`

## Test Plan
- [x] `FilterSelect` tests — 4 tests pass
- [x] `FilterBar` tests — all pass
- [x] `useFilterBar` + `filterBar.url` tests — pass
- [x] Page filter tests (CustomersPage, StockAdjustmentsPage, InventoryPage, UserManagementPage) — pass
- [x] Full filter component suite — 17 files / 104 tests pass
- [x] `npm run lint` — clean
- [x] `grep -R "type: 'select'" frontend/src/pages/` — no output
- [x] `grep -R "FilterSelect" frontend/src/pages/` — no output

Closes #320