### PR TITLE
refactor: rewrite GoodsReceivedPage using Master-Detail pattern (#335)

### DIFF
--- a/backend/src/modules/purchasing/services/goods-received-note.service.spec.ts
+++ b/backend/src/modules/purchasing/services/goods-received-note.service.spec.ts
@@ -357,4 +357,44 @@ describe('GoodsReceivedNoteService', () => {
       expect(accountingService.postGoodsReceivedEntry).toHaveBeenCalled();
     });
   });
+
+  describe('findAll', () => {
+    const mockQueryBuilder = {
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([]),
+    };
+
+    beforeEach(() => {
+      grnRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder as any);
+    });
+
+    it('applies supplierId WHERE clause when supplierId is provided', async () => {
+      await service.findAll({ supplierId: 'supplier-123' } as any);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'grn.supplierId = :supplierId',
+        { supplierId: 'supplier-123' },
+      );
+    });
+
+    it('applies status WHERE clause when status is provided', async () => {
+      await service.findAll({ status: GrnStatus.RECEIVED } as any);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'grn.status = :status',
+        { status: GrnStatus.RECEIVED },
+      );
+    });
+
+    it('does not apply supplierId or status clauses when neither is provided', async () => {
+      await service.findAll({} as any);
+
+      const calls = mockQueryBuilder.andWhere.mock.calls.map(([clause]) => clause as string);
+      expect(calls.some((clause) => clause.includes('supplierId'))).toBe(false);
+      expect(calls.some((clause) => clause.includes('status'))).toBe(false);
+    });
+  });
 });

--- a/backend/src/modules/purchasing/services/goods-received-note.service.spec.ts
+++ b/backend/src/modules/purchasing/services/goods-received-note.service.spec.ts
@@ -396,5 +396,31 @@ describe('GoodsReceivedNoteService', () => {
       expect(calls.some((clause) => clause.includes('supplierId'))).toBe(false);
       expect(calls.some((clause) => clause.includes('status'))).toBe(false);
     });
+
+    it('applies receivedDateFrom WHERE clause when provided', async () => {
+      await service.findAll({ receivedDateFrom: '2025-01-01' } as any);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'grn.receivedDate >= :receivedDateFrom',
+        { receivedDateFrom: '2025-01-01' },
+      );
+    });
+
+    it('applies receivedDateTo WHERE clause when provided', async () => {
+      await service.findAll({ receivedDateTo: '2025-01-31' } as any);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'grn.receivedDate <= :receivedDateTo',
+        { receivedDateTo: '2025-01-31' },
+      );
+    });
+
+    it('does not apply date clauses when neither is provided', async () => {
+      await service.findAll({} as any);
+
+      const calls = mockQueryBuilder.andWhere.mock.calls.map(([clause]) => clause as string);
+      expect(calls.some((clause) => clause.includes('receivedDateFrom'))).toBe(false);
+      expect(calls.some((clause) => clause.includes('receivedDateTo'))).toBe(false);
+    });
   });
 });

--- a/backend/src/modules/purchasing/services/goods-received-note.service.ts
+++ b/backend/src/modules/purchasing/services/goods-received-note.service.ts
@@ -239,6 +239,8 @@ export class GoodsReceivedNoteService {
       status,
       supplierId,
       purchaseOrderId,
+      receivedDateFrom,
+      receivedDateTo,
       sortBy = 'grnNumber',
       sortOrder = 'ASC',
     } = query;
