### PR TITLE
refactor: rewrite VendorPaymentsPage using Master-Detail pattern

### DIFF
--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -18,6 +18,7 @@ import { FilterStockStatus } from './FilterStockStatus'
 import { FilterSupplier } from './FilterSupplier'
 import { FilterSupplierType } from './FilterSupplierType'
 import { FilterTransactionStatus } from './FilterTransactionStatus'
+import { FilterVendorPaymentStatus } from './FilterVendorPaymentStatus'
 import { FilterUserStatus } from './FilterUserStatus'
 import { AppButton } from '@/components/common/AppButton'
 import type {
@@ -201,6 +202,17 @@ function renderQuickField<TFilters extends object>(
   if (field.type === 'purchasing-status') {
     return (
       <FilterPurchasingStatus
+        key={fieldKey}
+        field={fieldKey}
+        value={(value as string | null) ?? null}
+        onChange={onChange}
+      />
+    )
+  }
+
+  if (field.type === 'vendor-payment-status') {
+    return (
+      <FilterVendorPaymentStatus
         key={fieldKey}
         field={fieldKey}
         value={(value as string | null) ?? null}

--- a/frontend/src/components/filters/FilterVendorPaymentStatus.tsx
+++ b/frontend/src/components/filters/FilterVendorPaymentStatus.tsx
@@ -1,0 +1,25 @@
+import { FilterSelect } from './FilterSelect'
+
+const VENDOR_PAYMENT_STATUS_OPTIONS = [
+  { value: 'pending', label: 'Pending' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'cancelled', label: 'Cancelled' },
+]
+
+interface Props {
+  field: string
+  value: string | null
+  onChange: (value: string | null) => void
+}
+
+export function FilterVendorPaymentStatus({ field, value, onChange }: Props) {
+  return (
+    <FilterSelect
+      field={field}
+      label="Status"
+      value={value}
+      options={VENDOR_PAYMENT_STATUS_OPTIONS}
+      onChange={onChange}
+    />
+  )
+}

--- a/frontend/src/hooks/useFilterBar.ts
+++ b/frontend/src/hooks/useFilterBar.ts
@@ -35,7 +35,8 @@ function getDefaults<TFilters extends object>(
       field.type === 'product-type' ||
       field.type === 'stock-status' ||
       field.type === 'price-list' ||
-      field.type === 'transaction-status'
+      field.type === 'transaction-status' ||
+      field.type === 'vendor-payment-status'
     ) {
       defaults[key] = null
     }

--- a/frontend/src/pages/purchasing/VendorPaymentsPage.tsx
+++ b/frontend/src/pages/purchasing/VendorPaymentsPage.tsx
@@ -67,7 +67,7 @@ const VendorPaymentsPage: React.FC = () => {
 
   const queryParams = useMemo(() => ({
     sortBy: pageState.sorting.sortBy,
-    sortOrder: pageState.sorting.sortOrder.toUpperCase(),
+    sortOrder: pageState.sorting.sortOrder,
     search: filterBar.appliedFilters.search || undefined,
     supplierId: filterBar.appliedFilters.supplierId || undefined,
     status: filterBar.appliedFilters.status || undefined,

--- a/frontend/src/pages/purchasing/VendorPaymentsPage.tsx
+++ b/frontend/src/pages/purchasing/VendorPaymentsPage.tsx
@@ -42,7 +42,7 @@ const VendorPaymentsPage: React.FC = () => {
       fields: [
         { field: 'period', label: 'Period', type: 'period' },
         { field: 'supplierId', label: 'Supplier', type: 'supplier' },
-        { field: 'status', label: 'Status', type: 'purchasing-status' },
+        { field: 'status', label: 'Status', type: 'vendor-payment-status' },
       ],
       defaults: {
         search: '',

--- a/frontend/src/pages/purchasing/VendorPaymentsPage.tsx
+++ b/frontend/src/pages/purchasing/VendorPaymentsPage.tsx
@@ -1,1001 +1,192 @@
-import React, { useState, useEffect, useCallback, useMemo, useRef, memo } from 'react'
-import { useSearchParams, useNavigate } from 'react-router-dom'
-import {
-  Box,
-  Typography,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Button,
-  Chip,
-  TextField,
-  InputAdornment,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  Divider,
-  Skeleton,
-  Alert,
-  Grid,
-  IconButton,
-  useTheme,
-  useMediaQuery,
-} from '@mui/material'
-import { default as SearchIcon } from '@mui/icons-material/Search'
-import { default as RestoreIcon } from '@mui/icons-material/RestoreFromTrash'
-import { default as SortIcon } from '@mui/icons-material/Sort'
-import { default as ArrowUpIcon } from '@mui/icons-material/ArrowUpward'
-import { default as ArrowDownIcon } from '@mui/icons-material/ArrowDownward'
-import { default as PrintIcon } from '@mui/icons-material/Print'
+import React, { useCallback, useMemo } from 'react'
+import { Alert, Box, useMediaQuery, useTheme } from '@mui/material'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+
+import MasterDetailWorkspace from '@/components/common/MasterDetailWorkspace'
 import PageHeader from '@/components/common/PageHeader'
-import { formatDate, formatCurrency, formatWholeQuantity } from '@/utils/formatters'
-import { TABLE_STYLES } from '@/constants/tableStyles'
-import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
-import {
-  setSelectedVendorPayment,
-  selectSelectedVendorPayment
-} from '@/store/slices/purchasingSlice'
-import { useGetVendorPaymentsQuery } from '@/store/api/purchasingApi'
+import { FilterBar } from '@/components/filters'
+import { useFilterBar } from '@/hooks/useFilterBar'
 import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
-import DeletedVendorPaymentsDialog from '@/components/purchasing/DeletedVendorPaymentsDialog'
-import { VendorPaymentPrint } from '@/components/print'
-import { useLazyGetJournalEntriesQuery } from '@/store/api/accountingApi'
-import { useGetActivePaymentMethodsQuery } from '@/store/api/paymentMethodsApi'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
+import { useGetVendorPaymentsQuery } from '@/store/api/purchasingApi'
+import { selectSelectedVendorPayment } from '@/store/slices/purchasingSlice'
+import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
+import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
 
-interface VendorPaymentFilters {
+import VendorPaymentContextHeader from './components/VendorPaymentContextHeader'
+import VendorPaymentsDialogs from './components/VendorPaymentsDialogs'
+import VendorPaymentTable from './components/VendorPaymentTable'
+import VendorPaymentWorkspaceCard from './components/VendorPaymentWorkspaceCard'
+import { useVendorPaymentsPageState } from './hooks/useVendorPaymentsPageState'
+import { useVendorPaymentsSelection } from './hooks/useVendorPaymentsSelection'
+
+interface VPFilters {
   search: string
-  sortBy: string
-  sortOrder: 'asc' | 'desc'
-  status: string
-  paymentMethodId: string
-  dateFilter: string
-  customFromDate: string
-  customToDate: string
+  supplierId: string | null
+  period: PeriodValue
+  status: 'pending' | 'completed' | 'cancelled' | null
 }
-
-const getDateRangeFromFilter = (filter: string, customFromDate: string, customToDate: string) => {
-  const today = new Date()
-  const yesterday = new Date(today)
-  yesterday.setDate(yesterday.getDate() - 1)
-
-  const startOfWeek = new Date(today)
-  startOfWeek.setDate(today.getDate() - today.getDay())
-
-  const startOfMonth = new Date(today.getFullYear(), today.getMonth(), 1)
-  const startOfYear = new Date(today.getFullYear(), 0, 1)
-
-  const formatLocalDate = (date: Date) => date.toISOString().split('T')[0]
-
-  switch (filter) {
-    case 'today':
-      return { startDate: formatLocalDate(today), endDate: formatLocalDate(today) }
-    case 'yesterday':
-      return { startDate: formatLocalDate(yesterday), endDate: formatLocalDate(yesterday) }
-    case 'this_week':
-      return { startDate: formatLocalDate(startOfWeek), endDate: formatLocalDate(today) }
-    case 'this_month':
-      return { startDate: formatLocalDate(startOfMonth), endDate: formatLocalDate(today) }
-    case 'this_year':
-      return { startDate: formatLocalDate(startOfYear), endDate: formatLocalDate(today) }
-    case 'custom':
-      return { startDate: customFromDate, endDate: customToDate }
-    default:
-      return { startDate: undefined, endDate: undefined }
-  }
-}
-
-// Memoized Payment Row Component
-interface PaymentRowProps {
-  payment: any
-  index: number
-  selectedPaymentId?: string
-  focusedPaymentIndex: number
-  onPaymentSelect: (payment: any) => void
-}
-
-const PaymentRow = memo(({ payment, index, selectedPaymentId, focusedPaymentIndex, onPaymentSelect }: PaymentRowProps) => {
-  const isSelected = selectedPaymentId === payment.id
-  const isFocused = index === focusedPaymentIndex
-
-  return (
-    <TableRow
-      key={payment.id}
-      hover
-      onClick={() => onPaymentSelect(payment)}
-      data-payment-index={index}
-      sx={{
-        cursor: 'pointer',
-        backgroundColor: isSelected ? 'action.selected' : isFocused ? 'action.focus' : 'inherit',
-        '&:hover': {
-          backgroundColor: isSelected ? 'action.selected' : 'action.hover'
-        },
-        transition: 'background-color 0.2s ease',
-        height: TABLE_STYLES.row.height,
-        ...(isFocused && {
-          outline: '2px solid',
-          outlineColor: 'primary.main',
-          outlineOffset: '-2px'
-        })
-      }}
-    >
-      <TableCell>
-        <Typography
-          variant="body2"
-          sx={{
-            fontWeight: 400,
-            fontSize: '0.8rem',
-            lineHeight: 1.2
-          }}
-        >
-          {payment.paymentNumber}
-        </Typography>
-      </TableCell>
-    </TableRow>
-  )
-})
-
-PaymentRow.displayName = 'PaymentRow'
 
 const VendorPaymentsPage: React.FC = () => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('md'))
-  const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
-
   const dispatch = useAppDispatch()
-  const selectedPaymentFromRedux = useAppSelector(selectSelectedVendorPayment)
-  const [selectedPayment, setSelectedPaymentLocal] = useState<any | null>(null)
+  const [searchParams, setSearchParams] = useSearchParams()
+  const pageState = useVendorPaymentsPageState()
+  const selectedPayment = useAppSelector(selectSelectedVendorPayment)
 
-  const [filters, setFilters] = useState<VendorPaymentFilters>({
-    search: '',
-    sortBy: 'paymentNumber',
-    sortOrder: 'asc',
-    status: 'all',
-    paymentMethodId: 'all',
-    dateFilter: 'all',
-    customFromDate: '',
-    customToDate: '',
+  const filterConfig = useMemo<FilterBarConfig<VPFilters>>(
+    () => ({
+      search: { placeholder: 'Search vendor payments...' },
+      fields: [
+        { field: 'period', label: 'Period', type: 'period' },
+        { field: 'supplierId', label: 'Supplier', type: 'supplier' },
+        { field: 'status', label: 'Status', type: 'purchasing-status' },
+      ],
+      defaults: {
+        search: '',
+        supplierId: null,
+        period: { key: null, from: null, to: null },
+        status: null,
+      },
+    }),
+    [],
+  )
+
+  const filterBar = useFilterBar(filterConfig)
+  const weekStartsOn = getStartOfWeek()
+
+  const dateRange = useMemo(() => {
+    const period = filterBar.appliedFilters.period
+    if (!period || period.key === null) return { startDate: undefined, endDate: undefined }
+    if (period.key === 'custom') return { startDate: period.from ?? undefined, endDate: period.to ?? undefined }
+    const range = getPeriodDateRange(period.key, weekStartsOn)
+    return { startDate: range.from, endDate: range.to }
+  }, [filterBar.appliedFilters.period, weekStartsOn])
+
+  const queryParams = useMemo(() => ({
+    sortBy: pageState.sorting.sortBy,
+    sortOrder: pageState.sorting.sortOrder.toUpperCase(),
+    search: filterBar.appliedFilters.search || undefined,
+    supplierId: filterBar.appliedFilters.supplierId || undefined,
+    status: filterBar.appliedFilters.status || undefined,
+    startDate: dateRange.startDate,
+    endDate: dateRange.endDate,
+  }), [dateRange, filterBar.appliedFilters, pageState.sorting])
+
+  const {
+    data: paymentsResponse,
+    isFetching: loading,
+    error: paymentsError,
+  } = useGetVendorPaymentsQuery(queryParams)
+
+  const payments = paymentsResponse?.data || []
+  const total = paymentsResponse?.meta?.total || 0
+  const error = paymentsError && typeof paymentsError === 'object'
+    ? ((paymentsError as any).data?.message || (paymentsError as any).data || 'Failed to fetch vendor payments')
+    : null
+
+  const selection = useVendorPaymentsSelection({
+    dispatch,
+    payments,
+    selectedPayment,
+    focusedPaymentIndex: pageState.focusedPaymentIndex,
+    setFocusedPaymentIndex: pageState.setFocusedPaymentIndex,
+    searchParams,
+    setSearchParams,
+    paymentListRef: pageState.paymentListRef,
+    searchInputRef: pageState.searchInputRef,
+    userHasNavigatedRef: pageState.userHasNavigatedRef,
+    setJournalEntryRef: pageState.setJournalEntryRef,
+    setJournalEntryRefLoading: pageState.setJournalEntryRefLoading,
   })
-
-  const [fetchJournalEntries] = useLazyGetJournalEntriesQuery()
-  const [journalEntryRef, setJournalEntryRef] = useState<{ id: string; referenceNumber: string } | null>(null)
-  const [deletedPaymentsDialogOpen, setDeletedPaymentsDialogOpen] = useState(false)
-  const [printDialogOpen, setPrintDialogOpen] = useState(false)
-  const [focusedPaymentIndex, setFocusedPaymentIndex] = useState(-1)
-  const paymentListRef = useRef<HTMLDivElement>(null)
-  const searchInputRef = useRef<HTMLInputElement>(null)
-  const { data: paymentMethods = [] } = useGetActivePaymentMethodsQuery()
-  const queryParams = useMemo(() => {
-    const dateRange = getDateRangeFromFilter(filters.dateFilter, filters.customFromDate, filters.customToDate)
-    return {
-      search: filters.search,
-      sortBy: filters.sortBy,
-      sortOrder: filters.sortOrder,
-      status: filters.status !== 'all' ? filters.status : undefined,
-      paymentMethodId: filters.paymentMethodId !== 'all' ? filters.paymentMethodId : undefined,
-      startDate: dateRange.startDate,
-      endDate: dateRange.endDate,
-    }
-  }, [filters])
-  const { data: vendorPaymentsResponse, isFetching: loading, error: vendorPaymentsError } = useGetVendorPaymentsQuery(queryParams)
-  const vendorPayments = vendorPaymentsResponse?.data || []
-  const pagination = vendorPaymentsResponse?.meta
-  const error =
-    vendorPaymentsError && typeof vendorPaymentsError === 'object'
-      ? ((vendorPaymentsError as any).data?.message ||
-          (vendorPaymentsError as any).data ||
-          'Failed to fetch vendor payments')
-      : null
-
-  const handlePaymentSelect = useCallback((payment: any) => {
-    setSelectedPaymentLocal(payment)
-    dispatch(setSelectedVendorPayment(payment))
-    const paymentIndex = vendorPayments.findIndex(p => p.id === payment.id)
-    setFocusedPaymentIndex(paymentIndex)
-  }, [dispatch, vendorPayments])
-
-  // Restore selected payment from Redux on mount
-  useEffect(() => {
-    if (selectedPaymentFromRedux && vendorPayments.length > 0 && !selectedPayment) {
-      const payment = vendorPayments.find((p: any) => p.id === selectedPaymentFromRedux.id)
-      if (payment) {
-        handlePaymentSelect(payment)
-      }
-    }
-  }, [selectedPaymentFromRedux, vendorPayments, selectedPayment, handlePaymentSelect])
-
-  // Handle vpId query parameter to auto-select payment
-  useEffect(() => {
-    const vpId = searchParams.get('vpId')
-    if (vpId) {
-      const payment = vendorPayments.find((p: any) => p.id === vpId)
-      if (payment) {
-        handlePaymentSelect(payment)
-        setSearchParams({})
-      }
-    }
-  }, [handlePaymentSelect, searchParams, setSearchParams, vendorPayments])
-
-  // Auto-refresh selected payment when the list updates
-  useEffect(() => {
-    if (selectedPayment && vendorPayments.length > 0) {
-      const updatedPayment = vendorPayments.find((p: any) => p.id === selectedPayment.id)
-      if (updatedPayment) {
-        setSelectedPaymentLocal(updatedPayment)
-        dispatch(setSelectedVendorPayment(updatedPayment))
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [vendorPayments])
-
-  // Auto-select first payment when payments load
-  useEffect(() => {
-    if (vendorPayments.length > 0 && focusedPaymentIndex === -1) {
-      if (!selectedPayment && searchInputRef.current !== document.activeElement) {
-        // Don't auto-select if we have a vpId query parameter or a persisted selection
-        const vpId = searchParams.get('vpId')
-        if (!vpId && !selectedPaymentFromRedux) {
-          setFocusedPaymentIndex(0)
-          handlePaymentSelect(vendorPayments[0])
-        }
-      }
-    }
-  }, [vendorPayments, focusedPaymentIndex, selectedPayment, handlePaymentSelect, searchParams, selectedPaymentFromRedux])
-
-  // Clear selection when no payments exist
-  useEffect(() => {
-    if (vendorPayments.length === 0 && selectedPayment) {
-      setSelectedPaymentLocal(null)
-      dispatch(setSelectedVendorPayment(null))
-      setFocusedPaymentIndex(-1)
-    }
-  }, [vendorPayments.length, selectedPayment, dispatch])
-
-  // Fetch journal entry reference for selected vendor payment
-  useEffect(() => {
-    if (!selectedPayment) {
-      setJournalEntryRef(null)
-      return
-    }
-    setJournalEntryRef(null)
-    fetchJournalEntries({ sourceType: 'vendor_payment', sourceId: selectedPayment.id, limit: 1 })
-      .unwrap()
-      .then((res) => {
-        const entry = res?.data?.[0]
-        if (entry) {
-          setJournalEntryRef({ id: entry.id, referenceNumber: entry.referenceNumber })
-        }
-      })
-      .catch(() => { /* silently ignore */ })
-  }, [selectedPayment?.id, fetchJournalEntries])
-
-  // Auto-scroll to keep focused item visible
-  useEffect(() => {
-    if (focusedPaymentIndex >= 0 && paymentListRef.current) {
-      const focusedRow = paymentListRef.current.querySelector(`[data-payment-index="${focusedPaymentIndex}"]`)
-      if (focusedRow) {
-        focusedRow.scrollIntoView({
-          behavior: 'smooth',
-          block: 'nearest'
-        })
-      }
-    }
-  }, [focusedPaymentIndex])
 
   const handleSort = useCallback((field: string) => {
-    setFilters(prev => ({
+    pageState.setSorting((prev) => ({
       ...prev,
       sortBy: field,
-      sortOrder: prev.sortBy === field && prev.sortOrder === 'asc' ? 'desc' : 'asc',
+      sortOrder: prev.sortBy === field && prev.sortOrder === 'desc' ? 'asc' : 'desc',
     }))
-  }, [])
-
-  const getStatusColor = (status: string) => {
-    switch (status?.toLowerCase()) {
-      case 'completed':
-        return 'success'
-      case 'pending':
-        return 'warning'
-      case 'cancelled':
-        return 'error'
-      default:
-        return 'default'
-    }
-  }
-
-  // Keyboard navigation handlers
-  const handleNavigateUp = useCallback(() => {
-    if (focusedPaymentIndex > 0) {
-      const newIndex = focusedPaymentIndex - 1
-      setFocusedPaymentIndex(newIndex)
-      handlePaymentSelect(vendorPayments[newIndex])
-    }
-  }, [focusedPaymentIndex, vendorPayments, handlePaymentSelect])
-
-  const handleNavigateDown = useCallback(() => {
-    if (focusedPaymentIndex < vendorPayments.length - 1) {
-      const newIndex = focusedPaymentIndex + 1
-      setFocusedPaymentIndex(newIndex)
-      handlePaymentSelect(vendorPayments[newIndex])
-    }
-  }, [focusedPaymentIndex, vendorPayments, handlePaymentSelect])
-
-  const focusSearchInput = useCallback(() => {
-    searchInputRef.current?.focus()
-  }, [])
+  }, [pageState])
 
   useKeyboardShortcuts({
-    onSearch: focusSearchInput,
-    onArrowUp: handleNavigateUp,
-    onArrowDown: handleNavigateDown,
+    onSearch: selection.focusSearchInput,
+    onArrowUp: selection.handleNavigateUp,
+    onArrowDown: selection.handleNavigateDown,
   })
 
+  const navigateToJournalEntry = useCallback(() => {
+    if (!pageState.journalEntryRef) return
+    navigate(
+      `/accounting/journal-entries?sourceType=${pageState.journalEntryRef.sourceType}&sourceId=${pageState.journalEntryRef.sourceId}`,
+    )
+  }, [navigate, pageState.journalEntryRef])
+
   return (
-    <>
-      {/* Header */}
+    <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
       <PageHeader
         title="Vendor Payments"
         subtitle="Track and manage payments to suppliers"
-        secondaryAction={{ label: 'View Deleted', onClick: () => setDeletedPaymentsDialogOpen(true) }}
+        variant="workflow"
+        secondaryAction={{ label: 'View Deleted', onClick: () => pageState.setDeletedPaymentsOpen(true) }}
+        toolbar={(
+          <FilterBar
+            config={filterConfig}
+            draftFilters={filterBar.draftFilters}
+            handlers={filterBar.handlers}
+            hasActiveFilters={filterBar.hasActiveFilters}
+            searchInputRef={pageState.searchInputRef}
+            sort={{
+              field: 'paymentNumber',
+              sortBy: pageState.sorting.sortBy,
+              sortOrder: pageState.sorting.sortOrder,
+              onSort: handleSort,
+            }}
+          />
+        )}
       />
-      {/* Filters and Search */}
-      <Box sx={{ mb: 3 }}>
-      <Box sx={{
-        display: 'flex',
-        flexDirection: isMobile ? 'column' : 'row',
-        gap: isMobile ? 2 : 1,
-        alignItems: isMobile ? 'stretch' : 'center',
-        '& > *': {
-          alignSelf: isMobile ? 'stretch' : 'flex-start'
-        }
-      }}>
-        <TextField
-          inputRef={searchInputRef}
-          placeholder="Search payments..."
-          value={filters.search}
-          onChange={(e) => setFilters((prev) => ({ ...prev, search: e.target.value }))}
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 250,
-            flex: isMobile ? 'none' : 1,
-            maxWidth: isMobile ? 'none' : 400,
-            '& .MuiOutlinedInput-root': {
-              height: '40px',
-              fontSize: '0.875rem',
-              '& input': {
-                padding: '8.5px 14px',
-                fontSize: '0.875rem'
-              }
-            }
-          }}
-          slotProps={{
-            input: {
-              startAdornment: (
-                <InputAdornment position="start">
-                  <SearchIcon sx={{ fontSize: '1.25rem' }} />
-                </InputAdornment>
-              ),
-            },
-          }}
-        />
 
-        <FormControl
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 120,
-            width: isMobile ? 'auto' : 120,
-            '& .MuiOutlinedInput-root': {
-              height: '40px',
-            }
-          }}
-        >
-          <InputLabel>Date Filter</InputLabel>
-          <Select
-            value={filters.dateFilter}
-            label="Date Filter"
-            onChange={(e) => setFilters(prev => ({ ...prev, dateFilter: e.target.value }))}
-            sx={{ fontSize: '0.875rem' }}
-          >
-            <MenuItem value="all">All</MenuItem>
-            <MenuItem value="today">Today</MenuItem>
-            <MenuItem value="yesterday">Yesterday</MenuItem>
-            <MenuItem value="this_week">This Week</MenuItem>
-            <MenuItem value="this_month">This Month</MenuItem>
-            <MenuItem value="this_year">This Year</MenuItem>
-            <Divider />
-            <MenuItem value="custom">Custom Date Range</MenuItem>
-          </Select>
-        </FormControl>
-
-        {filters.dateFilter === 'custom' && (
-          <>
-            <TextField
-              label="From Date"
-              type="date"
-              value={filters.customFromDate}
-              onChange={(e) => setFilters(prev => ({ ...prev, customFromDate: e.target.value }))}
-              size="medium"
-              sx={{
-                minWidth: isMobile ? 'auto' : 120,
-                '& .MuiOutlinedInput-root': {
-                  height: '40px',
-                  fontSize: '0.875rem',
-                }
-              }}
-              slotProps={{ inputLabel: { shrink: true } }}
-            />
-            <TextField
-              label="To Date"
-              type="date"
-              value={filters.customToDate}
-              onChange={(e) => setFilters(prev => ({ ...prev, customToDate: e.target.value }))}
-              size="medium"
-              sx={{
-                minWidth: isMobile ? 'auto' : 120,
-                '& .MuiOutlinedInput-root': {
-                  height: '40px',
-                  fontSize: '0.875rem',
-                }
-              }}
-              slotProps={{ inputLabel: { shrink: true } }}
-            />
-          </>
-        )}
-
-        <FormControl
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 120,
-            width: isMobile ? 'auto' : 120,
-            '& .MuiOutlinedInput-root': {
-              height: '40px',
-              fontSize: '0.875rem'
-            }
-          }}
-        >
-          <InputLabel>Status</InputLabel>
-          <Select
-            value={filters.status}
-            label="Status"
-            onChange={(e) => setFilters((prev) => ({ ...prev, status: e.target.value }))}
-            sx={{
-              fontSize: '0.875rem',
-              '& .MuiSelect-select': {
-                padding: '8.5px 14px',
-                fontSize: '0.875rem'
-              }
-            }}
-          >
-            <MenuItem value="all">All</MenuItem>
-            <MenuItem value="pending">Pending</MenuItem>
-            <MenuItem value="completed">Completed</MenuItem>
-            <MenuItem value="cancelled">Cancelled</MenuItem>
-          </Select>
-        </FormControl>
-
-        <FormControl
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 140,
-            width: isMobile ? 'auto' : 140,
-            '& .MuiOutlinedInput-root': {
-              height: '40px',
-              fontSize: '0.875rem'
-            }
-          }}
-        >
-          <InputLabel>Payment Method</InputLabel>
-          <Select
-            value={filters.paymentMethodId}
-            label="Payment Method"
-            onChange={(e) => setFilters((prev) => ({ ...prev, paymentMethodId: e.target.value }))}
-            sx={{
-              fontSize: '0.875rem',
-              '& .MuiSelect-select': {
-                padding: '8.5px 14px',
-                fontSize: '0.875rem'
-              }
-            }}
-          >
-            <MenuItem value="all">All</MenuItem>
-            {paymentMethods.map((method) => (
-              <MenuItem key={method.id} value={method.id}>
-                {method.name}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-
-        {(filters.dateFilter !== 'all' || filters.status !== 'all' || filters.paymentMethodId !== 'all' || filters.search) && (
-          <Button
-            variant="outlined"
-            size="medium"
-            onClick={() => {
-              setFilters({
-                search: '',
-                sortBy: 'paymentNumber',
-                sortOrder: 'asc',
-                status: 'all',
-                paymentMethodId: 'all',
-                dateFilter: 'all',
-                customFromDate: '',
-                customToDate: '',
-              })
-            }}
-            sx={{
-              minWidth: 'auto',
-              px: 2,
-              height: '40px',
-              fontSize: '0.875rem'
-            }}
-          >
-            Clear Filters
-          </Button>
-        )}
-
-        <Button
-          variant={filters.sortBy === 'paymentNumber' ? 'contained' : 'outlined'}
-          size="medium"
-          startIcon={filters.sortBy === 'paymentNumber' ? (filters.sortOrder === 'asc' ? <ArrowUpIcon /> : <ArrowDownIcon />) : <SortIcon />}
-          onClick={() => handleSort('paymentNumber')}
-          sx={{
-            height: '40px',
-            fontSize: '0.875rem',
-            minWidth: 'auto',
-            px: 2
-          }}
-        >
-          Sort
-        </Button>
-      </Box>
-      </Box>
-      {/* Error Display */}
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>
           {error}
         </Alert>
       )}
-      {/* Split Layout: Payment List and Payment Details */}
-      <Grid container spacing={3}>
-        {/* Left Side - Payment List */}
-        <Grid
-          size={{
-            xs: 12,
-            md: 3
-          }}>
-          <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', flexDirection: 'column' }}>
-            <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
-              <Typography variant="tableHeader" sx={{
-                fontWeight: 600,
-                fontSize: '0.8rem',
-                textTransform: 'uppercase',
-                letterSpacing: '0.5px'
-              }}>
-                VP List ({vendorPayments.length})
-              </Typography>
-            </Box>
 
-            <TableContainer sx={{ flex: 1, overflow: 'auto' }} ref={paymentListRef}>
-              <Table
-                size={TABLE_STYLES.size}
-                sx={{
-                  '& .MuiTableCell-root': {
-                    borderBottom: TABLE_STYLES.cell.border,
-                    py: TABLE_STYLES.cell.padding.py * 0.75,
-                    px: TABLE_STYLES.cell.padding.px * 0.75
-                  }
-                }}
-              >
-                <TableBody>
-                  {loading && vendorPayments.length === 0 ? (
-                    [...Array(10)].map((_, i) => (
-                      <TableRow key={`skeleton-${i}`}>
-                        <TableCell>
-                          <Skeleton height={40} />
-                        </TableCell>
-                      </TableRow>
-                    ))
-                  ) : (
-                    vendorPayments.map((payment: any, index: number) => (
-                      <PaymentRow
-                        key={payment.id}
-                        payment={payment}
-                        index={index}
-                        selectedPaymentId={selectedPayment?.id}
-                        focusedPaymentIndex={focusedPaymentIndex}
-                        onPaymentSelect={handlePaymentSelect}
-                      />
-                    ))
-                  )}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          </Paper>
-        </Grid>
-
-        {/* Right Side - Payment Details */}
-        <Grid
-          size={{
-            xs: 12,
-            md: 9
-          }}>
-          {selectedPayment ? (
-            <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', flexDirection: 'column' }}>
-              {/* Header with Payment Info */}
-              <Box sx={{
-                p: TABLE_STYLES.cell.padding.px,
-                borderBottom: TABLE_STYLES.cell.border,
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center'
-              }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-                  <Typography variant="tableHeader" sx={{
-                    fontWeight: 600,
-                    fontSize: '0.8rem',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px'
-                  }}>
-                    VP Details - {selectedPayment.paymentNumber}
-                  </Typography>
-                  <Chip
-                    label={selectedPayment.status}
-                    size="small"
-                    color={getStatusColor(selectedPayment.status) as any}
-                    sx={{
-                      textTransform: 'capitalize',
-                      fontSize: '0.75rem',
-                      fontWeight: 600
-                    }}
-                  />
-                </Box>
-                <Box>
-                  <IconButton
-                    size="small"
-                    title="Print Payment"
-                    onClick={() => setPrintDialogOpen(true)}
-                    sx={{
-                      height: `${TABLE_STYLES.row.height * 0.75}px`,
-                      width: `${TABLE_STYLES.row.height * 0.75}px`,
-                      minHeight: 20,
-                      minWidth: 20,
-                      p: 0.125,
-                      color: 'info.main',
-                      '&:hover': {
-                        backgroundColor: 'info.light',
-                        color: 'info.dark'
-                      }
-                    }}
-                  >
-                    <PrintIcon sx={{
-                      fontSize: `${TABLE_STYLES.row.height * 0.5}px`
-                    }} />
-                  </IconButton>
-                </Box>
-              </Box>
-
-              <Box sx={{ flex: 1, overflow: 'auto', p: TABLE_STYLES.cell.padding.px }}>
-                {/* Payment Details Section */}
-                <Grid container spacing={3}>
-                  {/* Left Column - Payment Information */}
-                  <Grid
-                    size={{
-                      xs: 12,
-                      md: 6
-                    }}>
-                    <TableContainer>
-                      <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': { border: 'none', py: 0.75, px: 1 } }}>
-                        <TableBody>
-                          <TableRow>
-                            <TableCell colSpan={2} sx={{ pb: 0.5, borderTop: TABLE_STYLES.cell.border }}>
-                              <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.9rem' }}>
-                                VP Information
-                              </Typography>
-                            </TableCell>
-                          </TableRow>
-                          <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                            <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem', width: '40%' }}>
-                              Supplier
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem' }}>
-                              {selectedPayment.supplier?.companyName || 'Unknown'}
-                            </TableCell>
-                          </TableRow>
-                          <TableRow>
-                            <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                              VP Amount
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem', fontWeight: 600, color: 'primary.main' }}>
-                              {formatCurrency(selectedPayment.amount)}
-                            </TableCell>
-                          </TableRow>
-                          {selectedPayment.purchaseOrder && (
-                            <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                              <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                                PO Amount
-                              </TableCell>
-                              <TableCell sx={{ fontSize: '0.8rem' }}>
-                                {formatCurrency(selectedPayment.purchaseOrder.totalAmount)}
-                              </TableCell>
-                            </TableRow>
-                          )}
-                          <TableRow>
-                            <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                              Payment Date
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem' }}>
-                              {formatDate(selectedPayment.paymentDate)}
-                            </TableCell>
-                          </TableRow>
-                          {selectedPayment.referenceNumber && (
-                            <TableRow>
-                              <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                                Reference Number
-                              </TableCell>
-                              <TableCell sx={{ fontSize: '0.8rem' }}>
-                                {selectedPayment.referenceNumber}
-                              </TableCell>
-                            </TableRow>
-                          )}
-                        </TableBody>
-                      </Table>
-                    </TableContainer>
-                  </Grid>
-
-                  {/* Right Column - Amount Information */}
-                  <Grid
-                    size={{
-                      xs: 12,
-                      md: 6
-                    }}>
-                    <TableContainer>
-                      <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': { border: 'none', py: 0.75, px: 1 } }}>
-                        <TableBody>
-                          <TableRow>
-                            <TableCell colSpan={2} sx={{ pb: 0.5, borderTop: TABLE_STYLES.cell.border }}>
-                              <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.9rem' }}>
-                                Related Information
-                              </Typography>
-                            </TableCell>
-                          </TableRow>
-                          {selectedPayment.purchaseOrder && (
-                            <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                              <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem', width: '40%' }}>
-                                PO No
-                              </TableCell>
-                              <TableCell sx={{ fontSize: '0.8rem' }}>
-                                <Typography
-                                  component="button"
-                                  sx={{
-                                    fontSize: '0.8rem',
-                                    color: 'primary.main',
-                                    cursor: 'pointer',
-                                    textDecoration: 'none',
-                                    border: 'none',
-                                    background: 'none',
-                                    padding: 0,
-                                    '&:hover': {
-                                      color: 'primary.dark'
-                                    }
-                                  }}
-                                  onClick={() => navigate(`/purchasing/orders?poId=${selectedPayment.purchaseOrder.id}`)}
-                                >
-                                  {selectedPayment.purchaseOrder.orderNumber}
-                                </Typography>
-                              </TableCell>
-                            </TableRow>
-                          )}
-                          {selectedPayment.grn && (
-                            <TableRow>
-                              <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                                GRN No
-                              </TableCell>
-                              <TableCell sx={{ fontSize: '0.8rem' }}>
-                                <Typography
-                                  component="button"
-                                  sx={{
-                                    fontSize: '0.8rem',
-                                    color: 'primary.main',
-                                    cursor: 'pointer',
-                                    textDecoration: 'none',
-                                    border: 'none',
-                                    background: 'none',
-                                    padding: 0,
-                                    '&:hover': {
-                                      color: 'primary.dark'
-                                    }
-                                  }}
-                                  onClick={() => navigate(`/purchasing/goods-received?grnId=${selectedPayment.grn.id}`)}
-                                >
-                                  {selectedPayment.grn.grnNumber}
-                                </Typography>
-                              </TableCell>
-                            </TableRow>
-                          )}
-                          <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                            <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                              Journal Entry
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem' }}>
-                              {journalEntryRef ? (
-                                <Typography
-                                  component="button"
-                                  sx={{
-                                    fontSize: '0.8rem',
-                                    color: 'primary.main',
-                                    cursor: 'pointer',
-                                    textDecoration: 'none',
-                                    border: 'none',
-                                    background: 'none',
-                                    padding: 0,
-                                    '&:hover': {
-                                      color: 'primary.dark'
-                                    }
-                                  }}
-                                  onClick={() => navigate(`/accounting/journal-entries/${journalEntryRef.id}`)}
-                                >
-                                  {journalEntryRef.referenceNumber}
-                                </Typography>
-                              ) : (
-                                <Typography variant="body2" sx={{ color: 'text.disabled', fontSize: '0.8rem' }}>
-                                  —
-                                </Typography>
-                              )}
-                            </TableCell>
-                          </TableRow>
-                        </TableBody>
-                      </Table>
-                    </TableContainer>
-                  </Grid>
-
-                </Grid>
-
-                {/* Page Break */}
-                <Box sx={{ borderTop: '2px solid', borderColor: 'divider', my: 3 }} />
-
-                {/* Payment Items Section */}
-                <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-                  <Typography variant="tableHeader" sx={{
-                    fontWeight: 600,
-                    fontSize: '0.8rem',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px',
-                    mb: 1
-                  }}>
-                    Payment Items
-                  </Typography>
-
-                  {selectedPayment.purchaseOrder?.items && selectedPayment.purchaseOrder.items.length > 0 ? (
-                    <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
-                      <Table
-                        size={TABLE_STYLES.size}
-                        sx={{
-                          '& .MuiTableCell-root': {
-                            borderBottom: TABLE_STYLES.cell.border,
-                            py: TABLE_STYLES.cell.padding.py,
-                            px: TABLE_STYLES.cell.padding.px
-                          }
-                        }}
-                      >
-                        <TableHead>
-                          <TableRow sx={{ '& .MuiTableCell-head': {
-                            fontWeight: 600,
-                            backgroundColor: 'grey.50',
-                            color: 'text.primary',
-                            fontSize: '0.8rem'
-                          } }}>
-                            <TableCell sx={{ width: '40%' }}>Product</TableCell>
-                            <TableCell align="center" sx={{ width: '12%' }}>Quantity</TableCell>
-                            <TableCell align="right" sx={{ width: '16%' }}>Unit Cost</TableCell>
-                            <TableCell align="right" sx={{ width: '16%' }}>Discount</TableCell>
-                            <TableCell align="right" sx={{ width: '16%' }}>Total</TableCell>
-                          </TableRow>
-                        </TableHead>
-                        <TableBody>
-                          {selectedPayment.purchaseOrder.items.map((item: any, index: number) => (
-                            <TableRow
-                              key={item.id || index}
-                              hover
-                              sx={{
-                                '&:hover': { backgroundColor: 'action.hover' },
-                                transition: 'background-color 0.2s ease',
-                                height: TABLE_STYLES.row.height
-                              }}
-                            >
-                              <TableCell sx={{ fontSize: '0.8rem' }}>
-                                {item.product?.name || 'Unknown Product'}
-                              </TableCell>
-                              <TableCell align="center" sx={{ fontSize: '0.8rem' }}>
-                                {formatWholeQuantity(item.quantity)}
-                              </TableCell>
-                              <TableCell align="right" sx={{ fontSize: '0.8rem' }}>
-                                {formatCurrency(item.unitCost)}
-                              </TableCell>
-                              <TableCell align="right" sx={{ fontSize: '0.8rem' }}>
-                                {item.discountType === 'percentage' && parseFloat(item.discountPercent) > 0 ? (
-                                  `${item.discountPercent}%`
-                                ) : parseFloat(item.discountAmount) > 0 ? (
-                                  `-${formatCurrency(item.discountAmount)}`
-                                ) : (
-                                  '-'
-                                )}
-                              </TableCell>
-                              <TableCell align="right" sx={{ fontSize: '0.8rem' }}>
-                                {formatCurrency(item.totalAmount)}
-                              </TableCell>
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    </TableContainer>
-                  ) : (
-                    <Alert severity="info">No payment items available</Alert>
-                  )}
-                </Box>
-
-                {/* Payment Notes Section */}
-                <Box sx={{ mt: 2 }}>
-                  <TableContainer>
-                    <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': { border: 'none', py: 0.75, px: 1 } }}>
-                      <TableBody>
-                        <TableRow>
-                          <TableCell sx={{ pb: 0.5, borderTop: TABLE_STYLES.cell.border }}>
-                            <Typography variant="h6" sx={{ fontWeight: 600, color: 'info.main', fontSize: '0.9rem' }}>
-                              Notes
-                            </Typography>
-                          </TableCell>
-                        </TableRow>
-                        <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                          <TableCell sx={{ fontSize: '0.8rem' }}>
-                            {selectedPayment.purchaseOrder && selectedPayment.grn ? (
-                              `Payment recorded for purchase order ${selectedPayment.purchaseOrder.orderNumber} (GRN: ${selectedPayment.grn.grnNumber})`
-                            ) : selectedPayment.purchaseOrder ? (
-                              `Payment recorded for purchase order ${selectedPayment.purchaseOrder.orderNumber}`
-                            ) : selectedPayment.grn ? (
-                              `Payment recorded for GRN ${selectedPayment.grn.grnNumber}`
-                            ) : (
-                              selectedPayment.notes || 'Payment recorded'
-                            )}
-                          </TableCell>
-                        </TableRow>
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
-                </Box>
-
-                </Box>
-            </Paper>
-          ) : (
-            <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-              <Typography variant="h6" sx={{
-                color: "text.secondary"
-              }}>
-                Select a payment to view details
-              </Typography>
-            </Paper>
-          )}
-        </Grid>
-      </Grid>
-      {/* Deleted Vendor Payments Dialog */}
-      <DeletedVendorPaymentsDialog
-        open={deletedPaymentsDialogOpen}
-        onClose={() => setDeletedPaymentsDialogOpen(false)}
+      <MasterDetailWorkspace
+        isMobile={isMobile}
+        listSlot={(
+          <VendorPaymentTable
+            payments={payments}
+            loading={loading}
+            total={total}
+            selectedPaymentId={selectedPayment?.id}
+            focusedPaymentIndex={pageState.focusedPaymentIndex}
+            onPaymentSelect={selection.handlePaymentSelect}
+            paymentListRef={pageState.paymentListRef}
+          />
+        )}
+        headerSlot={(
+          <VendorPaymentContextHeader
+            selectedPayment={selectedPayment}
+            journalEntryRef={pageState.journalEntryRef}
+            journalEntryRefLoading={pageState.journalEntryRefLoading}
+            onPrint={() => pageState.setPrintDialogOpen(true)}
+            onNavigateToJournalEntry={navigateToJournalEntry}
+          />
+        )}
+        workspaceSlot={<VendorPaymentWorkspaceCard selectedPayment={selectedPayment} />}
       />
-      {/* Print Dialog */}
-      {selectedPayment && (
-        <VendorPaymentPrint
-          open={printDialogOpen}
-          onClose={() => setPrintDialogOpen(false)}
-          payment={selectedPayment}
-        />
-      )}
-    </>
-  );
+
+      <VendorPaymentsDialogs
+        selectedPayment={selectedPayment}
+        deletedPaymentsOpen={pageState.deletedPaymentsOpen}
+        onCloseDeletedPayments={() => pageState.setDeletedPaymentsOpen(false)}
+        printDialogOpen={pageState.printDialogOpen}
+        onClosePrintDialog={() => pageState.setPrintDialogOpen(false)}
+      />
+    </Box>
+  )
 }
 
 export default VendorPaymentsPage

--- a/frontend/src/pages/purchasing/__tests__/VendorPaymentsPage.filterbar.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/VendorPaymentsPage.filterbar.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import VendorPaymentsPage from '../VendorPaymentsPage'
+import purchasingReducer from '@/store/slices/purchasingSlice'
+
+const { useGetVendorPaymentsQuery } = vi.hoisted(() => ({
+  useGetVendorPaymentsQuery: vi.fn(() => ({
+    data: { data: [], meta: { total: 0 } },
+    isFetching: false,
+    error: null,
+  })),
+}))
+
+const filterBarSpy = vi.fn()
+
+vi.mock('@/store/api/purchasingApi', () => ({
+  useGetVendorPaymentsQuery,
+  useLazyGetVendorPaymentQuery: vi.fn(() => [vi.fn()]),
+  useGetSuppliersQuery: vi.fn(() => ({
+    data: { data: [{ id: 'sup-1', companyName: 'Anaheim Electronics' }] },
+  })),
+}))
+
+vi.mock('@/store/api/accountingApi', () => ({
+  useLazyGetJournalEntriesQuery: vi.fn(() => [vi.fn()]),
+}))
+
+vi.mock('@/components/filters', () => ({
+  FilterBar: (props: unknown) => {
+    filterBarSpy(props)
+    return (
+      <div>
+        <input placeholder="Search vendor payments..." />
+      </div>
+    )
+  },
+}))
+
+vi.mock('@/components/common/MasterDetailWorkspace', () => ({
+  default: ({ listSlot, headerSlot, workspaceSlot }: any) => (
+    <div>
+      <div>MasterDetailWorkspace</div>
+      <div>{listSlot}</div>
+      <div>{headerSlot}</div>
+      <div>{workspaceSlot}</div>
+    </div>
+  ),
+}))
+
+vi.mock('../components/VendorPaymentContextHeader', () => ({ default: () => <div>VendorPaymentContextHeader</div> }))
+vi.mock('../components/VendorPaymentTable', () => ({ default: () => <div>VendorPaymentTable</div> }))
+vi.mock('../components/VendorPaymentWorkspaceCard', () => ({ default: () => <div>VendorPaymentWorkspaceCard</div> }))
+vi.mock('../components/VendorPaymentsDialogs', () => ({ default: () => <div>VendorPaymentsDialogs</div> }))
+vi.mock('../hooks/useVendorPaymentsSelection', () => ({
+  useVendorPaymentsSelection: () => ({
+    handlePaymentSelect: vi.fn(),
+    handleNavigateUp: vi.fn(),
+    handleNavigateDown: vi.fn(),
+    focusSearchInput: vi.fn(),
+  }),
+}))
+
+function renderPage(initialUrl = '/') {
+  const store = configureStore({
+    reducer: { purchasing: purchasingReducer },
+  })
+
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <VendorPaymentsPage />
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('VendorPaymentsPage FilterBar integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the shared filter search input', () => {
+    renderPage()
+    expect(screen.getByPlaceholderText(/search vendor payments/i)).toBeInTheDocument()
+  })
+
+  it('renders the master-detail workspace with VP components', () => {
+    renderPage()
+    expect(screen.getByText('MasterDetailWorkspace')).toBeInTheDocument()
+    expect(screen.getByText('VendorPaymentTable')).toBeInTheDocument()
+    expect(screen.getByText('VendorPaymentWorkspaceCard')).toBeInTheDocument()
+  })
+
+  it('passes search and supplierId from URL params to the query', () => {
+    renderPage('/?search=vp-001&supplierId=sup-1')
+    expect(useGetVendorPaymentsQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        search: 'vp-001',
+        supplierId: 'sup-1',
+      }),
+    )
+  })
+
+  it('passes status filter to the query', () => {
+    renderPage('/?status=completed')
+    expect(useGetVendorPaymentsQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        status: 'completed',
+      }),
+    )
+  })
+
+  it('configures the supplier filter with the supplier type', () => {
+    renderPage()
+    const latestProps = filterBarSpy.mock.calls.at(-1)?.[0] as {
+      config: { fields: Array<{ field: string; type: string }> }
+    }
+    expect(latestProps.config.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'supplierId', type: 'supplier' }),
+      ]),
+    )
+  })
+
+  it('configures the status filter with purchasing-status type', () => {
+    renderPage()
+    const latestProps = filterBarSpy.mock.calls.at(-1)?.[0] as {
+      config: { fields: Array<{ field: string; type: string }> }
+    }
+    expect(latestProps.config.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'status', type: 'purchasing-status' }),
+      ]),
+    )
+  })
+
+  it('sends no startDate or endDate when period is not selected (default)', () => {
+    renderPage()
+    expect(useGetVendorPaymentsQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        startDate: undefined,
+        endDate: undefined,
+      }),
+    )
+  })
+
+  it('restores period=this_week from URL and resolves to startDate/endDate in the query', () => {
+    renderPage('/?period=this_week')
+    expect(useGetVendorPaymentsQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        startDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        endDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      }),
+    )
+  })
+
+  it('sort default is paymentNumber', () => {
+    renderPage()
+    const latestProps = filterBarSpy.mock.calls.at(-1)?.[0] as {
+      sort: { field: string }
+    }
+    expect(latestProps.sort.field).toBe('paymentNumber')
+  })
+})

