### PR TITLE
feat(inventory): category workspace + header polish (#350, #351)

### DIFF
--- a/frontend/src/pages/inventory/CategoriesPage.tsx
+++ b/frontend/src/pages/inventory/CategoriesPage.tsx
@@ -161,6 +161,7 @@ const CategoriesPage: React.FC = () => {
         headerSlot={(
           <CategoryContextHeader
             selectedCategory={selectedCategory}
+            allCategories={categories}
             onEdit={() => selectedCategory && actions.handleEditCategory(selectedCategory)}
             onDelete={() => selectedCategory && actions.handleDeleteCategory(selectedCategory)}
           />

--- a/frontend/src/pages/inventory/components/CategoryContextHeader.test.tsx
+++ b/frontend/src/pages/inventory/components/CategoryContextHeader.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import CategoryContextHeader from './CategoryContextHeader'
+
+import type { Category } from '@/types'
+
+const makeCategory = (overrides: Partial<Category> = {}): Category => ({
+  id: 'root',
+  name: 'Root',
+  level: 0,
+  parentId: null,
+  fullPath: 'BROKEN PATH',
+  isRoot: true,
+  hasChildren: false,
+  isActive: true,
+  productCount: 0,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+})
+
+describe('CategoryContextHeader', () => {
+  it('builds the category path from the category list and resolves the parent from parentId', () => {
+    const root = makeCategory()
+    const child = makeCategory({
+      id: 'child',
+      name: 'Child',
+      level: 1,
+      parentId: root.id,
+      isRoot: false,
+      fullPath: 'WRONG CHILD PATH',
+    })
+    const leaf = makeCategory({
+      id: 'leaf',
+      name: 'Leaf',
+      level: 2,
+      parentId: child.id,
+      isRoot: false,
+      fullPath: 'WRONG LEAF PATH',
+    })
+
+    render(
+      <CategoryContextHeader
+        selectedCategory={leaf}
+        allCategories={[root, child, leaf]}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Root > Child > Leaf')).toBeInTheDocument()
+    expect(screen.getByText('Child')).toBeInTheDocument()
+    expect(screen.queryByText('WRONG LEAF PATH')).not.toBeInTheDocument()
+  })
+
+  it('does not render a status row', () => {
+    render(
+      <CategoryContextHeader
+        selectedCategory={makeCategory({ id: 'child', name: 'Child', level: 1, isRoot: false })}
+        allCategories={[]}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByText('Status')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/inventory/components/CategoryContextHeader.test.tsx
+++ b/frontend/src/pages/inventory/components/CategoryContextHeader.test.tsx
@@ -50,7 +50,10 @@ describe('CategoryContextHeader', () => {
     )
 
     expect(screen.getByText('Root > Child > Leaf')).toBeInTheDocument()
-    expect(screen.getByText('Child')).toBeInTheDocument()
+    // Parent Category row value should show the parent's name
+    const cells = screen.getAllByRole('cell')
+    const parentLabelIndex = cells.findIndex(cell => cell.textContent === 'Parent Category')
+    expect(cells[parentLabelIndex + 1]).toHaveTextContent('Child')
     expect(screen.queryByText('WRONG LEAF PATH')).not.toBeInTheDocument()
   })
 

--- a/frontend/src/pages/inventory/components/CategoryContextHeader.tsx
+++ b/frontend/src/pages/inventory/components/CategoryContextHeader.tsx
@@ -21,8 +21,23 @@ import { formatDate } from '@/utils/formatters'
 
 interface CategoryContextHeaderProps {
   selectedCategory: Category | null
+  allCategories: Category[]
   onEdit: () => void
   onDelete: () => void
+}
+
+function buildCategoryHierarchy(categoryId: string, allCategories: Category[]): string {
+  const names: string[] = []
+  let current = allCategories.find(c => c.id === categoryId)
+
+  while (current) {
+    names.unshift(current.name)
+    current = current.parentId
+      ? allCategories.find(c => c.id === current.parentId)
+      : undefined
+  }
+
+  return names.length > 0 ? names.join(' > ') : '—'
 }
 
 const actionIconSx = {
@@ -56,6 +71,7 @@ const valueCellSx = {
 
 const CategoryContextHeader: React.FC<CategoryContextHeaderProps> = ({
   selectedCategory,
+  allCategories,
   onEdit,
   onDelete,
 }) => {
@@ -70,8 +86,11 @@ const CategoryContextHeader: React.FC<CategoryContextHeaderProps> = ({
   }
 
   const levelLabel = selectedCategory.level === 0 ? 'Root' : `Level ${selectedCategory.level}`
-  const parentLabel = selectedCategory.parent?.name ?? (selectedCategory.isRoot || selectedCategory.level === 0 ? 'None' : '—')
+  const parentName = selectedCategory.parentId
+    ? allCategories.find(c => c.id === selectedCategory.parentId)?.name ?? '—'
+    : 'None'
   const productCount = selectedCategory.productCount ?? 0
+  const fullHierarchy = buildCategoryHierarchy(selectedCategory.id, allCategories)
 
   return (
     <Paper sx={{ overflow: 'hidden' }}>
@@ -134,7 +153,7 @@ const CategoryContextHeader: React.FC<CategoryContextHeaderProps> = ({
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
                     <TableCell sx={labelCellSx}>Category Path</TableCell>
-                    <TableCell sx={valueCellSx}>{selectedCategory.fullPath}</TableCell>
+                    <TableCell sx={valueCellSx}>{fullHierarchy}</TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell sx={labelCellSx}>Level</TableCell>
@@ -142,7 +161,7 @@ const CategoryContextHeader: React.FC<CategoryContextHeaderProps> = ({
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
                     <TableCell sx={labelCellSx}>Parent Category</TableCell>
-                    <TableCell sx={valueCellSx}>{parentLabel}</TableCell>
+                    <TableCell sx={valueCellSx}>{parentName}</TableCell>
                   </TableRow>
                 </TableBody>
               </Table>
@@ -182,17 +201,6 @@ const CategoryContextHeader: React.FC<CategoryContextHeaderProps> = ({
                   <TableRow>
                     <TableCell sx={labelCellSx}>Created</TableCell>
                     <TableCell sx={valueCellSx}>{formatDate(selectedCategory.createdAt)}</TableCell>
-                  </TableRow>
-                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                    <TableCell sx={labelCellSx}>Status</TableCell>
-                    <TableCell
-                      sx={{
-                        ...valueCellSx,
-                        color: selectedCategory.isActive ? 'success.main' : 'text.disabled',
-                      }}
-                    >
-                      {selectedCategory.isActive ? 'Active' : 'Inactive'}
-                    </TableCell>
                   </TableRow>
                 </TableBody>
               </Table>

--- a/frontend/src/pages/inventory/components/CategoryContextHeader.tsx
+++ b/frontend/src/pages/inventory/components/CategoryContextHeader.tsx
@@ -28,9 +28,11 @@ interface CategoryContextHeaderProps {
 
 function buildCategoryHierarchy(categoryId: string, allCategories: Category[]): string {
   const names: string[] = []
+  const visited = new Set<string>()
   let current = allCategories.find(c => c.id === categoryId)
 
-  while (current) {
+  while (current && !visited.has(current.id)) {
+    visited.add(current.id)
     names.unshift(current.name)
     current = current.parentId
       ? allCategories.find(c => c.id === current.parentId)

--- a/frontend/src/pages/inventory/components/CategoryProductsList.tsx
+++ b/frontend/src/pages/inventory/components/CategoryProductsList.tsx
@@ -15,6 +15,7 @@ import {
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { useGetProductsQuery } from '@/store/api/inventoryApi'
 import { useGetRegionalSettingsQuery } from '@/store/api/settingsApi'
+import { getStockStatus } from '@/utils/stockUtils'
 
 interface CategoryProductsListProps {
   categoryId: string
@@ -26,14 +27,6 @@ const CategoryProductsList: React.FC<CategoryProductsListProps> = ({ categoryId 
 
   const products = productsResponse?.data ?? []
   const lowStockThreshold = regionalSettings?.lowStockThreshold ?? 10
-
-  const getStockStatus = (
-    stockQuantity: number,
-  ): { label: string; color: 'error' | 'warning' | 'success' } => {
-    if (stockQuantity <= 0) return { label: 'Out of Stock', color: 'error' }
-    if (stockQuantity <= lowStockThreshold) return { label: 'Low Stock', color: 'warning' }
-    return { label: 'In Stock', color: 'success' }
-  }
 
   if (isLoading) {
     return (
@@ -72,7 +65,7 @@ const CategoryProductsList: React.FC<CategoryProductsListProps> = ({ categoryId 
         <TableBody>
           {products.map((product) => {
             const stock = product.stockQuantity ?? 0
-            const status = getStockStatus(stock)
+            const status = getStockStatus(stock, lowStockThreshold)
 
             return (
               <TableRow key={product.id} hover>

--- a/frontend/src/pages/inventory/components/CategoryWorkspaceCard.test.tsx
+++ b/frontend/src/pages/inventory/components/CategoryWorkspaceCard.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import CategoryWorkspaceCard from './CategoryWorkspaceCard'
+
+import type { Category } from '@/types'
+
+const mockUseGetProductsQuery = vi.hoisted(() => vi.fn())
+const mockUseGetRegionalSettingsQuery = vi.hoisted(() => vi.fn())
+
+vi.mock('@/store/api/inventoryApi', () => ({
+  useGetProductsQuery: mockUseGetProductsQuery,
+}))
+
+vi.mock('@/store/api/settingsApi', () => ({
+  useGetRegionalSettingsQuery: mockUseGetRegionalSettingsQuery,
+}))
+
+const makeCategory = (overrides: Partial<Category> = {}): Category => ({
+  id: 'cat-1',
+  name: 'Hardware',
+  level: 0,
+  parentId: null,
+  fullPath: 'Hardware',
+  isRoot: true,
+  hasChildren: false,
+  isActive: true,
+  productCount: 0,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+})
+
+const makeProduct = (overrides: Partial<{ id: string; name: string; stockQuantity: number }> = {}) => ({
+  id: 'prod-1',
+  name: 'Widget',
+  stockQuantity: 12,
+  ...overrides,
+})
+
+describe('CategoryWorkspaceCard', () => {
+  beforeEach(() => {
+    mockUseGetProductsQuery.mockReset()
+    mockUseGetRegionalSettingsQuery.mockReset()
+    mockUseGetRegionalSettingsQuery.mockReturnValue({ data: { lowStockThreshold: 10 } })
+  })
+
+  it('renders a products table and notes section instead of tab panels', () => {
+    mockUseGetProductsQuery.mockReturnValue({
+      data: { data: [makeProduct({ name: 'Widget', stockQuantity: 3 })] },
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<CategoryWorkspaceCard selectedCategory={makeCategory({ description: 'Shelf A' })} />)
+
+    expect(screen.getByText('Category Products')).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Stock' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Status' })).toBeInTheDocument()
+    expect(screen.getByText('Low Stock')).toBeInTheDocument()
+    expect(screen.getByText('Notes')).toBeInTheDocument()
+    expect(screen.getByText('Shelf A')).toBeInTheDocument()
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument()
+    expect(screen.queryByText('Full Path')).not.toBeInTheDocument()
+  })
+
+  it('skips the products query when no category is selected', () => {
+    mockUseGetProductsQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<CategoryWorkspaceCard selectedCategory={null} />)
+
+    expect(mockUseGetProductsQuery).toHaveBeenCalledWith({ categoryId: '' }, { skip: true })
+    expect(screen.queryByText('Category Products')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/inventory/components/CategoryWorkspaceCard.tsx
+++ b/frontend/src/pages/inventory/components/CategoryWorkspaceCard.tsx
@@ -1,22 +1,47 @@
-import React, { useEffect, useState } from 'react'
-import { Box, Paper, Tab, Tabs, Typography } from '@mui/material'
+import React from 'react'
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material'
 
 import { TABLE_STYLES } from '@/constants/tableStyles'
+import { useGetProductsQuery } from '@/store/api/inventoryApi'
+import { useGetRegionalSettingsQuery } from '@/store/api/settingsApi'
 import type { Category } from '@/types'
-
-import CategoryProductsList from './CategoryProductsList'
 
 interface CategoryWorkspaceCardProps {
   selectedCategory: Category | null
 }
 
-const CategoryWorkspaceCard: React.FC<CategoryWorkspaceCardProps> = ({ selectedCategory }) => {
-  const [tabValue, setTabValue] = useState(0)
-  const categoryId = selectedCategory?.id ?? ''
+const getStockStatus = (
+  stockQuantity: number,
+  lowStockThreshold: number,
+): { label: string; color: 'error' | 'warning' | 'success' } => {
+  if (stockQuantity <= 0) return { label: 'Out of Stock', color: 'error' }
+  if (stockQuantity <= lowStockThreshold) return { label: 'Low Stock', color: 'warning' }
+  return { label: 'In Stock', color: 'success' }
+}
 
-  useEffect(() => {
-    setTabValue(0)
-  }, [categoryId])
+const CategoryWorkspaceCard: React.FC<CategoryWorkspaceCardProps> = ({ selectedCategory }) => {
+  const categoryId = selectedCategory?.id ?? ''
+  const { data: productsResponse, isLoading, isError } = useGetProductsQuery(
+    { categoryId },
+    { skip: !categoryId },
+  )
+  const { data: regionalSettings } = useGetRegionalSettingsQuery()
+
+  const products = productsResponse?.data ?? []
+  const lowStockThreshold = regionalSettings?.lowStockThreshold ?? 10
 
   if (!selectedCategory) {
     return <Paper sx={{ flex: 1 }} />
@@ -24,44 +49,110 @@ const CategoryWorkspaceCard: React.FC<CategoryWorkspaceCardProps> = ({ selectedC
 
   return (
     <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-        <Tabs
-          value={tabValue}
-          onChange={(_, value) => setTabValue(value)}
-          sx={{
-            minHeight: 40,
-            '& .MuiTab-root': { minHeight: 40, fontSize: '0.8rem', textTransform: 'none', fontWeight: 600 },
-          }}
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
+        <Typography
+          variant="tableHeader"
+          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
         >
-          <Tab label="Details" />
-          <Tab label="Products" />
-        </Tabs>
+          Category Products
+        </Typography>
       </Box>
 
-      <Box
-        role="tabpanel"
-        sx={{ flex: 1, overflow: 'auto', display: tabValue === 0 ? 'block' : 'none', p: TABLE_STYLES.cell.padding.px }}
-      >
-        {tabValue === 0 && (
-          <Box>
+      <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', p: TABLE_STYLES.cell.padding.px }}>
+        <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          {isLoading ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+              <CircularProgress />
+            </Box>
+          ) : isError ? (
+            <Alert severity="error">Failed to load products.</Alert>
+          ) : products.length === 0 ? (
+            <Alert severity="info">No products in this category.</Alert>
+          ) : (
+            <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
+              <Table
+                size={TABLE_STYLES.size}
+                sx={{
+                  '& .MuiTableCell-root': {
+                    borderBottom: TABLE_STYLES.cell.border,
+                    py: TABLE_STYLES.cell.padding.py,
+                    px: TABLE_STYLES.cell.padding.px,
+                  },
+                }}
+              >
+                <TableHead>
+                  <TableRow
+                    sx={{
+                      '& .MuiTableCell-head': {
+                        fontWeight: 600,
+                        backgroundColor: 'grey.50',
+                        color: 'text.primary',
+                        fontSize: '0.8rem',
+                      },
+                    }}
+                  >
+                    <TableCell>Name</TableCell>
+                    <TableCell align="right" sx={{ width: '15%' }}>
+                      Stock
+                    </TableCell>
+                    <TableCell align="center" sx={{ width: '25%' }}>
+                      Status
+                    </TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {products.map((product) => {
+                    const stock = product.stockQuantity ?? 0
+                    const status = getStockStatus(stock, lowStockThreshold)
+
+                    return (
+                      <TableRow key={product.id} hover sx={{ height: TABLE_STYLES.row.height }}>
+                        <TableCell sx={{ fontSize: '0.8rem', fontWeight: 600, color: 'primary.main' }}>
+                          {product.name}
+                        </TableCell>
+                        <TableCell align="right" sx={{ fontSize: '0.8rem' }}>
+                          {stock}
+                        </TableCell>
+                        <TableCell align="center">
+                          <Chip
+                            label={status.label}
+                            color={status.color}
+                            size="small"
+                            variant="outlined"
+                            sx={{ fontSize: '0.7rem', fontWeight: 500, height: 20 }}
+                          />
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </Box>
+
+        {selectedCategory.description && (
+          <Box sx={{ mt: 1 }}>
             <Typography
-              variant="caption"
-              sx={{ color: 'text.secondary', fontWeight: 600, fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+              variant="tableHeader"
+              sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px', mb: 1 }}
             >
-              Full Path
+              Notes
             </Typography>
-            <Typography variant="body2" sx={{ fontSize: '0.85rem', mt: 0.25 }}>
-              {selectedCategory.fullPath}
-            </Typography>
+            <Box
+              sx={{
+                p: 2,
+                backgroundColor: 'grey.50',
+                borderRadius: 1,
+                fontSize: '0.8rem',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+              }}
+            >
+              {selectedCategory.description}
+            </Box>
           </Box>
         )}
-      </Box>
-
-      <Box
-        role="tabpanel"
-        sx={{ flex: 1, overflow: 'auto', display: tabValue === 1 ? 'flex' : 'none', flexDirection: 'column', p: TABLE_STYLES.cell.padding.px }}
-      >
-        {tabValue === 1 && <CategoryProductsList categoryId={selectedCategory.id} />}
       </Box>
     </Paper>
   )

--- a/frontend/src/pages/inventory/components/CategoryWorkspaceCard.tsx
+++ b/frontend/src/pages/inventory/components/CategoryWorkspaceCard.tsx
@@ -18,18 +18,10 @@ import { TABLE_STYLES } from '@/constants/tableStyles'
 import { useGetProductsQuery } from '@/store/api/inventoryApi'
 import { useGetRegionalSettingsQuery } from '@/store/api/settingsApi'
 import type { Category } from '@/types'
+import { getStockStatus } from '@/utils/stockUtils'
 
 interface CategoryWorkspaceCardProps {
   selectedCategory: Category | null
-}
-
-const getStockStatus = (
-  stockQuantity: number,
-  lowStockThreshold: number,
-): { label: string; color: 'error' | 'warning' | 'success' } => {
-  if (stockQuantity <= 0) return { label: 'Out of Stock', color: 'error' }
-  if (stockQuantity <= lowStockThreshold) return { label: 'Low Stock', color: 'warning' }
-  return { label: 'In Stock', color: 'success' }
 }
 
 const CategoryWorkspaceCard: React.FC<CategoryWorkspaceCardProps> = ({ selectedCategory }) => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -48,6 +48,7 @@ export interface Product {
 export interface Category {
   id: string;
   name: string;
+  description?: string;
   path?: string | null;
   level: number;
   parentId?: string | null;

--- a/frontend/src/utils/stockUtils.ts
+++ b/frontend/src/utils/stockUtils.ts
@@ -1,0 +1,8 @@
+export const getStockStatus = (
+  stockQuantity: number,
+  lowStockThreshold: number,
+): { label: string; color: 'error' | 'warning' | 'success' } => {
+  if (stockQuantity <= 0) return { label: 'Out of Stock', color: 'error' }
+  if (stockQuantity <= lowStockThreshold) return { label: 'Low Stock', color: 'warning' }
+  return { label: 'In Stock', color: 'success' }
+}


### PR DESCRIPTION
## Summary
- **#350**: Rewrote `CategoryWorkspaceCard` — removed 2-tab layout, replaced with a focused products table (Name / Stock / Stock Status chip) + optional Notes section, matching the `PurchaseOrderWorkspaceCard` pattern
- **#351**: Fixed `CategoryContextHeader` — full hierarchy path now built from the cached category list via `buildCategoryHierarchy` (fixes broken `fullPath`), parent name resolved from `parentId` lookup, Status row removed
- Extracted `getStockStatus` to `src/utils/stockUtils.ts` to eliminate duplication between `CategoryWorkspaceCard` and `CategoryProductsList`

## Test Plan
- [x] Select a root category — Category Path shows just the name, Parent Category shows "None"
- [x] Select a mid-level category — Category Path shows `Root > Child`, Parent Category shows root name
- [x] Select a leaf category — Category Path shows full chain, Parent Category shows direct parent name
- [x] Status row is gone from the context header
- [x] Workspace card shows Name / Stock / Stock Status columns (no tabs)
- [x] Empty category shows "No products in this category."
- [x] Category with `description` set shows Notes section at bottom of workspace card
- [x] `npx vitest run src/pages/inventory/components/CategoryContextHeader.test.tsx src/pages/inventory/components/CategoryWorkspaceCard.test.tsx src/pages/inventory/components/CategoryProductsList.test.tsx` — all pass

Closes #350
Closes #351