@@ -271,6 +273,14 @@ export class GoodsReceivedNoteService {
 
     if (purchaseOrderId) {
       queryBuilder.andWhere('grn.purchaseOrderId = :purchaseOrderId', { purchaseOrderId });
+    }
+
+    if (receivedDateFrom) {
+      queryBuilder.andWhere('grn.receivedDate >= :receivedDateFrom', { receivedDateFrom });
+    }
+
+    if (receivedDateTo) {
+      queryBuilder.andWhere('grn.receivedDate <= :receivedDateTo', { receivedDateTo });
     }
 
     // Apply sorting

--- a/frontend/src/pages/purchasing/GoodsReceivedPage.tsx
+++ b/frontend/src/pages/purchasing/GoodsReceivedPage.tsx
@@ -1,919 +1,192 @@
-import React, { useState, useEffect, useCallback, useMemo, useRef, memo } from 'react'
-import { useSearchParams, useNavigate } from 'react-router-dom'
-import {
-  Box,
-  Typography,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Button,
-  Chip,
-  TextField,
-  InputAdornment,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  Divider,
-  Skeleton,
-  Alert,
-  Grid,
-  IconButton,
-  useTheme,
-  useMediaQuery,
-} from '@mui/material'
-import { default as SearchIcon } from '@mui/icons-material/Search'
-import { default as RestoreIcon } from '@mui/icons-material/RestoreFromTrash'
-import { default as SortIcon } from '@mui/icons-material/Sort'
-import { default as ArrowUpIcon } from '@mui/icons-material/ArrowUpward'
-import { default as ArrowDownIcon } from '@mui/icons-material/ArrowDownward'
-import { default as PrintIcon } from '@mui/icons-material/Print'
-import PageHeader from '@/components/common/PageHeader'
-import { formatDate } from '@/utils/formatters'
-import { TABLE_STYLES } from '@/constants/tableStyles'
-import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
-import {
-  setSelectedGRN,
-  selectSelectedGRN
-} from '@/store/slices/purchasingSlice'
-import { useGetGoodsReceivedNotesQuery } from '@/store/api/purchasingApi'
-import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
-import DeletedGRNsDialog from '@/components/purchasing/DeletedGRNsDialog'
-import { GRNPrint } from '@/components/print'
-import { useLazyGetJournalEntriesQuery } from '@/store/api/accountingApi'
+import React, { useCallback, useMemo } from 'react'
+import { Alert, Box, useMediaQuery, useTheme } from '@mui/material'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 
+import MasterDetailWorkspace from '@/components/common/MasterDetailWorkspace'
+import PageHeader from '@/components/common/PageHeader'
+import { FilterBar } from '@/components/filters'
+import { useFilterBar } from '@/hooks/useFilterBar'
+import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
+import { useGetGoodsReceivedNotesQuery } from '@/store/api/purchasingApi'
+import { selectSelectedGRN } from '@/store/slices/purchasingSlice'
+import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
+import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
+
+import GRNContextHeader from './components/GRNContextHeader'
+import GRNDialogs from './components/GRNDialogs'
+import GRNTable from './components/GRNTable'
+import GRNWorkspaceCard from './components/GRNWorkspaceCard'
+import { useGRNPageState } from './hooks/useGRNPageState'
+import { useGRNSelection } from './hooks/useGRNSelection'
 
 interface GRNFilters {
   search: string
-  sortBy: string
-  sortOrder: 'asc' | 'desc'
-  status: string
-  dateFilter: string
-  customFromDate: string
-  customToDate: string
+  supplierId: string | null
+  period: PeriodValue
+  status: 'draft' | 'received' | null
 }
 
-const getDateRangeFromFilter = (filter: string, customFromDate: string, customToDate: string) => {
-  const today = new Date()
-  const yesterday = new Date(today)
-  yesterday.setDate(yesterday.getDate() - 1)
-
-  const startOfWeek = new Date(today)
-  startOfWeek.setDate(today.getDate() - today.getDay())
-
-  const startOfMonth = new Date(today.getFullYear(), today.getMonth(), 1)
-  const startOfYear = new Date(today.getFullYear(), 0, 1)
-
-  const formatLocalDate = (date: Date) => date.toISOString().split('T')[0]
-
-  switch (filter) {
-    case 'today':
-      return { fromDate: formatLocalDate(today), toDate: formatLocalDate(today) }
-    case 'yesterday':
-      return { fromDate: formatLocalDate(yesterday), toDate: formatLocalDate(yesterday) }
-    case 'this_week':
-      return { fromDate: formatLocalDate(startOfWeek), toDate: formatLocalDate(today) }
-    case 'this_month':
-      return { fromDate: formatLocalDate(startOfMonth), toDate: formatLocalDate(today) }
-    case 'this_year':
-      return { fromDate: formatLocalDate(startOfYear), toDate: formatLocalDate(today) }
-    case 'custom':
-      return { fromDate: customFromDate, toDate: customToDate }
-    default:
-      return { fromDate: undefined, toDate: undefined }
-  }
-}
-
-// Memoized GRN Row Component
-interface GRNRowProps {
-  grn: any
-  index: number
-  selectedGRNId?: string
-  focusedGRNIndex: number
-  onGRNSelect: (grn: any) => void
-}
-
-const GRNRow = memo(({ grn, index, selectedGRNId, focusedGRNIndex, onGRNSelect }: GRNRowProps) => {
-  const isSelected = selectedGRNId === grn.id
-  const isFocused = index === focusedGRNIndex
-
-  return (
-    <TableRow
-      key={grn.id}
-      hover
-      onClick={() => onGRNSelect(grn)}
-      data-grn-index={index}
-      sx={{
-        cursor: 'pointer',
-        backgroundColor: isSelected ? 'action.selected' : isFocused ? 'action.focus' : 'inherit',
-        '&:hover': {
-          backgroundColor: isSelected ? 'action.selected' : 'action.hover'
-        },
-        transition: 'background-color 0.2s ease',
-        height: TABLE_STYLES.row.height,
-        ...(isFocused && {
-          outline: '2px solid',
-          outlineColor: 'primary.main',
-          outlineOffset: '-2px'
-        })
-      }}
-    >
-      <TableCell>
-        <Typography
-          variant="body2"
-          sx={{
-            fontWeight: 400,
-            fontSize: '0.8rem',
-            lineHeight: 1.2
-          }}
-        >
-          {grn.grnNumber}
-        </Typography>
-      </TableCell>
-    </TableRow>
-  )
-})
-
-GRNRow.displayName = 'GRNRow'
-
-const GoodsReceivedPage: React.FC = () => {
+export const GoodsReceivedPage: React.FC = () => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('md'))
   const navigate = useNavigate()
-  const [searchParams, setSearchParams] = useSearchParams()
-
   const dispatch = useAppDispatch()
-  const selectedGRNFromRedux = useAppSelector(selectSelectedGRN)
-  const [selectedGRN, setSelectedGRNLocal] = useState<any | null>(null)
+  const [searchParams, setSearchParams] = useSearchParams()
+  const pageState = useGRNPageState()
+  const selectedGRN = useAppSelector(selectSelectedGRN)
 
-  const [filters, setFilters] = useState<GRNFilters>({
-    search: '',
-    sortBy: 'grnNumber',
-    sortOrder: 'asc',
-    status: 'all',
-    dateFilter: 'all',
-    customFromDate: '',
-    customToDate: '',
+  const filterConfig = useMemo<FilterBarConfig<GRNFilters>>(
+    () => ({
+      search: { placeholder: 'Search goods received notes...' },
+      fields: [
+        { field: 'period', label: 'Period', type: 'period' },
+        { field: 'supplierId', label: 'Supplier', type: 'supplier' },
+        { field: 'status', label: 'Status', type: 'purchasing-status' },
+      ],
+      defaults: {
+        search: '',
+        supplierId: null,
+        period: { key: null, from: null, to: null },
+        status: null,
+      },
+    }),
+    [],
+  )
+
+  const filterBar = useFilterBar(filterConfig)
+  const weekStartsOn = getStartOfWeek()
+
+  const dateRange = useMemo(() => {
+    const period = filterBar.appliedFilters.period
+    if (!period || period.key === null) return { fromDate: undefined, toDate: undefined }
+    if (period.key === 'custom') return { fromDate: period.from ?? undefined, toDate: period.to ?? undefined }
+    const range = getPeriodDateRange(period.key, weekStartsOn)
+    return { fromDate: range.from, toDate: range.to }
+  }, [filterBar.appliedFilters.period, weekStartsOn])
+
+  const queryParams = useMemo(() => ({
+    sortBy: pageState.sorting.sortBy,
+    sortOrder: pageState.sorting.sortOrder.toUpperCase(),
+    search: filterBar.appliedFilters.search || undefined,
+    supplierId: filterBar.appliedFilters.supplierId || undefined,
+    status: filterBar.appliedFilters.status || undefined,
+    receivedDateFrom: dateRange.fromDate,
+    receivedDateTo: dateRange.toDate,
+  }), [dateRange, filterBar.appliedFilters, pageState.sorting])
+
+  const {
+    data: grnsResponse,
+    isFetching: loading,
+    error: grnsError,
+  } = useGetGoodsReceivedNotesQuery(queryParams)
+
+  const grns = grnsResponse?.data || []
+  const total = grnsResponse?.meta?.total || 0
+  const error = grnsError && typeof grnsError === 'object'
+    ? ((grnsError as any).data?.message || (grnsError as any).data || 'Failed to fetch goods received notes')
+    : null
+
+  const selection = useGRNSelection({
+    dispatch,
+    grns,
+    selectedGRN,
+    focusedGRNIndex: pageState.focusedGRNIndex,
+    setFocusedGRNIndex: pageState.setFocusedGRNIndex,
+    searchParams,
+    setSearchParams,
+    grnListRef: pageState.grnListRef,
+    searchInputRef: pageState.searchInputRef,
+    userHasNavigatedRef: pageState.userHasNavigatedRef,
+    setJournalEntryRef: pageState.setJournalEntryRef,
+    setJournalEntryRefLoading: pageState.setJournalEntryRefLoading,
   })
-
-  const [fetchJournalEntries] = useLazyGetJournalEntriesQuery()
-  const [journalEntryRef, setJournalEntryRef] = useState<{ id: string; referenceNumber: string } | null>(null)
-  const [deletedGRNsDialogOpen, setDeletedGRNsDialogOpen] = useState(false)
-  const [printDialogOpen, setPrintDialogOpen] = useState(false)
-  const [focusedGRNIndex, setFocusedGRNIndex] = useState(-1)
-  const grnListRef = useRef<HTMLDivElement>(null)
-  const searchInputRef = useRef<HTMLInputElement>(null)
-  const queryParams = useMemo(() => {
-    const dateRange = getDateRangeFromFilter(filters.dateFilter, filters.customFromDate, filters.customToDate)
-    return {
-      search: filters.search,
-      sortBy: filters.sortBy,
-      sortOrder: filters.sortOrder,
-      receivedDateFrom: dateRange.fromDate,
-      receivedDateTo: dateRange.toDate,
-    }
-  }, [filters])
-  const { data: grnsResponse, isFetching: loading, error: grnsError } = useGetGoodsReceivedNotesQuery(queryParams)
-  const goodsReceivedNotes = grnsResponse?.data || []
-  const pagination = grnsResponse?.meta
-  const error =
-    grnsError && typeof grnsError === 'object'
-      ? ((grnsError as any).data?.message || (grnsError as any).data || 'Failed to fetch GRNs')
-      : null
-
-  // Filter GRNs (status filter only - backend handles search and sorting)
-  const filteredGRNs = useMemo(() => {
-    let filtered = [...(goodsReceivedNotes || [])]
-
-    // Status filter (client-side only)
-    if (filters.status !== 'all') {
-      filtered = filtered.filter((grn: any) => grn.status === filters.status)
-    }
-
-    return filtered
-  }, [goodsReceivedNotes, filters.status])
-
-  const handleGRNSelect = useCallback((grn: any) => {
-    setSelectedGRNLocal(grn)
-    dispatch(setSelectedGRN(grn))
-    const grnIndex = filteredGRNs.findIndex(g => g.id === grn.id)
-    setFocusedGRNIndex(grnIndex)
-  }, [dispatch, filteredGRNs])
-
-  // Restore selected GRN from Redux on mount
-  useEffect(() => {
-    if (selectedGRNFromRedux && goodsReceivedNotes.length > 0 && !selectedGRN) {
-      const grn = goodsReceivedNotes.find((g: any) => g.id === selectedGRNFromRedux.id)
-      if (grn) {
-        handleGRNSelect(grn)
-      }
-    }
-  }, [selectedGRNFromRedux, goodsReceivedNotes, selectedGRN, handleGRNSelect])
-
-  // Handle grnId query parameter to auto-select GRN from PO page
-  useEffect(() => {
-    const grnId = searchParams.get('grnId')
-    if (grnId) {
-      const grn = goodsReceivedNotes.find((g: any) => g.id === grnId)
-      if (grn) {
-        handleGRNSelect(grn)
-        setSearchParams({})
-      }
-    }
-  }, [goodsReceivedNotes, handleGRNSelect, searchParams, setSearchParams])
-
-  // Auto-refresh selected GRN when the list updates (e.g., after PO edit/return/receive)
-  useEffect(() => {
-    if (selectedGRN && goodsReceivedNotes.length > 0) {
-      const updatedGRN = goodsReceivedNotes.find((g: any) => g.id === selectedGRN.id)
-      if (updatedGRN) {
-        // Always update to ensure fresh data, especially for status and quantity changes
-        setSelectedGRNLocal(updatedGRN)
-        dispatch(setSelectedGRN(updatedGRN))
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [goodsReceivedNotes])
-
-  // Auto-select first GRN when GRNs load
-  useEffect(() => {
-    if (filteredGRNs.length > 0 && focusedGRNIndex === -1) {
-      if (!selectedGRN && searchInputRef.current !== document.activeElement) {
-        // Don't auto-select if we have a grnId query parameter or a persisted selection
-        const grnId = searchParams.get('grnId')
-        if (!grnId && !selectedGRNFromRedux) {
-          setFocusedGRNIndex(0)
-          handleGRNSelect(filteredGRNs[0])
-        }
-      }
-    }
-  }, [filteredGRNs, focusedGRNIndex, selectedGRN, handleGRNSelect, searchParams, selectedGRNFromRedux])
-
-  // Clear selection when no GRNs exist
-  useEffect(() => {
-    if (filteredGRNs.length === 0 && selectedGRN) {
-      setSelectedGRNLocal(null)
-      dispatch(setSelectedGRN(null))
-      setFocusedGRNIndex(-1)
-    }
-  }, [filteredGRNs.length, selectedGRN, dispatch])
-
-  // Fetch journal entry reference for selected GRN
-  useEffect(() => {
-    if (!selectedGRN) {
-      setJournalEntryRef(null)
-      return
-    }
-    setJournalEntryRef(null)
-    fetchJournalEntries({ sourceType: 'goods_received_note', sourceId: selectedGRN.id, limit: 1 })
-      .unwrap()
-      .then((res) => {
-        const entry = res?.data?.[0]
-        if (entry) {
-          setJournalEntryRef({ id: entry.id, referenceNumber: entry.referenceNumber })
-        }
-      })
-      .catch(() => { /* silently ignore */ })
-  }, [selectedGRN?.id, fetchJournalEntries])
-
-  // Auto-scroll to keep focused item visible
-  useEffect(() => {
-    if (focusedGRNIndex >= 0 && grnListRef.current) {
-      const focusedRow = grnListRef.current.querySelector(`[data-grn-index="${focusedGRNIndex}"]`)
-      if (focusedRow) {
-        focusedRow.scrollIntoView({
-          behavior: 'smooth',
-          block: 'nearest'
-        })
-      }
-    }
-  }, [focusedGRNIndex])
 
   const handleSort = useCallback((field: string) => {
-    setFilters(prev => ({
+    pageState.setSorting((prev) => ({
       ...prev,
       sortBy: field,
-      sortOrder: prev.sortBy === field && prev.sortOrder === 'asc' ? 'desc' : 'asc',
+      sortOrder: prev.sortBy === field && prev.sortOrder === 'desc' ? 'asc' : 'desc',
     }))
-  }, [])
-
-  const getStatusColor = (status: string) => {
-    switch (status?.toLowerCase()) {
-      case 'received':
-        return 'success'
-      case 'draft':
-        return 'default'
-      default:
-        return 'default'
-    }
-  }
-
-  // Keyboard navigation handlers
-  const handleNavigateUp = useCallback(() => {
-    if (focusedGRNIndex > 0) {
-      const newIndex = focusedGRNIndex - 1
-      setFocusedGRNIndex(newIndex)
-      handleGRNSelect(filteredGRNs[newIndex])
-    }
-  }, [focusedGRNIndex, filteredGRNs, handleGRNSelect])
-
-  const handleNavigateDown = useCallback(() => {
-    if (focusedGRNIndex < filteredGRNs.length - 1) {
-      const newIndex = focusedGRNIndex + 1
-      setFocusedGRNIndex(newIndex)
-      handleGRNSelect(filteredGRNs[newIndex])
-    }
-  }, [focusedGRNIndex, filteredGRNs, handleGRNSelect])
-
-  const focusSearchInput = useCallback(() => {
-    searchInputRef.current?.focus()
-  }, [])
+  }, [pageState])
 
   useKeyboardShortcuts({
-    onSearch: focusSearchInput,
-    onArrowUp: handleNavigateUp,
-    onArrowDown: handleNavigateDown,
+    onSearch: selection.focusSearchInput,
+    onArrowUp: selection.handleNavigateUp,
+    onArrowDown: selection.handleNavigateDown,
   })
 
+  const navigateToJournalEntry = useCallback(() => {
+    if (!pageState.journalEntryRef) return
+    navigate(
+      `/accounting/journal-entries?sourceType=${pageState.journalEntryRef.sourceType}&sourceId=${pageState.journalEntryRef.sourceId}`,
+    )
+  }, [navigate, pageState.journalEntryRef])
+
   return (
-    <>
-      {/* Header */}
+    <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
       <PageHeader
         title="Goods Received Notes"
-        subtitle="Track and manage incoming goods from suppliers"
-        secondaryAction={{ label: 'View Deleted', onClick: () => setDeletedGRNsDialogOpen(true) }}
+        subtitle="Track and manage goods received from suppliers"
+        variant="workflow"
+        secondaryAction={{ label: 'View Deleted', onClick: () => pageState.setDeletedGRNsOpen(true) }}
+        toolbar={(
+          <FilterBar
+            config={filterConfig}
+            draftFilters={filterBar.draftFilters}
+            handlers={filterBar.handlers}
+            hasActiveFilters={filterBar.hasActiveFilters}
+            searchInputRef={pageState.searchInputRef}
+            sort={{
+              field: 'grnNumber',
+              sortBy: pageState.sorting.sortBy,
+              sortOrder: pageState.sorting.sortOrder,
+              onSort: handleSort,
+            }}
+          />
+        )}
       />
-      {/* Filters and Search */}
-      <Box sx={{ mb: 3 }}>
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        gap: isMobile ? 2 : 1,
-        alignItems: isMobile ? 'stretch' : 'center',
-        '& > *': {
-          alignSelf: isMobile ? 'stretch' : 'flex-start'
-        }
-      }}>
-        <TextField
-          inputRef={searchInputRef}
-          placeholder="Search GRNs..."
-          value={filters.search}
-          onChange={(e) => setFilters((prev) => ({ ...prev, search: e.target.value }))}
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 250,
-            flex: isMobile ? 'none' : 1,
-            maxWidth: isMobile ? 'none' : 400,
-            '& .MuiOutlinedInput-root': {
-              height: '40px',
-              fontSize: '0.875rem',
-              '& input': {
-                padding: '8.5px 14px',
-                fontSize: '0.875rem'
-              }
-            }
-          }}
-          slotProps={{
-            input: {
-              startAdornment: (
-                <InputAdornment position="start">
-                  <SearchIcon sx={{ fontSize: '1.25rem' }} />
-                </InputAdornment>
-              ),
-            },
-          }}
-        />
 
-        <FormControl
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 120,
-            width: isMobile ? 'auto' : 120,
-            '& .MuiOutlinedInput-root': {
-              height: '40px',
-            }
-          }}
-        >
-          <InputLabel>Date Filter</InputLabel>
-          <Select
-            value={filters.dateFilter}
-            label="Date Filter"
-            onChange={(e) => setFilters(prev => ({ ...prev, dateFilter: e.target.value }))}
-            sx={{ fontSize: '0.875rem' }}
-          >
-            <MenuItem value="all">All</MenuItem>
-            <MenuItem value="today">Today</MenuItem>
-            <MenuItem value="yesterday">Yesterday</MenuItem>
-            <MenuItem value="this_week">This Week</MenuItem>
-            <MenuItem value="this_month">This Month</MenuItem>
-            <MenuItem value="this_year">This Year</MenuItem>
-            <Divider />
-            <MenuItem value="custom">Custom Date Range</MenuItem>
-          </Select>
-        </FormControl>
-
-        {filters.dateFilter === 'custom' && (
-          <>
-            <TextField
-              label="From Date"
-              type="date"
-              value={filters.customFromDate}
-              onChange={(e) => setFilters(prev => ({ ...prev, customFromDate: e.target.value }))}
-              size="medium"
-              sx={{
-                minWidth: isMobile ? 'auto' : 120,
-                '& .MuiOutlinedInput-root': {
-                  height: '40px',
-                  fontSize: '0.875rem',
-                }
-              }}
-              slotProps={{ inputLabel: { shrink: true } }}
-            />
-            <TextField
-              label="To Date"
-              type="date"
-              value={filters.customToDate}
-              onChange={(e) => setFilters(prev => ({ ...prev, customToDate: e.target.value }))}
-              size="medium"
-              sx={{
-                minWidth: isMobile ? 'auto' : 120,
-                '& .MuiOutlinedInput-root': {
-                  height: '40px',
-                  fontSize: '0.875rem',
-                }
-              }}
-              slotProps={{ inputLabel: { shrink: true } }}
-            />
-          </>
-        )}
-
-        <FormControl
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 120,
-            width: isMobile ? 'auto' : 120,
-            '& .MuiOutlinedInput-root': {
-              height: '40px',
-              fontSize: '0.875rem'
-            }
-          }}
-        >
-          <InputLabel>Status</InputLabel>
-          <Select
-            value={filters.status}
-            label="Status"
-            onChange={(e) => setFilters((prev) => ({ ...prev, status: e.target.value }))}
-            sx={{
-              fontSize: '0.875rem',
-              '& .MuiSelect-select': {
-                padding: '8.5px 14px',
-                fontSize: '0.875rem'
-              }
-            }}
-          >
-            <MenuItem value="all">All</MenuItem>
-            <MenuItem value="draft">Draft</MenuItem>
-            <MenuItem value="received">Received</MenuItem>
-          </Select>
-        </FormControl>
-
-        {(filters.dateFilter !== 'all' || filters.status !== 'all' || filters.search) && (
-          <Button
-            variant="outlined"
-            size="medium"
-            onClick={() => {
-              setFilters({
-                search: '',
-                sortBy: 'grnNumber',
-                sortOrder: 'asc',
-                status: 'all',
-                dateFilter: 'all',
-                customFromDate: '',
-                customToDate: '',
-              })
-            }}
-            sx={{
-              minWidth: 'auto',
-              px: 2,
-              height: '40px',
-              fontSize: '0.875rem'
-            }}
-          >
-            Clear Filters
-          </Button>
-        )}
-
-        <Button
-          variant={filters.sortBy === 'grnNumber' ? 'contained' : 'outlined'}
-          size="medium"
-          startIcon={filters.sortBy === 'grnNumber' ? (filters.sortOrder === 'asc' ? <ArrowUpIcon /> : <ArrowDownIcon />) : <SortIcon />}
-          onClick={() => handleSort('grnNumber')}
-          sx={{
-            height: '40px',
-            fontSize: '0.875rem',
-            minWidth: 'auto',
-            px: 2
-          }}
-        >
-          Sort
-        </Button>
-      </Box>
-      </Box>
-      {/* Error Display */}
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>
           {error}
         </Alert>
       )}
