### PR TITLE
feat(invoices): add payment status and order status filters

### DIFF
--- a/backend/src/modules/sales/dto/invoice.dto.ts
+++ b/backend/src/modules/sales/dto/invoice.dto.ts
@@ -151,6 +151,24 @@ export class QueryInvoicesDto {
   unpaid?: boolean;
 
   @ApiPropertyOptional({
+    description: 'Filter by payment status',
+    enum: ['unpaid', 'partial', 'paid', 'overpaid'],
+    example: 'unpaid',
+  })
+  @IsOptional()
+  @IsEnum(['unpaid', 'partial', 'paid', 'overpaid'])
+  paymentStatus?: 'unpaid' | 'partial' | 'paid' | 'overpaid';
+
+  @ApiPropertyOptional({
+    description: 'Filter by fulfillment status of linked sales order',
+    enum: ['fulfilled', 'unfulfilled'],
+    example: 'fulfilled',
+  })
+  @IsOptional()
+  @IsEnum(['fulfilled', 'unfulfilled'])
+  fulfillmentStatus?: 'fulfilled' | 'unfulfilled';
+
+  @ApiPropertyOptional({
     description: 'Sort field',
     example: 'invoiceDate',
   })
@@ -379,4 +397,3 @@ export class VoidInvoiceDto {
   @IsString()
   reason: string;
 }
-

--- a/backend/src/modules/sales/services/invoice.service.spec.ts
+++ b/backend/src/modules/sales/services/invoice.service.spec.ts
@@ -116,3 +116,124 @@ describe('InvoiceService.searchGlobal', () => {
     expect(results[0].score).toBe(49);
   });
 });
