### PR TITLE
feat(suppliers): add sort button to SuppliersPage

### DIFF
--- a/frontend/src/pages/purchasing/SuppliersPage.tsx
+++ b/frontend/src/pages/purchasing/SuppliersPage.tsx
@@ -37,13 +37,6 @@ const SuppliersPage: React.FC = () => {
   const [pageError, setPageError] = useState<string | null>(null)
 
   const pageState = useSuppliersPageState()
-  const [sortBy, setSortBy] = useState('companyName')
-  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
-
-  const handleSort = useCallback((field: string) => {
-    setSortOrder((prev) => (sortBy === field && prev === 'desc' ? 'asc' : 'desc'))
-    setSortBy(field)
-  }, [sortBy])
 
   const filterConfig = useMemo<FilterBarConfig<SupplierFilters>>(
     () => ({
@@ -58,6 +51,14 @@ const SuppliersPage: React.FC = () => {
   )
 
   const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
+
+  const [sortBy, setSortBy] = useState('companyName')
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
+
+  const handleSort = useCallback((field: string) => {
+    setSortOrder((prev) => (sortBy === field && prev === 'desc' ? 'asc' : 'desc'))
+    setSortBy(field)
+  }, [sortBy])
 
   const filterHandlers = useMemo(() => ({
     ...handlers,
@@ -74,7 +75,7 @@ const SuppliersPage: React.FC = () => {
         appliedFilters.status === 'active'
           ? true
           : appliedFilters.status === 'inactive'
-          ? false
+            ? false
             : undefined,
       type: appliedFilters.type ?? undefined,
       sortBy,

--- a/frontend/src/pages/purchasing/SuppliersPage.tsx
+++ b/frontend/src/pages/purchasing/SuppliersPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Alert, Box, useMediaQuery, useTheme } from '@mui/material'
 import { useNavigate } from 'react-router-dom'
 
@@ -37,6 +37,13 @@ const SuppliersPage: React.FC = () => {
   const [pageError, setPageError] = useState<string | null>(null)
 
   const pageState = useSuppliersPageState()
+  const [sortBy, setSortBy] = useState('companyName')
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
+
+  const handleSort = useCallback((field: string) => {
+    setSortOrder((prev) => (sortBy === field && prev === 'desc' ? 'asc' : 'desc'))
+    setSortBy(field)
+  }, [sortBy])
 
   const filterConfig = useMemo<FilterBarConfig<SupplierFilters>>(
     () => ({
@@ -67,11 +74,13 @@ const SuppliersPage: React.FC = () => {
         appliedFilters.status === 'active'
           ? true
           : appliedFilters.status === 'inactive'
-            ? false
+          ? false
             : undefined,
       type: appliedFilters.type ?? undefined,
+      sortBy,
+      sortOrder: sortOrder.toUpperCase() as 'ASC' | 'DESC',
     }),
-    [appliedFilters],
+    [appliedFilters, sortBy, sortOrder],
   )
 
   const { data: suppliersResponse, isLoading, isFetching, error, refetch } = useGetSuppliersQuery(supplierQueryParams)
@@ -150,6 +159,7 @@ const SuppliersPage: React.FC = () => {
             handlers={filterHandlers}
             hasActiveFilters={hasActiveFilters}
             searchInputRef={pageState.searchInputRef}
+            sort={{ field: 'companyName', sortBy, sortOrder, onSort: handleSort }}
           />
         )}
       />

--- a/frontend/src/pages/purchasing/__tests__/SuppliersPage.filterbar.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/SuppliersPage.filterbar.test.tsx
@@ -163,4 +163,16 @@ describe('SuppliersPage FilterBar', () => {
       expect.not.objectContaining({ type: expect.anything() }),
     )
   })
+
+  it('renders a Sort button', () => {
+    renderPage()
+    expect(screen.getByRole('button', { name: /sort/i })).toBeInTheDocument()
+  })
+
+  it('passes default sortBy=companyName and sortOrder=ASC to query', () => {
+    renderPage()
+    expect(useGetSuppliersQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sortBy: 'companyName', sortOrder: 'ASC' }),
+    )
+  })
 })

--- a/frontend/src/pages/purchasing/__tests__/SuppliersPage.filterbar.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/SuppliersPage.filterbar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import { MemoryRouter } from 'react-router-dom'
@@ -171,6 +171,21 @@ describe('SuppliersPage FilterBar', () => {
 
   it('passes default sortBy=companyName and sortOrder=ASC to query', () => {
     renderPage()
+    expect(useGetSuppliersQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sortBy: 'companyName', sortOrder: 'ASC' }),
+    )
+  })
+
+  it('toggles sortOrder to DESC after clicking Sort, then back to ASC on second click', () => {
+    renderPage()
+    const sortButton = screen.getByRole('button', { name: /sort/i })
+
+    fireEvent.click(sortButton)
+    expect(useGetSuppliersQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sortBy: 'companyName', sortOrder: 'DESC' }),
+    )
+
+    fireEvent.click(sortButton)
     expect(useGetSuppliersQuery).toHaveBeenLastCalledWith(
       expect.objectContaining({ sortBy: 'companyName', sortOrder: 'ASC' }),
     )


### PR DESCRIPTION
## Summary
- Adds A→Z / Z→A sort toggle button to the Suppliers page FilterBar
- Passes `sortBy=companyName` and `sortOrder=ASC/DESC` to the API (backend already supported these params)
- Mirrors the existing CustomersPage pattern exactly

## Test Plan
- [x] 8/8 unit tests pass: `npx vitest run src/pages/purchasing/__tests__/SuppliersPage.filterbar.test.tsx`
- [x] TypeScript check passes: `npm run type-check`
- [x] Sort button appears in FilterBar on Suppliers page
- [x] Clicking toggles between A→Z and Z→A, list reorders accordingly

Closes #325