-      {/* Split Layout: GRN List and GRN Details */}
-      <Grid container spacing={3}>
-        {/* Left Side - GRN List */}
-        <Grid
-          size={{
-            xs: 12,
-            md: 3
-          }}>
-          <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', flexDirection: 'column' }}>
-            <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
-              <Typography variant="tableHeader" sx={{
-                fontWeight: 600,
-                fontSize: '0.8rem',
-                textTransform: 'uppercase',
-                letterSpacing: '0.5px'
-              }}>
-                GRN List ({filteredGRNs.length})
-              </Typography>
-            </Box>
 
-            <TableContainer sx={{ flex: 1, overflow: 'auto' }} ref={grnListRef}>
-              <Table
-                size={TABLE_STYLES.size}
-                sx={{
-                  '& .MuiTableCell-root': {
-                    borderBottom: TABLE_STYLES.cell.border,
-                    py: TABLE_STYLES.cell.padding.py * 0.75,
-                    px: TABLE_STYLES.cell.padding.px * 0.75
-                  }
-                }}
-              >
-                <TableBody>
-                  {loading && filteredGRNs.length === 0 ? (
-                    [...Array(10)].map((_, i) => (
-                      <TableRow key={`skeleton-${i}`}>
-                        <TableCell>
-                          <Skeleton height={40} />
-                        </TableCell>
-                      </TableRow>
-                    ))
-                  ) : (
-                    filteredGRNs.map((grn: any, index: number) => (
-                      <GRNRow
-                        key={grn.id}
-                        grn={grn}
-                        index={index}
-                        selectedGRNId={selectedGRN?.id}
-                        focusedGRNIndex={focusedGRNIndex}
-                        onGRNSelect={handleGRNSelect}
-                      />
-                    ))
-                  )}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          </Paper>
-        </Grid>
-
-        {/* Right Side - GRN Details */}
-        <Grid
-          size={{
-            xs: 12,
-            md: 9
-          }}>
-          {selectedGRN ? (
-            <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', flexDirection: 'column' }}>
-              {/* Header with GRN Info */}
-              <Box sx={{
-                p: TABLE_STYLES.cell.padding.px,
-                borderBottom: TABLE_STYLES.cell.border,
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center'
-              }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-                  <Typography variant="tableHeader" sx={{
-                    fontWeight: 600,
-                    fontSize: '0.8rem',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px'
-                  }}>
-                    GRN Details - {selectedGRN.grnNumber}
-                  </Typography>
-                  <Chip
-                    label={selectedGRN.status}
-                    size="small"
-                    color={getStatusColor(selectedGRN.status) as any}
-                    sx={{
-                      textTransform: 'capitalize',
-                      fontSize: '0.75rem',
-                      fontWeight: 600
-                    }}
-                  />
-                </Box>
-                <Box>
-                  <IconButton
-                    size="small"
-                    title="Print GRN"
-                    onClick={() => setPrintDialogOpen(true)}
-                    sx={{
-                      height: `${TABLE_STYLES.row.height * 0.75}px`,
-                      width: `${TABLE_STYLES.row.height * 0.75}px`,
-                      minHeight: 20,
-                      minWidth: 20,
-                      p: 0.125,
-                      color: 'info.main',
-                      '&:hover': {
-                        backgroundColor: 'info.light',
-                        color: 'info.dark'
-                      }
-                    }}
-                  >
-                    <PrintIcon sx={{
-                      fontSize: `${TABLE_STYLES.row.height * 0.5}px`
-                    }} />
-                  </IconButton>
-                </Box>
-              </Box>
-
-              <Box sx={{ flex: 1, overflow: 'auto', p: TABLE_STYLES.cell.padding.px }}>
-                {/* GRN Details Section */}
-                <Grid container spacing={3}>
-                  {/* Left Column - GRN Information */}
-                  <Grid
-                    size={{
-                      xs: 12,
-                      md: 6
-                    }}>
-                    <TableContainer>
-                      <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': { border: 'none', py: 0.75, px: 1 } }}>
-                        <TableBody>
-                          <TableRow>
-                            <TableCell colSpan={2} sx={{ pb: 0.5, borderTop: TABLE_STYLES.cell.border }}>
-                              <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.9rem' }}>
-                                GRN Information
-                              </Typography>
-                            </TableCell>
-                          </TableRow>
-                          <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                            <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem', width: '40%' }}>
-                              Supplier
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem' }}>
-                              {selectedGRN.supplier?.companyName || 'Unknown'}
-                            </TableCell>
-                          </TableRow>
-                          <TableRow>
-                            <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                              GRN Date
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem' }}>
-                              {formatDate(selectedGRN.receivedDate)}
-                            </TableCell>
-                          </TableRow>
-                          {selectedGRN.purchaseOrder && (
-                            <>
-                              <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                                <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                                  PO No
-                                </TableCell>
-                                <TableCell sx={{ fontSize: '0.8rem' }}>
-                                  <Typography
-                                    component="button"
-                                    onClick={() => navigate(`/purchasing/orders?poId=${selectedGRN.purchaseOrder.id}`)}
-                                    sx={{
-                                      fontSize: '0.8rem',
-                                      color: 'primary.main',
-                                      cursor: 'pointer',
-                                      textDecoration: 'none',
-                                      border: 'none',
-                                      background: 'none',
-                                      padding: 0,
-                                      '&:hover': {
-                                        color: 'primary.dark'
-                                      }
-                                    }}
-                                  >
-                                    {selectedGRN.purchaseOrder.orderNumber}
-                                  </Typography>
-                                </TableCell>
-                              </TableRow>
-                              <TableRow>
-                                <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                                  VP No
-                                </TableCell>
-                                <TableCell sx={{ fontSize: '0.8rem' }}>
-                                  {selectedGRN.purchaseOrder.vendorPayments && selectedGRN.purchaseOrder.vendorPayments.length > 0 ? (
-                                    <Typography
-                                      component="button"
-                                      onClick={() => navigate(`/purchasing/vendor-payments?vpId=${selectedGRN.purchaseOrder.vendorPayments[0].id}`)}
-                                      sx={{
-                                        fontSize: '0.8rem',
-                                        color: 'primary.main',
-                                        cursor: 'pointer',
-                                        textDecoration: 'none',
-                                        border: 'none',
-                                        background: 'none',
-                                        padding: 0,
-                                        '&:hover': {
-                                          color: 'primary.dark'
-                                        }
-                                      }}
-                                    >
-                                      {selectedGRN.purchaseOrder.vendorPayments[0].paymentNumber}
-                                    </Typography>
-                                  ) : (
-                                    <Typography variant="body2" sx={{ color: 'text.disabled', fontSize: '0.8rem' }}>
-                                      Not yet paid
-                                    </Typography>
-                                  )}
-                                </TableCell>
-                              </TableRow>
-                            </>
-                          )}
-                          <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                            <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                              Journal Entry
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem' }}>
-                              {journalEntryRef ? (
-                                <Typography
-                                  component="button"
-                                  onClick={() => navigate(`/accounting/journal-entries/${journalEntryRef.id}`)}
-                                  sx={{
-                                    fontSize: '0.8rem',
-                                    color: 'primary.main',
-                                    cursor: 'pointer',
-                                    textDecoration: 'none',
-                                    border: 'none',
-                                    background: 'none',
-                                    padding: 0,
-                                    '&:hover': {
-                                      color: 'primary.dark'
-                                    }
-                                  }}
-                                >
-                                  {journalEntryRef.referenceNumber}
-                                </Typography>
-                              ) : (
-                                <Typography variant="body2" sx={{ color: 'text.disabled', fontSize: '0.8rem' }}>
-                                  —
-                                </Typography>
-                              )}
-                            </TableCell>
-                          </TableRow>
-                        </TableBody>
-                      </Table>
-                    </TableContainer>
-                  </Grid>
-
-                  {/* Right Column - Quantity Information */}
-                  <Grid
-                    size={{
-                      xs: 12,
-                      md: 6
-                    }}>
-                    <TableContainer>
-                      <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': { border: 'none', py: 0.75, px: 1 } }}>
-                        <TableBody>
-                          <TableRow>
-                            <TableCell colSpan={2} sx={{ pb: 0.5, borderTop: TABLE_STYLES.cell.border }}>
-                              <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.9rem' }}>
-                                Quantity Information
-                              </Typography>
-                            </TableCell>
-                          </TableRow>
-                          <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                            <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem', width: '40%' }}>
-                              Ordered Qty
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem' }}>
-                              {(selectedGRN.items && selectedGRN.items.reduce((sum: number, item: any) => sum + (item.orderedQuantity || 0), 0)) || 0}
-                            </TableCell>
-                          </TableRow>
-                          <TableRow>
-                            <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                              Received Qty
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem', color: 'success.main' }}>
-                              {selectedGRN.totalQuantityReceived || 0}
-                            </TableCell>
-                          </TableRow>
-                        </TableBody>
-                      </Table>
-                    </TableContainer>
-                  </Grid>
-
-                </Grid>
-
-                {/* Page Break */}
-                <Box sx={{ borderTop: '2px solid', borderColor: 'divider', my: 3 }} />
-
-                {/* GRN Items Section */}
-                <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-                  <Typography variant="tableHeader" sx={{
-                    fontWeight: 600,
-                    fontSize: '0.8rem',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px',
-                    mb: 1
-                  }}>
-                    GRN Items
-                  </Typography>
-
-                  {(selectedGRN.items && selectedGRN.items.length > 0) ? (
-                    <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
-                      <Table
-                        size={TABLE_STYLES.size}
-                        sx={{
-                          '& .MuiTableCell-root': {
-                            borderBottom: TABLE_STYLES.cell.border,
-                            py: TABLE_STYLES.cell.padding.py,
-                            px: TABLE_STYLES.cell.padding.px
-                          }
-                        }}
-                      >
-                        <TableHead>
-                          <TableRow sx={{ '& .MuiTableCell-head': {
-                            fontWeight: 600,
-                            backgroundColor: 'grey.50',
-                            color: 'text.primary',
-                            fontSize: '0.8rem'
-                          } }}>
-                            <TableCell sx={{ width: '50%' }}>Product</TableCell>
-                            <TableCell align="center" sx={{ width: '25%' }}>Ordered</TableCell>
-                            <TableCell align="center" sx={{ width: '25%' }}>Received</TableCell>
-                          </TableRow>
-                        </TableHead>
-                        <TableBody>
-                          {selectedGRN.items.map((item: any, index: number) => (
-                            <TableRow
-                              key={item.id || index}
-                              hover
-                              sx={{
-                                '&:hover': { backgroundColor: 'action.hover' },
-                                transition: 'background-color 0.2s ease',
-                                height: TABLE_STYLES.row.height
-                              }}
-                            >
-                              <TableCell sx={{ fontSize: '0.8rem' }}>
-                                {item.purchaseOrderItem?.product?.name || item.product?.name || 'N/A'}
-                              </TableCell>
-                              <TableCell align="center" sx={{ fontSize: '0.8rem' }}>
-                                {item.orderedQuantity || 0}
-                              </TableCell>
-                              <TableCell align="center" sx={{ fontSize: '0.8rem' }}>
-                                {item.receivedQuantity || 0}
-                              </TableCell>
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    </TableContainer>
-                  ) : (
-                    <Alert severity="info">No items in this GRN</Alert>
-                  )}
-                </Box>
-              </Box>
-            </Paper>
-          ) : (
-            <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-              <Typography variant="h6" sx={{
-                color: "text.secondary"
-              }}>
-                Select a GRN to view details
-              </Typography>
-            </Paper>
-          )}
-        </Grid>
-      </Grid>
-      {/* Deleted GRNs Dialog */}
-      <DeletedGRNsDialog
-        open={deletedGRNsDialogOpen}
-        onClose={() => setDeletedGRNsDialogOpen(false)}
+      <MasterDetailWorkspace
+        isMobile={isMobile}
+        listSlot={(
+          <GRNTable
+            grns={grns}
+            loading={loading}
+            total={total}
+            selectedGRNId={selectedGRN?.id}
+            focusedGRNIndex={pageState.focusedGRNIndex}
+            onGRNSelect={selection.handleGRNSelect}
+            grnListRef={pageState.grnListRef}
+          />
+        )}
+        headerSlot={(
+          <GRNContextHeader
+            selectedGRN={selectedGRN}
+            journalEntryRef={pageState.journalEntryRef}
+            journalEntryRefLoading={pageState.journalEntryRefLoading}
+            onPrint={() => pageState.setPrintDialogOpen(true)}
+            onNavigateToJournalEntry={navigateToJournalEntry}
+          />
+        )}
+        workspaceSlot={<GRNWorkspaceCard selectedGRN={selectedGRN} />}
       />
-      {/* Print Dialog */}
-      {selectedGRN && (
-        <GRNPrint
-          open={printDialogOpen}
-          onClose={() => setPrintDialogOpen(false)}
-          grn={selectedGRN}
-        />
-      )}
-    </>
-  );
+
+      <GRNDialogs
+        selectedGRN={selectedGRN}
+        deletedGRNsOpen={pageState.deletedGRNsOpen}
+        onCloseDeletedGRNs={() => pageState.setDeletedGRNsOpen(false)}
+        printDialogOpen={pageState.printDialogOpen}
+        onClosePrintDialog={() => pageState.setPrintDialogOpen(false)}
+      />
+    </Box>
+  )
 }
 
 export default GoodsReceivedPage

--- a/frontend/src/pages/purchasing/__tests__/GoodsReceivedPage.filterbar.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/GoodsReceivedPage.filterbar.test.tsx
@@ -138,10 +138,23 @@ describe('GoodsReceivedPage FilterBar integration', () => {
     )
   })
 