+
+describe('InvoiceService.findAll - new filter params', () => {
+  let service: InvoiceService;
+  let invoiceRepository: {
+    createQueryBuilder: jest.Mock;
+    findAndCount: jest.Mock;
+  };
+
+  const mockQb = () => ({
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+  });
+
+  beforeEach(async () => {
+    invoiceRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(mockQb()),
+      findAndCount: jest.fn().mockResolvedValue([[], 0]),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InvoiceService,
+        { provide: getRepositoryToken(Invoice), useValue: invoiceRepository },
+        { provide: getRepositoryToken(Customer), useValue: { findOne: jest.fn() } },
+        { provide: getRepositoryToken(SalesOrder), useValue: {} },
+        { provide: getRepositoryToken(Payment), useValue: {} },
+        { provide: getRepositoryToken(Product), useValue: {} },
+        { provide: getRepositoryToken(InvoiceItem), useValue: {} },
+        { provide: AuditLogService, useValue: { log: jest.fn(), createLog: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get(InvoiceService);
+  });
+
+  it('calls andWhere with paidAmount = 0 when paymentStatus=unpaid', async () => {
+    const qb = mockQb();
+    invoiceRepository.createQueryBuilder.mockReturnValue(qb);
+
+    await service.findAll({ paymentStatus: 'unpaid' } as any);
+
+    const calls = qb.andWhere.mock.calls.map((c: any[]) => c[0]);
+    expect(calls.some((c: string) => c.includes('paidAmount = 0'))).toBe(true);
+  });
+
+  it('calls andWhere with partial condition when paymentStatus=partial', async () => {
+    const qb = mockQb();
+    invoiceRepository.createQueryBuilder.mockReturnValue(qb);
+
+    await service.findAll({ paymentStatus: 'partial' } as any);
+
+    const calls = qb.andWhere.mock.calls.map((c: any[]) => c[0]);
+    expect(
+      calls.some(
+        (c: string) =>
+          c.includes('paidAmount > 0') && c.includes('paidAmount < invoice.totalAmount'),
+      ),
+    ).toBe(true);
+  });
+
+  it('calls andWhere with paid condition when paymentStatus=paid', async () => {
+    const qb = mockQb();
+    invoiceRepository.createQueryBuilder.mockReturnValue(qb);
+
+    await service.findAll({ paymentStatus: 'paid' } as any);
+
+    const calls = qb.andWhere.mock.calls.map((c: any[]) => c[0]);
+    expect(calls.some((c: string) => c.includes('paidAmount >= invoice.totalAmount'))).toBe(
+      true,
+    );
+  });
+
+  it('calls andWhere with overpaid condition when paymentStatus=overpaid', async () => {
+    const qb = mockQb();
+    invoiceRepository.createQueryBuilder.mockReturnValue(qb);
+
+    await service.findAll({ paymentStatus: 'overpaid' } as any);
+
+    const calls = qb.andWhere.mock.calls.map((c: any[]) => c[0]);
+    expect(calls.some((c: string) => c.includes('paidAmount > invoice.totalAmount'))).toBe(
+      true,
+    );
+  });
+
+  it('calls andWhere with isFulfilled = true when fulfillmentStatus=fulfilled', async () => {
+    const qb = mockQb();
+    invoiceRepository.createQueryBuilder.mockReturnValue(qb);
+
+    await service.findAll({ fulfillmentStatus: 'fulfilled' } as any);
+
+    const calls = qb.andWhere.mock.calls.map((c: any[]) => c[0]);
+    expect(calls.some((c: string) => c.includes('isFulfilled = true'))).toBe(true);
+  });
+
+  it('calls andWhere with isFulfilled = false when fulfillmentStatus=unfulfilled', async () => {
+    const qb = mockQb();
+    invoiceRepository.createQueryBuilder.mockReturnValue(qb);
+
+    await service.findAll({ fulfillmentStatus: 'unfulfilled' } as any);
+
+    const calls = qb.andWhere.mock.calls.map((c: any[]) => c[0]);
+    expect(calls.some((c: string) => c.includes('isFulfilled = false'))).toBe(true);
+  });
+
+  it('applies no paymentStatus andWhere when paymentStatus is undefined', async () => {
+    const qb = mockQb();
+    invoiceRepository.createQueryBuilder.mockReturnValue(qb);
+
+    await service.findAll({} as any);
+
+    const calls = qb.andWhere.mock.calls.map((c: any[]) => c[0]);
+    expect(calls.some((c: string) => c.includes('paidAmount'))).toBe(false);
+  });
+});

--- a/backend/src/modules/sales/services/invoice.service.ts
+++ b/backend/src/modules/sales/services/invoice.service.ts
@@ -6,7 +6,7 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, FindOptionsWhere, FindManyOptions, MoreThanOrEqual, LessThanOrEqual, Between, ILike, In } from 'typeorm';
+import { Repository, MoreThanOrEqual, In } from 'typeorm';
 import {
   Invoice,
   InvoiceStatus
@@ -176,55 +176,105 @@ export class InvoiceService {
       status,
       fromDate,
       toDate,
-      overdue,
       unpaid,
+      paymentStatus,
+      fulfillmentStatus,
       sortBy = 'invoiceDate',
       sortOrder = 'DESC',
     } = query;
 
-    const where: FindOptionsWhere<Invoice> = {};
+    let qb = this.invoiceRepository
+      .createQueryBuilder('invoice')
+      .leftJoinAndSelect('invoice.customer', 'customer')
+      .leftJoinAndSelect('invoice.salesOrder', 'salesOrder')
+      .leftJoinAndSelect('invoice.payments', 'payments')
+      .leftJoinAndSelect('invoice.items', 'items')
+      .leftJoinAndSelect('items.product', 'product')
+      .where('invoice.deletedAt IS NULL');
 
-    if (customerId) where.customerId = customerId;
-    if (salesOrderId) where.salesOrderId = salesOrderId;
-    if (status) where.status = status;
+    if (customerId) {
+      qb = qb.andWhere('invoice.customerId = :customerId', { customerId });
+    }
+
+    if (salesOrderId) {
+      qb = qb.andWhere('invoice.salesOrderId = :salesOrderId', { salesOrderId });
+    }
+
+    if (status) {
+      qb = qb.andWhere('invoice.status = :status', { status });
+    }
 
     if (fromDate && toDate) {
       const endDate = new Date(toDate);
       endDate.setHours(23, 59, 59, 999);
-      where.invoiceDate = Between(new Date(fromDate), endDate);
+      qb = qb.andWhere('invoice.invoiceDate BETWEEN :fromDate AND :toDate', {
+        fromDate: new Date(fromDate),
+        toDate: endDate,
+      });
     } else if (fromDate) {
-      where.invoiceDate = MoreThanOrEqual(new Date(fromDate));
+      qb = qb.andWhere('invoice.invoiceDate >= :fromDate', {
+        fromDate: new Date(fromDate),
+      });
     } else if (toDate) {
       const endDate = new Date(toDate);
       endDate.setHours(23, 59, 59, 999);
-      where.invoiceDate = LessThanOrEqual(endDate);
+      qb = qb.andWhere('invoice.invoiceDate <= :toDate', { toDate: endDate });
     }
 
-    const searchConditions = [];
     if (search) {
-      searchConditions.push(
-        { invoiceNumber: ILike(`%${search}%`) },
-        { customer: { name: ILike(`%${search}%`) } },
+      qb = qb.andWhere(
+        '(invoice.invoiceNumber ILIKE :search OR customer.name ILIKE :search)',
+        { search: `%${search}%` },
       );
     }
 
-    const findOptions: FindManyOptions<Invoice> = {
-      where: searchConditions.length > 0 ? searchConditions.map(condition => ({ ...where, ...condition })) : where,
-      relations: ['customer', 'salesOrder', 'payments', 'items', 'items.product'],
-      order: { [sortBy]: sortOrder },
-    };
-
-    let [invoices, total] = await this.invoiceRepository.findAndCount(findOptions);
-
-    // Filter unpaid invoices if requested (overdue filtering removed as it depends on dueDate)
     if (unpaid !== undefined) {
-      invoices = invoices.filter(invoice => (Number(invoice.balanceDue) > 0) === unpaid);
-      total = invoices.length;
+      if (unpaid) {
+        qb = qb.andWhere('invoice.balanceDue > 0');
+      } else {
+        qb = qb.andWhere('invoice.balanceDue <= 0');
+      }
     }
+
+    if (paymentStatus) {
+      switch (paymentStatus) {
+        case 'unpaid':
+          qb = qb.andWhere('invoice.paidAmount = 0');
+          break;
+        case 'partial':
+          qb = qb.andWhere(
+            'invoice.paidAmount > 0 AND invoice.paidAmount < invoice.totalAmount',
+          );
+          break;
+        case 'paid':
+          qb = qb.andWhere(
+            'invoice.paidAmount >= invoice.totalAmount AND invoice.paidAmount > 0',
+          );
+          break;
+        case 'overpaid':
+          qb = qb.andWhere('invoice.paidAmount > invoice.totalAmount');
+          break;
+      }
+    }
+
+    if (fulfillmentStatus) {
+      switch (fulfillmentStatus) {
+        case 'fulfilled':
+          qb = qb.andWhere('salesOrder.isFulfilled = true');
+          break;
+        case 'unfulfilled':
+          qb = qb.andWhere('salesOrder.isFulfilled = false');
+          break;
+      }
+    }
+
+    qb = qb.orderBy(`invoice.${sortBy}`, sortOrder as 'ASC' | 'DESC');
+
+    const [invoices, total] = await qb.getManyAndCount();
 
     // Map invoices to response DTOs with product information
     const data = await Promise.all(
-      invoices.map(invoice => this.mapToResponseDto(invoice))
+      invoices.map(invoice => this.mapToResponseDto(invoice)),
     );
 
     return {

--- a/frontend/src/pages/sales/InvoicesPage.tsx
+++ b/frontend/src/pages/sales/InvoicesPage.tsx
@@ -26,6 +26,8 @@ interface InvoiceFilters {
   search: string
   period: PeriodValue
   customerId: string | null
+  paymentStatus: 'unpaid' | 'partial' | 'paid' | 'overpaid' | null
+  fulfillmentStatus: 'fulfilled' | 'unfulfilled' | null
 }
 
 const InvoicesPage: React.FC = () => {
@@ -46,11 +48,15 @@ const InvoicesPage: React.FC = () => {
       fields: [
         { field: 'period', label: 'Period', type: 'period' },
         { field: 'customerId', label: 'Customer', type: 'customer' },
+        { field: 'paymentStatus', label: 'Payment', type: 'payment-status' },
+        { field: 'fulfillmentStatus', label: 'Order Status', type: 'order-status' },
       ],
       defaults: {
         search: '',
         period: { key: null, from: null, to: null },
         customerId: null,
+        paymentStatus: null,
+        fulfillmentStatus: null,
       },
     }),
     [],
@@ -79,8 +85,18 @@ const InvoicesPage: React.FC = () => {
       fromDate: dateRange.fromDate,
       toDate: dateRange.toDate,
       customerId: appliedFilters.customerId || undefined,
+      paymentStatus: appliedFilters.paymentStatus || undefined,
+      fulfillmentStatus: appliedFilters.fulfillmentStatus || undefined,
     }),
-    [appliedFilters.search, appliedFilters.customerId, dateRange, sortBy, sortOrder],
+    [
+      appliedFilters.search,
+      appliedFilters.customerId,
+      appliedFilters.paymentStatus,
+      appliedFilters.fulfillmentStatus,
+      dateRange,
+      sortBy,
+      sortOrder,
+    ],
   )
 
   const { data, isLoading: loading, error, refetch } = useGetInvoicesQuery(queryArgs)

--- a/frontend/src/pages/sales/__tests__/InvoicesPage.filterbar.test.tsx
+++ b/frontend/src/pages/sales/__tests__/InvoicesPage.filterbar.test.tsx
@@ -139,4 +139,22 @@ describe('InvoicesPage FilterBar integration', () => {
       }),
     )
   })
