### PR TITLE
feat(inventory): categories master-detail polish (#348, #349)

### DIFF
--- a/frontend/src/pages/inventory/components/CategoryContextHeader.tsx
+++ b/frontend/src/pages/inventory/components/CategoryContextHeader.tsx
@@ -1,10 +1,23 @@
 import React from 'react'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as EditIcon } from '@mui/icons-material/Edit'
-import { Box, IconButton, Paper, Typography } from '@mui/material'
+import {
+  Box,
+  Chip,
+  Grid,
+  IconButton,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+} from '@mui/material'
 
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { Category } from '@/types'
+import { formatDate } from '@/utils/formatters'
 
 interface CategoryContextHeaderProps {
   selectedCategory: Category | null
@@ -18,6 +31,27 @@ const actionIconSx = {
   minHeight: 20,
   minWidth: 20,
   p: 0.125,
+}
+
+const detailTableSx = {
+  tableLayout: 'fixed',
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const labelCellSx = {
+  fontWeight: 600,
+  color: 'text.secondary',
+  fontSize: '0.8rem',
+}
+
+const valueCellSx = {
+  fontSize: '0.8rem',
 }
 
 const CategoryContextHeader: React.FC<CategoryContextHeaderProps> = ({
@@ -35,6 +69,10 @@ const CategoryContextHeader: React.FC<CategoryContextHeaderProps> = ({
     )
   }
 
+  const levelLabel = selectedCategory.level === 0 ? 'Root' : `Level ${selectedCategory.level}`
+  const parentLabel = selectedCategory.parent?.name ?? (selectedCategory.isRoot ? 'None' : '—')
+  const productCount = selectedCategory.productCount ?? 0
+
   return (
     <Paper sx={{ overflow: 'hidden' }}>
       <Box
@@ -46,19 +84,12 @@ const CategoryContextHeader: React.FC<CategoryContextHeaderProps> = ({
           alignItems: 'center',
         }}
       >
-        <Box>
-          <Typography
-            variant="tableHeader"
-            sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
-          >
-            Category - {selectedCategory.name}
-          </Typography>
-          {selectedCategory.fullPath && selectedCategory.fullPath !== selectedCategory.name && (
-            <Typography variant="body2" sx={{ color: 'text.secondary', fontSize: '0.75rem', mt: 0.25 }}>
-              {selectedCategory.fullPath}
-            </Typography>
-          )}
-        </Box>
+        <Typography
+          variant="tableHeader"
+          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+        >
+          Category - {selectedCategory.name}
+        </Typography>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
           <IconButton
             size="small"
@@ -79,6 +110,95 @@ const CategoryContextHeader: React.FC<CategoryContextHeaderProps> = ({
             <DeleteIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
           </IconButton>
         </Box>
+      </Box>
+
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell
+                      colSpan={2}
+                      sx={{
+                        pb: TABLE_STYLES.cell.padding.py * 0.67,
+                        py: TABLE_STYLES.cell.padding.py * 0.67,
+                        borderTop: TABLE_STYLES.cell.border,
+                      }}
+                    >
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Category Info
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Category Path</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedCategory.fullPath}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Level</TableCell>
+                    <TableCell sx={valueCellSx}>{levelLabel}</TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Parent Category</TableCell>
+                    <TableCell sx={valueCellSx}>{parentLabel}</TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell
+                      colSpan={2}
+                      sx={{
+                        pb: TABLE_STYLES.cell.padding.py * 0.67,
+                        py: TABLE_STYLES.cell.padding.py * 0.67,
+                        borderTop: TABLE_STYLES.cell.border,
+                      }}
+                    >
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Summary
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Product Count</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      <Chip
+                        label={`${productCount} ${productCount === 1 ? 'item' : 'items'}`}
+                        size="small"
+                        color={productCount > 0 ? 'primary' : 'default'}
+                        variant="outlined"
+                        sx={{ fontSize: '0.7rem', fontWeight: 500 }}
+                      />
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Created</TableCell>
+                    <TableCell sx={valueCellSx}>{formatDate(selectedCategory.createdAt)}</TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Status</TableCell>
+                    <TableCell
+                      sx={{
+                        ...valueCellSx,
+                        color: selectedCategory.isActive ? 'success.main' : 'text.disabled',
+                      }}
+                    >
+                      {selectedCategory.isActive ? 'Active' : 'Inactive'}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+        </Grid>
       </Box>
     </Paper>
   )

--- a/frontend/src/pages/inventory/components/CategoryContextHeader.tsx
+++ b/frontend/src/pages/inventory/components/CategoryContextHeader.tsx
@@ -70,7 +70,7 @@ const CategoryContextHeader: React.FC<CategoryContextHeaderProps> = ({
   }
 
   const levelLabel = selectedCategory.level === 0 ? 'Root' : `Level ${selectedCategory.level}`
-  const parentLabel = selectedCategory.parent?.name ?? (selectedCategory.isRoot ? 'None' : '—')
+  const parentLabel = selectedCategory.parent?.name ?? (selectedCategory.isRoot || selectedCategory.level === 0 ? 'None' : '—')
   const productCount = selectedCategory.productCount ?? 0
 
   return (

--- a/frontend/src/pages/inventory/components/CategoryList.test.tsx
+++ b/frontend/src/pages/inventory/components/CategoryList.test.tsx
@@ -62,6 +62,38 @@ describe('CategoryList', () => {
     expect(screen.getByText(/no categories found/i)).toBeInTheDocument()
   })
 
+  it('does not show product count chip in rows', () => {
+    const cat = makeCategory('1', 'Alpha')
+
+    render(
+      <CategoryList
+        categories={[cat]}
+        loading={false}
+        focusedIndex={-1}
+        categoryListRef={{ current: null }}
+        onSelect={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByText(/item/i)).not.toBeInTheDocument()
+  })
+
+  it('does not show creation date in rows', () => {
+    const cat = makeCategory('1', 'Alpha')
+
+    render(
+      <CategoryList
+        categories={[cat]}
+        loading={false}
+        focusedIndex={-1}
+        categoryListRef={{ current: null }}
+        onSelect={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByText(/2026/)).not.toBeInTheDocument()
+  })
+
   it('calls onSelect when a row is clicked', async () => {
     const onSelect = vi.fn()
     const alpha = makeCategory('1', 'Alpha')

--- a/frontend/src/pages/inventory/components/CategoryList.tsx
+++ b/frontend/src/pages/inventory/components/CategoryList.tsx
@@ -1,7 +1,6 @@
 import React, { memo } from 'react'
 import {
   Box,
-  Chip,
   Paper,
   Skeleton,
   Table,
@@ -10,13 +9,10 @@ import {
   TableContainer,
   TableRow,
   Typography,
-  useMediaQuery,
-  useTheme,
 } from '@mui/material'
 import { default as DragIndicatorIcon } from '@mui/icons-material/DragIndicator'
 
 import { TABLE_STYLES } from '@/constants/tableStyles'
-import { formatDate } from '@/utils/formatters'
 import type { Category } from '@/types'
 
 interface CategoryRowProps {
@@ -25,7 +21,6 @@ interface CategoryRowProps {
   selectedCategoryId: string | undefined
   focusedIndex: number
   onSelect: (category: Category) => void
-  isMobile: boolean
 }
 
 const CategoryRow = memo(({
@@ -34,7 +29,6 @@ const CategoryRow = memo(({
   selectedCategoryId,
   focusedIndex,
   onSelect,
-  isMobile,
 }: CategoryRowProps) => {
   const isSelected = selectedCategoryId === category.id
   const isFocused = index === focusedIndex
@@ -72,22 +66,6 @@ const CategoryRow = memo(({
           </Typography>
         </Box>
       </TableCell>
-      <TableCell sx={{ width: isMobile ? '30%' : '35%' }}>
-        <Chip
-          label={`${category.productCount ?? 0} ${(category.productCount ?? 0) === 1 ? 'item' : 'items'}`}
-          size="small"
-          color={category.productCount && category.productCount > 0 ? 'primary' : 'default'}
-          variant="outlined"
-          sx={{ fontSize: '0.7rem', fontWeight: 500 }}
-        />
-      </TableCell>
-      {!isMobile && (
-        <TableCell sx={{ width: '30%' }}>
-          <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: '0.7rem' }}>
-            {formatDate(category.createdAt)}
-          </Typography>
-        </TableCell>
-      )}
     </TableRow>
   )
 })
@@ -111,9 +89,6 @@ const CategoryList: React.FC<CategoryListProps> = ({
   onSelect,
   categoryListRef,
 }) => {
-  const theme = useTheme()
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
-
   return (
     <Paper sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
@@ -157,7 +132,7 @@ const CategoryList: React.FC<CategoryListProps> = ({
               {loading && categories.length === 0
                 ? [...Array(10)].map((_, index) => (
                     <TableRow key={`skeleton-${index}`}>
-                      <TableCell colSpan={isMobile ? 2 : 3}>
+                      <TableCell colSpan={1}>
                         <Skeleton height={40} />
                       </TableCell>
                     </TableRow>
@@ -165,7 +140,7 @@ const CategoryList: React.FC<CategoryListProps> = ({
                 : categories.length === 0
                   ? (
                       <TableRow>
-                        <TableCell colSpan={isMobile ? 2 : 3}>
+                        <TableCell colSpan={1}>
                           <Typography variant="body2" sx={{ color: 'text.secondary', textAlign: 'center', py: 2 }}>
                             No categories found
                           </Typography>
@@ -180,7 +155,6 @@ const CategoryList: React.FC<CategoryListProps> = ({
                         selectedCategoryId={selectedCategoryId}
                         focusedIndex={focusedIndex}
                         onSelect={onSelect}
-                        isMobile={isMobile}
                       />
                     ))}
             </TableBody>

--- a/frontend/src/pages/inventory/components/CategoryList.tsx
+++ b/frontend/src/pages/inventory/components/CategoryList.tsx
@@ -132,7 +132,7 @@ const CategoryList: React.FC<CategoryListProps> = ({
               {loading && categories.length === 0
                 ? [...Array(10)].map((_, index) => (
                     <TableRow key={`skeleton-${index}`}>
-                      <TableCell colSpan={1}>
+                      <TableCell>
                         <Skeleton height={40} />
                       </TableCell>
                     </TableRow>
@@ -140,7 +140,7 @@ const CategoryList: React.FC<CategoryListProps> = ({
                 : categories.length === 0
                   ? (
                       <TableRow>
-                        <TableCell colSpan={1}>
+                        <TableCell>
                           <Typography variant="body2" sx={{ color: 'text.secondary', textAlign: 'center', py: 2 }}>
                             No categories found
                           </Typography>

--- a/frontend/src/pages/inventory/components/CategoryProductsList.test.tsx
+++ b/frontend/src/pages/inventory/components/CategoryProductsList.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import CategoryProductsList from './CategoryProductsList'
+
+const mockUseGetProductsQuery = vi.hoisted(() => vi.fn())
+const mockUseGetRegionalSettingsQuery = vi.hoisted(() => vi.fn())
+
+vi.mock('@/store/api/inventoryApi', () => ({
+  useGetProductsQuery: mockUseGetProductsQuery,
+}))
+
+vi.mock('@/store/api/settingsApi', () => ({
+  useGetRegionalSettingsQuery: mockUseGetRegionalSettingsQuery,
+}))
+
+const makeProduct = (overrides: Partial<{
+  id: string
+  name: string
+  barcode: string | null
+  stockQuantity: number
+}> = {}) => ({
+  id: 'prod-1',
+  name: 'Widget',
+  barcode: 'WGT-001',
+  stockQuantity: 50,
+  ...overrides,
+})
+
+describe('CategoryProductsList', () => {
+  beforeEach(() => {
+    mockUseGetProductsQuery.mockReset()
+    mockUseGetRegionalSettingsQuery.mockReset()
+    mockUseGetRegionalSettingsQuery.mockReturnValue({ data: { lowStockThreshold: 10 } })
+  })
+
+  it('shows a loading spinner while fetching', () => {
+    mockUseGetProductsQuery.mockReturnValue({ data: undefined, isLoading: true, isError: false })
+
+    render(<CategoryProductsList categoryId="cat-1" />)
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('shows error message when fetch fails', () => {
+    mockUseGetProductsQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true })
+
+    render(<CategoryProductsList categoryId="cat-1" />)
+
+    expect(screen.getByText('Failed to load products.')).toBeInTheDocument()
+  })
+
+  it('shows empty state when category has no products', () => {
+    mockUseGetProductsQuery.mockReturnValue({ data: { data: [] }, isLoading: false, isError: false })
+
+    render(<CategoryProductsList categoryId="cat-1" />)
+
+    expect(screen.getByText('No products in this category.')).toBeInTheDocument()
+  })
+
+  it('renders product name and barcode', () => {
+    mockUseGetProductsQuery.mockReturnValue({
+      data: { data: [makeProduct({ name: 'Widget', barcode: 'WGT-001' })] },
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<CategoryProductsList categoryId="cat-1" />)
+
+    expect(screen.getByText('Widget')).toBeInTheDocument()
+    expect(screen.getByText('WGT-001')).toBeInTheDocument()
+  })
+
+  it('shows em dash when product has no barcode', () => {
+    mockUseGetProductsQuery.mockReturnValue({
+      data: { data: [makeProduct({ barcode: null })] },
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<CategoryProductsList categoryId="cat-1" />)
+
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  it('shows In Stock chip when stock is above threshold', () => {
+    mockUseGetRegionalSettingsQuery.mockReturnValue({ data: { lowStockThreshold: 10 } })
+    mockUseGetProductsQuery.mockReturnValue({
+      data: { data: [makeProduct({ stockQuantity: 11 })] },
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<CategoryProductsList categoryId="cat-1" />)
+
+    expect(screen.getByText('In Stock')).toBeInTheDocument()
+  })
+
+  it('shows Low Stock chip when stock is at or below threshold', () => {
+    mockUseGetRegionalSettingsQuery.mockReturnValue({ data: { lowStockThreshold: 10 } })
+    mockUseGetProductsQuery.mockReturnValue({
+      data: { data: [makeProduct({ stockQuantity: 10 })] },
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<CategoryProductsList categoryId="cat-1" />)
+
+    expect(screen.getByText('Low Stock')).toBeInTheDocument()
+  })
+
+  it('shows Out of Stock chip when stock is zero', () => {
+    mockUseGetProductsQuery.mockReturnValue({
+      data: { data: [makeProduct({ stockQuantity: 0 })] },
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<CategoryProductsList categoryId="cat-1" />)
+
+    expect(screen.getByText('Out of Stock')).toBeInTheDocument()
+  })
+
+  it('uses lowStockThreshold from regional settings, not the hardcoded fallback', () => {
+    mockUseGetRegionalSettingsQuery.mockReturnValue({ data: { lowStockThreshold: 25 } })
+    mockUseGetProductsQuery.mockReturnValue({
+      data: { data: [makeProduct({ stockQuantity: 20 })] },
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<CategoryProductsList categoryId="cat-1" />)
+
+    // 20 <= 25 threshold → Low Stock (not In Stock, which the hardcoded fallback of 10 would give)
+    expect(screen.getByText('Low Stock')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/inventory/components/CategoryProductsList.tsx
+++ b/frontend/src/pages/inventory/components/CategoryProductsList.tsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import { useGetProductsQuery } from '@/store/api/inventoryApi'
+import { useGetRegionalSettingsQuery } from '@/store/api/settingsApi'
+
+interface CategoryProductsListProps {
+  categoryId: string
+}
+
+const CategoryProductsList: React.FC<CategoryProductsListProps> = ({ categoryId }) => {
+  const { data: productsResponse, isLoading, isError } = useGetProductsQuery({ categoryId })
+  const { data: regionalSettings } = useGetRegionalSettingsQuery()
+
+  const products = productsResponse?.data ?? []
+  const lowStockThreshold = regionalSettings?.lowStockThreshold ?? 10
+
+  const getStockStatus = (
+    stockQuantity: number,
+  ): { label: string; color: 'error' | 'warning' | 'success' } => {
+    if (stockQuantity <= 0) return { label: 'Out of Stock', color: 'error' }
+    if (stockQuantity <= lowStockThreshold) return { label: 'Low Stock', color: 'warning' }
+    return { label: 'In Stock', color: 'success' }
+  }
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  if (isError) {
+    return (
+      <Typography sx={{ color: 'error.main', py: 4, textAlign: 'center' }}>
+        Failed to load products.
+      </Typography>
+    )
+  }
+
+  if (products.length === 0) {
+    return (
+      <Typography sx={{ color: 'text.secondary', py: 4, textAlign: 'center' }}>
+        No products in this category.
+      </Typography>
+    )
+  }
+
+  return (
+    <TableContainer component={Box}>
+      <Table size={TABLE_STYLES.size}>
+        <TableHead>
+          <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50' } }}>
+            <TableCell>Name</TableCell>
+            <TableCell>Barcode</TableCell>
+            <TableCell>Stock</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {products.map((product) => {
+            const stock = product.stockQuantity ?? 0
+            const status = getStockStatus(stock)
+
+            return (
+              <TableRow key={product.id} hover>
+                <TableCell>
+                  <Typography variant="body2" color="primary" sx={{ fontWeight: 600, fontSize: '0.8rem' }}>
+                    {product.name}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography
+                    variant="body2"
+                    sx={{ fontSize: '0.8rem', color: product.barcode ? 'text.primary' : 'text.secondary' }}
+                  >
+                    {product.barcode || '—'}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Typography variant="body2" sx={{ fontSize: '0.8rem' }}>
+                      {stock}
+                    </Typography>
+                    <Chip
+                      label={status.label}
+                      color={status.color}
+                      size="small"
+                      variant="outlined"
+                      sx={{ fontSize: '0.7rem', fontWeight: 500, height: 20 }}
+                    />
+                  </Box>
+                </TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  )
+}
+
+export default CategoryProductsList

--- a/frontend/src/pages/inventory/components/CategoryWorkspaceCard.tsx
+++ b/frontend/src/pages/inventory/components/CategoryWorkspaceCard.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react'
-import { Box, Grid, Paper, Tab, Tabs, Typography } from '@mui/material'
+import { Box, Paper, Tab, Tabs, Typography } from '@mui/material'
 
 import { TABLE_STYLES } from '@/constants/tableStyles'
-import { useGetProductsQuery } from '@/store/api/inventoryApi'
 import type { Category } from '@/types'
-import { formatDate } from '@/utils/formatters'
+
+import CategoryProductsList from './CategoryProductsList'
 
 interface CategoryWorkspaceCardProps {
   selectedCategory: Category | null
@@ -18,18 +18,9 @@ const CategoryWorkspaceCard: React.FC<CategoryWorkspaceCardProps> = ({ selectedC
     setTabValue(0)
   }, [categoryId])
 
-  const { data: productsResponse } = useGetProductsQuery(
-    { categoryId },
-    { skip: !categoryId || tabValue !== 1 },
-  )
-  const products = productsResponse?.data ?? []
-
   if (!selectedCategory) {
     return <Paper sx={{ flex: 1 }} />
   }
-
-  const levelLabel = selectedCategory.level === 0 ? 'Root' : `Level ${selectedCategory.level}`
-  const parentLabel = selectedCategory.parent?.name ?? (selectedCategory.isRoot ? 'None' : '-')
 
   return (
     <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
@@ -52,64 +43,25 @@ const CategoryWorkspaceCard: React.FC<CategoryWorkspaceCardProps> = ({ selectedC
         sx={{ flex: 1, overflow: 'auto', display: tabValue === 0 ? 'block' : 'none', p: TABLE_STYLES.cell.padding.px }}
       >
         {tabValue === 0 && (
-          <Grid container spacing={2} sx={{ mt: 0.5 }}>
-            {[
-              { label: 'Full Path', value: selectedCategory.fullPath },
-              { label: 'Level', value: levelLabel },
-              { label: 'Parent', value: parentLabel },
-              { label: 'Products', value: String(selectedCategory.productCount ?? 0) },
-              { label: 'Created', value: formatDate(selectedCategory.createdAt) },
-            ].map(({ label, value }) => (
-              <Grid key={label} size={{ xs: 12, sm: 6 }}>
-                <Typography
-                  variant="caption"
-                  sx={{ color: 'text.secondary', fontWeight: 600, fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
-                >
-                  {label}
-                </Typography>
-                <Typography variant="body2" sx={{ fontSize: '0.85rem', mt: 0.25 }}>
-                  {value}
-                </Typography>
-              </Grid>
-            ))}
-          </Grid>
+          <Box>
+            <Typography
+              variant="caption"
+              sx={{ color: 'text.secondary', fontWeight: 600, fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+            >
+              Full Path
+            </Typography>
+            <Typography variant="body2" sx={{ fontSize: '0.85rem', mt: 0.25 }}>
+              {selectedCategory.fullPath}
+            </Typography>
+          </Box>
         )}
       </Box>
 
       <Box
         role="tabpanel"
-        sx={{ flex: 1, overflow: 'auto', display: tabValue === 1 ? 'flex' : 'none', flexDirection: 'column' }}
+        sx={{ flex: 1, overflow: 'auto', display: tabValue === 1 ? 'flex' : 'none', flexDirection: 'column', p: TABLE_STYLES.cell.padding.px }}
       >
-        {tabValue === 1 && (
-          <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
-            {products.length === 0 ? (
-              <Typography variant="body2" sx={{ color: 'text.secondary', textAlign: 'center', py: 2 }}>
-                No products in this category
-              </Typography>
-            ) : (
-              products.map((product) => (
-                <Box
-                  key={product.id}
-                  sx={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                    py: 0.75,
-                    borderBottom: TABLE_STYLES.cell.border,
-                    '&:last-child': { borderBottom: 'none' },
-                  }}
-                >
-                  <Typography variant="body2" sx={{ fontSize: '0.8rem' }}>
-                    {product.name}
-                  </Typography>
-                  <Typography variant="body2" sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>
-                    {product.stockQuantity} in stock
-                  </Typography>
-                </Box>
-              ))
-            )}
-          </Box>
-        )}
+        {tabValue === 1 && <CategoryProductsList categoryId={selectedCategory.id} />}
       </Box>
     </Paper>
   )


### PR DESCRIPTION
## Summary

- **#348** — Strip `CategoryList` to name-only rows: removes product count Chip and creation date columns, drops `isMobile` logic entirely
- **#349** — Add two-column info grid to `CategoryContextHeader` (Category Path, Level, Parent / Product Count chip, Created, Status) following the `CustomerContextHeader` pattern
- **#349** — New `CategoryProductsList` component: proper table with Name, Barcode, Stock columns (stock status chip using regional `lowStockThreshold`), with loading/error/empty states
- **#349** — Refactor `CategoryWorkspaceCard`: simplified Details tab, Products tab now uses `CategoryProductsList`

## Test Plan

- [x] Select a category — info grid appears in context header with correct path, level, parent, product count, created date, and status
- [x] Category with no parent shows "None" (not "—") for Parent Category
- [x] Switch to Products tab — table loads with Name, Barcode, Stock columns and correct stock chips
- [x] Category with no products shows "No products in this category."
- [x] Category list shows only category names (no chip, no date)
- [x] `CategoryList` tests: 7/7 passing (includes regression tests for removed columns)
- [x] `CategoryProductsList` tests: 9/9 passing (loading/error/empty states, stock chip logic, `lowStockThreshold` respected)

Closes #348
Closes #349