--- a/frontend/src/pages/purchasing/__tests__/VendorPaymentsPage.filterbar.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/VendorPaymentsPage.filterbar.test.tsx
@@ -126,14 +126,14 @@ describe('VendorPaymentsPage FilterBar integration', () => {
     )
   })
 
-  it('configures the status filter with purchasing-status type', () => {
+  it('configures the status filter with vendor-payment-status type', () => {
     renderPage()
     const latestProps = filterBarSpy.mock.calls.at(-1)?.[0] as {
       config: { fields: Array<{ field: string; type: string }> }
     }
     expect(latestProps.config.fields).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ field: 'status', type: 'purchasing-status' }),
+        expect.objectContaining({ field: 'status', type: 'vendor-payment-status' }),
       ]),
     )
   })

--- a/frontend/src/pages/purchasing/components/VendorPaymentContextHeader.tsx
+++ b/frontend/src/pages/purchasing/components/VendorPaymentContextHeader.tsx
@@ -1,0 +1,235 @@
+import React from 'react'
+import { default as PrintIcon } from '@mui/icons-material/Print'
+import {
+  Box,
+  IconButton,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+} from '@mui/material'
+import Grid from '@mui/material/Grid'
+import { useNavigate } from 'react-router-dom'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { VendorPayment } from '@/types'
+import { formatCurrency, formatDate } from '@/utils/formatters'
+
+import type { VPJournalEntryRef } from '../hooks/useVendorPaymentsPageState'
+
+interface VendorPaymentContextHeaderProps {
+  selectedPayment: VendorPayment | null
+  journalEntryRef: VPJournalEntryRef | null
+  journalEntryRefLoading: boolean
+  onPrint: () => void
+  onNavigateToJournalEntry: () => void
+}
+
+const actionIconSx = {
+  height: `${TABLE_STYLES.row.height * 0.75}px`,
+  width: `${TABLE_STYLES.row.height * 0.75}px`,
+  minHeight: 20,
+  minWidth: 20,
+  p: 0.125,
+}
+
+const detailTableSx = {
+  tableLayout: 'fixed' as const,
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const labelCellSx = { fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }
+const valueCellSx = { fontSize: '0.8rem' }
+
+const VendorPaymentContextHeader: React.FC<VendorPaymentContextHeaderProps> = ({
+  selectedPayment,
+  journalEntryRef,
+  journalEntryRefLoading,
+  onPrint,
+  onNavigateToJournalEntry,
+}) => {
+  const navigate = useNavigate()
+
+  if (!selectedPayment) {
+    return (
+      <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
+        <Typography variant="h6" sx={{ color: 'text.secondary' }}>
+          Select a vendor payment to view details
+        </Typography>
+      </Paper>
+    )
+  }
+
+  const handleNavigateToPO = () => {
+    if (selectedPayment.purchaseOrder?.id) {
+      navigate(`/purchasing/purchase-orders?poId=${selectedPayment.purchaseOrder.id}`)
+    }
+  }
+
+  return (
+    <Paper sx={{ overflow: 'hidden' }}>
+      <Box
+        sx={{
+          p: TABLE_STYLES.cell.padding.px,
+          borderBottom: TABLE_STYLES.cell.border,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Typography
+          variant="tableHeader"
+          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+        >
+          Payment Details — {selectedPayment.paymentNumber}
+        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+          <IconButton size="small" title="Print Payment" onClick={onPrint} sx={{ ...actionIconSx, color: 'info.main' }}>
+            <PrintIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
+          </IconButton>
+        </Box>
+      </Box>
+
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell
+                      colSpan={2}
+                      sx={{
+                        pb: TABLE_STYLES.cell.padding.py * 0.67,
+                        py: TABLE_STYLES.cell.padding.py * 0.67,
+                        borderTop: TABLE_STYLES.cell.border,
+                      }}
+                    >
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Payment Information
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Payment Number</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedPayment.paymentNumber}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Status</TableCell>
+                    <TableCell sx={valueCellSx} style={{ textTransform: 'capitalize' }}>
+                      {selectedPayment.status}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Payment Date</TableCell>
+                    <TableCell sx={valueCellSx}>{formatDate(selectedPayment.paymentDate)}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Journal Entry</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {journalEntryRefLoading ? (
+                        <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}>
+                          Loading...
+                        </Typography>
+                      ) : journalEntryRef ? (
+                        <Typography
+                          component="button"
+                          onClick={onNavigateToJournalEntry}
+                          sx={{
+                            fontSize: '0.8rem',
+                            color: 'primary.main',
+                            cursor: 'pointer',
+                            textDecoration: 'none',
+                            border: 'none',
+                            background: 'none',
+                            padding: 0,
+                          }}
+                        >
+                          {journalEntryRef.referenceNumber}
+                        </Typography>
+                      ) : (
+                        <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}>
+                          Pending
+                        </Typography>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell
+                      colSpan={2}
+                      sx={{
+                        pb: TABLE_STYLES.cell.padding.py * 0.67,
+                        py: TABLE_STYLES.cell.padding.py * 0.67,
+                        borderTop: TABLE_STYLES.cell.border,
+                      }}
+                    >
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Supplier & Order
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Supplier</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedPayment.supplier?.companyName || '—'}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Purchase Order</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {selectedPayment.purchaseOrder ? (
+                        <Typography
+                          component="button"
+                          onClick={handleNavigateToPO}
+                          sx={{
+                            fontSize: '0.8rem',
+                            color: 'primary.main',
+                            cursor: 'pointer',
+                            textDecoration: 'none',
+                            border: 'none',
+                            background: 'none',
+                            padding: 0,
+                          }}
+                        >
+                          {selectedPayment.purchaseOrder.orderNumber}
+                        </Typography>
+                      ) : '—'}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Amount</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(selectedPayment.amount)}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Payment Method</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {selectedPayment.paymentMethodEntity?.name ?? selectedPayment.paymentMethodId ?? '—'}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+        </Grid>
+      </Box>
+    </Paper>
+  )
+}
+
+export default VendorPaymentContextHeader