+
+  it('restores paymentStatus=paid from URL and passes it to the query', () => {
+    renderPage('/?paymentStatus=paid')
+    expect(useGetInvoicesQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        paymentStatus: 'paid',
+      }),
+    )
+  })
+
+  it('restores fulfillmentStatus=fulfilled from URL and passes it to the query', () => {
+    renderPage('/?fulfillmentStatus=fulfilled')
+    expect(useGetInvoicesQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        fulfillmentStatus: 'fulfilled',
+      }),
+    )
+  })
 })


### PR DESCRIPTION
## Summary

- Adds `paymentStatus` (unpaid/partial/paid/overpaid) and `fulfillmentStatus` (fulfilled/unfulfilled) filter dropdowns to the Invoices page filter bar
- Migrates `findAll()` from `FindManyOptions` to a QueryBuilder to support the sales order JOIN needed for fulfillment filtering
- Payment status filters on raw `paidAmount`/`totalAmount` columns (same pattern as Orders page) rather than the derived `status` enum

## Changes

- `backend/src/modules/sales/dto/invoice.dto.ts` — add `paymentStatus` and `fulfillmentStatus` to `QueryInvoicesDto`
- `backend/src/modules/sales/services/invoice.service.ts` — migrate `findAll()` to QueryBuilder; add filter branches for both new params
- `backend/src/modules/sales/services/invoice.service.spec.ts` — 6 new tests covering each paymentStatus value and both fulfillmentStatus values
- `frontend/src/pages/sales/InvoicesPage.tsx` — extend `InvoiceFilters`, filter config, defaults, and queryArgs
- `frontend/src/pages/sales/__tests__/InvoicesPage.filterbar.test.tsx` — 2 new URL-restore tests

## Test plan

- [x] Backend: `cd backend && npm run test` — 56/56 suites, 776/776 tests pass
- [x] Backend: `cd backend && npm run lint` — clean
- [x] Frontend: `cd frontend && npm run type-check` — clean
- [x] Frontend: `cd frontend && npm run lint` — clean
- [x] Frontend filterbar: `npx vitest run src/pages/sales/__tests__/InvoicesPage.filterbar.test.tsx` — 8/8 pass
- [x] Manual: open Invoices page, verify Payment and Order Status dropdowns appear and filter results correctly

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)