### PR TITLE
refactor(inventory): rewrite CategoriesPage using Master-Detail pattern

### DIFF
--- a/frontend/src/pages/inventory/CategoriesPage.tsx
+++ b/frontend/src/pages/inventory/CategoriesPage.tsx
@@ -1,717 +1,199 @@
-import React, { useState, useEffect } from 'react'
-import {
-  Box,
-  Typography,
-  Paper,
-  Button,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Chip,
-  IconButton,
-  CircularProgress,
-  Alert,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  TextField,
-  Grid,
-  useTheme,
-  useMediaQuery,
-  InputAdornment,
-} from '@mui/material'
-import { default as EditIcon } from '@mui/icons-material/Edit'
-import { default as DeleteIcon } from '@mui/icons-material/Delete'
-import { default as DragIndicatorIcon } from '@mui/icons-material/DragIndicator'
-import { default as SearchIcon } from '@mui/icons-material/Search'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
+import { Box, useMediaQuery, useTheme } from '@mui/material'
+
+import MasterDetailWorkspace from '@/components/common/MasterDetailWorkspace'
 import PageHeader from '@/components/common/PageHeader'
-import { useForm, Controller } from 'react-hook-form'
-import { yupResolver } from '@hookform/resolvers/yup'
-import * as yup from 'yup'
+import { FilterBar } from '@/components/filters'
+import { useFilterBar } from '@/hooks/useFilterBar'
 import { useNotification } from '@/hooks/useNotification'