-  it('maps period filter to receivedDateFrom/receivedDateTo params', () => {
-    renderPage('/?periodKey=custom&periodFrom=2025-01-01&periodTo=2025-01-31')
+  it('sends no receivedDateFrom or receivedDateTo when period is not selected (default)', () => {
+    renderPage()
     expect(useGetGoodsReceivedNotesQuery).toHaveBeenLastCalledWith(
-      expect.not.objectContaining({ periodKey: expect.anything() }),
+      expect.objectContaining({
+        receivedDateFrom: undefined,
+        receivedDateTo: undefined,
+      }),
+    )
+  })
+
+  it('restores period=this_week from URL and resolves to receivedDateFrom/receivedDateTo in the query', () => {
+    renderPage('/?period=this_week')
+    expect(useGetGoodsReceivedNotesQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        receivedDateFrom: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        receivedDateTo: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      }),
     )
   })
 })

--- a/frontend/src/pages/purchasing/__tests__/GoodsReceivedPage.filterbar.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/GoodsReceivedPage.filterbar.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { GoodsReceivedPage } from '../GoodsReceivedPage'
+import purchasingReducer from '@/store/slices/purchasingSlice'
+
+const { useGetGoodsReceivedNotesQuery } = vi.hoisted(() => ({
+  useGetGoodsReceivedNotesQuery: vi.fn(() => ({
+    data: { data: [], meta: { total: 0 } },
+    isFetching: false,
+    error: null,
+  })),
+}))
+
+const filterBarSpy = vi.fn()
+
+vi.mock('@/store/api/purchasingApi', () => ({
+  useGetGoodsReceivedNotesQuery,
+  useLazyGetGoodsReceivedNoteQuery: vi.fn(() => [vi.fn()]),
+  useGetSuppliersQuery: vi.fn(() => ({
+    data: { data: [{ id: 'sup-1', companyName: 'Anaheim Electronics' }] },
+  })),
+}))
+
+vi.mock('@/store/api/accountingApi', () => ({
+  useLazyGetJournalEntriesQuery: vi.fn(() => [vi.fn()]),
+}))
+
+vi.mock('@/components/filters', () => ({
+  FilterBar: (props: unknown) => {
+    filterBarSpy(props)
+    return (
+      <div>
+        <input placeholder="Search goods received notes..." />
+      </div>
+    )
+  },
+}))
+
+vi.mock('@/components/common/MasterDetailWorkspace', () => ({
+  default: ({ listSlot, headerSlot, workspaceSlot }: any) => (
+    <div>
+      <div>MasterDetailWorkspace</div>
+      <div>{listSlot}</div>
+      <div>{headerSlot}</div>
+      <div>{workspaceSlot}</div>
+    </div>
+  ),
+}))
+
+vi.mock('../components/GRNContextHeader', () => ({ default: () => <div>GRNContextHeader</div> }))
+vi.mock('../components/GRNTable', () => ({ default: () => <div>GRNTable</div> }))
+vi.mock('../components/GRNWorkspaceCard', () => ({ default: () => <div>GRNWorkspaceCard</div> }))
+vi.mock('../components/GRNDialogs', () => ({ default: () => <div>GRNDialogs</div> }))
+vi.mock('../hooks/useGRNSelection', () => ({
+  useGRNSelection: () => ({
+    handleGRNSelect: vi.fn(),
+    handleNavigateUp: vi.fn(),
+    handleNavigateDown: vi.fn(),
+    focusSearchInput: vi.fn(),
+  }),
+}))
+
+function renderPage(initialUrl = '/') {
+  const store = configureStore({
+    reducer: { purchasing: purchasingReducer },
+  })
+
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <GoodsReceivedPage />
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('GoodsReceivedPage FilterBar integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the shared filter search input', () => {
+    renderPage()
+    expect(screen.getByPlaceholderText(/search goods received notes/i)).toBeInTheDocument()
+  })
+
+  it('renders the master-detail workspace with GRN components', () => {
+    renderPage()
+    expect(screen.getByText('MasterDetailWorkspace')).toBeInTheDocument()
+    expect(screen.getByText('GRNTable')).toBeInTheDocument()
+    expect(screen.getByText('GRNWorkspaceCard')).toBeInTheDocument()
+  })
+
+  it('passes search and supplierId from URL params to the query', () => {
+    renderPage('/?search=grn-001&supplierId=sup-1')
+    expect(useGetGoodsReceivedNotesQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        search: 'grn-001',
+        supplierId: 'sup-1',
+      }),
+    )
+  })
+
+  it('passes status filter to the query', () => {
+    renderPage('/?status=received')
+    expect(useGetGoodsReceivedNotesQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        status: 'received',
+      }),
+    )
+  })
+
+  it('configures the supplier filter with the supplier type', () => {
+    renderPage()
+    const latestProps = filterBarSpy.mock.calls.at(-1)?.[0] as {
+      config: { fields: Array<{ field: string; type: string }> }
+    }
+    expect(latestProps.config.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'supplierId', type: 'supplier' }),
+      ]),
+    )
+  })
+
+  it('configures the status filter with purchasing-status type', () => {
+    renderPage()
+    const latestProps = filterBarSpy.mock.calls.at(-1)?.[0] as {
+      config: { fields: Array<{ field: string; type: string }> }
+    }
+    expect(latestProps.config.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'status', type: 'purchasing-status' }),
+      ]),
+    )
+  })
+
+  it('maps period filter to receivedDateFrom/receivedDateTo params', () => {
+    renderPage('/?periodKey=custom&periodFrom=2025-01-01&periodTo=2025-01-31')
+    expect(useGetGoodsReceivedNotesQuery).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ periodKey: expect.anything() }),
+    )
+  })
+})

