### PR TITLE
feat(suppliers): add supplier type filter (#323)

### DIFF
--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -16,6 +16,7 @@ import { FilterStatus } from './FilterStatus'
 import { FilterStockAdjustmentStatus } from './FilterStockAdjustmentStatus'
 import { FilterStockStatus } from './FilterStockStatus'
 import { FilterSupplier } from './FilterSupplier'
+import { FilterSupplierType } from './FilterSupplierType'
 import { FilterUserStatus } from './FilterUserStatus'
 import { AppButton } from '@/components/common/AppButton'
 import type {
@@ -59,6 +60,17 @@ function renderQuickField<TFilters extends object>(
   if (field.type === 'customer-type') {
     return (
       <FilterCustomerType
+        key={fieldKey}
+        field={fieldKey}
+        value={(value as string | null) ?? null}
+        onChange={onChange}
+      />
+    )
+  }
+
+  if (field.type === 'supplier-type') {
+    return (
+      <FilterSupplierType
         key={fieldKey}
         field={fieldKey}
         value={(value as string | null) ?? null}

--- a/frontend/src/components/filters/FilterSupplierType.tsx
+++ b/frontend/src/components/filters/FilterSupplierType.tsx
@@ -1,0 +1,24 @@
+import { FilterSelect } from './FilterSelect'
+
+const SUPPLIER_TYPE_OPTIONS = [
+  { value: 'local', label: 'Local' },
+  { value: 'international', label: 'International' },
+]
+
+interface Props {
+  field: string
+  value: string | null
+  onChange: (value: string | null) => void
+}
+
+export function FilterSupplierType({ field, value, onChange }: Props) {
+  return (
+    <FilterSelect
+      field={field}
+      label="Supplier Type"
+      value={value}
+      options={SUPPLIER_TYPE_OPTIONS}
+      onChange={onChange}
+    />
+  )
+}

--- a/frontend/src/hooks/useFilterBar.ts
+++ b/frontend/src/hooks/useFilterBar.ts
@@ -23,6 +23,7 @@ function getDefaults<TFilters extends object>(
       field.type === 'status' ||
       field.type === 'user-status' ||
       field.type === 'customer-type' ||
+      field.type === 'supplier-type' ||
       field.type === 'role' ||
       field.type === 'stock-adjustment-status' ||
       field.type === 'customer' ||

--- a/frontend/src/pages/purchasing/SuppliersPage.tsx
+++ b/frontend/src/pages/purchasing/SuppliersPage.tsx
@@ -24,6 +24,7 @@ import { useSuppliersSelection } from './hooks/useSuppliersSelection'
 interface SupplierFilters {
   search: string
   status: 'active' | 'inactive' | null
+  type: 'local' | 'international' | null
 }
 
 const SuppliersPage: React.FC = () => {
@@ -42,8 +43,9 @@ const SuppliersPage: React.FC = () => {
       search: { placeholder: 'Search by company name...' },
       fields: [
         { field: 'status', label: 'Status', type: 'status' },
+        { field: 'type', label: 'Supplier Type', type: 'supplier-type' },
       ],
-      defaults: { search: '', status: null },
+      defaults: { search: '', status: null, type: null },
     }),
     [],
   )
@@ -67,6 +69,7 @@ const SuppliersPage: React.FC = () => {
           : appliedFilters.status === 'inactive'
             ? false
             : undefined,
+      type: appliedFilters.type ?? undefined,
     }),
     [appliedFilters],
   )

--- a/frontend/src/pages/purchasing/__tests__/SuppliersPage.filterbar.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/SuppliersPage.filterbar.test.tsx
@@ -149,4 +149,18 @@ describe('SuppliersPage FilterBar', () => {
       expect.not.objectContaining({ isActive: expect.anything() }),
     )
   })
+
+  it('passes type=local to query when type filter is set', () => {
+    renderPage('/?type=local')
+    expect(useGetSuppliersQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: 'local' }),
+    )
+  })
+
+  it('does not pass type when type filter is unset', () => {
+    renderPage('/')
+    expect(useGetSuppliersQuery).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ type: expect.anything() }),
+    )
+  })
 })