-import { useSearchAndFilter, useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
-import { useCategoryDuplicateCheck } from '@/hooks/useCategoryDuplicateCheck'
-import CategorySelector from '@/components/inventory/CategorySelector'
-import DeletedCategoriesDialog from '@/components/inventory/DeletedCategoriesDialog'
-import { SmartCategoryDeleteDialog } from '@/components/inventory/SmartCategoryDeleteDialog'
-import ConfirmationDialog from '@/components/common/ConfirmationDialog'
-import type { Category } from '@/types'
-import { TABLE_STYLES } from '@/constants/tableStyles'
-import { formatDate } from '@/utils/formatters'
-import {
-  setCategoryFilters,
-  selectCategoryFilters,
-} from '@/store/slices/inventorySlice'
+import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import {
   useCreateCategoryMutation,
   useDeleteCategoryMutation,
   useGetCategoriesQuery,
   useUpdateCategoryMutation,
 } from '@/store/api/inventoryApi'
-import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
+import { selectSelectedCategory } from '@/store/slices/inventorySlice'
+import type { FilterBarConfig } from '@/types/filterBar.types'
 
+import CategoryContextHeader from './components/CategoryContextHeader'
+import CategoryDialogs from './components/CategoryDialogs'
+import CategoryList from './components/CategoryList'
+import CategoryWorkspaceCard from './components/CategoryWorkspaceCard'
+import { useCategoriesActions } from './hooks/useCategoriesActions'
+import { useCategoriesPageState } from './hooks/useCategoriesPageState'
+import { useCategoriesSelection } from './hooks/useCategoriesSelection'
 
-interface CategoryFormData {
-  name: string
-  parentId?: string | null
+interface CategoryFilters {
+  search: string
 }
 
-const categorySchema = yup.object({
-  name: yup.string().required('Category name is required').min(2, 'Name must be at least 2 characters'),
-  parentId: yup.string().optional().nullable(),
-})
-
 const CategoriesPage: React.FC = () => {
-  const dispatch = useAppDispatch()
-  const { showSuccess, showError } = useNotification()
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('md'))
-  const categoryFilters = useAppSelector(selectCategoryFilters) || { search: '' }
+  const dispatch = useAppDispatch()
+  const { showSuccess, showError } = useNotification()
+  const selectedCategory = useAppSelector(selectSelectedCategory)
+  const pageState = useCategoriesPageState()
+
+  const filterConfig = useMemo<FilterBarConfig<CategoryFilters>>(
+    () => ({
+      search: { placeholder: 'Search categories by name...' },
+      fields: [],
+      defaults: { search: '' },
+    }),
+    [],
+  )
+
+  const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
+
   const {
     data: categories = [],
-    isFetching: isCategoriesFetching,
+    isFetching,
     refetch: refetchCategories,
   } = useGetCategoriesQuery({
     includeProductCount: true,
-    search: categoryFilters.search || undefined,
+    search: appliedFilters.search || undefined,
   })
+
   const [createCategory] = useCreateCategoryMutation()
   const [updateCategory] = useUpdateCategoryMutation()
   const [deleteCategory] = useDeleteCategoryMutation()
-  const [dialogOpen, setDialogOpen] = useState(false)
-  const [editMode, setEditMode] = useState(false)
-  const [selectedCategory, setSelectedCategory] = useState<Category | null>(null)
-  const [submitting, setSubmitting] = useState(false)
-  const [parentCategory, setParentCategory] = useState<Category | null>(null)
-  const [deletedCategoriesDialogOpen, setDeletedCategoriesDialogOpen] = useState(false)
-  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
-  const [categoryToDelete, setCategoryToDelete] = useState<Category | null>(null)
-  const [smartDeleteOpen, setSmartDeleteOpen] = useState(false)
-  const [deleteError, setDeleteError] = useState<any>(null)
+  const [isDuplicateName, setIsDuplicateName] = useState(false)
+  const [duplicateNameError, setDuplicateNameError] = useState<string | null>(null)
+  const resetFormRef = useRef<((values: { name: string; parentId: string | null }) => void) | null>(null)
 
-  const {
-    control,
-    handleSubmit,
-    reset,
-    watch,
-    formState: { errors },
-  } = useForm<CategoryFormData>({
-    resolver: yupResolver(categorySchema) as any,
-    defaultValues: {
-      name: '',
-      parentId: null,
-    },
+  const handleFormReady = useCallback((resetFn: (values: { name: string; parentId: string | null }) => void) => {
+    resetFormRef.current = resetFn
+  }, [])
+
+  const handleDuplicateStateChange = useCallback((isDuplicate: boolean, error: string | null) => {
+    setIsDuplicateName(isDuplicate)
+    setDuplicateNameError(error)
+  }, [])
+
+  const resetForm = useCallback((values: { name: string; parentId: string | null }) => {
+    resetFormRef.current?.(values)
+  }, [])
+
+  const selection = useCategoriesSelection({
+    dispatch,
+    categories,
+    selectedCategory,
+    focusedCategoryIndex: pageState.focusedCategoryIndex,
+    setFocusedCategoryIndex: pageState.setFocusedCategoryIndex,
+    categoryListRef: pageState.categoryListRef,
   })
 
-  // Search and filter functionality
-  const { searchTerm, setSearchTerm, focusSearchInput } = useSearchAndFilter({
-    initialSearchTerm: categoryFilters.search,
-    onSearchChange: (searchTerm) => {
-      dispatch(setCategoryFilters({ search: searchTerm }))
-    },
-  })
-
-  // Duplicate check functionality
-  const {
-    checkDuplicate,
-    nameError: duplicateNameError,
-    hasNameDuplicate: isDuplicateName
-  } = useCategoryDuplicateCheck()
-
-  // Watch form fields for real-time validation
-  const watchedName = watch('name')
-  const watchedParentId = watch('parentId')
-
-  // Real-time duplicate checking for form fields
-  useEffect(() => {
-    const timeoutId = setTimeout(async () => {
-      if (watchedName && watchedName.trim().length >= 2) {
-        await checkDuplicate({
-          name: watchedName.trim(),
-          parentId: watchedParentId || undefined,
-          excludeId: editMode && selectedCategory ? selectedCategory.id : undefined,
-        })
-      }
-    }, 500) // Debounce API calls
-
-    return () => clearTimeout(timeoutId)
-  }, [watchedName, watchedParentId, editMode, selectedCategory, checkDuplicate])
-
-  const handleAddCategory = (parentId?: string) => {
-    const parent = parentId ? findCategoryById(categories, parentId) : null
-    reset({
-      name: '',
-      parentId: parentId || null,
-    })
-    setEditMode(false)
-    setSelectedCategory(null)
-    setParentCategory(parent)
-    setDialogOpen(true)
-  }
-
-  // Keyboard shortcuts - only search
-  useKeyboardShortcuts({
-    onSearch: focusSearchInput,
-  })
-
-  const handleEditCategory = (category: Category) => {
-    const parent = category.parentId ? findCategoryById(categories, category.parentId) : null
-    reset({
-      name: category.name,
-      parentId: category.parentId,
-    })
-    setEditMode(true)
-    setSelectedCategory(category)
-    setParentCategory(parent)
-    setDialogOpen(true)
-  }
-
-  const handleDeleteCategory = (category: Category) => {
-    setCategoryToDelete(category)
-    setDeleteError(null)
-    setDeleteConfirmOpen(true)
-  }
-
-  const handleConfirmDelete = async () => {
-    if (categoryToDelete) {
-      try {
-        await deleteCategory(categoryToDelete.id).unwrap()
-        showSuccess(`Category "${categoryToDelete.name}" deleted successfully.`)
-        setDeleteConfirmOpen(false)
-        setCategoryToDelete(null)
-      } catch (error: any) {
-        console.error('Delete category error:', error)
-
-        // Check if this is a "category has products" error
-        if (error?.productCount || (error?.includes && error.includes('contains'))) {
-          // Close the basic confirmation dialog and show smart delete dialog
-          setDeleteConfirmOpen(false)
-          setDeleteError({
-            message: error?.message || error,
-            productCount: error?.productCount,
-            categoryName: categoryToDelete.name,
-            suggestions: error?.suggestions
-          })
-          setSmartDeleteOpen(true)
-        } else {
-          // For other errors, show error message and close dialog
-          const errorMessage = error || 'Failed to delete category'
-          showError(errorMessage)
-          setDeleteConfirmOpen(false)
-          setCategoryToDelete(null)
-        }
-      }
-    }
-  }
-
-  const handleSmartDelete = async (moveToUncategorized: boolean) => {
-    if (!categoryToDelete) return
-
-    try {
-      const params = new URLSearchParams()
-      params.set('force', 'true')
-      if (moveToUncategorized) {
-        params.set('moveToUncategorized', 'true')
-      }
-
-      // Call delete API with force parameters
-      const response = await fetch(`/api/inventory/categories/${categoryToDelete.id}?${params.toString()}`, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      })
-
-      if (!response.ok) {
-        throw new Error(`Failed to delete category: ${response.statusText}`)
-      }
-
-      const result = await response.json()
-
-      // Show success message
-      if (result.moved && result.moved > 0) {
-        showSuccess(`Category "${categoryToDelete.name}" deleted. ${result.moved} product${result.moved === 1 ? '' : 's'} moved to Uncategorized.`)
-      } else {
-        showSuccess(result.message || `Category "${categoryToDelete.name}" deleted successfully.`)
-      }
-
-      // Refresh the categories list
+  const actions = useCategoriesActions({
+    categories,
+    selectedCategory,
+    editMode: pageState.editMode,
+    isDuplicateName,
+    duplicateNameError,
+    deleteCategory,
+    createCategory,
+    updateCategory,
+    showSuccess,
+    showError,
+    refetchCategories: () => {
       void refetchCategories()
-    } catch (error: any) {
-      console.error('Smart delete error:', error)
-      showError(error.message || 'Failed to delete category')
-      throw error // Re-throw to let the dialog handle loading state
-    }
-  }
+    },
+    setDialogOpen: pageState.setDialogOpen,
+    setEditMode: pageState.setEditMode,
+    setDeleteConfirmOpen: pageState.setDeleteConfirmOpen,
+    setCategoryToDelete: pageState.setCategoryToDelete,
+    setSmartDeleteOpen: pageState.setSmartDeleteOpen,
+    setDeleteError: pageState.setDeleteError,
+    setSubmitting: pageState.setSubmitting,
+    resetForm,
+  })
 
-  const handleCancelDelete = () => {
-    setDeleteConfirmOpen(false)
-    setCategoryToDelete(null)
-  }
-
-  const handleSmartDeleteClose = () => {
-    setSmartDeleteOpen(false)
-    setCategoryToDelete(null)
-    setDeleteError(null)
-  }
-
-
-  const onSubmit = async (data: CategoryFormData) => {
-    try {
-      setSubmitting(true)
-
-      // Check for duplicate errors from real-time validation
-      if (isDuplicateName) {
-        showError(duplicateNameError || 'Category name already exists')
-        return
-      }
-
-      if (editMode && selectedCategory) {
-        await updateCategory({ id: selectedCategory.id, data }).unwrap()
-        showSuccess('Category updated successfully')
-      } else {
-        const createData = {
-          ...data,
-          parentId: data.parentId || null
-        }
-        await createCategory(createData).unwrap()
-        showSuccess('Category created successfully')
-      }
-      
-      setDialogOpen(false)
-      reset()
-    } catch (error: any) {
-      console.error('Category save error:', error)
-      
-      // Handle specific error types
-      if (error?.response?.status === 409) {
-        showError(`Duplicate entry detected: A category named "${data.name}" already exists. Please choose a different name.`)
-      } else if (error?.response?.status === 400) {
-        const message = error?.response?.data?.message || 'Invalid category data'
-        showError(`Validation error: ${message}`)
-      } else {
-        const message = error?.response?.data?.message || error?.message || 'Failed to save category'
-        showError(`Failed to save category: ${message}`)
-      }
-    } finally {
-      setSubmitting(false)
-    }
-  }
-
-  const renderCategoryName = (category: Category) => {
-    const indentLevel = category.level
-    const indentSize = 1.5 // Reduced indentation for more compact display
-
-    return (
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          ml: indentLevel * indentSize,
-          gap: 0.5
-        }}
-        aria-level={indentLevel + 1}
-        role="treeitem"
-        aria-label={`${category.name} ${indentLevel === 0 ? 'root category' : `level ${indentLevel} category`}`}
-      >
-        {/* DragIndicator Icon for all categories */}
-        <DragIndicatorIcon
-          sx={{
-            color: 'text.secondary',
-            fontSize: '0.875rem'
-          }}
-        />
-
-        {/* Category Name */}
-        <Typography
-          variant="body2"
-          sx={{
-            fontSize: '0.8rem',
-            lineHeight: 1.2,
-            fontWeight: 400,
-            color: 'text.primary',
-            wordBreak: 'break-word'
-          }}
-        >
-          {category.name}
-        </Typography>
-      </Box>
-    )
-  }
-
-  const findCategoryById = (cats: Category[], id: string): Category | null => {
-    return cats.find(cat => cat.id === id) || null
-  }
-
+  useKeyboardShortcuts({
+    onSearch: () => {
+      pageState.searchInputRef.current?.focus()
+      pageState.searchInputRef.current?.select()
+    },
+    onArrowUp: selection.handleNavigateUp,
+    onArrowDown: selection.handleNavigateDown,
+    onHome: selection.handleNavigateToFirst,
+    onEnd: selection.handleNavigateToLast,
+    onPageUp: selection.handlePageUpNavigation,
+    onPageDown: selection.handlePageDownNavigation,
+    onEscape: selection.handleEscapeAction,
+  })
 
   return (
-    <>
+    <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
       <PageHeader
-        variant="structure"
+        variant="workflow"
         title="Categories"
-        subtitle={`Organize your products with categories (${categories.length} ${categoryFilters.search ? 'found' : 'total'})`}
-        primaryAction={{
-          label: isMobile ? 'Add New Category' : 'Add Category',
-          onClick: () => handleAddCategory(),
-        }}
+        subtitle={`Organize your products with categories (${categories.length} ${appliedFilters.search ? 'found' : 'total'})`}
+        primaryAction={{ label: 'Add Category', onClick: () => actions.handleAddCategory() }}
         secondaryAction={{
           label: 'View Deleted',
-          onClick: () => setDeletedCategoriesDialogOpen(true),
+          onClick: () => pageState.setDeletedCategoriesDialogOpen(true),
         }}
-      />
-      {/* Search / Filter */}
-      <Box sx={{ mb: 3 }}>
-        <TextField
-          placeholder="Search categories by name..."
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          size="medium"
-          sx={{
-            minWidth: isMobile ? 'auto' : 250,
-            width: isMobile ? '100%' : 'auto',
-            maxWidth: isMobile ? 'none' : 400,
-            '& .MuiOutlinedInput-root': {
-              height: '40px',
-              fontSize: '0.875rem',
-              '& input': {
-                padding: '8.5px 14px',
-                fontSize: '0.875rem'
-              }
-            },
-            '& .MuiInputAdornment-root': {
-              '& .MuiSvgIcon-root': {
-                fontSize: '1.25rem',
-                color: 'action.active'
-              }
-            }
-          }}
-          slotProps={{
-            input: {
-              startAdornment: (
-                <InputAdornment position="start">
-                  <SearchIcon fontSize="small" />
-                </InputAdornment>
-              ),
-            },
-          }}
-        />
-      </Box>
-      {/* Categories Content */}
-      <Paper sx={{ borderRadius: 2, overflow: 'hidden' }}>
-        {isCategoriesFetching ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
-            <CircularProgress />
-          </Box>
-        ) : categories.length === 0 ? (
-          <Box sx={{ p: 4, textAlign: 'center' }}>
-            <Typography variant="body1" sx={{
-              color: "text.secondary"
-            }}>
-              No categories found. Create your first category to get started.
-            </Typography>
-          </Box>
-        ) : (
-          <TableContainer sx={{ overflowX: 'auto' }}>
-            <Table
-              size={TABLE_STYLES.size}
-              sx={{
-                minWidth: isMobile ? 650 : 800,
-                '& .MuiTableCell-root': {
-                  borderBottom: TABLE_STYLES.cell.border,
-                  py: TABLE_STYLES.cell.padding.py,
-                  px: TABLE_STYLES.cell.padding.px
-                },
-                '& .MuiTableBody-root .MuiTableRow-root:last-child .MuiTableCell-root': {
-                  borderBottom: 'none'
-                }
-              }}
-            >
-              <TableHead>
-                <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50', py: 1 } }}>
-                  <TableCell sx={{ width: isMobile ? '45%' : '40%' }}>
-                    <Typography variant="tableHeader" sx={{
-                      fontWeight: 600,
-                      color: 'text.primary',
-                      fontSize: '0.8rem'
-                    }}>
-                      Category Hierarchy
-                    </Typography>
-                  </TableCell>
-                  <TableCell sx={{ width: isMobile ? '15%' : '15%' }}>
-                    <Typography variant="tableHeader" sx={{
-                      fontWeight: 600,
-                      color: 'text.primary',
-                      fontSize: '0.8rem'
-                    }}>
-                      Products
-                    </Typography>
-                  </TableCell>
-                  {!isMobile && (
-                    <TableCell sx={{ width: '20%' }}>
-                      <Typography variant="tableHeader" sx={{
-                        fontWeight: 600,
-                        color: 'text.primary',
-                        fontSize: '0.8rem'
-                      }}>
-                        Created Date
-                      </Typography>
-                    </TableCell>
-                  )}
-                  <TableCell align="right" sx={{ width: isMobile ? '40%' : '25%' }}>
-                    <Typography variant="tableHeader" sx={{
-                      fontWeight: 600,
-                      color: 'text.primary',
-                      fontSize: '0.8rem'
-                    }}>
-                      Actions
-                    </Typography>
-                  </TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody role="tree" aria-label="Categories hierarchy">
-                {categories.map((category) => (
-                  <TableRow 
-                    key={category.id} 
-                    hover
-                    tabIndex={0}
-                    sx={{
-                      '&:hover, &:focus-within': {
-                        backgroundColor: 'action.hover',
-                        '& .category-actions': {
-                          opacity: 1
-                        }
-                      },
-                      transition: 'background-color 0.2s ease',
-                      cursor: 'default',
-                      height: TABLE_STYLES.row.height
-                    }}
-                  >
-                    <TableCell>
-                      {renderCategoryName(category)}
-                    </TableCell>
-                    <TableCell>
-                      <Chip
-                        label={`${category.productCount ?? 0} ${(category.productCount ?? 0) === 1 ? 'item' : 'items'}`}
-                        size="small"
-                        color={category.productCount && category.productCount > 0 ? 'primary' : 'default'}
-                        variant="outlined"
-                        sx={{
-                          fontSize: '0.7rem',
-                          fontWeight: 500,
-                          height: `${TABLE_STYLES.row.height * 0.65}px`, // Scale to 65% of row height for better proportion
-                          minWidth: `${TABLE_STYLES.row.height * 1.8}px`, // Scale min width proportionally
-                          '& .MuiChip-label': {
-                            fontSize: `${Math.max(10, TABLE_STYLES.row.height * 0.35)}px`, // Scale font size with row height
-                            lineHeight: 1
-                          }
-                        }}
-                      />
-                    </TableCell>
-                    {!isMobile && (
-                      <TableCell>
-                        <Typography
-                          variant="tableCaption"
-                          sx={{
-                            color: "text.secondary",
-                            fontSize: '0.7rem'
-                          }}>
-                          {formatDate(category.createdAt)}
-                        </Typography>
-                      </TableCell>
-                    )}
-                    <TableCell align="right">
-                      <Box
-                        className="category-actions"
-                        sx={{
-                          display: 'flex',
-                          justifyContent: 'flex-end',
-                          alignItems: 'center',
-                          height: '100%', // Fill the full cell height
-                          gap: 0.25,
-                          opacity: isMobile ? 1 : 0.7,
-                          transition: 'opacity 0.2s ease'
-                        }}
-                      >
-                        <IconButton
-                          size="small"
-                          title={`Edit ${category.name}`}
-                          aria-label={`Edit category ${category.name}`}
-                          onClick={() => handleEditCategory(category)}
-                          sx={{
-                            height: `${TABLE_STYLES.row.height * 0.75}px`, // Scale to 75% of row height
-                            width: `${TABLE_STYLES.row.height * 0.75}px`, // Square aspect ratio
-                            minHeight: 20, // Reduced minimum size for better scaling
-                            minWidth: 20,
-                            p: 0.125, // Reduced padding for better proportion
-                            color: 'primary.main',
-                            '&:hover': {
-                              backgroundColor: 'primary.light',
-                              color: 'primary.dark'
-                            }
-                          }}
-                        >
-                          <EditIcon sx={{
-                            fontSize: `${TABLE_STYLES.row.height * 0.5}px` // Scale to 50% of row height for better proportion
-                          }} />
-                        </IconButton>
-                        <IconButton
-                          size="small"
-                          title={`Delete ${category.name}`}
-                          aria-label={`Delete category ${category.name}`}
-                          onClick={() => handleDeleteCategory(category)}
-                          sx={{
-                            height: `${TABLE_STYLES.row.height * 0.75}px`, // Scale to 75% of row height
-                            width: `${TABLE_STYLES.row.height * 0.75}px`, // Square aspect ratio
-                            minHeight: 20, // Reduced minimum size for better scaling
-                            minWidth: 20,
-                            p: 0.125, // Reduced padding for better proportion
-                            color: 'error.main',
-                            '&:hover': {
-                              backgroundColor: 'error.light',
-                              color: 'error.dark'
-                            }
-                          }}
-                        >
-                          <DeleteIcon sx={{
-                            fontSize: `${TABLE_STYLES.row.height * 0.5}px` // Scale to 50% of row height for better proportion
-                          }} />
-                        </IconButton>
-                      </Box>
-                      {/* Mobile-only date indicator */}
-                      {isMobile && (
-                        <Typography
-                          variant="caption"
-                          sx={{
-                            color: "text.secondary",
-                            display: 'block',
-                            textAlign: 'right',
-
-                            // Reduced margin
-                            mt: 0.25,
-
-                            fontSize: '0.65rem'
-                          }}>
-                          {formatDate(category.createdAt)}
-                        </Typography>
-                      )}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
+        toolbar={(
+          <FilterBar
+            config={filterConfig}
+            draftFilters={draftFilters}
+            handlers={handlers}
+            hasActiveFilters={hasActiveFilters}
+            searchInputRef={pageState.searchInputRef}
+          />
         )}
-      </Paper>
-      {/* Category Form Dialog */}
-      <Dialog
-        open={dialogOpen}
-        onClose={() => setDialogOpen(false)}
-        maxWidth="sm"
-        fullWidth
-      >
-        <DialogTitle>
-          {editMode ? 'Edit Category' : 'Add New Category'}
-          {parentCategory && (
-            <Typography
-              variant="body2"
-              sx={{
-                color: "text.secondary",
-                mt: 1
-              }}>
-              Parent: {parentCategory.name}
-            </Typography>
-          )}
-        </DialogTitle>
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <DialogContent>
-            <Grid container spacing={3} sx={{ mt: 1 }}>
-              <Grid size={12}>
-                <Controller
-                  name="name"
-                  control={control}
-                  render={({ field }) => {
-                    const hasValidationError = !!errors.name || isDuplicateName
-                    const helperText = errors.name?.message || duplicateNameError || ''
-                    
-                    return (
-                      <TextField
-                        {...field}
-                        fullWidth
-                        label="Category Name"
-                        error={hasValidationError}
-                        helperText={helperText}
-                        onChange={field.onChange}
-                        onBlur={field.onBlur}
-                      />
-                    )
-                  }}
-                />
-              </Grid>
-              <Grid size={12}>
-                <Controller
-                  name="parentId"
-                  control={control}
-                  render={({ field }) => (
-                    <CategorySelector
-                      value={field.value ? findCategoryById(categories, field.value) : null}
-                      onChange={(category) => field.onChange(category?.id || null)}
-                      label="Parent Category"
-                      placeholder="Select parent category (optional)"
-                      allowRoot
-                      excludeCategories={editMode && selectedCategory ? [selectedCategory.id] : []}
-                    />
-                  )}
-                />
-              </Grid>
-            </Grid>
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setDialogOpen(false)} disabled={submitting}>
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              variant="contained"
-              disabled={submitting}
-            >
-              {submitting ? 'Saving...' : editMode ? 'Update' : 'Create'}
-            </Button>
-          </DialogActions>
-        </form>
-      </Dialog>
-      {/* Deleted Categories Dialog */}
-      <DeletedCategoriesDialog
-        open={deletedCategoriesDialogOpen}
-        onClose={() => setDeletedCategoriesDialogOpen(false)}
-        onCategoryRestored={() => {
-          void refetchCategories()
-        }}
       />
-      {/* Smart Delete Dialog */}
-      <SmartCategoryDeleteDialog
-        open={smartDeleteOpen}
-        category={categoryToDelete}
-        error={deleteError}
-        onClose={handleSmartDeleteClose}
-        onConfirm={handleSmartDelete}
+
+      <MasterDetailWorkspace
+        isMobile={isMobile}
+        listSlot={(
+          <CategoryList
+            categories={categories}
+            loading={isFetching}
+            selectedCategoryId={selectedCategory?.id}
+            focusedIndex={pageState.focusedCategoryIndex}
+            onSelect={selection.handleCategorySelect}
+            categoryListRef={pageState.categoryListRef}
+          />
+        )}
+        headerSlot={(
+          <CategoryContextHeader
+            selectedCategory={selectedCategory}
+            onEdit={() => selectedCategory && actions.handleEditCategory(selectedCategory)}
+            onDelete={() => selectedCategory && actions.handleDeleteCategory(selectedCategory)}
+          />
+        )}
+        workspaceSlot={<CategoryWorkspaceCard selectedCategory={selectedCategory} />}
       />
-      {/* Fallback Delete Confirmation Dialog */}
-      <ConfirmationDialog
-        open={deleteConfirmOpen}
-        title="Confirm Delete"
-        message={`Are you sure you want to delete the category "${categoryToDelete?.name}"?`}
-        confirmText="Delete"
-        cancelText="Cancel"
-        onConfirm={handleConfirmDelete}
-        onCancel={handleCancelDelete}
-        severity="warning"
+
+      <CategoryDialogs
+        dialogOpen={pageState.dialogOpen}
+        editMode={pageState.editMode}
+        selectedCategory={selectedCategory}
+        submitting={pageState.submitting}
+        categories={categories}
+        onSubmit={actions.onSubmit}
+        onDialogClose={() => pageState.setDialogOpen(false)}
+        onFormReady={handleFormReady}
+        onDuplicateStateChange={handleDuplicateStateChange}
+        deletedCategoriesDialogOpen={pageState.deletedCategoriesDialogOpen}
+        onCloseDeletedCategories={() => pageState.setDeletedCategoriesDialogOpen(false)}
+        onCategoryRestored={() => void refetchCategories()}
+        deleteConfirmOpen={pageState.deleteConfirmOpen}
+        categoryToDelete={pageState.categoryToDelete}
+        onConfirmDelete={() => void actions.handleConfirmDelete(pageState.categoryToDelete)}
+        onCancelDelete={actions.handleCancelDelete}
+        smartDeleteOpen={pageState.smartDeleteOpen}
+        deleteError={pageState.deleteError}
+        onSmartDelete={(moveToUncategorized) =>
+          actions.handleSmartDelete(pageState.categoryToDelete, moveToUncategorized)
+        }
+        onSmartDeleteClose={actions.handleSmartDeleteClose}
       />
-    </>
-  );
+    </Box>
+  )
 }
 
 export default CategoriesPage

--- a/frontend/src/pages/inventory/components/CategoryContextHeader.tsx
+++ b/frontend/src/pages/inventory/components/CategoryContextHeader.tsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import { default as DeleteIcon } from '@mui/icons-material/Delete'
+import { default as EditIcon } from '@mui/icons-material/Edit'
+import { Box, IconButton, Paper, Typography } from '@mui/material'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { Category } from '@/types'
+
+interface CategoryContextHeaderProps {
+  selectedCategory: Category | null
+  onEdit: () => void
+  onDelete: () => void
+}
+
+const actionIconSx = {
+  height: `${TABLE_STYLES.row.height * 0.75}px`,
+  width: `${TABLE_STYLES.row.height * 0.75}px`,
+  minHeight: 20,
+  minWidth: 20,
+  p: 0.125,
+}
+
+const CategoryContextHeader: React.FC<CategoryContextHeaderProps> = ({
+  selectedCategory,
+  onEdit,
+  onDelete,
+}) => {
+  if (!selectedCategory) {
+    return (
+      <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
+        <Typography variant="h6" sx={{ color: 'text.secondary' }}>
+          Select a category to view details
+        </Typography>
+      </Paper>
+    )
+  }
+
+  return (
+    <Paper sx={{ overflow: 'hidden' }}>
+      <Box
+        sx={{
+          p: TABLE_STYLES.cell.padding.px,
+          borderBottom: TABLE_STYLES.cell.border,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Box>
+          <Typography
+            variant="tableHeader"
+            sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+          >
+            Category - {selectedCategory.name}
+          </Typography>
+          {selectedCategory.fullPath && selectedCategory.fullPath !== selectedCategory.name && (
+            <Typography variant="body2" sx={{ color: 'text.secondary', fontSize: '0.75rem', mt: 0.25 }}>
+              {selectedCategory.fullPath}
+            </Typography>
+          )}
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+          <IconButton
+            size="small"
+            title={`Edit ${selectedCategory.name}`}
+            aria-label={`Edit category ${selectedCategory.name}`}
+            onClick={onEdit}
+            sx={{ ...actionIconSx, color: 'primary.main' }}
+          >
+            <EditIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
+          </IconButton>
+          <IconButton
+            size="small"
+            title={`Delete ${selectedCategory.name}`}
+            aria-label={`Delete category ${selectedCategory.name}`}
+            onClick={onDelete}
+            sx={{ ...actionIconSx, color: 'error.main' }}
+          >
+            <DeleteIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
+          </IconButton>
+        </Box>
+      </Box>
+    </Paper>
+  )
+}
+
+export default CategoryContextHeader

--- a/frontend/src/pages/inventory/components/CategoryDialogs.tsx
+++ b/frontend/src/pages/inventory/components/CategoryDialogs.tsx
@@ -1,0 +1,211 @@
+import React, { useEffect } from 'react'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Grid,
+  TextField,
+  Typography,
+} from '@mui/material'
+import { yupResolver } from '@hookform/resolvers/yup'
+import { Controller, useForm, type UseFormReset } from 'react-hook-form'
+import * as yup from 'yup'
+
+import ConfirmationDialog from '@/components/common/ConfirmationDialog'
+import CategorySelector from '@/components/inventory/CategorySelector'
+import DeletedCategoriesDialog from '@/components/inventory/DeletedCategoriesDialog'
+import { SmartCategoryDeleteDialog } from '@/components/inventory/SmartCategoryDeleteDialog'
+import { useCategoryDuplicateCheck } from '@/hooks/useCategoryDuplicateCheck'
+import type { Category } from '@/types'
+
+interface CategoryFormData {
+  name: string
+  parentId?: string | null
+}
+
+const categorySchema = yup.object({
+  name: yup.string().required('Category name is required').min(2, 'Name must be at least 2 characters'),
+  parentId: yup.string().optional().nullable(),
+})
+
+interface CategoryDialogsProps {
+  dialogOpen: boolean
+  editMode: boolean
+  selectedCategory: Category | null
+  submitting: boolean
+  categories: Category[]
+  onSubmit: (data: CategoryFormData) => Promise<void>
+  onDialogClose: () => void
+  onFormReady: (resetFn: UseFormReset<CategoryFormData>) => void
+  onDuplicateStateChange: (isDuplicate: boolean, error: string | null) => void
+  deletedCategoriesDialogOpen: boolean
+  onCloseDeletedCategories: () => void
+  onCategoryRestored: () => void
+  deleteConfirmOpen: boolean
+  categoryToDelete: Category | null
+  onConfirmDelete: () => void
+  onCancelDelete: () => void
+  smartDeleteOpen: boolean
+  deleteError: any
+  onSmartDelete: (moveToUncategorized: boolean) => Promise<void>
+  onSmartDeleteClose: () => void
+}
+
+const CategoryDialogs: React.FC<CategoryDialogsProps> = ({
+  dialogOpen,
+  editMode,
+  selectedCategory,
+  submitting,
+  categories,
+  onSubmit,
+  onDialogClose,
+  onFormReady,
+  onDuplicateStateChange,
+  deletedCategoriesDialogOpen,
+  onCloseDeletedCategories,
+  onCategoryRestored,
+  deleteConfirmOpen,
+  categoryToDelete,
+  onConfirmDelete,
+  onCancelDelete,
+  smartDeleteOpen,
+  deleteError,
+  onSmartDelete,
+  onSmartDeleteClose,
+}) => {
+  const {
+    control,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { errors },
+  } = useForm<CategoryFormData>({
+    resolver: yupResolver(categorySchema) as any,
+    defaultValues: { name: '', parentId: null },
+  })
+
+  const {
+    checkDuplicate,
+    nameError: duplicateNameError,
+    hasNameDuplicate: isDuplicateName,
+  } = useCategoryDuplicateCheck()
+
+  const watchedName = watch('name')
+  const watchedParentId = watch('parentId')
+
+  useEffect(() => {
+    onFormReady(reset)
+  }, [onFormReady, reset])
+
+  useEffect(() => {
+    onDuplicateStateChange(isDuplicateName, duplicateNameError)
+  }, [duplicateNameError, isDuplicateName, onDuplicateStateChange])
+
+  useEffect(() => {
+    const timeoutId = setTimeout(async () => {
+      if (watchedName && watchedName.trim().length >= 2) {
+        await checkDuplicate({
+          name: watchedName.trim(),
+          parentId: watchedParentId || undefined,
+          excludeId: editMode && selectedCategory ? selectedCategory.id : undefined,
+        })
+      }
+    }, 500)
+
+    return () => clearTimeout(timeoutId)
+  }, [watchedName, watchedParentId, editMode, selectedCategory, checkDuplicate])
+
+  const findCategoryById = (id: string): Category | null =>
+    categories.find((category) => category.id === id) || null
+
+  const parentCategory = watchedParentId ? findCategoryById(watchedParentId) : null
+
+  return (
+    <>
+      <Dialog open={dialogOpen} onClose={onDialogClose} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          {editMode ? 'Edit Category' : 'Add New Category'}
+          {parentCategory && (
+            <Typography variant="body2" sx={{ color: 'text.secondary', mt: 1 }}>
+              Parent: {parentCategory.name}
+            </Typography>
+          )}
+        </DialogTitle>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <DialogContent>
+            <Grid container spacing={3} sx={{ mt: 1 }}>
+              <Grid size={12}>
+                <Controller
+                  name="name"
+                  control={control}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      fullWidth
+                      label="Category Name"
+                      error={!!errors.name || isDuplicateName}
+                      helperText={errors.name?.message || duplicateNameError || ''}
+                    />
+                  )}
+                />
+              </Grid>
+              <Grid size={12}>
+                <Controller
+                  name="parentId"
+                  control={control}
+                  render={({ field }) => (
+                    <CategorySelector
+                      value={field.value ? findCategoryById(field.value) : null}
+                      onChange={(category) => field.onChange(category?.id || null)}
+                      label="Parent Category"
+                      placeholder="Select parent category (optional)"
+                      allowRoot
+                      excludeCategories={editMode && selectedCategory ? [selectedCategory.id] : []}
+                    />
+                  )}
+                />
+              </Grid>
+            </Grid>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={onDialogClose} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="contained" disabled={submitting}>
+              {submitting ? 'Saving...' : editMode ? 'Update' : 'Create'}
+            </Button>
+          </DialogActions>
+        </form>
+      </Dialog>
+
+      <DeletedCategoriesDialog
+        open={deletedCategoriesDialogOpen}
+        onClose={onCloseDeletedCategories}
+        onCategoryRestored={onCategoryRestored}
+      />
+
+      <ConfirmationDialog
+        open={deleteConfirmOpen}
+        title="Confirm Delete"
+        message={`Are you sure you want to delete the category "${categoryToDelete?.name}"?`}
+        confirmText="Delete"
+        cancelText="Cancel"
+        onConfirm={onConfirmDelete}
+        onCancel={onCancelDelete}
+        severity="warning"
+      />
+
+      <SmartCategoryDeleteDialog
+        open={smartDeleteOpen}
+        category={categoryToDelete}
+        error={deleteError}
+        onClose={onSmartDeleteClose}
+        onConfirm={onSmartDelete}
+      />
+    </>
+  )
+}
+
+export default CategoryDialogs

--- a/frontend/src/pages/inventory/components/CategoryList.test.tsx
+++ b/frontend/src/pages/inventory/components/CategoryList.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import CategoryList from './CategoryList'
+
+import type { Category } from '@/types'
+
+const makeCategory = (id: string, name: string, level = 0): Category => ({
+  id,
+  name,
+  level,
+  fullPath: name,
+  isRoot: level === 0,
+  hasChildren: false,
+  isActive: true,
+  productCount: 0,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+})
+
+describe('CategoryList', () => {
+  it('shows the category count in the header', () => {
+    render(
+      <CategoryList
+        categories={[makeCategory('1', 'Alpha'), makeCategory('2', 'Beta')]}
+        loading={false}
+        focusedIndex={-1}
+        categoryListRef={{ current: null }}
+        onSelect={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Categories (2)')).toBeInTheDocument()
+  })
+
+  it('shows skeleton rows when loading with no categories', () => {
+    render(
+      <CategoryList
+        categories={[]}
+        loading={true}
+        focusedIndex={-1}
+        categoryListRef={{ current: null }}
+        onSelect={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByText(/no categories/i)).not.toBeInTheDocument()
+  })
+
+  it('shows empty state when not loading and no categories', () => {
+    render(
+      <CategoryList
+        categories={[]}
+        loading={false}
+        focusedIndex={-1}
+        categoryListRef={{ current: null }}
+        onSelect={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText(/no categories found/i)).toBeInTheDocument()
+  })
+
+  it('calls onSelect when a row is clicked', async () => {
+    const onSelect = vi.fn()
+    const alpha = makeCategory('1', 'Alpha')
+
+    render(
+      <CategoryList
+        categories={[alpha]}
+        loading={false}
+        focusedIndex={-1}
+        categoryListRef={{ current: null }}
+        onSelect={onSelect}
+      />,
+    )
+
+    await userEvent.click(screen.getByText('Alpha'))
+    expect(onSelect).toHaveBeenCalledWith(alpha)
+  })
+
+  it('highlights the selected category row', () => {
+    const alpha = makeCategory('1', 'Alpha')
+
+    render(
+      <CategoryList
+        categories={[alpha]}
+        loading={false}
+        selectedCategoryId="1"
+        focusedIndex={0}
+        categoryListRef={{ current: null }}
+        onSelect={vi.fn()}
+      />,
+    )
+
+    expect(document.querySelector('[data-category-index="0"]')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/inventory/components/CategoryList.tsx
+++ b/frontend/src/pages/inventory/components/CategoryList.tsx
@@ -1,0 +1,194 @@
+import React, { memo } from 'react'
+import {
+  Box,
+  Chip,
+  Paper,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material'
+import { default as DragIndicatorIcon } from '@mui/icons-material/DragIndicator'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import { formatDate } from '@/utils/formatters'
+import type { Category } from '@/types'
+
+interface CategoryRowProps {
+  category: Category
+  index: number
+  selectedCategoryId: string | undefined
+  focusedIndex: number
+  onSelect: (category: Category) => void
+  isMobile: boolean
+}
+
+const CategoryRow = memo(({
+  category,
+  index,
+  selectedCategoryId,
+  focusedIndex,
+  onSelect,
+  isMobile,
+}: CategoryRowProps) => {
+  const isSelected = selectedCategoryId === category.id
+  const isFocused = index === focusedIndex
+
+  return (
+    <TableRow
+      hover
+      onClick={() => onSelect(category)}
+      data-category-index={index}
+      sx={{
+        cursor: 'pointer',
+        backgroundColor: isSelected ? 'action.selected' : isFocused ? 'action.focus' : 'inherit',
+        '&:hover': {
+          backgroundColor: isSelected ? 'action.selected' : 'action.hover',
+        },
+        transition: 'background-color 0.2s ease',
+        height: TABLE_STYLES.row.height,
+        ...(isFocused && {
+          outline: '2px solid',
+          outlineColor: 'primary.main',
+          outlineOffset: '-2px',
+        }),
+      }}
+    >
+      <TableCell>
+        <Box
+          sx={{ display: 'flex', alignItems: 'center', ml: category.level * 1.5, gap: 0.5 }}
+          aria-level={category.level + 1}
+          role="treeitem"
+          aria-label={`${category.name} ${category.level === 0 ? 'root category' : `level ${category.level} category`}`}
+        >
+          <DragIndicatorIcon sx={{ color: 'text.secondary', fontSize: '0.875rem' }} />
+          <Typography variant="body2" sx={{ fontSize: '0.8rem', lineHeight: 1.2, fontWeight: 400 }}>
+            {category.name}
+          </Typography>
+        </Box>
+      </TableCell>
+      <TableCell sx={{ width: isMobile ? '30%' : '35%' }}>
+        <Chip
+          label={`${category.productCount ?? 0} ${(category.productCount ?? 0) === 1 ? 'item' : 'items'}`}
+          size="small"
+          color={category.productCount && category.productCount > 0 ? 'primary' : 'default'}
+          variant="outlined"
+          sx={{ fontSize: '0.7rem', fontWeight: 500 }}
+        />
+      </TableCell>
+      {!isMobile && (
+        <TableCell sx={{ width: '30%' }}>
+          <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: '0.7rem' }}>
+            {formatDate(category.createdAt)}
+          </Typography>
+        </TableCell>
+      )}
+    </TableRow>
+  )
+})
+
+CategoryRow.displayName = 'CategoryRow'
+
+interface CategoryListProps {
+  categories: Category[]
+  loading: boolean
+  selectedCategoryId?: string
+  focusedIndex: number
+  onSelect: (category: Category) => void
+  categoryListRef: React.RefObject<HTMLDivElement | null>
+}
+
+const CategoryList: React.FC<CategoryListProps> = ({
+  categories,
+  loading,
+  selectedCategoryId,
+  focusedIndex,
+  onSelect,
+  categoryListRef,
+}) => {
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
+
+  return (
+    <Paper sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Typography
+            variant="tableHeader"
+            sx={{
+              fontWeight: 600,
+              fontSize: '0.8rem',
+              textTransform: 'uppercase',
+              letterSpacing: '0.5px',
+            }}
+          >
+            Categories ({categories.length})
+          </Typography>
+          {loading && categories.length > 0 && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                Searching...
+              </Typography>
+              <Box sx={{ width: 16, height: 16 }}>
+                <Skeleton variant="circular" width={16} height={16} />
+              </Box>
+            </Box>
+          )}
+        </Box>
+      </Box>
+      <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }} ref={categoryListRef}>
+        <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
+          <Table
+            size={TABLE_STYLES.size}
+            sx={{
+              '& .MuiTableCell-root': {
+                borderBottom: TABLE_STYLES.cell.border,
+                py: TABLE_STYLES.cell.padding.py * 0.75,
+                px: TABLE_STYLES.cell.padding.px * 0.75,
+              },
+            }}
+          >
+            <TableBody>
+              {loading && categories.length === 0
+                ? [...Array(10)].map((_, index) => (
+                    <TableRow key={`skeleton-${index}`}>
+                      <TableCell colSpan={isMobile ? 2 : 3}>
+                        <Skeleton height={40} />
+                      </TableCell>
+                    </TableRow>
+                  ))
+                : categories.length === 0
+                  ? (
+                      <TableRow>
+                        <TableCell colSpan={isMobile ? 2 : 3}>
+                          <Typography variant="body2" sx={{ color: 'text.secondary', textAlign: 'center', py: 2 }}>
+                            No categories found
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  : categories.map((category, index) => (
+                      <CategoryRow
+                        key={category.id}
+                        category={category}
+                        index={index}
+                        selectedCategoryId={selectedCategoryId}
+                        focusedIndex={focusedIndex}
+                        onSelect={onSelect}
+                        isMobile={isMobile}
+                      />
+                    ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+    </Paper>
+  )
+}
+
+export default CategoryList

--- a/frontend/src/pages/inventory/components/CategoryWorkspaceCard.tsx
+++ b/frontend/src/pages/inventory/components/CategoryWorkspaceCard.tsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useState } from 'react'
+import { Box, Grid, Paper, Tab, Tabs, Typography } from '@mui/material'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import { useGetProductsQuery } from '@/store/api/inventoryApi'
+import type { Category } from '@/types'
+import { formatDate } from '@/utils/formatters'
+
+interface CategoryWorkspaceCardProps {
+  selectedCategory: Category | null
+}
+
+const CategoryWorkspaceCard: React.FC<CategoryWorkspaceCardProps> = ({ selectedCategory }) => {
+  const [tabValue, setTabValue] = useState(0)
+  const categoryId = selectedCategory?.id ?? ''
+
+  useEffect(() => {
+    setTabValue(0)
+  }, [categoryId])
+
+  const { data: productsResponse } = useGetProductsQuery(
+    { categoryId },
+    { skip: !categoryId || tabValue !== 1 },
+  )
+  const products = productsResponse?.data ?? []
+
+  if (!selectedCategory) {
+    return <Paper sx={{ flex: 1 }} />
+  }
+
+  const levelLabel = selectedCategory.level === 0 ? 'Root' : `Level ${selectedCategory.level}`
+  const parentLabel = selectedCategory.parent?.name ?? (selectedCategory.isRoot ? 'None' : '-')
+
+  return (
+    <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs
+          value={tabValue}
+          onChange={(_, value) => setTabValue(value)}
+          sx={{
+            minHeight: 40,
+            '& .MuiTab-root': { minHeight: 40, fontSize: '0.8rem', textTransform: 'none', fontWeight: 600 },
+          }}
+        >
+          <Tab label="Details" />
+          <Tab label="Products" />
+        </Tabs>
+      </Box>
+
+      <Box
+        role="tabpanel"
+        sx={{ flex: 1, overflow: 'auto', display: tabValue === 0 ? 'block' : 'none', p: TABLE_STYLES.cell.padding.px }}
+      >
+        {tabValue === 0 && (
+          <Grid container spacing={2} sx={{ mt: 0.5 }}>
+            {[
+              { label: 'Full Path', value: selectedCategory.fullPath },
+              { label: 'Level', value: levelLabel },
+              { label: 'Parent', value: parentLabel },
+              { label: 'Products', value: String(selectedCategory.productCount ?? 0) },
+              { label: 'Created', value: formatDate(selectedCategory.createdAt) },
+            ].map(({ label, value }) => (
+              <Grid key={label} size={{ xs: 12, sm: 6 }}>
+                <Typography
+                  variant="caption"
+                  sx={{ color: 'text.secondary', fontWeight: 600, fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+                >
+                  {label}
+                </Typography>
+                <Typography variant="body2" sx={{ fontSize: '0.85rem', mt: 0.25 }}>
+                  {value}
+                </Typography>
+              </Grid>
+            ))}
+          </Grid>
+        )}
+      </Box>
+
+      <Box
+        role="tabpanel"
+        sx={{ flex: 1, overflow: 'auto', display: tabValue === 1 ? 'flex' : 'none', flexDirection: 'column' }}
+      >
+        {tabValue === 1 && (
+          <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
+            {products.length === 0 ? (
+              <Typography variant="body2" sx={{ color: 'text.secondary', textAlign: 'center', py: 2 }}>
+                No products in this category
+              </Typography>
+            ) : (
+              products.map((product) => (
+                <Box
+                  key={product.id}
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    py: 0.75,
+                    borderBottom: TABLE_STYLES.cell.border,
+                    '&:last-child': { borderBottom: 'none' },
+                  }}
+                >
+                  <Typography variant="body2" sx={{ fontSize: '0.8rem' }}>
+                    {product.name}
+                  </Typography>
+                  <Typography variant="body2" sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>
+                    {product.stockQuantity} in stock
+                  </Typography>
+                </Box>
+              ))
+            )}
+          </Box>
+        )}
+      </Box>
+    </Paper>
+  )
+}
+
+export default CategoryWorkspaceCard

--- a/frontend/src/pages/inventory/hooks/useCategoriesActions.ts
+++ b/frontend/src/pages/inventory/hooks/useCategoriesActions.ts
@@ -1,0 +1,226 @@
+import { useCallback } from 'react'
+
+import type { Category } from '@/types'
+
+interface UseCategoriesActionsParams {
+  categories: Category[]
+  selectedCategory: Category | null
+  editMode: boolean
+  isDuplicateName: boolean
+  duplicateNameError: string | null
+  deleteCategory: (id: string) => { unwrap: () => Promise<void> }
+  createCategory: (data: { name: string; parentId: string | null }) => { unwrap: () => Promise<unknown> }
+  updateCategory: (args: {
+    id: string
+    data: { name: string; parentId?: string | null }
+  }) => { unwrap: () => Promise<unknown> }
+  showSuccess: (message: string) => void
+  showError: (message: string) => void
+  refetchCategories: () => void
+  setDialogOpen: (open: boolean) => void
+  setEditMode: (mode: boolean) => void
+  setDeleteConfirmOpen: (open: boolean) => void
+  setCategoryToDelete: (category: Category | null) => void
+  setSmartDeleteOpen: (open: boolean) => void
+  setDeleteError: (error: any) => void
+  setSubmitting: (submitting: boolean) => void
+  resetForm: (values: { name: string; parentId: string | null }) => void
+}
+
+export function useCategoriesActions({
+  categories: _categories,
+  selectedCategory,
+  editMode,
+  isDuplicateName,
+  duplicateNameError,
+  deleteCategory,
+  createCategory,
+  updateCategory,
+  showSuccess,
+  showError,
+  refetchCategories,
+  setDialogOpen,
+  setEditMode,
+  setDeleteConfirmOpen,
+  setCategoryToDelete,
+  setSmartDeleteOpen,
+  setDeleteError,
+  setSubmitting,
+  resetForm,
+}: UseCategoriesActionsParams) {
+  const handleAddCategory = useCallback(
+    (parentId?: string) => {
+      resetForm({ name: '', parentId: parentId || null })
+      setEditMode(false)
+      setCategoryToDelete(null)
+      setDialogOpen(true)
+    },
+    [resetForm, setCategoryToDelete, setDialogOpen, setEditMode],
+  )
+
+  const handleEditCategory = useCallback(
+    (category: Category) => {
+      resetForm({ name: category.name, parentId: category.parentId || null })
+      setEditMode(true)
+      setDialogOpen(true)
+    },
+    [resetForm, setDialogOpen, setEditMode],
+  )
+
+  const handleDeleteCategory = useCallback(
+    (category: Category) => {
+      setCategoryToDelete(category)
+      setDeleteError(null)
+      setDeleteConfirmOpen(true)
+    },
+    [setCategoryToDelete, setDeleteConfirmOpen, setDeleteError],
+  )
+
+  const handleConfirmDelete = useCallback(
+    async (categoryToDelete: Category | null) => {
+      if (!categoryToDelete) return
+
+      try {
+        await deleteCategory(categoryToDelete.id).unwrap()
+        showSuccess(`Category "${categoryToDelete.name}" deleted successfully.`)
+        setDeleteConfirmOpen(false)
+        setCategoryToDelete(null)
+      } catch (error: any) {
+        console.error('Delete category error:', error)
+
+        if (error?.productCount || (error?.includes && error.includes('contains'))) {
+          setDeleteConfirmOpen(false)
+          setDeleteError({
+            message: error?.message || error,
+            productCount: error?.productCount,
+            categoryName: categoryToDelete.name,
+            suggestions: error?.suggestions,
+          })
+          setSmartDeleteOpen(true)
+        } else {
+          showError(error || 'Failed to delete category')
+          setDeleteConfirmOpen(false)
+          setCategoryToDelete(null)
+        }
+      }
+    },
+    [
+      deleteCategory,
+      setCategoryToDelete,
+      setDeleteConfirmOpen,
+      setDeleteError,
+      setSmartDeleteOpen,
+      showError,
+      showSuccess,
+    ],
+  )
+
+  const handleSmartDelete = useCallback(
+    async (categoryToDelete: Category | null, moveToUncategorized: boolean) => {
+      if (!categoryToDelete) return
+
+      const params = new URLSearchParams()
+      params.set('force', 'true')
+      if (moveToUncategorized) {
+        params.set('moveToUncategorized', 'true')
+      }
+
+      const response = await fetch(
+        `/api/inventory/categories/${categoryToDelete.id}?${params.toString()}`,
+        { method: 'DELETE', headers: { 'Content-Type': 'application/json' } },
+      )
+
+      if (!response.ok) {
+        throw new Error(`Failed to delete category: ${response.statusText}`)
+      }
+
+      const result = await response.json()
+
+      if (result.moved && result.moved > 0) {
+        showSuccess(
+          `Category "${categoryToDelete.name}" deleted. ${result.moved} product${result.moved === 1 ? '' : 's'} moved to Uncategorized.`,
+        )
+      } else {
+        showSuccess(result.message || `Category "${categoryToDelete.name}" deleted successfully.`)
+      }
+
+      void refetchCategories()
+    },
+    [refetchCategories, showSuccess],
+  )
+
+  const handleCancelDelete = useCallback(() => {
+    setDeleteConfirmOpen(false)
+    setCategoryToDelete(null)
+  }, [setCategoryToDelete, setDeleteConfirmOpen])
+
+  const handleSmartDeleteClose = useCallback(() => {
+    setSmartDeleteOpen(false)
+    setCategoryToDelete(null)
+    setDeleteError(null)
+  }, [setCategoryToDelete, setDeleteError, setSmartDeleteOpen])
+
+  const onSubmit = useCallback(
+    async (data: { name: string; parentId?: string | null }) => {
+      try {
+        setSubmitting(true)
+
+        if (isDuplicateName) {
+          showError(duplicateNameError || 'Category name already exists')
+          return
+        }
+
+        if (editMode && selectedCategory) {
+          await updateCategory({ id: selectedCategory.id, data }).unwrap()
+          showSuccess('Category updated successfully')
+        } else {
+          await createCategory({ name: data.name, parentId: data.parentId || null }).unwrap()
+          showSuccess('Category created successfully')
+        }
+
+        setDialogOpen(false)
+        resetForm({ name: '', parentId: null })
+      } catch (error: any) {
+        console.error('Category save error:', error)
+
+        if (error?.response?.status === 409) {
+          showError(
+            `Duplicate entry detected: A category named "${data.name}" already exists. Please choose a different name.`,
+          )
+        } else if (error?.response?.status === 400) {
+          const message = error?.response?.data?.message || 'Invalid category data'
+          showError(`Validation error: ${message}`)
+        } else {
+          const message = error?.response?.data?.message || error?.message || 'Failed to save category'
+          showError(`Failed to save category: ${message}`)
+        }
+      } finally {
+        setSubmitting(false)
+      }
+    },
+    [
+      createCategory,
+      duplicateNameError,
+      editMode,
+      isDuplicateName,
+      resetForm,
+      selectedCategory,
+      setDialogOpen,
+      setSubmitting,
+      showError,
+      showSuccess,
+      updateCategory,
+    ],
+  )
+
+  return {
+    handleAddCategory,
+    handleEditCategory,
+    handleDeleteCategory,
+    handleConfirmDelete,
+    handleSmartDelete,
+    handleCancelDelete,
+    handleSmartDeleteClose,
+    onSubmit,
+  }
+}

--- a/frontend/src/pages/inventory/hooks/useCategoriesPageState.test.tsx
+++ b/frontend/src/pages/inventory/hooks/useCategoriesPageState.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { useCategoriesPageState } from './useCategoriesPageState'
+
+describe('useCategoriesPageState', () => {
+  it('initializes the category page UI state', () => {
+    const { result } = renderHook(() => useCategoriesPageState())
+
+    expect(result.current.dialogOpen).toBe(false)
+    expect(result.current.editMode).toBe(false)
+    expect(result.current.deletedCategoriesDialogOpen).toBe(false)
+    expect(result.current.deleteConfirmOpen).toBe(false)
+    expect(result.current.categoryToDelete).toBeNull()
+    expect(result.current.smartDeleteOpen).toBe(false)
+    expect(result.current.deleteError).toBeNull()
+    expect(result.current.submitting).toBe(false)
+    expect(result.current.focusedCategoryIndex).toBe(-1)
+    expect(result.current.categoryListRef.current).toBeNull()
+    expect(result.current.searchInputRef.current).toBeNull()
+  })
+})

--- a/frontend/src/pages/inventory/hooks/useCategoriesPageState.ts
+++ b/frontend/src/pages/inventory/hooks/useCategoriesPageState.ts
@@ -1,0 +1,40 @@
+import { useRef, useState } from 'react'
+
+import type { Category } from '@/types'
+
+export function useCategoriesPageState() {
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editMode, setEditMode] = useState(false)
+  const [deletedCategoriesDialogOpen, setDeletedCategoriesDialogOpen] = useState(false)
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
+  const [categoryToDelete, setCategoryToDelete] = useState<Category | null>(null)
+  const [smartDeleteOpen, setSmartDeleteOpen] = useState(false)
+  const [deleteError, setDeleteError] = useState<any>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [focusedCategoryIndex, setFocusedCategoryIndex] = useState<number>(-1)
+  const categoryListRef = useRef<HTMLDivElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  return {
+    dialogOpen,
+    setDialogOpen,
+    editMode,
+    setEditMode,
+    deletedCategoriesDialogOpen,
+    setDeletedCategoriesDialogOpen,
+    deleteConfirmOpen,
+    setDeleteConfirmOpen,
+    categoryToDelete,
+    setCategoryToDelete,
+    smartDeleteOpen,
+    setSmartDeleteOpen,
+    deleteError,
+    setDeleteError,
+    submitting,
+    setSubmitting,
+    focusedCategoryIndex,
+    setFocusedCategoryIndex,
+    categoryListRef,
+    searchInputRef,
+  }
+}

--- a/frontend/src/pages/inventory/hooks/useCategoriesSelection.test.tsx
+++ b/frontend/src/pages/inventory/hooks/useCategoriesSelection.test.tsx
@@ -1,0 +1,122 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useCategoriesSelection } from './useCategoriesSelection'
+
+import type { Category } from '@/types'
+
+const makeCategory = (id: string, name: string, level = 0): Category => ({
+  id,
+  name,
+  level,
+  fullPath: name,
+  isRoot: level === 0,
+  hasChildren: false,
+  isActive: true,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+})
+
+describe('useCategoriesSelection', () => {
+  it('auto-selects the first category when none is selected', async () => {
+    const dispatch = vi.fn()
+    const setFocusedCategoryIndex = vi.fn()
+    const alpha = makeCategory('1', 'Alpha')
+    const beta = makeCategory('2', 'Beta')
+
+    renderHook(() =>
+      useCategoriesSelection({
+        dispatch: dispatch as never,
+        categories: [alpha, beta],
+        selectedCategory: null,
+        focusedCategoryIndex: -1,
+        setFocusedCategoryIndex,
+        categoryListRef: { current: null },
+      }),
+    )
+
+    await waitFor(() => {
+      expect(setFocusedCategoryIndex).toHaveBeenCalledWith(0)
+    })
+
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ payload: alpha }))
+  })
+
+  it('does not auto-select when a category is already selected', async () => {
+    const dispatch = vi.fn()
+    const setFocusedCategoryIndex = vi.fn()
+    const alpha = makeCategory('1', 'Alpha')
+
+    renderHook(() =>
+      useCategoriesSelection({
+        dispatch: dispatch as never,
+        categories: [alpha],
+        selectedCategory: alpha,
+        focusedCategoryIndex: 0,
+        setFocusedCategoryIndex,
+        categoryListRef: { current: null },
+      }),
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('deselects when the categories list becomes empty', async () => {
+    const dispatch = vi.fn()
+    const setFocusedCategoryIndex = vi.fn()
+    const alpha = makeCategory('1', 'Alpha')
+
+    const { rerender } = renderHook(
+      (props: Parameters<typeof useCategoriesSelection>[0]) => useCategoriesSelection(props),
+      {
+        initialProps: {
+          dispatch: dispatch as never,
+          categories: [alpha],
+          selectedCategory: alpha,
+          focusedCategoryIndex: 0,
+          setFocusedCategoryIndex,
+          categoryListRef: { current: null },
+        },
+      },
+    )
+
+    rerender({
+      dispatch: dispatch as never,
+      categories: [],
+      selectedCategory: alpha,
+      focusedCategoryIndex: 0,
+      setFocusedCategoryIndex,
+      categoryListRef: { current: null },
+    })
+
+    await waitFor(() => {
+      expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ payload: null }))
+    })
+    expect(setFocusedCategoryIndex).toHaveBeenCalledWith(-1)
+  })
+
+  it('handleCategorySelect selects the clicked category', async () => {
+    const dispatch = vi.fn()
+    const setFocusedCategoryIndex = vi.fn()
+    const alpha = makeCategory('1', 'Alpha')
+    const beta = makeCategory('2', 'Beta')
+
+    const { result } = renderHook(() =>
+      useCategoriesSelection({
+        dispatch: dispatch as never,
+        categories: [alpha, beta],
+        selectedCategory: alpha,
+        focusedCategoryIndex: 0,
+        setFocusedCategoryIndex,
+        categoryListRef: { current: null },
+      }),
+    )
+
+    result.current.handleCategorySelect(beta)
+
+    expect(setFocusedCategoryIndex).toHaveBeenCalledWith(1)
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ payload: beta }))
+  })
+})

--- a/frontend/src/pages/inventory/hooks/useCategoriesSelection.ts
+++ b/frontend/src/pages/inventory/hooks/useCategoriesSelection.ts
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useRef, type RefObject } from 'react'
+
+import type { AppDispatch } from '@/store'
+import { setSelectedCategory } from '@/store/slices/inventorySlice'
+import type { Category } from '@/types'
+
+interface UseCategoriesSelectionParams {
+  dispatch: AppDispatch
+  categories: Category[]
+  selectedCategory: Category | null
+  focusedCategoryIndex: number
+  setFocusedCategoryIndex: (index: number) => void
+  categoryListRef: RefObject<HTMLDivElement | null>
+}
+
+export function useCategoriesSelection({
+  dispatch,
+  categories,
+  selectedCategory,
+  focusedCategoryIndex,
+  setFocusedCategoryIndex,
+  categoryListRef,
+}: UseCategoriesSelectionParams) {
+  const hasAutoSelected = useRef(false)
+
+  useEffect(() => {
+    if (
+      categories.length > 0 &&
+      !hasAutoSelected.current &&
+      focusedCategoryIndex === -1 &&
+      !selectedCategory
+    ) {
+      hasAutoSelected.current = true
+      setFocusedCategoryIndex(0)
+      dispatch(setSelectedCategory(categories[0]))
+    } else if (categories.length === 0) {
+      dispatch(setSelectedCategory(null))
+      setFocusedCategoryIndex(-1)
+    }
+  }, [categories, dispatch, focusedCategoryIndex, selectedCategory, setFocusedCategoryIndex])
+
+  useEffect(() => {
+    if (selectedCategory && categories.length > 0) {
+      const updatedCategory = categories.find((category) => category.id === selectedCategory.id)
+      if (updatedCategory) {
+        const hasChanged = JSON.stringify(updatedCategory) !== JSON.stringify(selectedCategory)
+        if (hasChanged) {
+          dispatch(setSelectedCategory(updatedCategory))
+        }
+      } else {
+        dispatch(setSelectedCategory(null))
+      }
+    }
+  }, [dispatch, categories, selectedCategory])
+
+  useEffect(() => {
+    if (focusedCategoryIndex >= 0 && categoryListRef.current) {
+      const focusedRow = categoryListRef.current.querySelector(
+        `[data-category-index="${focusedCategoryIndex}"]`,
+      )
+      if (focusedRow) {
+        focusedRow.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      }
+    }
+  }, [focusedCategoryIndex, categoryListRef])
+
+  const selectAtIndex = useCallback(
+    (index: number) => {
+      setFocusedCategoryIndex(index)
+      dispatch(setSelectedCategory(categories[index]))
+    },
+    [dispatch, categories, setFocusedCategoryIndex],
+  )
+
+  const handleCategorySelect = useCallback(
+    (category: Category) => {
+      const index = categories.findIndex((candidate) => candidate.id === category.id)
+      setFocusedCategoryIndex(index)
+      dispatch(setSelectedCategory(category))
+    },
+    [dispatch, categories, setFocusedCategoryIndex],
+  )
+
+  const handleNavigateUp = useCallback(() => {
+    if (focusedCategoryIndex > 0) {
+      selectAtIndex(focusedCategoryIndex - 1)
+    }
+  }, [focusedCategoryIndex, selectAtIndex])
+
+  const handleNavigateDown = useCallback(() => {
+    if (focusedCategoryIndex < categories.length - 1) {
+      selectAtIndex(focusedCategoryIndex + 1)
+    }
+  }, [focusedCategoryIndex, categories.length, selectAtIndex])
+
+  const handleNavigateToFirst = useCallback(() => {
+    if (categories.length > 0) {
+      selectAtIndex(0)
+    }
+  }, [categories.length, selectAtIndex])
+
+  const handleNavigateToLast = useCallback(() => {
+    if (categories.length > 0) {
+      selectAtIndex(categories.length - 1)
+    }
+  }, [categories.length, selectAtIndex])
+
+  const handlePageUpNavigation = useCallback(() => {
+    const newIndex = Math.max(0, focusedCategoryIndex - 10)
+    if (categories[newIndex]) {
+      selectAtIndex(newIndex)
+    }
+  }, [focusedCategoryIndex, categories, selectAtIndex])
+
+  const handlePageDownNavigation = useCallback(() => {
+    const newIndex = Math.min(categories.length - 1, focusedCategoryIndex + 10)
+    if (categories[newIndex]) {
+      selectAtIndex(newIndex)
+    }
+  }, [focusedCategoryIndex, categories, selectAtIndex])
+
+  const handleEscapeAction = useCallback(() => {
+    setFocusedCategoryIndex(-1)
+    dispatch(setSelectedCategory(null))
+  }, [dispatch, setFocusedCategoryIndex])
+
+  return {
+    handleCategorySelect,
+    handleNavigateUp,
+    handleNavigateDown,
+    handleNavigateToFirst,
+    handleNavigateToLast,
+    handlePageUpNavigation,
+    handlePageDownNavigation,
+    handleEscapeAction,
+  }
+}