--- a/frontend/src/pages/purchasing/components/GRNContextHeader.tsx
+++ b/frontend/src/pages/purchasing/components/GRNContextHeader.tsx
@@ -1,0 +1,229 @@
+import React from 'react'
+import { default as PrintIcon } from '@mui/icons-material/Print'
+import {
+  Box,
+  IconButton,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+} from '@mui/material'
+import Grid from '@mui/material/Grid'
+import { useNavigate } from 'react-router-dom'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { GoodsReceivedNote } from '@/types'
+import { formatDate } from '@/utils/formatters'
+
+import type { GRNJournalEntryRef } from '../hooks/useGRNPageState'
+
+interface GRNContextHeaderProps {
+  selectedGRN: GoodsReceivedNote | null
+  journalEntryRef: GRNJournalEntryRef | null
+  journalEntryRefLoading: boolean
+  onPrint: () => void
+  onNavigateToJournalEntry: () => void
+}
+
+const actionIconSx = {
+  height: `${TABLE_STYLES.row.height * 0.75}px`,
+  width: `${TABLE_STYLES.row.height * 0.75}px`,
+  minHeight: 20,
+  minWidth: 20,
+  p: 0.125,
+}
+
+const detailTableSx = {
+  tableLayout: 'fixed' as const,
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const labelCellSx = { fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }
+const valueCellSx = { fontSize: '0.8rem' }
+
+const GRNContextHeader: React.FC<GRNContextHeaderProps> = ({
+  selectedGRN,
+  journalEntryRef,
+  journalEntryRefLoading,
+  onPrint,
+  onNavigateToJournalEntry,
+}) => {
+  const navigate = useNavigate()
+
+  if (!selectedGRN) {
+    return (
+      <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
+        <Typography variant="h6" sx={{ color: 'text.secondary' }}>
+          Select a goods received note to view details
+        </Typography>
+      </Paper>
+    )
+  }
+
+  const handleNavigateToPO = () => {
+    if (selectedGRN.purchaseOrder?.id) {
+      navigate(`/purchasing/purchase-orders?poId=${selectedGRN.purchaseOrder.id}`)
+    }
+  }
+
+  return (
+    <Paper sx={{ overflow: 'hidden' }}>
+      <Box
+        sx={{
+          p: TABLE_STYLES.cell.padding.px,
+          borderBottom: TABLE_STYLES.cell.border,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Typography
+          variant="tableHeader"
+          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+        >
+          GRN Details - {selectedGRN.grnNumber}
+        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+          <IconButton size="small" title="Print GRN" onClick={onPrint} sx={{ ...actionIconSx, color: 'info.main' }}>
+            <PrintIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
+          </IconButton>
+        </Box>
+      </Box>
+
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell
+                      colSpan={2}
+                      sx={{
+                        pb: TABLE_STYLES.cell.padding.py * 0.67,
+                        py: TABLE_STYLES.cell.padding.py * 0.67,
+                        borderTop: TABLE_STYLES.cell.border,
+                      }}
+                    >
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        GRN Information
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>GRN Number</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedGRN.grnNumber}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Status</TableCell>
+                    <TableCell sx={valueCellSx} style={{ textTransform: 'capitalize' }}>
+                      {selectedGRN.status}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Received Date</TableCell>
+                    <TableCell sx={valueCellSx}>{formatDate(selectedGRN.receivedDate)}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Journal Entry</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {journalEntryRefLoading ? (
+                        <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}>
+                          Loading...
+                        </Typography>
+                      ) : journalEntryRef ? (
+                        <Typography
+                          component="button"
+                          onClick={onNavigateToJournalEntry}
+                          sx={{
+                            fontSize: '0.8rem',
+                            color: 'primary.main',
+                            cursor: 'pointer',
+                            textDecoration: 'none',
+                            border: 'none',
+                            background: 'none',
+                            padding: 0,
+                          }}
+                        >
+                          {journalEntryRef.referenceNumber}
+                        </Typography>
+                      ) : (
+                        <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}>
+                          Pending
+                        </Typography>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell
+                      colSpan={2}
+                      sx={{
+                        pb: TABLE_STYLES.cell.padding.py * 0.67,
+                        py: TABLE_STYLES.cell.padding.py * 0.67,
+                        borderTop: TABLE_STYLES.cell.border,
+                      }}
+                    >
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Supplier & Order
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Supplier</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedGRN.supplier?.companyName || '—'}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Purchase Order</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {selectedGRN.purchaseOrder ? (
+                        <Typography
+                          component="button"
+                          onClick={handleNavigateToPO}
+                          sx={{
+                            fontSize: '0.8rem',
+                            color: 'primary.main',
+                            cursor: 'pointer',
+                            textDecoration: 'none',
+                            border: 'none',
+                            background: 'none',
+                            padding: 0,
+                          }}
+                        >
+                          {selectedGRN.purchaseOrder.orderNumber}
+                        </Typography>
+                      ) : '—'}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Qty Received</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedGRN.totalQuantityReceived ?? '—'}</TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+        </Grid>
+      </Box>
+    </Paper>
+  )
+}
+
+export default GRNContextHeader