--- a/frontend/src/types/filterBar.types.ts
+++ b/frontend/src/types/filterBar.types.ts
@@ -12,6 +12,7 @@ export type FilterFieldType =
   | 'status'
   | 'user-status'
   | 'customer-type'
+  | 'supplier-type'
   | 'role'
   | 'stock-adjustment-status'
   | 'period'
@@ -42,6 +43,11 @@ export interface StatusFilterFieldConfig<TFilters, K extends keyof TFilters>
 export interface CustomerTypeFilterFieldConfig<TFilters, K extends keyof TFilters>
   extends BaseFilterFieldConfig<TFilters, K> {
   type: 'customer-type'
+}
+
+export interface SupplierTypeFilterFieldConfig<TFilters, K extends keyof TFilters>
+  extends BaseFilterFieldConfig<TFilters, K> {
+  type: 'supplier-type'
 }
 
 export interface UserStatusFilterFieldConfig<TFilters, K extends keyof TFilters>
@@ -119,6 +125,7 @@ export type FilterFieldConfig<TFilters> =
   | StatusFilterFieldConfig<TFilters, keyof TFilters>
   | UserStatusFilterFieldConfig<TFilters, keyof TFilters>
   | CustomerTypeFilterFieldConfig<TFilters, keyof TFilters>
+  | SupplierTypeFilterFieldConfig<TFilters, keyof TFilters>
   | RoleFilterFieldConfig<TFilters, keyof TFilters>
   | StockAdjustmentStatusFilterFieldConfig<TFilters, keyof TFilters>
   | PeriodFilterFieldConfig<TFilters, keyof TFilters>

--- a/frontend/src/utils/filterBar.url.ts
+++ b/frontend/src/utils/filterBar.url.ts
@@ -68,6 +68,7 @@ export function serializeFilters<TFilters extends object>(
       field.type === 'status' ||
       field.type === 'user-status' ||
       field.type === 'customer-type' ||
+      field.type === 'supplier-type' ||
       field.type === 'role' ||
       field.type === 'stock-adjustment-status' ||
       field.type === 'customer' ||
@@ -142,6 +143,7 @@ export function parseFilters<TFilters extends object>(
       field.type === 'status' ||
       field.type === 'user-status' ||
       field.type === 'customer-type' ||
+      field.type === 'supplier-type' ||
       field.type === 'role' ||
       field.type === 'stock-adjustment-status' ||
       field.type === 'customer' ||
@@ -167,6 +169,9 @@ export function parseFilters<TFilters extends object>(
       } else if (field.type === 'customer-type') {
         const VALID_CUSTOMER_TYPE = ['individual', 'business']
         result[fieldKey] = VALID_CUSTOMER_TYPE.includes(raw) ? raw : (defaultValue ?? null)
+      } else if (field.type === 'supplier-type') {
+        const VALID_SUPPLIER_TYPE = ['local', 'international']
+        result[fieldKey] = VALID_SUPPLIER_TYPE.includes(raw) ? raw : (defaultValue ?? null)
       } else if (field.type === 'role') {
         const VALID_ROLE = ['admin', 'manager', 'sales_staff', 'inventory_staff', 'procurement_staff']
         result[fieldKey] = VALID_ROLE.includes(raw) ? raw : (defaultValue ?? null)


### PR DESCRIPTION
## Summary

- Adds `supplier-type` to the shared `FilterFieldType` union and type system (`filterBar.types.ts`)
- Introduces `FilterSupplierType` component (wraps `FilterSelect` with Local / International options)
- Registers `supplier-type` in `FilterBar.tsx`
- Wires the type filter into `SuppliersPage` — extends `SupplierFilters`, adds field to `filterConfig`, passes `type` to the query params
- Fixes URL hydration in `filterBar.url.ts` and `useFilterBar.ts` so `/?type=local` correctly sets `type: 'local'` instead of `undefined`
- Adds regression tests in `SuppliersPage.filterbar.test.tsx`

No backend changes — `SupplierQueryDto` and `SupplierService.findAll()` already supported `type` filtering.

## Test plan

- [x] `npx vitest run src/pages/purchasing/__tests__/SuppliersPage.filterbar.test.tsx` — passes
- [x] `npm run type-check` — passes
- [x] `npm run lint` — passes
- [x] Full suite (`npm run test`) — not waited on (~12 min); targeted tests pass

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)