--- a/frontend/src/store/slices/__tests__/inventorySlice.test.ts
+++ b/frontend/src/store/slices/__tests__/inventorySlice.test.ts
@@ -1,0 +1,49 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { describe, expect, it } from 'vitest'
+
+import inventoryReducer, {
+  selectSelectedCategory,
+  setSelectedCategory,
+} from '../inventorySlice'
+import type { Category } from '@/types'
+
+const makeCategory = (id: string, name: string): Category => ({
+  id,
+  name,
+  level: 0,
+  fullPath: name,
+  isRoot: true,
+  hasChildren: false,
+  isActive: true,
+  createdAt: new Date('2026-04-12T00:00:00.000Z'),
+  updatedAt: new Date('2026-04-12T00:00:00.000Z'),
+})
+
+describe('inventorySlice', () => {
+  it('stores the selected category', () => {
+    const store = configureStore({
+      reducer: {
+        inventory: inventoryReducer,
+      },
+    })
+    const category = makeCategory('cat-1', 'Electronics')
+
+    store.dispatch(setSelectedCategory(category))
+
+    expect(selectSelectedCategory(store.getState())).toEqual(category)
+  })
+
+  it('clears the selected category', () => {
+    const store = configureStore({
+      reducer: {
+        inventory: inventoryReducer,
+      },
+    })
+    const category = makeCategory('cat-1', 'Electronics')
+
+    store.dispatch(setSelectedCategory(category))
+    store.dispatch(setSelectedCategory(null))
+
+    expect(selectSelectedCategory(store.getState())).toBeNull()
+  })
+})

