### PR TITLE
refactor: payments page UI to match invoices page

### DIFF
--- a/backend/src/modules/sales/dto/payment.dto.ts
+++ b/backend/src/modules/sales/dto/payment.dto.ts
@@ -111,6 +111,15 @@ export class QueryPaymentsDto {
   toDate?: Date;
 
   @ApiPropertyOptional({
+    description: 'Filter by payment status',
+    enum: ['pending', 'completed', 'failed', 'cancelled', 'refunded'],
+    example: 'completed',
+  })
+  @IsOptional()
+  @IsString()
+  status?: string;
+
+  @ApiPropertyOptional({
     description: 'Search by payment number or customer name',
     example: 'PAY-000001',
   })

--- a/backend/src/modules/sales/dto/payment.dto.ts
+++ b/backend/src/modules/sales/dto/payment.dto.ts
@@ -112,12 +112,12 @@ export class QueryPaymentsDto {
 
   @ApiPropertyOptional({
     description: 'Filter by payment status',
-    enum: ['pending', 'completed', 'failed', 'cancelled', 'refunded'],
+    enum: PaymentStatus,
     example: 'completed',
   })
   @IsOptional()
-  @IsString()
-  status?: string;
+  @IsEnum(PaymentStatus)
+  status?: PaymentStatus;
 
   @ApiPropertyOptional({
     description: 'Search by payment number or customer name',

--- a/backend/src/modules/sales/services/payment.service.spec.ts
+++ b/backend/src/modules/sales/services/payment.service.spec.ts
@@ -101,6 +101,25 @@ describe('PaymentService', () => {
     expect(service).toBeDefined();
   });
 
+  describe('findAll', () => {
+    it('filters payments by status when status is provided', async () => {
+      const mockPayments = [
+        { id: '1', status: 'completed', paymentNumber: 'PAY-001' },
+      ];
+      jest.spyOn(paymentRepository, 'createQueryBuilder').mockReturnValue({
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([mockPayments, 1]),
+      } as any);
+
+      const result = await service.findAll({ status: 'completed' as any });
+
+      expect(result.data).toHaveLength(1);
+    });
+  });
+
   describe('create', () => {
     it('should post accounting entry successfully', async () => {
       // Arrange

--- a/backend/src/modules/sales/services/payment.service.ts
+++ b/backend/src/modules/sales/services/payment.service.ts
@@ -156,11 +156,13 @@ export class PaymentService {
       search,
       sortBy = 'paymentDate',
       sortOrder = 'DESC',
+      status,
     } = query;
 
     const where: FindOptionsWhere<Payment> = {};
 
     if (customerId) where.customerId = customerId;
+    if (status) where.status = status as PaymentStatus;
     if (invoiceId) where.invoiceId = invoiceId;
 
     if (fromDate || toDate) {

--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -17,6 +17,7 @@ import { FilterStockAdjustmentStatus } from './FilterStockAdjustmentStatus'
 import { FilterStockStatus } from './FilterStockStatus'
 import { FilterSupplier } from './FilterSupplier'
 import { FilterSupplierType } from './FilterSupplierType'
+import { FilterTransactionStatus } from './FilterTransactionStatus'
 import { FilterUserStatus } from './FilterUserStatus'
 import { AppButton } from '@/components/common/AppButton'
 import type {
@@ -237,6 +238,17 @@ function renderQuickField<TFilters extends object>(
         field={fieldKey}
         value={(value as string | null) ?? null}
         onChange={onChange}
+      />
+    )
+  }
+
+  if (field.type === 'transaction-status') {
+    return (
+      <FilterTransactionStatus
+        key={fieldKey}
+        field={fieldKey}
+        value={(value as string | null) ?? null}
+        onChange={onChange as (value: string | null) => void}
       />
     )
   }

--- a/frontend/src/components/filters/FilterTransactionStatus.tsx
+++ b/frontend/src/components/filters/FilterTransactionStatus.tsx
@@ -1,0 +1,27 @@
+import { FilterSelect } from './FilterSelect'
+
+const TRANSACTION_STATUS_OPTIONS = [
+  { value: 'completed', label: 'Completed' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'cancelled', label: 'Cancelled' },
+  { value: 'refunded', label: 'Refunded' },
+]
+
+interface Props {
+  field: string
+  value: string | null
+  onChange: (value: string | null) => void
+}
+
+export function FilterTransactionStatus({ field, value, onChange }: Props) {
+  return (
+    <FilterSelect
+      field={field}
+      label="Status"
+      value={value}
+      options={TRANSACTION_STATUS_OPTIONS}
+      onChange={onChange}
+    />
+  )
+}

--- a/frontend/src/hooks/useFilterBar.ts
+++ b/frontend/src/hooks/useFilterBar.ts
@@ -34,7 +34,8 @@ function getDefaults<TFilters extends object>(
       field.type === 'category' ||
       field.type === 'product-type' ||
       field.type === 'stock-status' ||
-      field.type === 'price-list'
+      field.type === 'price-list' ||
+      field.type === 'transaction-status'
     ) {
       defaults[key] = null
     }

--- a/frontend/src/pages/sales/PaymentsPage.tsx
+++ b/frontend/src/pages/sales/PaymentsPage.tsx
@@ -1,994 +1,226 @@
-import React, { useState, useEffect, useRef, useCallback, memo, useMemo } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
-import {
-  Box,
-  Typography,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Button,
-  Chip,
-  IconButton,
-  TextField,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  Alert,
-  CircularProgress,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Grid,
-  Divider,
-  Link,
-  Stack,
-} from '@mui/material'
-import { default as EditIcon } from '@mui/icons-material/Edit'
-import { default as DeleteIcon } from '@mui/icons-material/Delete'
-import { default as SortIcon } from '@mui/icons-material/Sort'
-import { default as ArrowUpIcon } from '@mui/icons-material/ArrowUpward'
-import { default as ArrowDownIcon } from '@mui/icons-material/ArrowDownward'
-import { default as InvoiceIcon } from '@mui/icons-material/Receipt'
-import { default as OrderIcon } from '@mui/icons-material/ShoppingCart'
-import { default as PrintIcon } from '@mui/icons-material/Print'
-import { formatCurrency, formatDate, formatWholeQuantity } from '@/utils/formatters'
-import { TABLE_STYLES } from '@/constants/tableStyles'
-import { ListSkeleton } from '@/components/common/ListSkeleton'
-import { FilterBar } from '@/components/filters'
-import DeletedPaymentsDialog from '@/components/sales/DeletedPaymentsDialog'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { Alert, Box, Chip, Stack, useMediaQuery, useTheme } from '@mui/material'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+import PaymentContextHeader from './components/PaymentContextHeader'
+import PaymentsDialogs from './components/PaymentsDialogs'
+import PaymentsTable from './components/PaymentsTable'
+import PaymentWorkspaceCard from './components/PaymentWorkspaceCard'
+import type { PaymentListItem } from './hooks/usePaymentsPageState'
+import { usePaymentsPageState } from './hooks/usePaymentsPageState'
+import { usePaymentsSelection } from './hooks/usePaymentsSelection'
+
+import MasterDetailWorkspace from '@/components/common/MasterDetailWorkspace'
 import PageHeader from '@/components/common/PageHeader'
-import { PaymentReceiptPrint } from '@/components/print'
+import { FilterBar } from '@/components/filters/FilterBar'
 import { useFilterBar } from '@/hooks/useFilterBar'
 import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
-import { useLazyGetJournalEntriesQuery } from '@/store/api/accountingApi'
 import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import { useGetCustomersQuery, useGetPaymentsQuery } from '@/store/api/salesApi'
-import { setSelectedPayment, selectSelectedPayment } from '@/store/slices/salesSlice'
-import type { FilterBarConfig } from '@/types/filterBar.types'
-import type { InvoiceItem } from '@/types'
-
-// Payment types and interfaces
-interface Payment {
-  id: string
-  paymentNumber: string
-  customerName?: string
-  amount: number
-  paymentDate: string | Date
-  paymentMethodId?: string
-  paymentMethod?: string
-  paymentMethodEntity?: {
-    id: string
-    code: string
-    name: string
-  }
-  status: 'pending' | 'completed' | 'failed' | 'cancelled' | 'refunded'
-  notes?: string
-  reference?: string
-  relatedOrderId?: string
-  relatedInvoiceId?: string
-  relatedOrderNumber?: string
-  relatedInvoiceNumber?: string
-  customer?: {
-    id: string
-    name: string
-    email?: string
-    phone?: string
-  }
-  salesOrder?: {
-    id: string
-    orderNumber: string
-  }
-  invoice?: {
-    id: string
-    invoiceNumber: string
-    items?: InvoiceItem[]
-  }
-}
+import { selectSelectedPayment } from '@/store/slices/salesSlice'
+import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
+import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
 
 interface PaymentFilters {
   search: string
+  period: PeriodValue
+  customerId: string | null
+  transactionStatus: string | null
 }
-
-interface PaymentSortState {
-  sortBy: string
-  sortOrder: 'asc' | 'desc'
-}
-
-
-// Memoized Payment Row Component
-interface PaymentRowProps {
-  payment: Payment
-  index: number
-  selectedPaymentId?: string
-  focusedPaymentIndex: number
-  onPaymentSelect: (payment: Payment) => void
-}
-
-const PaymentRow = memo(({ payment, index, selectedPaymentId, focusedPaymentIndex, onPaymentSelect }: PaymentRowProps) => {
-  const isSelected = selectedPaymentId === payment.id
-  const isFocused = index === focusedPaymentIndex
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'completed': return 'success'
-      default: return 'default'
-    }
-  }
-
-  return (
-    <TableRow
-      key={payment.id}
-      hover
-      onClick={() => onPaymentSelect(payment)}
-      data-payment-index={index}
-      sx={{
-        cursor: 'pointer',
-        backgroundColor: isSelected ? 'action.selected' : isFocused ? 'action.focus' : 'inherit',
-        '&:hover': {
-          backgroundColor: isSelected ? 'action.selected' : 'action.hover'
-        },
-        transition: 'background-color 0.2s ease',
-        height: TABLE_STYLES.row.height,
-        ...(isFocused && {
-          outline: '2px solid',
-          outlineColor: 'primary.main',
-          outlineOffset: '-2px'
-        })
-      }}
-    >
-      <TableCell>
-        <Typography
-          variant="body2"
-          sx={{
-            fontWeight: 400,
-            fontSize: '0.8rem',
-            lineHeight: 1.2
-          }}
-        >
-          {payment.paymentNumber}
-        </Typography>
-      </TableCell>
-    </TableRow>
-  )
-})
-
-PaymentRow.displayName = 'PaymentRow'
 
 const PaymentsPage: React.FC = () => {
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
   const navigate = useNavigate()
   const location = useLocation()
   const dispatch = useAppDispatch()
-  const selectedPayment = useAppSelector(selectSelectedPayment) as Payment | null
+  const selectedPayment = useAppSelector(selectSelectedPayment) as PaymentListItem | null
+  const pageState = usePaymentsPageState()
+  const [sortBy, setSortBy] = useState('paymentNumber')
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
 
-  const [sortState, setSortState] = useState<PaymentSortState>({
-    sortBy: 'paymentNumber',
-    sortOrder: 'asc',
-  })
-  const [pendingPaymentToSelect, setPendingPaymentToSelect] = useState<string | null>(() => {
-    const id = new URLSearchParams(window.location.search).get('highlight')
-    return id
-  })
-  const [editDialog, setEditDialog] = useState(false)
-  const [focusedPaymentIndex, setFocusedPaymentIndex] = useState(-1)
-  const [deletedPaymentsDialogOpen, setDeletedPaymentsDialogOpen] = useState(false)
-  const [printDialogOpen, setPrintDialogOpen] = useState(false)
-  const [fetchJournalEntries] = useLazyGetJournalEntriesQuery()
-  const [journalEntryRef, setJournalEntryRef] = useState<{ referenceNumber: string; id: string } | null>(null)
-  const searchInputRef = useRef<HTMLInputElement | null>(null)
-  const paymentListRef = useRef<HTMLDivElement>(null)
-  const hasRestoredSelection = useRef(false)
-  const selectedPaymentRef = useRef(selectedPayment)
-  const previousPathnameRef = useRef(location.pathname)
+  const presetCustomerId = (location.state as { customerId?: string } | null)?.customerId ?? null
   const { data: customersData } = useGetCustomersQuery({})
   const customers = customersData?.data ?? []
-  const presetCustomerId = (location.state as { customerId?: string } | null)?.customerId ?? null
 
   const filterConfig = useMemo<FilterBarConfig<PaymentFilters>>(
     () => ({
       search: { placeholder: 'Search by payment number or customer...' },
-      fields: [],
-      defaults: { search: '' },
+      fields: [
+        { field: 'period', label: 'Period', type: 'period' },
+        { field: 'customerId', label: 'Customer', type: 'customer', paramKey: 'customer' },
+        { field: 'transactionStatus', label: 'Status', type: 'transaction-status' },
+      ],
+      defaults: {
+        search: '',
+        period: { key: null, from: null, to: null },
+        customerId: null,
+        transactionStatus: null,
+      },
     }),
     [],
   )
 
   const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
+
   const filterBarHandlers = useMemo(
-    () => (
+    () =>
       presetCustomerId
-        ? {
-            ...handlers,
-            onClearAll: () => {
-              handlers.onClearField('search')
-            },
-          }
-        : handlers
-    ),
+        ? { ...handlers, onClearAll: () => handlers.onClearField('search') }
+        : handlers,
     [handlers, presetCustomerId],
   )
-  const paymentQueryArgs = useMemo(
+
+  const weekStartsOn = getStartOfWeek()
+  const dateRange = useMemo(() => {
+    const period = appliedFilters.period
+    if (!period || period.key === null) return { fromDate: undefined, toDate: undefined }
+    if (period.key === 'custom') return { fromDate: period.from ?? undefined, toDate: period.to ?? undefined }
+
+    const range = getPeriodDateRange(period.key, weekStartsOn)
+    return { fromDate: range.from, toDate: range.to }
+  }, [appliedFilters.period, weekStartsOn])
+
+  const queryArgs = useMemo(
     () => ({
-      sortBy: sortState.sortBy,
-      sortOrder: sortState.sortOrder,
       search: appliedFilters.search || undefined,
-      customerId: presetCustomerId ?? undefined,
+      sortBy,
+      sortOrder: sortOrder.toUpperCase() as 'ASC' | 'DESC',
+      fromDate: dateRange.fromDate,
+      toDate: dateRange.toDate,
+      customerId: presetCustomerId ?? appliedFilters.customerId ?? undefined,
+      status: appliedFilters.transactionStatus ?? undefined,
     }),
-    [appliedFilters, sortState, presetCustomerId],
+    [
+      appliedFilters.search,
+      appliedFilters.customerId,
+      appliedFilters.transactionStatus,
+      dateRange,
+      sortBy,
+      sortOrder,
+      presetCustomerId,
+    ],
   )
 
-  // Keep ref in sync with selectedPayment
-  useEffect(() => {
-    selectedPaymentRef.current = selectedPayment
-  }, [selectedPayment])
-
-  // Fetch journal entry reference number for selected payment
-  useEffect(() => {
-    if (!selectedPayment) {
-      setJournalEntryRef(null)
-      return
-    }
-    fetchJournalEntries({ sourceType: 'payment', sourceId: selectedPayment.id, limit: 1 })
-      .unwrap()
-      .then((res) => {
-        const entry = res?.data?.[0]
-        setJournalEntryRef(entry ? { referenceNumber: entry.referenceNumber, id: entry.id } : null)
-      })
-      .catch(() => setJournalEntryRef(null))
-  }, [selectedPayment?.id, fetchJournalEntries])
-
-  const { data, isLoading, isFetching, error, refetch } = useGetPaymentsQuery(paymentQueryArgs)
-  const loading = isLoading || isFetching
-  const payments = data?.data ?? []
-  const totalPayments = data?.meta.total ?? 0
-
-  // Filter and sort payments
-  // Since backend handles filtering, sorting, and pagination, use payments directly
-  const filteredPayments = payments
-  const paginatedPayments = payments
+  const { data, isLoading: loading, error, refetch } = useGetPaymentsQuery(queryArgs)
+  const payments = (data?.data ?? []) as PaymentListItem[]
+  const totalPayments = data?.meta?.total ?? 0
 
   const handleSort = useCallback((field: string) => {
-    const newSortOrder = sortState.sortBy === field && sortState.sortOrder === 'desc' ? 'asc' : 'desc'
-    setSortState((prev: PaymentSortState) => ({
-      ...prev,
-      sortBy: field,
-      sortOrder: newSortOrder,
-    }))
-  }, [sortState.sortBy, sortState.sortOrder])
+    setSortOrder((prev) => (sortBy === field && prev === 'desc' ? 'asc' : 'desc'))
+    setSortBy(field)
+  }, [sortBy])
 
-  const handlePaymentSelect = useCallback((payment: Payment) => {
-    dispatch(setSelectedPayment(payment as any))
-    const paymentIndex = paginatedPayments.findIndex((p: Payment) => p.id === payment.id)
-    setFocusedPaymentIndex(paymentIndex)
-  }, [paginatedPayments, dispatch])
-
-  // Refresh on route navigation (when coming back from another page)
-  useEffect(() => {
-    // Only refresh if we navigated TO payments page FROM somewhere else
-    if (previousPathnameRef.current !== '/sales/payments' && location.pathname === '/sales/payments') {
-      void refetch()
-      // Reset restoration flag so selection can be restored again
-      hasRestoredSelection.current = false
-      // Don't reset focusedPaymentIndex here - let the restoration effect handle it
-    }
-    previousPathnameRef.current = location.pathname
-  }, [location.pathname, refetch, selectedPayment])
-
-  // Update selected payment when fresh data arrives (to reflect customer changes)
-  useEffect(() => {
-    if (payments && payments.length > 0 && selectedPaymentRef.current) {
-      const freshPayment = payments.find((payment: any) => payment.id === selectedPaymentRef.current?.id)
-      if (freshPayment) {
-        // Only update if the data actually changed (to avoid infinite loops)
-        const hasChanged = JSON.stringify(freshPayment) !== JSON.stringify(selectedPaymentRef.current)
-        if (hasChanged) {
-          dispatch(setSelectedPayment(freshPayment as any))
-        }
-      }
-    }
-  }, [payments, dispatch])
-
-  // Initialize: Restore persisted selected payment on mount
-  useEffect(() => {
-    if (!hasRestoredSelection.current && selectedPayment && paginatedPayments.length > 0) {
-      const index = paginatedPayments.findIndex((p: Payment) => p.id === selectedPayment.id)
-      if (index >= 0) {
-        // Force update the focused index even if it's already set
-        setFocusedPaymentIndex(-1) // Reset first
-        setTimeout(() => {
-          setFocusedPaymentIndex(index)
-          hasRestoredSelection.current = true
-        }, 0)
-      }
-    }
-  }, [selectedPayment, paginatedPayments])
-
-  const handleOrderClick = useCallback((orderId: string, event: React.MouseEvent) => {
-    event.stopPropagation()
-    navigate(`/sales/orders?highlight=${orderId}`)
-  }, [navigate])
-
-  const handleInvoiceClick = useCallback((invoiceId: string, event: React.MouseEvent) => {
-    event.stopPropagation()
-    navigate('/sales/invoices', { state: { highlightInvoiceId: invoiceId } })
-  }, [navigate])
-
-  // Auto-select first payment when payments load OR restore focus for persisted selection
-  useEffect(() => {
-    if (paginatedPayments.length > 0 && focusedPaymentIndex === -1) {
-      // If we have a persisted selected payment from Redux, restore its focus
-      if (selectedPayment) {
-        const index = paginatedPayments.findIndex((p: Payment) => p.id === selectedPayment.id)
-        if (index >= 0) {
-          setFocusedPaymentIndex(index)
-        }
-      }
-      // Only auto-focus first payment if we don't have a selected payment
-      else if (searchInputRef.current !== document.activeElement) {
-        setFocusedPaymentIndex(0)
-        dispatch(setSelectedPayment(paginatedPayments[0] as any))
-      }
-    } else if (paginatedPayments.length === 0 && !loading) {
-      // Only clear selection when no payments in list AND we're done loading
-      dispatch(setSelectedPayment(null))
-      setFocusedPaymentIndex(-1)
-    }
-  }, [paginatedPayments, focusedPaymentIndex, selectedPayment, dispatch, loading])
-
-  // Handle pending payment selection from ?highlight query param (e.g. navigating from journal entries)
-  useEffect(() => {
-    if (!pendingPaymentToSelect || paginatedPayments.length === 0) return
-    const paymentIndex = paginatedPayments.findIndex(p => p.id === pendingPaymentToSelect)
-    if (paymentIndex >= 0) {
-      dispatch(setSelectedPayment(paginatedPayments[paymentIndex] as any))
-      setFocusedPaymentIndex(paymentIndex)
-      setPendingPaymentToSelect(null)
-      window.history.replaceState(null, '', window.location.pathname)
-    }
-  }, [paginatedPayments, pendingPaymentToSelect, dispatch])
-
-  // Handle navigation from order page with highlightPaymentId
-  useEffect(() => {
-    const state = location.state as { highlightPaymentId?: string }
-    if (state?.highlightPaymentId && paginatedPayments.length > 0) {
-      const paymentIndex = paginatedPayments.findIndex(p => p.id === state.highlightPaymentId)
-      if (paymentIndex >= 0) {
-        dispatch(setSelectedPayment(paginatedPayments[paymentIndex] as any))
-        setFocusedPaymentIndex(paymentIndex)
-        // Clear the state to prevent repeated highlighting
-        window.history.replaceState(null, '', window.location.pathname + window.location.search)
-      }
-    }
-  }, [paginatedPayments, location.state, dispatch])
-
-  // Auto-scroll to keep focused item visible
-  useEffect(() => {
-    if (focusedPaymentIndex >= 0 && paymentListRef.current) {
-      const focusedRow = paymentListRef.current.querySelector(`[data-payment-index="${focusedPaymentIndex}"]`)
-      if (focusedRow) {
-        focusedRow.scrollIntoView({
-          behavior: 'smooth',
-          block: 'nearest'
-        })
-      }
-    }
-  }, [focusedPaymentIndex])
-
-  // Keyboard navigation functions
-  const handleNavigateUp = useCallback(() => {
-    if (focusedPaymentIndex > 0) {
-      const newIndex = focusedPaymentIndex - 1
-      setFocusedPaymentIndex(newIndex)
-      dispatch(setSelectedPayment(paginatedPayments[newIndex] as any))
-    }
-  }, [focusedPaymentIndex, paginatedPayments, dispatch])
-
-  const handleNavigateDown = useCallback(() => {
-    if (focusedPaymentIndex < paginatedPayments.length - 1) {
-      const newIndex = focusedPaymentIndex + 1
-      setFocusedPaymentIndex(newIndex)
-      dispatch(setSelectedPayment(paginatedPayments[newIndex] as any))
-    }
-  }, [focusedPaymentIndex, paginatedPayments, dispatch])
-
-  const handleNavigateToFirst = useCallback(() => {
-    if (paginatedPayments.length > 0) {
-      setFocusedPaymentIndex(0)
-      dispatch(setSelectedPayment(paginatedPayments[0] as any))
-    }
-  }, [paginatedPayments, dispatch])
-
-  const handleNavigateToLast = useCallback(() => {
-    if (paginatedPayments.length > 0) {
-      const lastIndex = paginatedPayments.length - 1
-      setFocusedPaymentIndex(lastIndex)
-      dispatch(setSelectedPayment(paginatedPayments[lastIndex] as any))
-    }
-  }, [paginatedPayments, dispatch])
-
-  const handlePageUpNavigation = useCallback(() => {
-    const pageSize = 20
-    const newIndex = Math.max(0, focusedPaymentIndex - pageSize)
-    setFocusedPaymentIndex(newIndex)
-    if (paginatedPayments[newIndex]) {
-      dispatch(setSelectedPayment(paginatedPayments[newIndex] as any))
-    }
-  }, [focusedPaymentIndex, paginatedPayments, dispatch])
-
-  const handlePageDownNavigation = useCallback(() => {
-    const pageSize = 20
-    const newIndex = Math.min(paginatedPayments.length - 1, focusedPaymentIndex + pageSize)
-    setFocusedPaymentIndex(newIndex)
-    if (paginatedPayments[newIndex]) {
-      dispatch(setSelectedPayment(paginatedPayments[newIndex] as any))
-    }
-  }, [focusedPaymentIndex, paginatedPayments, dispatch])
-
-  const handleEnterAction = useCallback(() => {
-    if (focusedPaymentIndex >= 0 && paginatedPayments[focusedPaymentIndex]) {
-      setEditDialog(true)
-    }
-  }, [focusedPaymentIndex, paginatedPayments, dispatch])
-
-  const handleEscapeAction = useCallback(() => {
-    setFocusedPaymentIndex(-1)
-    dispatch(setSelectedPayment(null))
-    setEditDialog(false)
-  }, [dispatch])
-
-  // Setup keyboard shortcuts - only navigation and search
-  useKeyboardShortcuts({
-    onSearch: () => {
-      searchInputRef.current?.focus()
-      searchInputRef.current?.select()
-    },
-    onArrowUp: handleNavigateUp,
-    onArrowDown: handleNavigateDown,
-    onEnter: handleEnterAction,
-    onPageUp: handlePageUpNavigation,
-    onPageDown: handlePageDownNavigation,
-    onHome: handleNavigateToFirst,
-    onEnd: handleNavigateToLast,
-    onEscape: handleEscapeAction,
+  const selection = usePaymentsSelection({
+    dispatch,
+    navigate,
+    payments,
+    selectedPayment,
+    focusedPaymentIndex: pageState.focusedPaymentIndex,
+    setFocusedPaymentIndex: pageState.setFocusedPaymentIndex,
+    location,
+    refetch,
+    paymentListRef: pageState.paymentListRef,
+    searchInputRef: pageState.searchInputRef,
+    hasRestoredSelection: pageState.hasRestoredSelection,
+    selectedPaymentRef: pageState.selectedPaymentRef,
+    setJournalEntryRef: pageState.setJournalEntryRef,
+    setJournalEntryRefLoading: pageState.setJournalEntryRefLoading,
   })
 
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'completed': return 'success'
-      default: return 'default'
+  useEffect(() => {
+    if (pageState.previousPathnameRef.current !== '/sales/payments' && location.pathname === '/sales/payments') {
+      void refetch()
     }
-  }
+    pageState.previousPathnameRef.current = location.pathname
+  }, [location.pathname, pageState.previousPathnameRef, refetch])
 
-  const getPaymentMethodLabel = (payment: Payment) => {
-    if (payment.paymentMethodEntity?.name) return payment.paymentMethodEntity.name
-    if (payment.paymentMethod) return payment.paymentMethod
-    return 'Unknown'
-  }
-
+  useKeyboardShortcuts({
+    onSearch: () => {
+      pageState.searchInputRef.current?.focus()
+      pageState.searchInputRef.current?.select()
+    },
+    onArrowUp: selection.handleNavigateUp,
+    onArrowDown: selection.handleNavigateDown,
+    onEnter: selection.handleEnterAction,
+    onPageUp: selection.handlePageUpNavigation,
+    onPageDown: selection.handlePageDownNavigation,
+    onHome: selection.handleNavigateToFirst,
+    onEnd: selection.handleNavigateToLast,
+    onEscape: selection.handleEscapeAction,
+  })
 
   return (
-    <>
-      {/* Header */}
+    <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
       <PageHeader
         title="Payments"
         subtitle="Review customer payments and transaction history"
         variant="workflow"
-        secondaryAction={{ label: 'View Deleted', onClick: () => setDeletedPaymentsDialogOpen(true) }}
+        secondaryAction={{ label: 'View Deleted', onClick: () => pageState.setDeletedPaymentsDialogOpen(true) }}
         toolbar={(
           <FilterBar
             config={filterConfig}
             draftFilters={draftFilters}
             handlers={filterBarHandlers}
             hasActiveFilters={hasActiveFilters}
-            searchInputRef={searchInputRef}
+            searchInputRef={pageState.searchInputRef}
+            sort={{ field: 'paymentNumber', sortBy, sortOrder, onSort: handleSort }}
           />
         )}
       />
-      {/* Preset customer chip + sort button */}
-      <Box sx={{ mb: 3, display: 'flex', alignItems: 'flex-start', gap: 1 }}>
-        {presetCustomerId ? (
-          <Stack direction="row" sx={{ flex: 1 }}>
-            <Chip
-              label={`Customer: ${customers.find((customer) => customer.id === presetCustomerId)?.name ?? presetCustomerId}`}
-              size="small"
-              variant="filled"
-            />
-          </Stack>
-        ) : (
-          <Box sx={{ flex: 1 }} />
-        )}
-        <Button
-          variant={sortState.sortBy === 'paymentNumber' ? 'contained' : 'outlined'}
-          size="medium"
-          startIcon={sortState.sortBy === 'paymentNumber' ? (sortState.sortOrder === 'desc' ? <ArrowDownIcon /> : <ArrowUpIcon />) : <SortIcon />}
-          onClick={() => handleSort('paymentNumber')}
-          sx={{
-            height: '40px',
-            fontSize: '0.875rem',
-            minWidth: 'auto',
-            px: 2,
-          }}
-        >
-          Sort
-        </Button>
-      </Box>
-      {/* Error Display */}
+
+      {presetCustomerId && (
+        <Stack direction="row" sx={{ mb: 2 }}>
+          <Chip
+            label={`Customer: ${customers.find((customer) => customer.id === presetCustomerId)?.name ?? presetCustomerId}`}
+            size="small"
+            variant="filled"
+          />
+        </Stack>
+      )}
+
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>
           Failed to load payments.
         </Alert>
       )}
-      {/* Split Layout: Payment List and Payment Details */}
-      <Grid container spacing={3}>
-        {/* Left Side - Payment List */}
-        <Grid
-          size={{
-            xs: 12,
-            md: 3
-          }}>
-          <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', flexDirection: 'column' }}>
-            <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
-              <Typography variant="tableHeader" sx={{
-                fontWeight: 600,
-                fontSize: '0.8rem',
-                textTransform: 'uppercase',
-                letterSpacing: '0.5px'
-              }}>
-                Payment List ({totalPayments})
-              </Typography>
-            </Box>
 
-            <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }} ref={paymentListRef}>
-              {(isLoading || (isFetching && !data)) ? (
-                <ListSkeleton rows={8} columns={1} />
-              ) : (
-                <Box sx={{ flex: 1, opacity: isFetching ? 0.6 : 1, position: 'relative' }}>
-                  {isFetching ? (
-                    <CircularProgress size={16} sx={{ position: 'absolute', top: 8, right: 8, zIndex: 1 }} />
-                  ) : null}
-                  <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
-                    <Table
-                      size={TABLE_STYLES.size}
-                      sx={{
-                        '& .MuiTableCell-root': {
-                          borderBottom: TABLE_STYLES.cell.border,
-                          py: TABLE_STYLES.cell.padding.py * 0.75,
-                          px: TABLE_STYLES.cell.padding.px * 0.75,
-                        },
-                      }}
-                    >
-                      <TableHead sx={{ display: 'none' }}>
-                        <TableRow sx={{ '& .MuiTableCell-head': {
-                          fontWeight: 600,
-                          backgroundColor: 'grey.50',
-                          color: 'text.primary',
-                          fontSize: '0.8rem',
-                        } }}>
-                          <TableCell>Payment #</TableCell>
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        {paginatedPayments.map((payment: Payment, index: number) => (
-                          <PaymentRow
-                            key={payment.id}
-                            payment={payment}
-                            index={index}
-                            selectedPaymentId={selectedPayment?.id}
-                            focusedPaymentIndex={focusedPaymentIndex}
-                            onPaymentSelect={handlePaymentSelect}
-                          />
-                        ))}
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
-                </Box>
-              )}
-            </Box>
-          </Paper>
-        </Grid>
-
-        {/* Right Side - Payment Details */}
-        <Grid
-          size={{
-            xs: 12,
-            md: 9
-          }}>
-          {selectedPayment ? (
-            <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', flexDirection: 'column' }}>
-              {/* Header with Payment Info and Actions */}
-              <Box sx={{
-                p: TABLE_STYLES.cell.padding.px,
-                borderBottom: TABLE_STYLES.cell.border,
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center'
-              }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-                  <Typography variant="tableHeader" sx={{
-                    fontWeight: 600,
-                    fontSize: '0.8rem',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px'
-                  }}>
-                    Payment Details - {selectedPayment.paymentNumber}
-                  </Typography>
-                  <Chip
-                    label={selectedPayment.status.charAt(0).toUpperCase() + selectedPayment.status.slice(1)}
-                    color={getStatusColor(selectedPayment.status)}
-                    size="small"
-                    sx={{
-                      textTransform: 'capitalize',
-                      fontSize: '0.75rem',
-                      fontWeight: 600
-                    }}
-                  />
-                </Box>
-                <Box>
-                  <IconButton
-                    size="small"
-                    title="Print Receipt"
-                    onClick={() => setPrintDialogOpen(true)}
-                    sx={{
-                      height: `${TABLE_STYLES.row.height * 0.75}px`,
-                      width: `${TABLE_STYLES.row.height * 0.75}px`,
-                      minHeight: 20,
-                      minWidth: 20,
-                      p: 0.125,
-                      color: 'info.main',
-                      '&:hover': {
-                        backgroundColor: 'info.light',
-                        color: 'info.dark'
-                      }
-                    }}
-                  >
-                    <PrintIcon sx={{
-                      fontSize: `${TABLE_STYLES.row.height * 0.5}px`
-                    }} />
-                  </IconButton>
-                </Box>
-              </Box>
-
-              <Box sx={{ flex: 1, overflow: 'auto', p: TABLE_STYLES.cell.padding.px }}>
-                {/* Payment Details Section */}
-                <Grid container spacing={3}>
-                  {/* Left Column - Payment Information */}
-                  <Grid
-                    size={{
-                      xs: 12,
-                      md: 6
-                    }}>
-                    <TableContainer>
-                      <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': { border: 'none', py: 0.75, px: 1 } }}>
-                        <TableBody>
-                          <TableRow>
-                            <TableCell colSpan={2} sx={{ pb: 0.5, borderTop: TABLE_STYLES.cell.border }}>
-                              <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.9rem' }}>
-                                Payment Information
-                              </Typography>
-                            </TableCell>
-                          </TableRow>
-                          <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                            <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem', width: '40%' }}>
-                              Customer
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem' }}>
-                              {selectedPayment.customerName}
-                            </TableCell>
-                          </TableRow>
-                          <TableRow>
-                            <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                              Amount
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem' }}>
-                              {formatCurrency(selectedPayment.amount)}
-                            </TableCell>
-                          </TableRow>
-                          <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                            <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                              Payment Date
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem' }}>
-                              {formatDate(selectedPayment.paymentDate)}
-                            </TableCell>
-                          </TableRow>
-                          <TableRow>
-                            <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                              Method
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem' }}>
-                              {getPaymentMethodLabel(selectedPayment)}
-                            </TableCell>
-                          </TableRow>
-                          {selectedPayment.reference && (
-                            <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                              <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                                Reference
-                              </TableCell>
-                              <TableCell sx={{ fontSize: '0.8rem' }}>
-                                {selectedPayment.reference}
-                              </TableCell>
-                            </TableRow>
-                          )}
-                        </TableBody>
-                      </Table>
-                    </TableContainer>
-                  </Grid>
-
-                  {/* Right Column - Related Information */}
-                  <Grid
-                    size={{
-                      xs: 12,
-                      md: 6
-                    }}>
-                    <TableContainer>
-                      <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': { border: 'none', py: 0.75, px: 1 } }}>
-                        <TableBody>
-                          <TableRow>
-                            <TableCell colSpan={2} sx={{ pb: 0.5, borderTop: TABLE_STYLES.cell.border }}>
-                              <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.9rem' }}>
-                                Related Information
-                              </Typography>
-                            </TableCell>
-                          </TableRow>
-                          <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                            <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem', width: '40%' }}>
-                              Order No
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem' }}>
-                              {selectedPayment.relatedOrderNumber ? (
-                                <Typography
-                                  component="button"
-                                  onClick={(event) => handleOrderClick(selectedPayment.relatedOrderId!, event)}
-                                  sx={{
-                                    fontSize: '0.8rem',
-                                    color: 'primary.main',
-                                    cursor: 'pointer',
-                                    textDecoration: 'none',
-                                    border: 'none',
-                                    background: 'none',
-                                    padding: 0,
-                                    '&:hover': {
-                                      color: 'primary.dark'
-                                    }
-                                  }}
-                                >
-                                  {selectedPayment.relatedOrderNumber}
-                                </Typography>
-                              ) : (
-                                <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}>
-                                  N/A
-                                </Typography>
-                              )}
-                            </TableCell>
-                          </TableRow>
-                          <TableRow>
-                            <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                              Invoice No
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem' }}>
-                              {selectedPayment.relatedInvoiceNumber ? (
-                                <Typography
-                                  component="button"
-                                  onClick={(event) => handleInvoiceClick(selectedPayment.relatedInvoiceId!, event)}
-                                  sx={{
-                                    fontSize: '0.8rem',
-                                    color: 'primary.main',
-                                    cursor: 'pointer',
-                                    textDecoration: 'none',
-                                    border: 'none',
-                                    background: 'none',
-                                    padding: 0,
-                                    '&:hover': {
-                                      color: 'primary.dark'
-                                    }
-                                  }}
-                                >
-                                  {selectedPayment.relatedInvoiceNumber}
-                                </Typography>
-                              ) : (
-                                <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}>
-                                  N/A
-                                </Typography>
-                              )}
-                            </TableCell>
-                          </TableRow>
-                          {selectedPayment.customer?.email && (
-                            <TableRow>
-                              <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                                Customer Email
-                              </TableCell>
-                              <TableCell sx={{ fontSize: '0.8rem' }}>
-                                {selectedPayment.customer.email}
-                              </TableCell>
-                            </TableRow>
-                          )}
-                          <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                            <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem', width: '40%' }}>
-                              Journal Entry
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem' }}>
-                              {journalEntryRef ? (
-                                <Link
-                                  component="button"
-                                  onClick={() => navigate(`/accounting/journal-entries/${journalEntryRef.id}`)}
-                                  sx={{
-                                    fontSize: '0.8rem',
-                                    color: 'primary.main',
-                                    cursor: 'pointer',
-                                    textDecoration: 'none',
-                                    border: 'none',
-                                    background: 'none',
-                                    padding: 0,
-                                    '&:hover': { color: 'primary.dark' }
-                                  }}
-                                >
-                                  {journalEntryRef.referenceNumber}
-                                </Link>
-                              ) : (
-                                <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}>
-                                  N/A
-                                </Typography>
-                              )}
-                            </TableCell>
-                          </TableRow>
-                        </TableBody>
-                      </Table>
-                    </TableContainer>
-                  </Grid>
-                </Grid>
-
-                {/* Page Break */}
-                <Box sx={{ borderTop: '2px solid', borderColor: 'divider', my: 3 }} />
-
-                {/* Payment Items Section */}
-                <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-                  <Typography variant="tableHeader" sx={{
-                    fontWeight: 600,
-                    fontSize: '0.8rem',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px',
-                    mb: 1
-                  }}>
-                    Payment Items
-                  </Typography>
-
-                  {selectedPayment.invoice?.items && selectedPayment.invoice.items.length > 0 ? (
-                    <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
-                      <Table
-                        size={TABLE_STYLES.size}
-                        sx={{
-                          '& .MuiTableCell-root': {
-                            borderBottom: TABLE_STYLES.cell.border,
-                            py: TABLE_STYLES.cell.padding.py,
-                            px: TABLE_STYLES.cell.padding.px
-                          }
-                        }}
-                      >
-                        <TableHead>
-                          <TableRow sx={{ '& .MuiTableCell-head': {
-                            fontWeight: 600,
-                            backgroundColor: 'grey.50',
-                            color: 'text.primary',
-                            fontSize: '0.8rem'
-                          } }}>
-                            <TableCell sx={{ width: '40%' }}>Product</TableCell>
-                            <TableCell align="center" sx={{ width: '12%' }}>Quantity</TableCell>
-                            <TableCell align="right" sx={{ width: '16%' }}>Unit Price</TableCell>
-                            <TableCell align="right" sx={{ width: '16%' }}>Discount</TableCell>
-                            <TableCell align="right" sx={{ width: '16%' }}>Total</TableCell>
-                          </TableRow>
-                        </TableHead>
-                        <TableBody>
-                          {selectedPayment.invoice.items.map((item: any, index: number) => (
-                            <TableRow
-                              key={item.id || index}
-                              hover
-                              sx={{
-                                '&:hover': { backgroundColor: 'action.hover' },
-                                transition: 'background-color 0.2s ease',
-                                height: TABLE_STYLES.row.height
-                              }}
-                            >
-                              <TableCell sx={{ fontSize: '0.8rem' }}>
-                                {item.product?.name || 'Unknown Product'}
-                              </TableCell>
-                              <TableCell align="center" sx={{ fontSize: '0.8rem' }}>
-                                {formatWholeQuantity(item.quantity)}
-                              </TableCell>
-                              <TableCell align="right" sx={{ fontSize: '0.8rem' }}>
-                                {formatCurrency(item.unitPrice)}
-                              </TableCell>
-                              <TableCell align="right" sx={{ fontSize: '0.8rem' }}>
-                                {item.discountType === 'percentage' && item.discountPercent ? (
-                                  `${item.discountPercent}%`
-                                ) : item.discount ? (
-                                  `-${formatCurrency(item.discount)}`
-                                ) : (
-                                  '-'
-                                )}
-                              </TableCell>
-                              <TableCell align="right" sx={{ fontSize: '0.8rem' }}>
-                                {formatCurrency(item.totalAmount || item.total)}
-                              </TableCell>
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    </TableContainer>
-                  ) : (
-                    <Alert severity="info">No payment items available</Alert>
-                  )}
-                </Box>
-
-                {/* Payment Notes Section */}
-                {selectedPayment.notes && (
-                  <Box sx={{ mt: 1 }}>
-                    <Typography variant="tableHeader" sx={{
-                      fontWeight: 600,
-                      fontSize: '0.8rem',
-                      textTransform: 'uppercase',
-                      letterSpacing: '0.5px',
-                      mb: 1
-                    }}>
-                      NOTES
-                    </Typography>
-
-                    <Box sx={{
-                      p: 2,
-                      backgroundColor: 'grey.50',
-                      borderRadius: 1,
-                      fontSize: '0.8rem',
-                      whiteSpace: 'pre-wrap',
-                      wordBreak: 'break-word'
-                    }}>
-                      {selectedPayment.notes}
-                    </Box>
-                  </Box>
-                )}
-              </Box>
-            </Paper>
-          ) : (
-            <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-              <Typography variant="h6" sx={{
-                color: "text.secondary"
-              }}>
-                Select a payment to view details
-              </Typography>
-            </Paper>
-          )}
-        </Grid>
-      </Grid>
-      {/* Placeholder Dialogs */}
-      <Dialog open={editDialog} onClose={() => setEditDialog(false)} maxWidth="md" fullWidth>
-        <DialogTitle>Edit Payment</DialogTitle>
-        <DialogContent>
-          <Typography>Payment editing form will be implemented here.</Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setEditDialog(false)}>Cancel</Button>
-          <Button variant="contained">Save Changes</Button>
-        </DialogActions>
-      </Dialog>
-      {/* Deleted Payments Dialog */}
-      <DeletedPaymentsDialog
-        open={deletedPaymentsDialogOpen}
-        onClose={() => setDeletedPaymentsDialogOpen(false)}
+      <MasterDetailWorkspace
+        isMobile={isMobile}
+        listSlot={(
+          <PaymentsTable
+            payments={payments}
+            loading={loading}
+            total={totalPayments}
+            selectedPaymentId={selectedPayment?.id}
+            focusedPaymentIndex={pageState.focusedPaymentIndex}
+            onPaymentSelect={selection.handlePaymentSelect}
+            paymentListRef={pageState.paymentListRef}
+          />
+        )}
+        headerSlot={(
+          <PaymentContextHeader
+            selectedPayment={selectedPayment}
+            journalEntryRef={pageState.journalEntryRef}
+            journalEntryRefLoading={pageState.journalEntryRefLoading}
+            onPrint={() => pageState.setPrintDialogOpen(true)}
+            onOrderClick={selection.handleOrderClick}
+            onInvoiceClick={selection.handleInvoiceClick}
+            onNavigateToJournalEntry={selection.handleNavigateToJournalEntry}
+          />
+        )}
+        workspaceSlot={<PaymentWorkspaceCard selectedPayment={selectedPayment} />}
       />
-      {/* Print Dialog */}
-      {selectedPayment && (
-        <PaymentReceiptPrint
-          open={printDialogOpen}
-          onClose={() => setPrintDialogOpen(false)}
-          payment={selectedPayment}
-        />
-      )}
-    </>
-  );
+
+      <PaymentsDialogs
+        deletedPaymentsDialogOpen={pageState.deletedPaymentsDialogOpen}
+        printDialogOpen={pageState.printDialogOpen}
+        selectedPayment={selectedPayment}
+        onCloseDeletedPaymentsDialog={() => pageState.setDeletedPaymentsDialogOpen(false)}
+        onClosePrintDialog={() => pageState.setPrintDialogOpen(false)}
+      />
+    </Box>
+  )
 }
 
 export default PaymentsPage

--- a/frontend/src/pages/sales/PaymentsPage.tsx
+++ b/frontend/src/pages/sales/PaymentsPage.tsx
@@ -107,7 +107,7 @@ const PaymentsPage: React.FC = () => {
   const totalPayments = data?.meta?.total ?? 0
 
   const handleSort = useCallback((field: string) => {
-    setSortOrder((prev) => (sortBy === field && prev === 'desc' ? 'asc' : 'desc'))
+    setSortOrder((prev) => (sortBy === field && prev === 'asc' ? 'desc' : 'asc'))
     setSortBy(field)
   }, [sortBy])
 
@@ -175,6 +175,7 @@ const PaymentsPage: React.FC = () => {
             label={`Customer: ${customers.find((customer) => customer.id === presetCustomerId)?.name ?? presetCustomerId}`}
             size="small"
             variant="filled"
+            color="primary"
           />
         </Stack>
       )}

--- a/frontend/src/pages/sales/__tests__/PaymentsPage.filterbar.test.tsx
+++ b/frontend/src/pages/sales/__tests__/PaymentsPage.filterbar.test.tsx
@@ -12,6 +12,7 @@ const { useGetPaymentsQuery } = vi.hoisted(() => ({
     data: { data: [], meta: { total: 0 } },
     isLoading: false,
     isFetching: false,
+    error: undefined,
     refetch: vi.fn(),
   })),
 }))