--- a/frontend/src/pages/purchasing/components/GRNDialogs.tsx
+++ b/frontend/src/pages/purchasing/components/GRNDialogs.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+import DeletedGRNsDialog from '@/components/purchasing/DeletedGRNsDialog'
+import { GRNPrint } from '@/components/print'
+import type { GoodsReceivedNote } from '@/types'
+
+interface GRNDialogsProps {
+  selectedGRN: GoodsReceivedNote | null
+  deletedGRNsOpen: boolean
+  onCloseDeletedGRNs: () => void
+  printDialogOpen: boolean
+  onClosePrintDialog: () => void
+}
+
+const GRNDialogs: React.FC<GRNDialogsProps> = ({
+  selectedGRN,
+  deletedGRNsOpen,
+  onCloseDeletedGRNs,
+  printDialogOpen,
+  onClosePrintDialog,
+}) => {
+  return (
+    <>
+      <DeletedGRNsDialog
+        open={deletedGRNsOpen}
+        onClose={onCloseDeletedGRNs}
+      />
+
+      {selectedGRN && (
+        <GRNPrint
+          open={printDialogOpen}
+          onClose={onClosePrintDialog}
+          grn={selectedGRN}
+        />
+      )}
+    </>
+  )
+}
+
+export default GRNDialogs