--- a/frontend/src/store/slices/inventorySlice.ts
+++ b/frontend/src/store/slices/inventorySlice.ts
@@ -1,10 +1,11 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 
-import type { Product, StockAdjustment } from '@/types'
+import type { Category, Product, StockAdjustment } from '@/types'
 import type { RootState } from '@/store'
 
 interface InventoryState {
   selectedProduct: Product | null
+  selectedCategory: Category | null
   selectedStockAdjustment: StockAdjustment | null
   filters: {
     categories: {
@@ -15,6 +16,7 @@ interface InventoryState {
 
 const initialState: InventoryState = {
   selectedProduct: null,
+  selectedCategory: null,
   selectedStockAdjustment: null,
   filters: {
     categories: {
@@ -30,6 +32,9 @@ const inventorySlice = createSlice({
     setSelectedProduct: (state, action: PayloadAction<Product | null>) => {
       state.selectedProduct = action.payload
     },
+    setSelectedCategory: (state, action: PayloadAction<Category | null>) => {
+      state.selectedCategory = action.payload
+    },
     setSelectedStockAdjustment: (state, action: PayloadAction<StockAdjustment | null>) => {
       state.selectedStockAdjustment = action.payload
     },
@@ -41,11 +46,13 @@ const inventorySlice = createSlice({
 
 export const {
   setSelectedProduct,
+  setSelectedCategory,
   setSelectedStockAdjustment,
   setCategoryFilters,
 } = inventorySlice.actions
 
 export const selectSelectedProduct = (state: RootState) => state.inventory.selectedProduct
+export const selectSelectedCategory = (state: RootState) => state.inventory.selectedCategory
 export const selectSelectedStockAdjustment = (state: RootState) => state.inventory.selectedStockAdjustment
 export const selectCategoryFilters = (state: RootState) => state.inventory.filters.categories
 


### PR DESCRIPTION
## Summary

- Decomposes the 700+ line `CategoriesPage.tsx` monolith into focused hooks (`useCategoriesPageState`, `useCategoriesSelection`, `useCategoriesActions`) and UI components (`CategoryList`, `CategoryContextHeader`, `CategoryWorkspaceCard`, `CategoryDialogs`)
- Adds `selectedCategory` to the Redux inventory slice alongside `selectedProduct`
- Replaces the plain search `TextField` with `FilterBar` for consistency with other pages
- New `CategoryWorkspaceCard` shows category metadata (Details tab) and products in the selected category (Products tab) — useful context before delete/rename decisions
- All existing behaviours preserved: hierarchical indentation, smart delete escalation, real-time duplicate name validation, keyboard navigation, `DeletedCategoriesDialog` restore flow

## Test plan

- [x] `cd frontend && npx vitest run src/store/slices/__tests__/inventorySlice.test.ts` — passes
- [x] `cd frontend && npx vitest run src/pages/inventory/hooks/useCategoriesPageState.test.tsx` — passes
- [x] `cd frontend && npx vitest run src/pages/inventory/hooks/useCategoriesSelection.test.tsx` — passes
- [x] `cd frontend && npx vitest run src/pages/inventory/components/CategoryList.test.tsx` — passes
- [x] Navigate to Categories page: hierarchical indentation renders correctly
- [x] Click a category: context header shows name + path + Edit/Delete buttons
- [x] Workspace card Details tab: full path, level, parent, product count, created date
- [x] Workspace card Products tab: lists products in the selected category
- [x] Delete a category with products: confirm dialog escalates to smart delete dialog
- [x] FilterBar search filters the list; keyboard nav (arrows, Escape, Home/End) works
- [x] Add/Edit category form dialog with real-time duplicate validation works

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)