@@ -31,12 +32,35 @@ vi.mock('@/hooks/useNotification', () => ({
   useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
 }))
 
-vi.mock('@/components/sales/DeletedPaymentsDialog', () => ({
-  default: () => <div>DeletedPaymentsDialog</div>,
+vi.mock('@/components/common/MasterDetailWorkspace', () => ({
+  default: ({ listSlot, headerSlot, workspaceSlot }: any) => (
+    <div>
+      <div>{listSlot}</div>
+      <div>{headerSlot}</div>
+      <div>{workspaceSlot}</div>
+    </div>
+  ),
 }))
 
-vi.mock('@/components/print', () => ({
-  PaymentReceiptPrint: () => <div>PaymentReceiptPrint</div>,
+vi.mock('../components/PaymentsTable', () => ({ default: () => <div>PaymentsTable</div> }))
+vi.mock('../components/PaymentContextHeader', () => ({ default: () => <div>PaymentContextHeader</div> }))
+vi.mock('../components/PaymentWorkspaceCard', () => ({ default: () => <div>PaymentWorkspaceCard</div> }))
+vi.mock('../components/PaymentsDialogs', () => ({ default: () => <div>PaymentsDialogs</div> }))
+vi.mock('../hooks/usePaymentsSelection', () => ({
+  usePaymentsSelection: () => ({
+    handlePaymentSelect: vi.fn(),
+    handleNavigateUp: vi.fn(),
+    handleNavigateDown: vi.fn(),
+    handleEnterAction: vi.fn(),
+    handlePageUpNavigation: vi.fn(),
+    handlePageDownNavigation: vi.fn(),
+    handleNavigateToFirst: vi.fn(),
+    handleNavigateToLast: vi.fn(),
+    handleEscapeAction: vi.fn(),
+    handleOrderClick: vi.fn(),
+    handleInvoiceClick: vi.fn(),
+    handleNavigateToJournalEntry: vi.fn(),
+  }),
 }))
 
 function renderPage(initialUrl = '/', state?: unknown) {
@@ -82,5 +106,34 @@ describe('PaymentsPage FilterBar', () => {
     expect(chip).toBeInTheDocument()
     const chipEl = chip.closest('[class*="MuiChip"]')
     expect(chipEl?.querySelector('[data-testid="CancelIcon"]')).not.toBeInTheDocument()
+  })
+
+  it('passes customerId from location state to query', () => {
+    renderPage('/', { customerId: 'cust-1' })
+    expect(useGetPaymentsQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ customerId: 'cust-1' }),
+    )
+  })
+
+  it('renders period filter button', () => {
+    renderPage()
+    expect(screen.getByRole('combobox', { name: /period/i })).toBeInTheDocument()
+  })
+
+  it('renders customer filter button', () => {
+    renderPage()
+    expect(screen.getByRole('combobox', { name: /customer/i })).toBeInTheDocument()
+  })
+
+  it('renders status filter button', () => {
+    renderPage()
+    expect(screen.getByRole('combobox', { name: /status/i })).toBeInTheDocument()
+  })
+
+  it('passes status filter to query when applied', () => {
+    renderPage('/?transactionStatus=completed')
+    expect(useGetPaymentsQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({ status: 'completed' }),
+    )
   })
 })

--- a/frontend/src/pages/sales/components/PaymentContextHeader.tsx
+++ b/frontend/src/pages/sales/components/PaymentContextHeader.tsx
@@ -3,6 +3,7 @@ import { default as PrintIcon } from '@mui/icons-material/Print'
 import {
   Box,
   Chip,
+  CircularProgress,
   IconButton,
   Paper,
   Table,
@@ -79,7 +80,7 @@ const getPaymentMethodLabel = (payment: PaymentListItem) => {
 const PaymentContextHeader: React.FC<PaymentContextHeaderProps> = ({
   selectedPayment,
   journalEntryRef,
-  journalEntryRefLoading: _journalEntryRefLoading,
+  journalEntryRefLoading,
   onPrint,
   onOrderClick,
   onInvoiceClick,
@@ -228,7 +229,9 @@ const PaymentContextHeader: React.FC<PaymentContextHeaderProps> = ({
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
                     <TableCell sx={labelCellSx}>Journal Entry</TableCell>
                     <TableCell sx={valueCellSx}>
-                      {journalEntryRef ? (
+                      {journalEntryRefLoading ? (
+                        <CircularProgress size={12} />
+                      ) : journalEntryRef ? (
                         <Typography
                           component="button"
                           onClick={() => onNavigateToJournalEntry(journalEntryRef)}

--- a/frontend/src/pages/sales/components/PaymentContextHeader.tsx
+++ b/frontend/src/pages/sales/components/PaymentContextHeader.tsx
@@ -1,0 +1,254 @@
+import React from 'react'
+import { default as PrintIcon } from '@mui/icons-material/Print'
+import {
+  Box,
+  Chip,
+  IconButton,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+} from '@mui/material'
+import Grid from '@mui/material/Grid'
+
+import type { PaymentJournalEntryRef, PaymentListItem } from '../hooks/usePaymentsPageState'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import { formatCurrency, formatDate } from '@/utils/formatters'
+
+interface PaymentContextHeaderProps {
+  selectedPayment: PaymentListItem | null
+  journalEntryRef: PaymentJournalEntryRef | null
+  journalEntryRefLoading: boolean
+  onPrint: () => void
+  onOrderClick: (orderId: string, event: React.MouseEvent) => void
+  onInvoiceClick: (invoiceId: string, event: React.MouseEvent) => void
+  onNavigateToJournalEntry: (ref: PaymentJournalEntryRef | null) => void
+}
+
+const actionIconSx = {
+  height: `${TABLE_STYLES.row.height * 0.75}px`,
+  width: `${TABLE_STYLES.row.height * 0.75}px`,
+  minHeight: 20,
+  minWidth: 20,
+  p: 0.125,
+}
+
+const detailTableSx = {
+  tableLayout: 'fixed' as const,
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const labelCellSx = { fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }
+const valueCellSx = { fontSize: '0.8rem' }
+
+const linkButtonSx = {
+  fontSize: '0.8rem',
+  color: 'primary.main',
+  cursor: 'pointer',
+  textDecoration: 'none',
+  border: 'none',
+  background: 'none',
+  padding: 0,
+  '&:hover': { color: 'primary.dark' },
+}
+
+const STATUS_COLORS: Record<string, 'success' | 'warning' | 'error' | 'default'> = {
+  completed: 'success',
+  pending: 'warning',
+  failed: 'error',
+  cancelled: 'default',
+  refunded: 'default',
+}
+
+const getPaymentMethodLabel = (payment: PaymentListItem) => {
+  if (payment.paymentMethodEntity?.name) return payment.paymentMethodEntity.name
+  if (payment.paymentMethod) return payment.paymentMethod
+  return 'Unknown'
+}
+
+const PaymentContextHeader: React.FC<PaymentContextHeaderProps> = ({
+  selectedPayment,
+  journalEntryRef,
+  journalEntryRefLoading: _journalEntryRefLoading,
+  onPrint,
+  onOrderClick,
+  onInvoiceClick,
+  onNavigateToJournalEntry,
+}) => {
+  if (!selectedPayment) {
+    return (
+      <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
+        <Typography variant="h6" sx={{ color: 'text.secondary' }}>
+          Select a payment to view details
+        </Typography>
+      </Paper>
+    )
+  }
+
+  return (
+    <Paper sx={{ overflow: 'hidden' }}>
+      <Box
+        sx={{
+          p: TABLE_STYLES.cell.padding.px,
+          borderBottom: TABLE_STYLES.cell.border,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Typography
+            variant="tableHeader"
+            sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+          >
+            Payment Details - {selectedPayment.paymentNumber}
+          </Typography>
+          <Chip
+            label={selectedPayment.status.charAt(0).toUpperCase() + selectedPayment.status.slice(1)}
+            color={STATUS_COLORS[selectedPayment.status] ?? 'default'}
+            size="small"
+            sx={{ textTransform: 'capitalize', fontSize: '0.75rem', fontWeight: 600 }}
+          />
+        </Box>
+        <IconButton
+          size="small"
+          title="Print Receipt"
+          onClick={onPrint}
+          sx={{ ...actionIconSx, color: 'info.main', '&:hover': { backgroundColor: 'info.light', color: 'info.dark' } }}
+        >
+          <PrintIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
+        </IconButton>
+      </Box>
+
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell
+                      colSpan={2}
+                      sx={{ pb: TABLE_STYLES.cell.padding.py * 0.67, py: TABLE_STYLES.cell.padding.py * 0.67, borderTop: TABLE_STYLES.cell.border }}
+                    >
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Payment Information
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Customer</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedPayment.customerName}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Amount</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(selectedPayment.amount)}</TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Payment Date</TableCell>
+                    <TableCell sx={valueCellSx}>{formatDate(selectedPayment.paymentDate)}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Method</TableCell>
+                    <TableCell sx={valueCellSx}>{getPaymentMethodLabel(selectedPayment)}</TableCell>
+                  </TableRow>
+                  {selectedPayment.reference && (
+                    <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                      <TableCell sx={labelCellSx}>Reference</TableCell>
+                      <TableCell sx={valueCellSx}>{selectedPayment.reference}</TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell
+                      colSpan={2}
+                      sx={{ pb: TABLE_STYLES.cell.padding.py * 0.67, py: TABLE_STYLES.cell.padding.py * 0.67, borderTop: TABLE_STYLES.cell.border }}
+                    >
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Related Information
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Order No</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {selectedPayment.relatedOrderNumber ? (
+                        <Typography
+                          component="button"
+                          onClick={(event) => onOrderClick(selectedPayment.relatedOrderId!, event)}
+                          sx={linkButtonSx}
+                        >
+                          {selectedPayment.relatedOrderNumber}
+                        </Typography>
+                      ) : (
+                        <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}>N/A</Typography>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Invoice No</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {selectedPayment.relatedInvoiceNumber ? (
+                        <Typography
+                          component="button"
+                          onClick={(event) => onInvoiceClick(selectedPayment.relatedInvoiceId!, event)}
+                          sx={linkButtonSx}
+                        >
+                          {selectedPayment.relatedInvoiceNumber}
+                        </Typography>
+                      ) : (
+                        <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}>N/A</Typography>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                  {selectedPayment.customer?.email && (
+                    <TableRow>
+                      <TableCell sx={labelCellSx}>Customer Email</TableCell>
+                      <TableCell sx={valueCellSx}>{selectedPayment.customer.email}</TableCell>
+                    </TableRow>
+                  )}
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Journal Entry</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {journalEntryRef ? (
+                        <Typography
+                          component="button"
+                          onClick={() => onNavigateToJournalEntry(journalEntryRef)}
+                          sx={linkButtonSx}
+                        >
+                          {journalEntryRef.referenceNumber}
+                        </Typography>
+                      ) : (
+                        <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}>N/A</Typography>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+        </Grid>
+      </Box>
+    </Paper>
+  )
+}
+
+export default PaymentContextHeader

--- a/frontend/src/pages/sales/components/PaymentWorkspaceCard.tsx
+++ b/frontend/src/pages/sales/components/PaymentWorkspaceCard.tsx
@@ -1,0 +1,156 @@
+import React from 'react'
+import {
+  Alert,
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material'
+
+import type { PaymentListItem } from '../hooks/usePaymentsPageState'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import { formatCurrency, formatWholeQuantity } from '@/utils/formatters'
+
+interface PaymentWorkspaceCardProps {
+  selectedPayment: PaymentListItem | null
+}
+
+const PaymentWorkspaceCard: React.FC<PaymentWorkspaceCardProps> = ({ selectedPayment }) => {
+  if (!selectedPayment) {
+    return <Paper sx={{ flex: 1 }} />
+  }
+
+  const items = selectedPayment.invoice?.items ?? []
+
+  return (
+    <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+      <TableContainer>
+        <Table
+          size={TABLE_STYLES.size}
+          sx={{
+            tableLayout: 'fixed',
+            '& .MuiTableCell-root': {
+              border: 'none',
+              py: TABLE_STYLES.cell.padding.py,
+              px: TABLE_STYLES.cell.padding.px,
+            },
+          }}
+        >
+          <TableBody>
+            <TableRow>
+              <TableCell
+                colSpan={5}
+                sx={{
+                  pb: TABLE_STYLES.cell.padding.py * 0.67,
+                  py: TABLE_STYLES.cell.padding.py * 0.67,
+                  borderTop: TABLE_STYLES.cell.border,
+                }}
+              >
+                <Typography
+                  variant="tableHeader"
+                  sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+                >
+                  Payment Items
+                </Typography>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', p: TABLE_STYLES.cell.padding.px }}>
+        <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          {items.length > 0 ? (
+            <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
+              <Table
+                size={TABLE_STYLES.size}
+                sx={{
+                  '& .MuiTableCell-root': {
+                    borderBottom: TABLE_STYLES.cell.border,
+                    py: TABLE_STYLES.cell.padding.py,
+                    px: TABLE_STYLES.cell.padding.px,
+                  },
+                }}
+              >
+                <TableHead>
+                  <TableRow
+                    sx={{
+                      '& .MuiTableCell-head': {
+                        fontWeight: 600,
+                        backgroundColor: 'grey.50',
+                        color: 'text.primary',
+                        fontSize: '0.8rem',
+                      },
+                    }}
+                  >
+                    <TableCell sx={{ width: '40%' }}>Product</TableCell>
+                    <TableCell align="center" sx={{ width: '12%' }}>Quantity</TableCell>
+                    <TableCell align="right" sx={{ width: '16%' }}>Unit Price</TableCell>
+                    <TableCell align="right" sx={{ width: '16%' }}>Discount</TableCell>
+                    <TableCell align="right" sx={{ width: '16%' }}>Total</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {items.map((item, index) => (
+                    <TableRow
+                      key={item.id ?? index}
+                      hover
+                      sx={{ '&:hover': { backgroundColor: 'action.hover' }, height: TABLE_STYLES.row.height }}
+                    >
+                      <TableCell sx={{ fontSize: '0.8rem' }}>{item.product?.name ?? 'Unknown Product'}</TableCell>
+                      <TableCell align="center" sx={{ fontSize: '0.8rem' }}>{formatWholeQuantity(item.quantity)}</TableCell>
+                      <TableCell align="right" sx={{ fontSize: '0.8rem' }}>{formatCurrency(item.unitPrice)}</TableCell>
+                      <TableCell align="right" sx={{ fontSize: '0.8rem' }}>
+                        {item.discountType === 'percentage' && item.discountPercent
+                          ? `${item.discountPercent}%`
+                          : item.discount
+                            ? `-${formatCurrency(item.discount)}`
+                            : '-'}
+                      </TableCell>
+                      <TableCell align="right" sx={{ fontSize: '0.8rem' }}>
+                        {formatCurrency(item.totalAmount ?? item.total)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          ) : (
+            <Alert severity="info">No payment items available</Alert>
+          )}
+        </Box>
+
+        {selectedPayment.notes && (
+          <Box sx={{ mt: 1 }}>
+            <Typography
+              variant="tableHeader"
+              sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px', mb: 1 }}
+            >
+              NOTES
+            </Typography>
+            <Box
+              sx={{
+                p: 2,
+                backgroundColor: 'grey.50',
+                borderRadius: 1,
+                fontSize: '0.8rem',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+              }}
+            >
+              {selectedPayment.notes}
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </Paper>
+  )
+}
+
+export default PaymentWorkspaceCard

--- a/frontend/src/pages/sales/components/PaymentsDialogs.tsx
+++ b/frontend/src/pages/sales/components/PaymentsDialogs.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+
+import type { PaymentListItem } from '../hooks/usePaymentsPageState'
+
+import { PaymentReceiptPrint } from '@/components/print'
+import DeletedPaymentsDialog from '@/components/sales/DeletedPaymentsDialog'
+
+interface PaymentsDialogsProps {
+  deletedPaymentsDialogOpen: boolean
+  printDialogOpen: boolean
+  selectedPayment: PaymentListItem | null
+  onCloseDeletedPaymentsDialog: () => void
+  onClosePrintDialog: () => void
+}
+
+const PaymentsDialogs: React.FC<PaymentsDialogsProps> = ({
+  deletedPaymentsDialogOpen,
+  printDialogOpen,
+  selectedPayment,
+  onCloseDeletedPaymentsDialog,
+  onClosePrintDialog,
+}) => {
+  return (
+    <>
+      <DeletedPaymentsDialog open={deletedPaymentsDialogOpen} onClose={onCloseDeletedPaymentsDialog} />
+      {selectedPayment && (
+        <PaymentReceiptPrint
+          open={printDialogOpen}
+          onClose={onClosePrintDialog}
+          payment={selectedPayment as any}
+        />
+      )}
+    </>
+  )
+}
+
+export default PaymentsDialogs

--- a/frontend/src/pages/sales/components/PaymentsTable.tsx
+++ b/frontend/src/pages/sales/components/PaymentsTable.tsx
@@ -1,0 +1,152 @@
+import React, { memo } from 'react'
+import {
+  Box,
+  Paper,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material'
+
+import type { PaymentListItem } from '../hooks/usePaymentsPageState'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+
+interface PaymentRowProps {
+  payment: PaymentListItem
+  index: number
+  selectedPaymentId?: string
+  focusedPaymentIndex: number
+  onPaymentSelect: (payment: PaymentListItem) => void
+}
+
+const PaymentRow = memo(({ payment, index, selectedPaymentId, focusedPaymentIndex, onPaymentSelect }: PaymentRowProps) => {
+  const isSelected = selectedPaymentId === payment.id
+  const isFocused = index === focusedPaymentIndex
+
+  return (
+    <TableRow
+      hover
+      onClick={() => onPaymentSelect(payment)}
+      data-payment-index={index}
+      sx={{
+        cursor: 'pointer',
+        backgroundColor: isSelected ? 'action.selected' : isFocused ? 'action.focus' : 'inherit',
+        '&:hover': { backgroundColor: isSelected ? 'action.selected' : 'action.hover' },
+        transition: 'background-color 0.2s ease',
+        height: TABLE_STYLES.row.height,
+        ...(isFocused && {
+          outline: '2px solid',
+          outlineColor: 'primary.main',
+          outlineOffset: '-2px',
+        }),
+      }}
+    >
+      <TableCell>
+        <Typography variant="body2" sx={{ fontWeight: 400, fontSize: '0.8rem', lineHeight: 1.2 }}>
+          {payment.paymentNumber}
+        </Typography>
+      </TableCell>
+    </TableRow>
+  )
+})
+
+PaymentRow.displayName = 'PaymentRow'
+
+interface PaymentsTableProps {
+  payments: PaymentListItem[]
+  loading: boolean
+  total: number
+  selectedPaymentId?: string
+  focusedPaymentIndex: number
+  onPaymentSelect: (payment: PaymentListItem) => void
+  paymentListRef: React.RefObject<HTMLDivElement | null>
+}
+
+const PaymentsTable: React.FC<PaymentsTableProps> = ({
+  payments,
+  loading,
+  total,
+  selectedPaymentId,
+  focusedPaymentIndex,
+  onPaymentSelect,
+  paymentListRef,
+}) => {
+  return (
+    <Paper sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Typography
+            variant="tableHeader"
+            sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+          >
+            Payment List ({total})
+          </Typography>
+          {loading && payments.length > 0 && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                Searching...
+              </Typography>
+              <Box sx={{ width: 16, height: 16 }}>
+                <Skeleton variant="circular" width={16} height={16} />
+              </Box>
+            </Box>
+          )}
+        </Box>
+      </Box>
+      <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }} ref={paymentListRef}>
+        <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
+          <Table
+            size={TABLE_STYLES.size}
+            sx={{
+              '& .MuiTableCell-root': {
+                borderBottom: TABLE_STYLES.cell.border,
+                py: TABLE_STYLES.cell.padding.py * 0.75,
+                px: TABLE_STYLES.cell.padding.px * 0.75,
+              },
+            }}
+          >
+            <TableHead>
+              <TableRow
+                sx={{
+                  '& .MuiTableCell-head': {
+                    fontWeight: 600,
+                    backgroundColor: 'grey.50',
+                    color: 'text.primary',
+                    fontSize: '0.8rem',
+                  },
+                }}
+              />
+            </TableHead>
+            <TableBody>
+              {loading && payments.length === 0
+                ? [...Array(10)].map((_, index) => (
+                    <TableRow key={`skeleton-${index}`}>
+                      <TableCell>
+                        <Skeleton height={40} />
+                      </TableCell>
+                    </TableRow>
+                  ))
+                : payments.map((payment, index) => (
+                    <PaymentRow
+                      key={payment.id}
+                      payment={payment}
+                      index={index}
+                      selectedPaymentId={selectedPaymentId}
+                      focusedPaymentIndex={focusedPaymentIndex}
+                      onPaymentSelect={onPaymentSelect}
+                    />
+                  ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+    </Paper>
+  )
+}
+
+export default PaymentsTable

--- a/frontend/src/pages/sales/components/PaymentsTable.tsx
+++ b/frontend/src/pages/sales/components/PaymentsTable.tsx
@@ -7,7 +7,6 @@ import {
   TableBody,
   TableCell,
   TableContainer,
-  TableHead,
   TableRow,
   Typography,
 } from '@mui/material'
@@ -110,18 +109,6 @@ const PaymentsTable: React.FC<PaymentsTableProps> = ({
               },
             }}
           >
-            <TableHead>
-              <TableRow
-                sx={{
-                  '& .MuiTableCell-head': {
-                    fontWeight: 600,
-                    backgroundColor: 'grey.50',
-                    color: 'text.primary',
-                    fontSize: '0.8rem',
-                  },
-                }}
-              />
-            </TableHead>
             <TableBody>
               {loading && payments.length === 0
                 ? [...Array(10)].map((_, index) => (

--- a/frontend/src/pages/sales/hooks/usePaymentsPageState.ts
+++ b/frontend/src/pages/sales/hooks/usePaymentsPageState.ts
@@ -1,0 +1,86 @@
+import { useRef, useState } from 'react'
+
+export interface PaymentJournalEntryRef {
+  referenceNumber: string
+  sourceType: string
+  sourceId: string
+}
+
+export interface PaymentListItem {
+  id: string
+  paymentNumber: string
+  customerName?: string
+  amount: number
+  paymentDate: string | Date
+  paymentMethodId?: string
+  paymentMethod?: string
+  paymentMethodEntity?: {
+    id: string
+    code: string
+    name: string
+  }
+  status: 'pending' | 'completed' | 'failed' | 'cancelled' | 'refunded'
+  notes?: string
+  reference?: string
+  relatedOrderId?: string
+  relatedInvoiceId?: string
+  relatedOrderNumber?: string
+  relatedInvoiceNumber?: string
+  customer?: {
+    id: string
+    name: string
+    email?: string
+    phone?: string
+  }
+  salesOrder?: {
+    id: string
+    orderNumber: string
+  }
+  invoice?: {
+    id: string
+    invoiceNumber: string
+    items?: Array<{
+      id?: string
+      product?: { name: string }
+      quantity: number
+      unitPrice: number
+      discountType?: string
+      discountPercent?: number
+      discount?: number
+      totalAmount?: number
+      total?: number
+    }>
+  }
+}
+
+export function usePaymentsPageState() {
+  const [focusedPaymentIndex, setFocusedPaymentIndex] = useState(-1)
+  const [deletedPaymentsDialogOpen, setDeletedPaymentsDialogOpen] = useState(false)
+  const [printDialogOpen, setPrintDialogOpen] = useState(false)
+  const [journalEntryRef, setJournalEntryRef] = useState<PaymentJournalEntryRef | null>(null)
+  const [journalEntryRefLoading, setJournalEntryRefLoading] = useState(false)
+
+  const searchInputRef = useRef<HTMLInputElement>(null)
+  const paymentListRef = useRef<HTMLDivElement>(null)
+  const hasRestoredSelection = useRef(false)
+  const previousPathnameRef = useRef(window.location.pathname)
+  const selectedPaymentRef = useRef<PaymentListItem | null>(null)
+
+  return {
+    focusedPaymentIndex,
+    setFocusedPaymentIndex,
+    deletedPaymentsDialogOpen,
+    setDeletedPaymentsDialogOpen,
+    printDialogOpen,
+    setPrintDialogOpen,
+    journalEntryRef,
+    setJournalEntryRef,
+    journalEntryRefLoading,
+    setJournalEntryRefLoading,
+    searchInputRef,
+    paymentListRef,
+    hasRestoredSelection,
+    previousPathnameRef,
+    selectedPaymentRef,
+  }
+}

--- a/frontend/src/pages/sales/hooks/usePaymentsSelection.ts
+++ b/frontend/src/pages/sales/hooks/usePaymentsSelection.ts
@@ -1,0 +1,244 @@
+import { useCallback, useEffect, type MutableRefObject, type RefObject } from 'react'
+import type { Location, NavigateFunction } from 'react-router-dom'
+
+import type { PaymentJournalEntryRef, PaymentListItem } from './usePaymentsPageState'
+
+import { useLazyGetJournalEntriesQuery } from '@/store/api/accountingApi'
+import type { AppDispatch } from '@/store'
+import { setSelectedPayment } from '@/store/slices/salesSlice'
+
+interface UsePaymentsSelectionParams {
+  dispatch: AppDispatch
+  navigate: NavigateFunction
+  payments: PaymentListItem[]
+  selectedPayment: PaymentListItem | null
+  focusedPaymentIndex: number
+  setFocusedPaymentIndex: (index: number) => void
+  location: Location
+  refetch: () => void
+  paymentListRef: RefObject<HTMLDivElement | null>
+  searchInputRef: RefObject<HTMLInputElement | null>
+  hasRestoredSelection: MutableRefObject<boolean>
+  selectedPaymentRef: MutableRefObject<PaymentListItem | null>
+  setJournalEntryRef: (value: PaymentJournalEntryRef | null) => void
+  setJournalEntryRefLoading: (value: boolean) => void
+}
+
+export function usePaymentsSelection({
+  dispatch,
+  navigate,
+  payments,
+  selectedPayment,
+  focusedPaymentIndex,
+  setFocusedPaymentIndex,
+  location,
+  refetch,
+  paymentListRef,
+  searchInputRef,
+  hasRestoredSelection,
+  selectedPaymentRef,
+  setJournalEntryRef,
+  setJournalEntryRefLoading,
+}: UsePaymentsSelectionParams) {
+  const [fetchJournalEntries] = useLazyGetJournalEntriesQuery()
+
+  useEffect(() => {
+    selectedPaymentRef.current = selectedPayment
+  }, [selectedPayment, selectedPaymentRef])
+
+  useEffect(() => {
+    if (!selectedPayment?.id) {
+      setJournalEntryRef(null)
+      setJournalEntryRefLoading(false)
+      return
+    }
+
+    let cancelled = false
+    setJournalEntryRefLoading(true)
+
+    ;(async () => {
+      try {
+        const res = await fetchJournalEntries({
+          sourceType: 'payment',
+          sourceId: selectedPayment.id,
+          limit: 1,
+        }).unwrap()
+
+        if (cancelled) return
+
+        const entry = res?.data?.[0]
+        if (entry) {
+          setJournalEntryRef({
+            referenceNumber: entry.referenceNumber,
+            sourceType: 'payment',
+            sourceId: selectedPayment.id,
+          })
+        } else {
+          setJournalEntryRef(null)
+        }
+      } catch {
+        if (!cancelled) setJournalEntryRef(null)
+      } finally {
+        if (!cancelled) setJournalEntryRefLoading(false)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [selectedPayment?.id, fetchJournalEntries, setJournalEntryRef, setJournalEntryRefLoading])
+
+  useEffect(() => {
+    if (location.pathname === '/sales/payments') {
+      void refetch()
+    }
+  }, [location.pathname, refetch])
+
+  useEffect(() => {
+    if (payments.length > 0 && selectedPaymentRef.current) {
+      const freshPayment = payments.find((payment) => payment.id === selectedPaymentRef.current?.id)
+      if (freshPayment) {
+        const hasChanged = JSON.stringify(freshPayment) !== JSON.stringify(selectedPaymentRef.current)
+        if (hasChanged) {
+          dispatch(setSelectedPayment(freshPayment as any))
+        }
+      }
+    }
+  }, [dispatch, payments, selectedPaymentRef])
+
+  useEffect(() => {
+    if (!hasRestoredSelection.current && selectedPayment && payments.length > 0) {
+      const index = payments.findIndex((payment) => payment.id === selectedPayment.id)
+      if (index >= 0) {
+        setFocusedPaymentIndex(index)
+        hasRestoredSelection.current = true
+      }
+    }
+  }, [hasRestoredSelection, payments, selectedPayment, setFocusedPaymentIndex])
+
+  useEffect(() => {
+    if (payments.length > 0 && focusedPaymentIndex === -1) {
+      if (selectedPayment) {
+        const index = payments.findIndex((payment) => payment.id === selectedPayment.id)
+        if (index >= 0) {
+          setFocusedPaymentIndex(index)
+        }
+      } else if (searchInputRef.current !== document.activeElement) {
+        setFocusedPaymentIndex(0)
+        dispatch(setSelectedPayment(payments[0] as any))
+      }
+    } else if (payments.length === 0) {
+      dispatch(setSelectedPayment(null))
+      setFocusedPaymentIndex(-1)
+    }
+  }, [dispatch, focusedPaymentIndex, payments, searchInputRef, selectedPayment, setFocusedPaymentIndex])
+
+  useEffect(() => {
+    const id = new URLSearchParams(window.location.search).get('highlight')
+    if (!id || payments.length === 0) return
+
+    const index = payments.findIndex((payment) => payment.id === id)
+    if (index >= 0) {
+      dispatch(setSelectedPayment(payments[index] as any))
+      setFocusedPaymentIndex(index)
+      window.history.replaceState(null, '', window.location.pathname)
+    }
+  }, [dispatch, payments, setFocusedPaymentIndex])
+
+  useEffect(() => {
+    const state = location.state as { highlightPaymentId?: string } | null
+    if (state?.highlightPaymentId && payments.length > 0) {
+      const index = payments.findIndex((payment) => payment.id === state.highlightPaymentId)
+      if (index >= 0) {
+        dispatch(setSelectedPayment(payments[index] as any))
+        setFocusedPaymentIndex(index)
+        window.history.replaceState(null, '', window.location.pathname + window.location.search)
+      }
+    }
+  }, [dispatch, location.state, payments, setFocusedPaymentIndex])
+
+  useEffect(() => {
+    if (focusedPaymentIndex >= 0 && paymentListRef.current) {
+      const row = paymentListRef.current.querySelector(`[data-payment-index="${focusedPaymentIndex}"]`)
+      if (row) {
+        row.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      }
+    }
+  }, [focusedPaymentIndex, paymentListRef])
+
+  const selectByIndex = useCallback((index: number) => {
+    setFocusedPaymentIndex(index)
+    dispatch(setSelectedPayment(payments[index] as any))
+  }, [dispatch, payments, setFocusedPaymentIndex])
+
+  const handlePaymentSelect = useCallback((payment: PaymentListItem) => {
+    const index = payments.findIndex((item) => item.id === payment.id)
+    dispatch(setSelectedPayment(payment as any))
+    setFocusedPaymentIndex(index)
+  }, [dispatch, payments, setFocusedPaymentIndex])
+
+  const handleNavigateUp = useCallback(() => {
+    if (focusedPaymentIndex > 0) selectByIndex(focusedPaymentIndex - 1)
+  }, [focusedPaymentIndex, selectByIndex])
+
+  const handleNavigateDown = useCallback(() => {
+    if (focusedPaymentIndex < payments.length - 1) selectByIndex(focusedPaymentIndex + 1)
+  }, [focusedPaymentIndex, payments.length, selectByIndex])
+
+  const handleNavigateToFirst = useCallback(() => {
+    if (payments.length > 0) selectByIndex(0)
+  }, [payments.length, selectByIndex])
+
+  const handleNavigateToLast = useCallback(() => {
+    if (payments.length > 0) selectByIndex(payments.length - 1)
+  }, [payments.length, selectByIndex])
+
+  const handlePageUpNavigation = useCallback(() => {
+    const newIndex = Math.max(0, focusedPaymentIndex - 20)
+    if (payments[newIndex]) selectByIndex(newIndex)
+  }, [focusedPaymentIndex, payments, selectByIndex])
+
+  const handlePageDownNavigation = useCallback(() => {
+    const newIndex = Math.min(payments.length - 1, focusedPaymentIndex + 20)
+    if (payments[newIndex]) selectByIndex(newIndex)
+  }, [focusedPaymentIndex, payments, selectByIndex])
+
+  const handleEnterAction = useCallback(() => {
+    // Payments cannot be edited; Enter is a no-op.
+  }, [])
+
+  const handleEscapeAction = useCallback(() => {
+    setFocusedPaymentIndex(-1)
+    dispatch(setSelectedPayment(null))
+  }, [dispatch, setFocusedPaymentIndex])
+
+  const handleOrderClick = useCallback((orderId: string, event: React.MouseEvent) => {
+    event.stopPropagation()
+    navigate(`/sales/orders?highlight=${orderId}`)
+  }, [navigate])
+
+  const handleInvoiceClick = useCallback((invoiceId: string, event: React.MouseEvent) => {
+    event.stopPropagation()
+    navigate('/sales/invoices', { state: { highlightInvoiceId: invoiceId } })
+  }, [navigate])
+
+  const handleNavigateToJournalEntry = useCallback((journalRef: PaymentJournalEntryRef | null) => {
+    if (!journalRef) return
+    navigate(`/accounting/journal-entries?sourceType=${journalRef.sourceType}&sourceId=${journalRef.sourceId}`)
+  }, [navigate])
+
+  return {
+    handlePaymentSelect,
+    handleNavigateUp,
+    handleNavigateDown,
+    handleNavigateToFirst,
+    handleNavigateToLast,
+    handlePageUpNavigation,
+    handlePageDownNavigation,
+    handleEnterAction,
+    handleEscapeAction,
+    handleOrderClick,
+    handleInvoiceClick,
+    handleNavigateToJournalEntry,
+  }
+}

--- a/frontend/src/types/filterBar.types.ts
+++ b/frontend/src/types/filterBar.types.ts
@@ -26,6 +26,7 @@ export type FilterFieldType =
   | 'product-type'
   | 'stock-status'
   | 'price-list'
+  | 'transaction-status'
 
 interface BaseFilterFieldConfig<TFilters, K extends keyof TFilters> {
   field: K
@@ -121,6 +122,11 @@ export interface PriceListFilterFieldConfig<TFilters, K extends keyof TFilters>
   type: 'price-list'
 }
 
+export interface TransactionStatusFilterFieldConfig<TFilters, K extends keyof TFilters>
+  extends BaseFilterFieldConfig<TFilters, K> {
+  type: 'transaction-status'
+}
+
 export type FilterFieldConfig<TFilters> =
   | StatusFilterFieldConfig<TFilters, keyof TFilters>
   | UserStatusFilterFieldConfig<TFilters, keyof TFilters>
@@ -139,6 +145,7 @@ export type FilterFieldConfig<TFilters> =
   | ProductTypeFilterFieldConfig<TFilters, keyof TFilters>
   | StockStatusFilterFieldConfig<TFilters, keyof TFilters>
   | PriceListFilterFieldConfig<TFilters, keyof TFilters>
+  | TransactionStatusFilterFieldConfig<TFilters, keyof TFilters>
 
 export interface FilterBarConfig<TFilters> {
   search?: {

--- a/frontend/src/utils/filterBar.url.ts
+++ b/frontend/src/utils/filterBar.url.ts
@@ -79,7 +79,8 @@ export function serializeFilters<TFilters extends object>(
       field.type === 'category' ||
       field.type === 'product-type' ||
       field.type === 'stock-status' ||
-      field.type === 'price-list'
+      field.type === 'price-list' ||
+      field.type === 'transaction-status'
 
     if (isSingleValueField) {
       if (value !== null && value !== undefined && value !== defaultValue) {
@@ -154,7 +155,8 @@ export function parseFilters<TFilters extends object>(
       field.type === 'category' ||
       field.type === 'product-type' ||
       field.type === 'stock-status' ||
-      field.type === 'price-list'
+      field.type === 'price-list' ||
+      field.type === 'transaction-status'
 
     if (isSingleValueField) {
       const raw = searchParams.get(key)

--- a/frontend/src/utils/filterBar.url.ts
+++ b/frontend/src/utils/filterBar.url.ts
@@ -195,6 +195,9 @@ export function parseFilters<TFilters extends object>(
       } else if (field.type === 'stock-status') {
         const VALID_STOCK_STATUS = ['in_stock', 'low_stock', 'out_of_stock']
         result[fieldKey] = VALID_STOCK_STATUS.includes(raw) ? raw : (defaultValue ?? null)
+      } else if (field.type === 'transaction-status') {
+        const VALID_TRANSACTION_STATUS = ['completed', 'pending', 'failed', 'cancelled', 'refunded']
+        result[fieldKey] = VALID_TRANSACTION_STATUS.includes(raw) ? raw : (defaultValue ?? null)
       } else {
         result[fieldKey] = raw
       }


### PR DESCRIPTION
## Summary

- Decomposes monolith `PaymentsPage.tsx` (~995 lines) into `usePaymentsPageState`, `usePaymentsSelection`, `PaymentsTable`, `PaymentContextHeader`, `PaymentWorkspaceCard`, `PaymentsDialogs` — mirroring the Invoices page architecture exactly
- Replaces custom `Grid` layout with `MasterDetailWorkspace`
- Adds period, customer, and transaction-status filter fields to FilterBar; new `FilterTransactionStatus` component + `transaction-status` type registered across `filterBar.types.ts`, `FilterBar.tsx`, and `filterBar.url.ts` (with allowlist validation)
- Removes placeholder edit dialog — payments cannot be edited
- Removes standalone sort button — sort now lives in FilterBar sort prop
- Fixes journal entry navigation to `?sourceType=payment&sourceId=...` pattern (consistent with Invoices)
- Backend: adds `status` filter to `QueryPaymentsDto` (`@IsEnum(PaymentStatus)`) and `payment.service.ts`

Closes #333

## Test Plan

- [x] `cd frontend && npm run type-check` — passes
- [x] `cd frontend && npx vitest run src/pages/sales/__tests__/PaymentsPage.filterbar.test.tsx` — 9 tests pass
- [x] `cd backend && npx jest src/modules/sales/services/payment.service.spec.ts --no-coverage` — 8 tests pass
- [x] Manual: Payments page renders, keyboard nav works, all 3 filters work, print works, deleted dialog works, preset customer chip shows when navigating from customer context

🤖 Generated with [Claude Code](https://claude.com/claude-code)