--- a/frontend/src/pages/purchasing/components/GRNTable.tsx
+++ b/frontend/src/pages/purchasing/components/GRNTable.tsx
@@ -1,0 +1,135 @@
+import React, { memo } from 'react'
+import {
+  Box,
+  Chip,
+  Paper,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+} from '@mui/material'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { GoodsReceivedNote } from '@/types'
+import { formatDate } from '@/utils/formatters'
+
+interface GRNRowProps {
+  grn: GoodsReceivedNote
+  index: number
+  selectedGRNId?: string
+  focusedGRNIndex: number
+  onGRNSelect: (grn: GoodsReceivedNote) => void
+}
+
+const GRNRow = memo(({ grn, index, selectedGRNId, focusedGRNIndex, onGRNSelect }: GRNRowProps) => {
+  const isSelected = selectedGRNId === grn.id
+  const isFocused = index === focusedGRNIndex
+
+  return (
+    <TableRow
+      hover
+      onClick={() => onGRNSelect(grn)}
+      data-grn-index={index}
+      sx={{
+        cursor: 'pointer',
+        backgroundColor: isSelected ? 'action.selected' : isFocused ? 'action.focus' : 'inherit',
+        '&:hover': { backgroundColor: isSelected ? 'action.selected' : 'action.hover' },
+        transition: 'background-color 0.2s ease',
+        height: TABLE_STYLES.row.height,
+        ...(isFocused && {
+          outline: '2px solid',
+          outlineColor: 'primary.main',
+          outlineOffset: '-2px',
+        }),
+      }}
+    >
+      <TableCell>
+        <Typography variant="body2" sx={{ fontWeight: 400, fontSize: '0.8rem', lineHeight: 1.2 }}>
+          {grn.grnNumber}
+        </Typography>
+        <Typography variant="body2" sx={{ fontSize: '0.72rem', color: 'text.secondary', lineHeight: 1.2 }}>
+          {grn.supplier?.companyName || '—'}
+        </Typography>
+      </TableCell>
+      <TableCell align="right" sx={{ whiteSpace: 'nowrap' }}>
+        <Typography variant="body2" sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>
+          {formatDate(grn.receivedDate)}
+        </Typography>
+        <Box sx={{ mt: 0.25 }}>
+          <Chip
+            label={grn.status}
+            size="small"
+            color={grn.status === 'received' ? 'success' : 'default'}
+            sx={{ fontSize: '0.68rem', height: 16 }}
+          />
+        </Box>
+      </TableCell>
+    </TableRow>
+  )
+})
+
+GRNRow.displayName = 'GRNRow'
+
+interface GRNTableProps {
+  grns: GoodsReceivedNote[]
+  loading: boolean
+  total: number
+  selectedGRNId?: string
+  focusedGRNIndex: number
+  onGRNSelect: (grn: GoodsReceivedNote) => void
+  grnListRef: React.RefObject<HTMLDivElement | null>
+}
+
+const GRNTable: React.FC<GRNTableProps> = ({
+  grns,
+  loading,
+  total,
+  selectedGRNId,
+  focusedGRNIndex,
+  onGRNSelect,
+  grnListRef,
+}) => {
+  return (
+    <Paper sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
+        <Typography
+          variant="tableHeader"
+          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+        >
+          GRN List ({total})
+        </Typography>
+      </Box>
+      <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }} ref={grnListRef}>
+        <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
+          <Table size={TABLE_STYLES.size}>
+            <TableBody>
+              {loading && grns.length === 0
+                ? [...Array(10)].map((_, index) => (
+                    <TableRow key={`skeleton-${index}`}>
+                      <TableCell colSpan={2}>
+                        <Skeleton height={40} />
+                      </TableCell>
+                    </TableRow>
+                  ))
+                : grns.map((grn, index) => (
+                    <GRNRow
+                      key={grn.id}
+                      grn={grn}
+                      index={index}
+                      selectedGRNId={selectedGRNId}
+                      focusedGRNIndex={focusedGRNIndex}
+                      onGRNSelect={onGRNSelect}
+                    />
+                  ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+    </Paper>
+  )
+}
+
+export default GRNTable

--- a/frontend/src/pages/purchasing/components/GRNTable.tsx
+++ b/frontend/src/pages/purchasing/components/GRNTable.tsx
@@ -1,7 +1,6 @@
 import React, { memo } from 'react'
 import {
   Box,
-  Chip,
   Paper,
   Skeleton,
   Table,
@@ -14,7 +13,6 @@ import {
 
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { GoodsReceivedNote } from '@/types'
-import { formatDate } from '@/utils/formatters'
 
 interface GRNRowProps {
   grn: GoodsReceivedNote
@@ -50,22 +48,6 @@ const GRNRow = memo(({ grn, index, selectedGRNId, focusedGRNIndex, onGRNSelect }
         <Typography variant="body2" sx={{ fontWeight: 400, fontSize: '0.8rem', lineHeight: 1.2 }}>
           {grn.grnNumber}
         </Typography>
-        <Typography variant="body2" sx={{ fontSize: '0.72rem', color: 'text.secondary', lineHeight: 1.2 }}>
-          {grn.supplier?.companyName || '—'}
-        </Typography>
-      </TableCell>
-      <TableCell align="right" sx={{ whiteSpace: 'nowrap' }}>
-        <Typography variant="body2" sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>
-          {formatDate(grn.receivedDate)}
-        </Typography>
-        <Box sx={{ mt: 0.25 }}>
-          <Chip
-            label={grn.status}
-            size="small"
-            color={grn.status === 'received' ? 'success' : 'default'}
-            sx={{ fontSize: '0.68rem', height: 16 }}
-          />
-        </Box>
       </TableCell>
     </TableRow>
   )
@@ -109,7 +91,7 @@ const GRNTable: React.FC<GRNTableProps> = ({
               {loading && grns.length === 0
                 ? [...Array(10)].map((_, index) => (
                     <TableRow key={`skeleton-${index}`}>
-                      <TableCell colSpan={2}>
+                      <TableCell>
                         <Skeleton height={40} />
                       </TableCell>
                     </TableRow>

--- a/frontend/src/pages/purchasing/components/GRNWorkspaceCard.tsx
+++ b/frontend/src/pages/purchasing/components/GRNWorkspaceCard.tsx
@@ -1,0 +1,118 @@
+import React from 'react'
+import {
+  Alert,
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { GoodsReceivedNote } from '@/types'
+
+interface GRNWorkspaceCardProps {
+  selectedGRN: GoodsReceivedNote | null
+}
+
+const GRNWorkspaceCard: React.FC<GRNWorkspaceCardProps> = ({ selectedGRN }) => {
+  if (!selectedGRN) {
+    return <Paper sx={{ flex: 1 }} />
+  }
+
+  return (
+    <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
+        <Typography
+          variant="tableHeader"
+          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+        >
+          GRN Items
+        </Typography>
+      </Box>
+
+      <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', p: TABLE_STYLES.cell.padding.px }}>
+        {selectedGRN.items && selectedGRN.items.length > 0 ? (
+          <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
+            <Table
+              size={TABLE_STYLES.size}
+              sx={{
+                '& .MuiTableCell-root': {
+                  borderBottom: TABLE_STYLES.cell.border,
+                  py: TABLE_STYLES.cell.padding.py,
+                  px: TABLE_STYLES.cell.padding.px,
+                },
+              }}
+            >
+              <TableHead>
+                <TableRow
+                  sx={{
+                    '& .MuiTableCell-head': {
+                      fontWeight: 600,
+                      backgroundColor: 'grey.50',
+                      color: 'text.primary',
+                      fontSize: '0.8rem',
+                    },
+                  }}
+                >
+                  <TableCell sx={{ width: '40%' }}>Product</TableCell>
+                  <TableCell align="center" sx={{ width: '20%' }}>
+                    Ordered Qty
+                  </TableCell>
+                  <TableCell align="center" sx={{ width: '20%' }}>
+                    Received Qty
+                  </TableCell>
+                  <TableCell align="center" sx={{ width: '20%' }}>
+                    Status
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {selectedGRN.items.map((item, index) => (
+                  <TableRow
+                    key={item.id || index}
+                    hover
+                    sx={{
+                      '&:hover': { backgroundColor: 'action.hover' },
+                      transition: 'background-color 0.2s ease',
+                      height: TABLE_STYLES.row.height,
+                    }}
+                  >
+                    <TableCell sx={{ fontSize: '0.8rem' }}>
+                      {item.purchaseOrderItem?.product?.name || item.product?.name || item.productName || 'N/A'}
+                    </TableCell>
+                    <TableCell align="center" sx={{ fontSize: '0.8rem' }}>
+                      {item.orderedQuantity}
+                    </TableCell>
+                    <TableCell align="center" sx={{ fontSize: '0.8rem' }}>
+                      {item.receivedQuantity}
+                    </TableCell>
+                    <TableCell align="center" sx={{ fontSize: '0.8rem' }}>
+                      {Number(item.receivedQuantity) >= Number(item.orderedQuantity) ? (
+                        <Typography sx={{ fontSize: '0.75rem', color: 'success.main', fontWeight: 600 }}>
+                          Full
+                        </Typography>
+                      ) : (
+                        <Typography sx={{ fontSize: '0.75rem', color: 'warning.main', fontWeight: 600 }}>
+                          Partial
+                        </Typography>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        ) : (
+          <Alert severity="info">No items in this GRN</Alert>
+        )}
+      </Box>
+    </Paper>
+  )
+}
+
+export default GRNWorkspaceCard

--- a/frontend/src/pages/purchasing/hooks/useGRNPageState.ts
+++ b/frontend/src/pages/purchasing/hooks/useGRNPageState.ts
@@ -1,0 +1,46 @@
+import { useRef, useState } from 'react'
+
+export interface GRNPageSorting {
+  sortBy: string
+  sortOrder: 'asc' | 'desc'
+}
+
+export interface GRNJournalEntryRef {
+  referenceNumber: string
+  sourceType: string
+  sourceId: string
+}
+
+export function useGRNPageState() {
+  const [sorting, setSorting] = useState<GRNPageSorting>({
+    sortBy: 'receivedDate',
+    sortOrder: 'desc',
+  })
+  const [focusedGRNIndex, setFocusedGRNIndex] = useState(-1)
+  const [deletedGRNsOpen, setDeletedGRNsOpen] = useState(false)
+  const [printDialogOpen, setPrintDialogOpen] = useState(false)
+  const [journalEntryRef, setJournalEntryRef] = useState<GRNJournalEntryRef | null>(null)
+  const [journalEntryRefLoading, setJournalEntryRefLoading] = useState(false)
+
+  const grnListRef = useRef<HTMLDivElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+  const userHasNavigatedRef = useRef(false)
+
+  return {
+    sorting,
+    setSorting,
+    focusedGRNIndex,
+    setFocusedGRNIndex,
+    deletedGRNsOpen,
+    setDeletedGRNsOpen,
+    printDialogOpen,
+    setPrintDialogOpen,
+    journalEntryRef,
+    setJournalEntryRef,
+    journalEntryRefLoading,
+    setJournalEntryRefLoading,
+    grnListRef,
+    searchInputRef,
+    userHasNavigatedRef,
+  }
+}

--- a/frontend/src/pages/purchasing/hooks/useGRNSelection.ts
+++ b/frontend/src/pages/purchasing/hooks/useGRNSelection.ts
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, type MutableRefObject, type RefObject } from 'react'
+import type { SetURLSearchParams } from 'react-router-dom'
+
+import { useLazyGetJournalEntriesQuery } from '@/store/api/accountingApi'
+import { useLazyGetGoodsReceivedNoteQuery } from '@/store/api/purchasingApi'
+import { setSelectedGRN } from '@/store/slices/purchasingSlice'
+import type { AppDispatch } from '@/store'
+import type { GoodsReceivedNote } from '@/types'
+
+import type { GRNJournalEntryRef } from './useGRNPageState'
+
+interface UseGRNSelectionParams {
+  dispatch: AppDispatch
+  grns: GoodsReceivedNote[]
+  selectedGRN: GoodsReceivedNote | null
+  focusedGRNIndex: number
+  setFocusedGRNIndex: (index: number) => void
+  searchParams: URLSearchParams
+  setSearchParams: SetURLSearchParams
+  grnListRef: RefObject<HTMLDivElement | null>
+  searchInputRef: RefObject<HTMLInputElement | null>
+  userHasNavigatedRef: MutableRefObject<boolean>
+  setJournalEntryRef: (value: GRNJournalEntryRef | null) => void
+  setJournalEntryRefLoading: (value: boolean) => void
+}
+
+export function useGRNSelection({
+  dispatch,
+  grns,
+  selectedGRN,
+  focusedGRNIndex,
+  setFocusedGRNIndex,
+  searchParams,
+  setSearchParams,
+  grnListRef,
+  searchInputRef,
+  userHasNavigatedRef,
+  setJournalEntryRef,
+  setJournalEntryRefLoading,
+}: UseGRNSelectionParams) {
+  const [fetchGRN] = useLazyGetGoodsReceivedNoteQuery()
+  const [fetchJournalEntries] = useLazyGetJournalEntriesQuery()
+
+  useEffect(() => {
+    if (!selectedGRN?.id) {
+      setJournalEntryRef(null)
+      setJournalEntryRefLoading(false)
+      return
+    }
+
+    let cancelled = false
+    setJournalEntryRefLoading(true)
+
+    ;(async () => {
+      try {
+        const res = await fetchJournalEntries({
+          sourceType: 'goods_received_note',
+          sourceId: selectedGRN.id,
+          sortBy: 'createdAt',
+          sortOrder: 'DESC',
+          limit: 1,
+        }).unwrap()
+
+        if (cancelled) return
+
+        const entry = res.data?.[0]
+        if (entry) {
+          setJournalEntryRef({
+            referenceNumber: entry.referenceNumber,
+            sourceType: 'goods_received_note',
+            sourceId: selectedGRN.id,
+          })
+        } else {
+          setJournalEntryRef(null)
+        }
+      } catch {
+        if (!cancelled) setJournalEntryRef(null)
+      } finally {
+        if (!cancelled) setJournalEntryRefLoading(false)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [fetchJournalEntries, selectedGRN?.id, setJournalEntryRef, setJournalEntryRefLoading])
+
+  useEffect(() => {
+    const grnId = searchParams.get('grnId')
+    if (grnId && grns.length > 0) {
+      const grn = grns.find((item) => item.id === grnId)
+      if (grn) {
+        dispatch(setSelectedGRN(grn))
+        const index = grns.findIndex((item) => item.id === grn.id)
+        setFocusedGRNIndex(index)
+        setSearchParams({})
+      }
+    }
+  }, [dispatch, grns, searchParams, setFocusedGRNIndex, setSearchParams])
+
+  useEffect(() => {
+    if (grns.length > 0 && focusedGRNIndex === -1) {
+      if (selectedGRN) {
+        const index = grns.findIndex((item) => item.id === selectedGRN.id)
+        setFocusedGRNIndex(index >= 0 ? index : 0)
+      } else if (searchInputRef.current !== document.activeElement) {
+        const grnId = searchParams.get('grnId')
+        if (!grnId) {
+          setFocusedGRNIndex(0)
+          dispatch(setSelectedGRN(grns[0]))
+        }
+      }
+    }
+  }, [dispatch, focusedGRNIndex, grns, searchInputRef, searchParams, selectedGRN, setFocusedGRNIndex])
+
+  useEffect(() => {
+    if (grns.length === 0 && selectedGRN) {
+      dispatch(setSelectedGRN(null))
+      setFocusedGRNIndex(-1)
+    }
+  }, [dispatch, grns.length, selectedGRN, setFocusedGRNIndex])
+
+  useEffect(() => {
+    if (focusedGRNIndex >= 0 && grnListRef.current) {
+      const row = grnListRef.current.querySelector(`[data-grn-index="${focusedGRNIndex}"]`)
+      if (row) {
+        row.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      }
+    }
+  }, [focusedGRNIndex, grnListRef])
+
+  const handleGRNSelect = useCallback(async (grn: GoodsReceivedNote) => {
+    const index = grns.findIndex((item) => item.id === grn.id)
+    setFocusedGRNIndex(index)
+    userHasNavigatedRef.current = true
+
+    try {
+      const freshGRN = await fetchGRN(grn.id).unwrap()
+      dispatch(setSelectedGRN(freshGRN))
+    } catch {
+      dispatch(setSelectedGRN(grn))
+    }
+  }, [dispatch, fetchGRN, grns, setFocusedGRNIndex, userHasNavigatedRef])
+
+  const handleNavigateUp = useCallback(() => {
+    if (focusedGRNIndex > 0) {
+      const newIndex = focusedGRNIndex - 1
+      setFocusedGRNIndex(newIndex)
+      dispatch(setSelectedGRN(grns[newIndex]))
+      userHasNavigatedRef.current = true
+    }
+  }, [dispatch, focusedGRNIndex, grns, setFocusedGRNIndex, userHasNavigatedRef])
+
+  const handleNavigateDown = useCallback(() => {
+    if (focusedGRNIndex < grns.length - 1) {
+      const newIndex = focusedGRNIndex + 1
+      setFocusedGRNIndex(newIndex)
+      dispatch(setSelectedGRN(grns[newIndex]))
+      userHasNavigatedRef.current = true
+    }
+  }, [dispatch, focusedGRNIndex, grns, setFocusedGRNIndex, userHasNavigatedRef])
+
+  const focusSearchInput = useCallback(() => {
+    searchInputRef.current?.focus()
+  }, [searchInputRef])
+
+  return {
+    handleGRNSelect,
+    handleNavigateUp,
+    handleNavigateDown,
+    focusSearchInput,
+  }
+}

--- a/frontend/src/pages/purchasing/hooks/useGRNSelection.ts
+++ b/frontend/src/pages/purchasing/hooks/useGRNSelection.ts
@@ -93,7 +93,10 @@ export function useGRNSelection({
         dispatch(setSelectedGRN(grn))
         const index = grns.findIndex((item) => item.id === grn.id)
         setFocusedGRNIndex(index)
-        setSearchParams({})
+        setSearchParams((prev) => {
+          prev.delete('grnId')
+          return prev
+        }, { replace: true })
       }
     }
   }, [dispatch, grns, searchParams, setFocusedGRNIndex, setSearchParams])

--- a/frontend/src/store/api/__tests__/purchasingApi.test.ts
+++ b/frontend/src/store/api/__tests__/purchasingApi.test.ts
@@ -12,6 +12,7 @@ describe('purchasingApiSlice', () => {
     expect(purchasingApiSlice.endpoints.createPurchaseOrder).toBeDefined()
     expect(purchasingApiSlice.endpoints.updatePurchaseOrder).toBeDefined()
     expect(purchasingApiSlice.endpoints.getGoodsReceivedNotes).toBeDefined()
+    expect(purchasingApiSlice.endpoints.getGoodsReceivedNote).toBeDefined()
     expect(purchasingApiSlice.endpoints.getVendorPayments).toBeDefined()
     expect(purchasingApiSlice.endpoints.getDeletedGRNs).toBeDefined()
     expect(purchasingApiSlice.endpoints.getDeletedVendorPayments).toBeDefined()

--- a/frontend/src/store/api/purchasingApi.ts
+++ b/frontend/src/store/api/purchasingApi.ts
@@ -219,6 +219,11 @@ export const purchasingApiSlice = createApi({
       transformResponse: (response: any) => normalizeNamedCollection<GoodsReceivedNote>(response, 'grns'),
       providesTags: ['DeletedGRN'],
     }),
+    getGoodsReceivedNote: builder.query<GoodsReceivedNote, string>({
+      query: (id) => ({ url: `/purchasing/goods-received-notes/${id}` }),
+      transformResponse: normalizeSingle<GoodsReceivedNote>,
+      providesTags: (_result, _error, id) => [{ type: 'GoodsReceivedNote', id }],
+    }),
 
     getVendorPayments: builder.query<PaginatedResponse<VendorPayment>, Record<string, unknown> | undefined>({
       query: (params) => ({ url: '/purchasing/vendor-payments', params: params ?? {} }),
@@ -264,6 +269,7 @@ export const {
   useMarkPurchaseOrderAsUnpaidMutation,
   useRecordOrderPaymentsMutation,
   useGetGoodsReceivedNotesQuery,
+  useLazyGetGoodsReceivedNoteQuery,
   useGetDeletedGRNsQuery,
   useGetVendorPaymentsQuery,
   useGetDeletedVendorPaymentsQuery,


### PR DESCRIPTION
## Summary
- Decomposes `GoodsReceivedPage.tsx` into `useGRNPageState`, `useGRNSelection`, `GRNTable`, `GRNContextHeader`, `GRNWorkspaceCard`, and `GRNDialogs`
- Replaces the custom GRN layout with `MasterDetailWorkspace`
- Wires up `FilterBar` with Search, Period, Supplier, and Status filters
- Adds `useLazyGetGoodsReceivedNoteQuery` to RTK Query for fresh data on selection
- Adds frontend filterbar coverage and backend `findAll` filter coverage

## Verification
- `cd frontend && npx vitest run src/store/api/__tests__/purchasingApi.test.ts src/pages/purchasing/__tests__/GoodsReceivedPage.filterbar.test.tsx --reporter=dot`
- `cd frontend && npx vitest run src/pages/purchasing/__tests__/ --reporter=dot`
- `cd frontend && timeout 180s npm run type-check`
- `cd backend && npx jest src/modules/purchasing/services/goods-received-note.service.spec.ts --no-coverage`

## Manual checks
- [ ] GRN page loads and renders the master-detail layout
- [ ] Filters update the server query
- [ ] Selecting a GRN shows details and items
- [ ] Keyboard navigation moves selection
- [ ] Print dialog opens
- [ ] Deleted GRNs dialog opens
- [ ] Clicking the purchase-order link navigates to the purchase order page

Closes #335