--- a/frontend/src/pages/purchasing/components/VendorPaymentTable.tsx
+++ b/frontend/src/pages/purchasing/components/VendorPaymentTable.tsx
@@ -1,7 +1,6 @@
 import React, { memo } from 'react'
 import {
   Box,
-  Chip,
   Paper,
   Skeleton,
   Table,
@@ -14,7 +13,6 @@ import {
 
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { VendorPayment } from '@/types'
-import { formatCurrency, formatDate } from '@/utils/formatters'
 
 interface VendorPaymentRowProps {
   payment: VendorPayment
@@ -22,12 +20,6 @@ interface VendorPaymentRowProps {
   selectedPaymentId?: string
   focusedPaymentIndex: number
   onPaymentSelect: (payment: VendorPayment) => void
-}
-
-const statusColor = (status: VendorPayment['status']): 'default' | 'success' | 'error' => {
-  if (status === 'completed') return 'success'
-  if (status === 'cancelled') return 'error'
-  return 'default'
 }
 
 const VendorPaymentRow = memo(({
@@ -59,28 +51,9 @@ const VendorPaymentRow = memo(({
       }}
     >
       <TableCell>
-        <Typography variant="body2" sx={{ fontWeight: 600, fontSize: '0.8rem', lineHeight: 1.2 }}>
+        <Typography variant="body2" sx={{ fontWeight: 400, fontSize: '0.8rem', lineHeight: 1.2 }}>
           {payment.paymentNumber}
         </Typography>
-        <Typography variant="body2" sx={{ fontSize: '0.75rem', color: 'text.secondary', lineHeight: 1.2 }}>
-          {payment.supplier?.companyName}
-        </Typography>
-      </TableCell>
-      <TableCell align="right" sx={{ whiteSpace: 'nowrap' }}>
-        <Typography variant="body2" sx={{ fontSize: '0.8rem', lineHeight: 1.2 }}>
-          {formatCurrency(payment.amount)}
-        </Typography>
-        <Typography variant="body2" sx={{ fontSize: '0.75rem', color: 'text.secondary', lineHeight: 1.2 }}>
-          {formatDate(payment.paymentDate)}
-        </Typography>
-      </TableCell>
-      <TableCell align="right" sx={{ width: 90 }}>
-        <Chip
-          label={payment.status}
-          size="small"
-          color={statusColor(payment.status)}
-          sx={{ fontSize: '0.7rem', height: 20, textTransform: 'capitalize' }}
-        />
       </TableCell>
     </TableRow>
   )
@@ -124,7 +97,7 @@ const VendorPaymentTable: React.FC<VendorPaymentTableProps> = ({
               {loading && payments.length === 0
                 ? [...Array(10)].map((_, index) => (
                     <TableRow key={`skeleton-${index}`}>
-                      <TableCell colSpan={3}>
+                      <TableCell>
                         <Skeleton height={40} />
                       </TableCell>
                     </TableRow>

--- a/frontend/src/pages/purchasing/components/VendorPaymentTable.tsx
+++ b/frontend/src/pages/purchasing/components/VendorPaymentTable.tsx
@@ -1,0 +1,150 @@
+import React, { memo } from 'react'
+import {
+  Box,
+  Chip,
+  Paper,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+} from '@mui/material'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { VendorPayment } from '@/types'
+import { formatCurrency, formatDate } from '@/utils/formatters'
+
+interface VendorPaymentRowProps {
+  payment: VendorPayment
+  index: number
+  selectedPaymentId?: string
+  focusedPaymentIndex: number
+  onPaymentSelect: (payment: VendorPayment) => void
+}
+
+const statusColor = (status: VendorPayment['status']): 'default' | 'success' | 'error' => {
+  if (status === 'completed') return 'success'
+  if (status === 'cancelled') return 'error'
+  return 'default'
+}
+
+const VendorPaymentRow = memo(({
+  payment,
+  index,
+  selectedPaymentId,
+  focusedPaymentIndex,
+  onPaymentSelect,
+}: VendorPaymentRowProps) => {
+  const isSelected = selectedPaymentId === payment.id
+  const isFocused = index === focusedPaymentIndex
+
+  return (
+    <TableRow
+      hover
+      onClick={() => onPaymentSelect(payment)}
+      data-payment-index={index}
+      sx={{
+        cursor: 'pointer',
+        backgroundColor: isSelected ? 'action.selected' : isFocused ? 'action.focus' : 'inherit',
+        '&:hover': { backgroundColor: isSelected ? 'action.selected' : 'action.hover' },
+        transition: 'background-color 0.2s ease',
+        height: TABLE_STYLES.row.height,
+        ...(isFocused && {
+          outline: '2px solid',
+          outlineColor: 'primary.main',
+          outlineOffset: '-2px',
+        }),
+      }}
+    >
+      <TableCell>
+        <Typography variant="body2" sx={{ fontWeight: 600, fontSize: '0.8rem', lineHeight: 1.2 }}>
+          {payment.paymentNumber}
+        </Typography>
+        <Typography variant="body2" sx={{ fontSize: '0.75rem', color: 'text.secondary', lineHeight: 1.2 }}>
+          {payment.supplier?.companyName}
+        </Typography>
+      </TableCell>
+      <TableCell align="right" sx={{ whiteSpace: 'nowrap' }}>
+        <Typography variant="body2" sx={{ fontSize: '0.8rem', lineHeight: 1.2 }}>
+          {formatCurrency(payment.amount)}
+        </Typography>
+        <Typography variant="body2" sx={{ fontSize: '0.75rem', color: 'text.secondary', lineHeight: 1.2 }}>
+          {formatDate(payment.paymentDate)}
+        </Typography>
+      </TableCell>
+      <TableCell align="right" sx={{ width: 90 }}>
+        <Chip
+          label={payment.status}
+          size="small"
+          color={statusColor(payment.status)}
+          sx={{ fontSize: '0.7rem', height: 20, textTransform: 'capitalize' }}
+        />
+      </TableCell>
+    </TableRow>
+  )
+})
+
+VendorPaymentRow.displayName = 'VendorPaymentRow'
+
+interface VendorPaymentTableProps {
+  payments: VendorPayment[]
+  loading: boolean
+  total: number
+  selectedPaymentId?: string
+  focusedPaymentIndex: number
+  onPaymentSelect: (payment: VendorPayment) => void
+  paymentListRef: React.RefObject<HTMLDivElement | null>
+}
+
+const VendorPaymentTable: React.FC<VendorPaymentTableProps> = ({
+  payments,
+  loading,
+  total,
+  selectedPaymentId,
+  focusedPaymentIndex,
+  onPaymentSelect,
+  paymentListRef,
+}) => {
+  return (
+    <Paper sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
+        <Typography
+          variant="tableHeader"
+          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+        >
+          Vendor Payments ({total})
+        </Typography>
+      </Box>
+      <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }} ref={paymentListRef}>
+        <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
+          <Table size={TABLE_STYLES.size}>
+            <TableBody>
+              {loading && payments.length === 0
+                ? [...Array(10)].map((_, index) => (
+                    <TableRow key={`skeleton-${index}`}>
+                      <TableCell colSpan={3}>
+                        <Skeleton height={40} />
+                      </TableCell>
+                    </TableRow>
+                  ))
+                : payments.map((payment, index) => (
+                    <VendorPaymentRow
+                      key={payment.id}
+                      payment={payment}
+                      index={index}
+                      selectedPaymentId={selectedPaymentId}
+                      focusedPaymentIndex={focusedPaymentIndex}
+                      onPaymentSelect={onPaymentSelect}
+                    />
+                  ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+    </Paper>
+  )
+}
+
+export default VendorPaymentTable

--- a/frontend/src/pages/purchasing/components/VendorPaymentWorkspaceCard.tsx
+++ b/frontend/src/pages/purchasing/components/VendorPaymentWorkspaceCard.tsx
@@ -1,80 +1,117 @@
 import React from 'react'
 import {
+  Alert,
   Box,
   Paper,
   Table,
   TableBody,
   TableCell,
   TableContainer,
+  TableHead,
   TableRow,
   Typography,
 } from '@mui/material'
 
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { VendorPayment } from '@/types'
-import { formatDate } from '@/utils/formatters'
+import { formatCurrency, formatWholeQuantity } from '@/utils/formatters'
 
 interface VendorPaymentWorkspaceCardProps {
   selectedPayment: VendorPayment | null
 }
-
-const detailTableSx = {
-  tableLayout: 'fixed' as const,
-  '& .MuiTableCell-root': {
-    borderBottom: TABLE_STYLES.cell.border,
-    py: TABLE_STYLES.cell.padding.py,
-    px: TABLE_STYLES.cell.padding.px,
-    '&:nth-of-type(1)': { width: '35%' },
-    '&:nth-of-type(2)': { width: '65%' },
-  },
-}
-
-const labelCellSx = { fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }
-const valueCellSx = { fontSize: '0.8rem' }
 
 const VendorPaymentWorkspaceCard: React.FC<VendorPaymentWorkspaceCardProps> = ({ selectedPayment }) => {
   if (!selectedPayment) {
     return <Paper sx={{ flex: 1 }} />
   }
 
+  const items = selectedPayment.purchaseOrder?.items ?? []
+
   return (
     <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
-        <Typography
-          variant="tableHeader"
-          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+      <TableContainer>
+        <Table
+          size={TABLE_STYLES.size}
+          sx={{
+            tableLayout: 'fixed',
+            '& .MuiTableCell-root': {
+              border: 'none',
+              py: TABLE_STYLES.cell.padding.py,
+              px: TABLE_STYLES.cell.padding.px,
+            },
+          }}
         >
-          Payment Details
-        </Typography>
-      </Box>
+          <TableBody>
+            <TableRow>
+              <TableCell
+                colSpan={4}
+                sx={{
+                  pb: TABLE_STYLES.cell.padding.py * 0.67,
+                  py: TABLE_STYLES.cell.padding.py * 0.67,
+                  borderTop: TABLE_STYLES.cell.border,
+                }}
+              >
+                <Typography
+                  variant="tableHeader"
+                  sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+                >
+                  PO Items
+                </Typography>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </TableContainer>
 
-      <Box sx={{ flex: 1, overflow: 'auto', p: TABLE_STYLES.cell.padding.px }}>
-        <TableContainer>
-          <Table size={TABLE_STYLES.size} sx={detailTableSx}>
-            <TableBody>
-              <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                <TableCell sx={labelCellSx}>Reference Number</TableCell>
-                <TableCell sx={valueCellSx}>{selectedPayment.referenceNumber || '—'}</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell sx={labelCellSx}>Notes</TableCell>
-                <TableCell sx={valueCellSx}>{selectedPayment.notes || '—'}</TableCell>
-              </TableRow>
-              <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                <TableCell sx={labelCellSx}>Created By</TableCell>
-                <TableCell sx={valueCellSx}>{selectedPayment.createdBy || '—'}</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell sx={labelCellSx}>Created At</TableCell>
-                <TableCell sx={valueCellSx}>{formatDate(selectedPayment.createdAt)}</TableCell>
-              </TableRow>
-              <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                <TableCell sx={labelCellSx}>Updated At</TableCell>
-                <TableCell sx={valueCellSx}>{formatDate(selectedPayment.updatedAt)}</TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
-        </TableContainer>
+      <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', p: TABLE_STYLES.cell.padding.px }}>
+        {items.length > 0 ? (
+          <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
+            <Table
+              size={TABLE_STYLES.size}
+              sx={{
+                '& .MuiTableCell-root': {
+                  borderBottom: TABLE_STYLES.cell.border,
+                  py: TABLE_STYLES.cell.padding.py,
+                  px: TABLE_STYLES.cell.padding.px,
+                },
+              }}
+            >
+              <TableHead>
+                <TableRow
+                  sx={{
+                    '& .MuiTableCell-head': {
+                      fontWeight: 600,
+                      backgroundColor: 'grey.50',
+                      color: 'text.primary',
+                      fontSize: '0.8rem',
+                    },
+                  }}
+                >
+                  <TableCell sx={{ width: '40%' }}>Product</TableCell>
+                  <TableCell align="center" sx={{ width: '20%' }}>Quantity</TableCell>
+                  <TableCell align="right" sx={{ width: '20%' }}>Unit Price</TableCell>
+                  <TableCell align="right" sx={{ width: '20%' }}>Total</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {items.map((item, index) => (
+                  <TableRow
+                    key={item.id ?? index}
+                    hover
+                    sx={{ '&:hover': { backgroundColor: 'action.hover' }, height: TABLE_STYLES.row.height }}
+                  >
+                    <TableCell sx={{ fontSize: '0.8rem' }}>{item.product?.name ?? 'Unknown Product'}</TableCell>
+                    <TableCell align="center" sx={{ fontSize: '0.8rem' }}>{formatWholeQuantity(item.quantity)}</TableCell>
+                    <TableCell align="right" sx={{ fontSize: '0.8rem' }}>{formatCurrency(item.unitPrice)}</TableCell>
+                    <TableCell align="right" sx={{ fontSize: '0.8rem' }}>{formatCurrency(item.total)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        ) : (
+          <Alert severity="info">No PO items available</Alert>
+        )}
       </Box>
     </Paper>
   )

--- a/frontend/src/pages/purchasing/components/VendorPaymentWorkspaceCard.tsx
+++ b/frontend/src/pages/purchasing/components/VendorPaymentWorkspaceCard.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+} from '@mui/material'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { VendorPayment } from '@/types'
+import { formatDate } from '@/utils/formatters'
+
+interface VendorPaymentWorkspaceCardProps {
+  selectedPayment: VendorPayment | null
+}
+
+const detailTableSx = {
+  tableLayout: 'fixed' as const,
+  '& .MuiTableCell-root': {
+    borderBottom: TABLE_STYLES.cell.border,
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '35%' },
+    '&:nth-of-type(2)': { width: '65%' },
+  },
+}
+
+const labelCellSx = { fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }
+const valueCellSx = { fontSize: '0.8rem' }
+
+const VendorPaymentWorkspaceCard: React.FC<VendorPaymentWorkspaceCardProps> = ({ selectedPayment }) => {
+  if (!selectedPayment) {
+    return <Paper sx={{ flex: 1 }} />
+  }
+
+  return (
+    <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
+        <Typography
+          variant="tableHeader"
+          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+        >
+          Payment Details
+        </Typography>
+      </Box>
+
+      <Box sx={{ flex: 1, overflow: 'auto', p: TABLE_STYLES.cell.padding.px }}>
+        <TableContainer>
+          <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+            <TableBody>
+              <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                <TableCell sx={labelCellSx}>Reference Number</TableCell>
+                <TableCell sx={valueCellSx}>{selectedPayment.referenceNumber || '—'}</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell sx={labelCellSx}>Notes</TableCell>
+                <TableCell sx={valueCellSx}>{selectedPayment.notes || '—'}</TableCell>
+              </TableRow>
+              <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                <TableCell sx={labelCellSx}>Created By</TableCell>
+                <TableCell sx={valueCellSx}>{selectedPayment.createdBy || '—'}</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell sx={labelCellSx}>Created At</TableCell>
+                <TableCell sx={valueCellSx}>{formatDate(selectedPayment.createdAt)}</TableCell>
+              </TableRow>
+              <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                <TableCell sx={labelCellSx}>Updated At</TableCell>
+                <TableCell sx={valueCellSx}>{formatDate(selectedPayment.updatedAt)}</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+    </Paper>
+  )
+}
+
+export default VendorPaymentWorkspaceCard

--- a/frontend/src/pages/purchasing/components/VendorPaymentsDialogs.tsx
+++ b/frontend/src/pages/purchasing/components/VendorPaymentsDialogs.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+import DeletedVendorPaymentsDialog from '@/components/purchasing/DeletedVendorPaymentsDialog'
+import { VendorPaymentPrint } from '@/components/print'
+import type { VendorPayment } from '@/types'
+
+interface VendorPaymentsDialogsProps {
+  selectedPayment: VendorPayment | null
+  deletedPaymentsOpen: boolean
+  onCloseDeletedPayments: () => void
+  printDialogOpen: boolean
+  onClosePrintDialog: () => void
+}
+
+const VendorPaymentsDialogs: React.FC<VendorPaymentsDialogsProps> = ({
+  selectedPayment,
+  deletedPaymentsOpen,
+  onCloseDeletedPayments,
+  printDialogOpen,
+  onClosePrintDialog,
+}) => {
+  return (
+    <>
+      <DeletedVendorPaymentsDialog
+        open={deletedPaymentsOpen}
+        onClose={onCloseDeletedPayments}
+      />
+
+      {selectedPayment && (
+        <VendorPaymentPrint
+          open={printDialogOpen}
+          onClose={onClosePrintDialog}
+          payment={selectedPayment}
+        />
+      )}
+    </>
+  )
+}
+
+export default VendorPaymentsDialogs

--- a/frontend/src/pages/purchasing/hooks/useVendorPaymentsPageState.ts
+++ b/frontend/src/pages/purchasing/hooks/useVendorPaymentsPageState.ts
@@ -1,0 +1,46 @@
+import { useRef, useState } from 'react'
+
+export interface VPSorting {
+  sortBy: string
+  sortOrder: 'asc' | 'desc'
+}
+
+export interface VPJournalEntryRef {
+  referenceNumber: string
+  sourceType: string
+  sourceId: string
+}
+
+export function useVendorPaymentsPageState() {
+  const [sorting, setSorting] = useState<VPSorting>({
+    sortBy: 'paymentNumber',
+    sortOrder: 'asc',
+  })
+  const [focusedPaymentIndex, setFocusedPaymentIndex] = useState(-1)
+  const [deletedPaymentsOpen, setDeletedPaymentsOpen] = useState(false)
+  const [printDialogOpen, setPrintDialogOpen] = useState(false)
+  const [journalEntryRef, setJournalEntryRef] = useState<VPJournalEntryRef | null>(null)
+  const [journalEntryRefLoading, setJournalEntryRefLoading] = useState(false)
+
+  const paymentListRef = useRef<HTMLDivElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+  const userHasNavigatedRef = useRef(false)
+
+  return {
+    sorting,
+    setSorting,
+    focusedPaymentIndex,
+    setFocusedPaymentIndex,
+    deletedPaymentsOpen,
+    setDeletedPaymentsOpen,
+    printDialogOpen,
+    setPrintDialogOpen,
+    journalEntryRef,
+    setJournalEntryRef,
+    journalEntryRefLoading,
+    setJournalEntryRefLoading,
+    paymentListRef,
+    searchInputRef,
+    userHasNavigatedRef,
+  }
+}

--- a/frontend/src/pages/purchasing/hooks/useVendorPaymentsSelection.ts
+++ b/frontend/src/pages/purchasing/hooks/useVendorPaymentsSelection.ts
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, type MutableRefObject, type RefObject } from 'react'
+import type { SetURLSearchParams } from 'react-router-dom'
+
+import type { AppDispatch } from '@/store'
+import { useLazyGetJournalEntriesQuery } from '@/store/api/accountingApi'
+import { useLazyGetVendorPaymentQuery } from '@/store/api/purchasingApi'
+import { setSelectedVendorPayment } from '@/store/slices/purchasingSlice'
+import type { VendorPayment } from '@/types'
+
+import type { VPJournalEntryRef } from './useVendorPaymentsPageState'
+
+interface UseVendorPaymentsSelectionParams {
+  dispatch: AppDispatch
+  payments: VendorPayment[]
+  selectedPayment: VendorPayment | null
+  focusedPaymentIndex: number
+  setFocusedPaymentIndex: (index: number) => void
+  searchParams: URLSearchParams
+  setSearchParams: SetURLSearchParams
+  paymentListRef: RefObject<HTMLDivElement | null>
+  searchInputRef: RefObject<HTMLInputElement | null>
+  userHasNavigatedRef: MutableRefObject<boolean>
+  setJournalEntryRef: (value: VPJournalEntryRef | null) => void
+  setJournalEntryRefLoading: (value: boolean) => void
+}
+
+export function useVendorPaymentsSelection({
+  dispatch,
+  payments,
+  selectedPayment,
+  focusedPaymentIndex,
+  setFocusedPaymentIndex,
+  searchParams,
+  setSearchParams,
+  paymentListRef,
+  searchInputRef,
+  userHasNavigatedRef,
+  setJournalEntryRef,
+  setJournalEntryRefLoading,
+}: UseVendorPaymentsSelectionParams) {
+  const [fetchPayment] = useLazyGetVendorPaymentQuery()
+  const [fetchJournalEntries] = useLazyGetJournalEntriesQuery()
+
+  useEffect(() => {
+    if (!selectedPayment?.id) {
+      setJournalEntryRef(null)
+      setJournalEntryRefLoading(false)
+      return
+    }
+
+    let cancelled = false
+    setJournalEntryRefLoading(true)
+
+    ;(async () => {
+      try {
+        const res = await fetchJournalEntries({
+          sourceType: 'vendor_payment',
+          sourceId: selectedPayment.id,
+          sortBy: 'createdAt',
+          sortOrder: 'DESC',
+          limit: 1,
+        }).unwrap()
+
+        if (cancelled) return
+
+        const entry = res.data?.[0]
+        if (entry) {
+          setJournalEntryRef({
+            referenceNumber: entry.referenceNumber,
+            sourceType: 'vendor_payment',
+            sourceId: selectedPayment.id,
+          })
+        } else {
+          setJournalEntryRef(null)
+        }
+      } catch {
+        if (!cancelled) setJournalEntryRef(null)
+      } finally {
+        if (!cancelled) setJournalEntryRefLoading(false)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [fetchJournalEntries, selectedPayment?.id, setJournalEntryRef, setJournalEntryRefLoading])
+
+  useEffect(() => {
+    const vpId = searchParams.get('vpId')
+    if (vpId && payments.length > 0) {
+      const payment = payments.find((item) => item.id === vpId)
+      if (payment) {
+        dispatch(setSelectedVendorPayment(payment))
+        const index = payments.findIndex((item) => item.id === payment.id)
+        setFocusedPaymentIndex(index)
+        setSearchParams((prev) => {
+          prev.delete('vpId')
+          return prev
+        }, { replace: true })
+      }
+    }
+  }, [dispatch, payments, searchParams, setFocusedPaymentIndex, setSearchParams])
+
+  useEffect(() => {
+    if (payments.length > 0 && focusedPaymentIndex === -1) {
+      if (selectedPayment) {
+        const index = payments.findIndex((item) => item.id === selectedPayment.id)
+        setFocusedPaymentIndex(index >= 0 ? index : 0)
+      } else if (searchInputRef.current !== document.activeElement) {
+        const vpId = searchParams.get('vpId')
+        if (!vpId) {
+          setFocusedPaymentIndex(0)
+          dispatch(setSelectedVendorPayment(payments[0]))
+        }
+      }
+    }
+  }, [dispatch, focusedPaymentIndex, payments, searchInputRef, searchParams, selectedPayment, setFocusedPaymentIndex])
+
+  useEffect(() => {
+    if (payments.length === 0 && selectedPayment) {
+      dispatch(setSelectedVendorPayment(null))
+      setFocusedPaymentIndex(-1)
+    }
+  }, [dispatch, payments.length, selectedPayment, setFocusedPaymentIndex])
+
+  useEffect(() => {
+    if (focusedPaymentIndex >= 0 && paymentListRef.current) {
+      const row = paymentListRef.current.querySelector(`[data-payment-index="${focusedPaymentIndex}"]`)
+      if (row) {
+        row.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      }
+    }
+  }, [focusedPaymentIndex, paymentListRef])
+
+  const handlePaymentSelect = useCallback(async (payment: VendorPayment) => {
+    const index = payments.findIndex((item) => item.id === payment.id)
+    setFocusedPaymentIndex(index)
+    userHasNavigatedRef.current = true
+
+    try {
+      const freshPayment = await fetchPayment(payment.id).unwrap()
+      dispatch(setSelectedVendorPayment(freshPayment))
+    } catch {
+      dispatch(setSelectedVendorPayment(payment))
+    }
+  }, [dispatch, fetchPayment, payments, setFocusedPaymentIndex, userHasNavigatedRef])
+
+  const handleNavigateUp = useCallback(() => {
+    if (focusedPaymentIndex > 0) {
+      const newIndex = focusedPaymentIndex - 1
+      setFocusedPaymentIndex(newIndex)
+      dispatch(setSelectedVendorPayment(payments[newIndex]))
+      userHasNavigatedRef.current = true
+    }
+  }, [dispatch, focusedPaymentIndex, payments, setFocusedPaymentIndex, userHasNavigatedRef])
+
+  const handleNavigateDown = useCallback(() => {
+    if (focusedPaymentIndex < payments.length - 1) {
+      const newIndex = focusedPaymentIndex + 1
+      setFocusedPaymentIndex(newIndex)
+      dispatch(setSelectedVendorPayment(payments[newIndex]))
+      userHasNavigatedRef.current = true
+    }
+  }, [dispatch, focusedPaymentIndex, payments, setFocusedPaymentIndex, userHasNavigatedRef])
+
+  const focusSearchInput = useCallback(() => {
+    searchInputRef.current?.focus()
+  }, [searchInputRef])
+
+  return {
+    handlePaymentSelect,
+    handleNavigateUp,
+    handleNavigateDown,
+    focusSearchInput,
+  }
+}

--- a/frontend/src/store/api/purchasingApi.ts
+++ b/frontend/src/store/api/purchasingApi.ts
@@ -230,6 +230,11 @@ export const purchasingApiSlice = createApi({
       transformResponse: (response: any) => normalizeNamedCollection<VendorPayment>(response, 'payments'),
       providesTags: ['VendorPayment'],
     }),
+    getVendorPayment: builder.query<VendorPayment, string>({
+      query: (id) => ({ url: `/purchasing/vendor-payments/${id}` }),
+      transformResponse: normalizeSingle<VendorPayment>,
+      providesTags: (_result, _error, id) => [{ type: 'VendorPayment' as const, id }],
+    }),
     getDeletedVendorPayments: builder.query<PaginatedResponse<VendorPayment>, Record<string, unknown> | undefined>({
       query: (params) => ({ url: '/purchasing/vendor-payments/deleted', params: params ?? {} }),
       transformResponse: (response: any) => normalizeNamedCollection<VendorPayment>(response, 'payments'),
@@ -273,4 +278,5 @@ export const {
   useGetDeletedGRNsQuery,
   useGetVendorPaymentsQuery,
   useGetDeletedVendorPaymentsQuery,
+  useLazyGetVendorPaymentQuery,
 } = purchasingApiSlice

--- a/frontend/src/types/filterBar.types.ts
+++ b/frontend/src/types/filterBar.types.ts
@@ -27,6 +27,7 @@ export type FilterFieldType =
   | 'stock-status'
   | 'price-list'
   | 'transaction-status'
+  | 'vendor-payment-status'
 
 interface BaseFilterFieldConfig<TFilters, K extends keyof TFilters> {
   field: K
@@ -127,6 +128,11 @@ export interface TransactionStatusFilterFieldConfig<TFilters, K extends keyof TF
   type: 'transaction-status'
 }
 
+export interface VendorPaymentStatusFilterFieldConfig<TFilters, K extends keyof TFilters>
+  extends BaseFilterFieldConfig<TFilters, K> {
+  type: 'vendor-payment-status'
+}
+
 export type FilterFieldConfig<TFilters> =
   | StatusFilterFieldConfig<TFilters, keyof TFilters>
   | UserStatusFilterFieldConfig<TFilters, keyof TFilters>
@@ -146,6 +152,7 @@ export type FilterFieldConfig<TFilters> =
   | StockStatusFilterFieldConfig<TFilters, keyof TFilters>
   | PriceListFilterFieldConfig<TFilters, keyof TFilters>
   | TransactionStatusFilterFieldConfig<TFilters, keyof TFilters>
+  | VendorPaymentStatusFilterFieldConfig<TFilters, keyof TFilters>
 
 export interface FilterBarConfig<TFilters> {
   search?: {

--- a/frontend/src/utils/filterBar.url.ts
+++ b/frontend/src/utils/filterBar.url.ts
@@ -80,7 +80,8 @@ export function serializeFilters<TFilters extends object>(
       field.type === 'product-type' ||
       field.type === 'stock-status' ||
       field.type === 'price-list' ||
-      field.type === 'transaction-status'
+      field.type === 'transaction-status' ||
+      field.type === 'vendor-payment-status'
 
     if (isSingleValueField) {
       if (value !== null && value !== undefined && value !== defaultValue) {
@@ -156,7 +157,8 @@ export function parseFilters<TFilters extends object>(
       field.type === 'product-type' ||
       field.type === 'stock-status' ||
       field.type === 'price-list' ||
-      field.type === 'transaction-status'
+      field.type === 'transaction-status' ||
+      field.type === 'vendor-payment-status'
 
     if (isSingleValueField) {
       const raw = searchParams.get(key)
@@ -184,8 +186,11 @@ export function parseFilters<TFilters extends object>(
         const VALID_ORDER_STATUS = ['fulfilled', 'unfulfilled']
         result[fieldKey] = VALID_ORDER_STATUS.includes(raw) ? raw : (defaultValue ?? null)
       } else if (field.type === 'purchasing-status') {
-        const VALID_PURCHASING_STATUS = ['draft', 'received', 'pending', 'completed', 'cancelled']
+        const VALID_PURCHASING_STATUS = ['draft', 'received']
         result[fieldKey] = VALID_PURCHASING_STATUS.includes(raw) ? raw : (defaultValue ?? null)
+      } else if (field.type === 'vendor-payment-status') {
+        const VALID_VENDOR_PAYMENT_STATUS = ['pending', 'completed', 'cancelled']
+        result[fieldKey] = VALID_VENDOR_PAYMENT_STATUS.includes(raw) ? raw : (defaultValue ?? null)
       } else if (field.type === 'payment-status') {
         const VALID_PAYMENT_STATUS = ['unpaid', 'partial', 'paid', 'overpaid']
         result[fieldKey] = VALID_PAYMENT_STATUS.includes(raw) ? raw : (defaultValue ?? null)

--- a/frontend/src/utils/filterBar.url.ts
+++ b/frontend/src/utils/filterBar.url.ts
@@ -184,7 +184,7 @@ export function parseFilters<TFilters extends object>(
         const VALID_ORDER_STATUS = ['fulfilled', 'unfulfilled']
         result[fieldKey] = VALID_ORDER_STATUS.includes(raw) ? raw : (defaultValue ?? null)
       } else if (field.type === 'purchasing-status') {
-        const VALID_PURCHASING_STATUS = ['draft', 'received']
+        const VALID_PURCHASING_STATUS = ['draft', 'received', 'pending', 'completed', 'cancelled']
         result[fieldKey] = VALID_PURCHASING_STATUS.includes(raw) ? raw : (defaultValue ?? null)
       } else if (field.type === 'payment-status') {
         const VALID_PAYMENT_STATUS = ['unpaid', 'partial', 'paid', 'overpaid']


### PR DESCRIPTION
## Summary

- Rewrites `VendorPaymentsPage` from a monolithic manual-grid layout into the standardized `MasterDetailWorkspace` pattern, matching `GoodsReceivedPage`, `PurchaseOrdersPage`, and `SuppliersPage`
- Extracts state into `useVendorPaymentsPageState` and `useVendorPaymentsSelection` hooks; UI into `VendorPaymentTable`, `VendorPaymentContextHeader`, `VendorPaymentWorkspaceCard`, and `VendorPaymentsDialogs` components
- Adds `FilterBar` with period / supplier / status filters; introduces a new `vendor-payment-status` filter type (`pending`/`completed`/`cancelled`) distinct from the existing `purchasing-status` type (`draft`/`received`)
- Workspace card shows PO line items (product, qty, unit price, total), mirroring the customer payments page in sales
- Adds `useLazyGetVendorPaymentQuery` to `purchasingApi` for fresh-data-on-selection
- Fixes `sortOrder` casing mismatch (VP backend expects lowercase `asc`/`desc`)

## Test Plan

- [x] `npx vitest run src/pages/purchasing/__tests__/VendorPaymentsPage.filterbar.test.tsx` — 9/9 passed
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] Verified list loads, selection works, PO items appear in workspace card, period/supplier/status filters function correctly
- [x] `vpId` deep-link from Purchase Orders page selects the correct payment

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)