### PR TITLE
refactor(inventory): rewrite StockAdjustmentsPage using Master-Detail pattern

### DIFF
--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -214,7 +214,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
         const saNumber = updatedAdjustment?.adjustmentNumber || 'N/A'
 
         showSuccess(`Stock adjustment ${saNumber} updated successfully`)
-        navigate('/inventory/stock-adjustments', { state: { newAdjustmentId: id } })
+        navigate(`/inventory/stock-adjustments?saId=${id}`)
       } else {
         // Create mode: Create new adjustment (kept as draft)
         const adjustment = await createStockAdjustment(adjustmentData).unwrap()
@@ -224,7 +224,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
         const status = adjustment?.status || 'draft'
 
         showSuccess(`Stock adjustment ${saNumber} created successfully (${itemsAdjusted} items) - Status: ${status}`)
-        navigate('/inventory/stock-adjustments', { state: { newAdjustmentId: adjustment.id } })
+        navigate(`/inventory/stock-adjustments?saId=${adjustment.id}`)
       }
     } catch (err: any) {
       setError(err.data?.message || err.message || 'Failed to record stock adjustments')

--- a/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
@@ -1,41 +1,14 @@
-import React, { useState, useEffect, useRef, useCallback, memo, useMemo } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
-import {
-  Box,
-  Typography,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Button,
-  Chip,
-  CircularProgress,
-  Alert,
-  Grid,
-  IconButton,
-  Stack,
-} from '@mui/material'
-import { default as SortIcon } from '@mui/icons-material/Sort'
-import { default as ArrowUpIcon } from '@mui/icons-material/ArrowUpward'
-import { default as ArrowDownIcon } from '@mui/icons-material/ArrowDownward'
-import { default as DeleteIcon } from '@mui/icons-material/Delete'
-import { default as EditIcon } from '@mui/icons-material/Edit'
-import { ListSkeleton } from '@/components/common/ListSkeleton'
+import React, { useCallback, useMemo } from 'react'
+import { Alert, Box, useMediaQuery, useTheme } from '@mui/material'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+
+import MasterDetailWorkspace from '@/components/common/MasterDetailWorkspace'
 import PageHeader from '@/components/common/PageHeader'
 import { FilterBar } from '@/components/filters'
-import DeletedStockAdjustmentsDialog from '@/components/inventory/DeletedStockAdjustmentsDialog'
-import ConfirmationDialog from '@/components/common/ConfirmationDialog'
 import { useFilterBar } from '@/hooks/useFilterBar'
-import { useLazyGetJournalEntriesQuery } from '@/store/api/accountingApi'
-import type { JournalEntry } from '@/types'
+import { useNotification } from '@/hooks/useNotification'
+import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
 import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
-import {
-  setSelectedStockAdjustment,
-  selectSelectedStockAdjustment,
-} from '@/store/slices/inventorySlice'
 import {
   useCompleteStockAdjustmentMutation,
   useDeleteStockAdjustmentMutation,
@@ -43,89 +16,31 @@ import {
   useLazyGetStockAdjustmentQuery,
   useUncompleteStockAdjustmentMutation,
 } from '@/store/api/inventoryApi'
-import { formatDate } from '@/utils/formatters'
-import { useNotification } from '@/hooks/useNotification'
-import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'
-import { TABLE_STYLES } from '@/constants/tableStyles'
-import type { StockAdjustment } from '@/types'
+import { selectSelectedStockAdjustment } from '@/store/slices/inventorySlice'
 import type { FilterBarConfig } from '@/types/filterBar.types'
+
+import StockAdjustmentContextHeader from './components/StockAdjustmentContextHeader'
+import StockAdjustmentList from './components/StockAdjustmentList'
+import StockAdjustmentWorkspaceCard from './components/StockAdjustmentWorkspaceCard'
+import StockAdjustmentsDialogs from './components/StockAdjustmentsDialogs'
+import { useStockAdjustmentsActions } from './hooks/useStockAdjustmentsActions'
+import { useStockAdjustmentsPageState } from './hooks/useStockAdjustmentsPageState'
+import { useStockAdjustmentsSelection } from './hooks/useStockAdjustmentsSelection'
 
 interface StockAdjustmentFilters {
   search: string
   status: 'draft' | 'completed' | 'cancelled' | null
 }
 
-interface StockAdjustmentsSortState {
-  sortBy: string
-  sortOrder: 'asc' | 'desc'
-}
-
-// Memoized Adjustment Row Component
-interface AdjustmentRowProps {
-  adjustment: StockAdjustment
-  index: number
-  selectedAdjustmentId?: string
-  focusedAdjustmentIndex: number
-  onAdjustmentSelect: (adjustment: StockAdjustment) => void
-}
-
-const AdjustmentRow = memo(({ adjustment, index, selectedAdjustmentId, focusedAdjustmentIndex, onAdjustmentSelect }: AdjustmentRowProps) => {
-  const isSelected = selectedAdjustmentId === adjustment.id
-  const isFocused = index === focusedAdjustmentIndex
-
-  return (
-    <TableRow
-      key={adjustment.id}
-      hover
-      onClick={() => onAdjustmentSelect(adjustment)}
-      data-adjustment-index={index}
-      sx={{
-        cursor: 'pointer',
-        backgroundColor: isSelected ? 'action.selected' : isFocused ? 'action.focus' : 'inherit',
-        '&:hover': {
-          backgroundColor: isSelected ? 'action.selected' : 'action.hover'
-        },
-        transition: 'background-color 0.2s ease',
-        height: TABLE_STYLES.row.height,
-        ...(isFocused && {
-          outline: '2px solid',
-          outlineColor: 'primary.main',
-          outlineOffset: '-2px'
-        })
-      }}
-    >
-      <TableCell>
-        <Typography
-          variant="body2"
-          sx={{
-            fontWeight: 400,
-            fontSize: '0.8rem',
-            lineHeight: 1.2
-          }}
-        >
-          {adjustment.adjustmentNumber}
-        </Typography>
-      </TableCell>
-    </TableRow>
-  )
-})
-
-AdjustmentRow.displayName = 'AdjustmentRow'
-
 const StockAdjustmentsPage: React.FC = () => {
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
   const navigate = useNavigate()
-  const location = useLocation()
   const dispatch = useAppDispatch()
   const { showSuccess, showError } = useNotification()
-
-  // Check for newly created adjustment ID from navigation state
-  const newAdjustmentId = (location.state as any)?.newAdjustmentId
-
-  const [sortState, setSortState] = useState<StockAdjustmentsSortState>({
-    sortBy: 'adjustmentNumber',
-    sortOrder: 'asc',
-  })
+  const [searchParams, setSearchParams] = useSearchParams()
   const selectedAdjustment = useAppSelector(selectSelectedStockAdjustment)
+  const pageState = useStockAdjustmentsPageState()
 
   const filterConfig = useMemo<FilterBarConfig<StockAdjustmentFilters>>(
     () => ({
@@ -138,891 +53,170 @@ const StockAdjustmentsPage: React.FC = () => {
     [],
   )
 
-  const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
+  const filterBar = useFilterBar(filterConfig)
 
-  const adjustmentQueryParams = useMemo(
+  const queryParams = useMemo(
     () => ({
-      search: appliedFilters.search || undefined,
-      status: appliedFilters.status ?? undefined,
-      sortBy: sortState.sortBy,
-      sortOrder: sortState.sortOrder.toUpperCase(),
+      search: filterBar.appliedFilters.search || undefined,
+      status: filterBar.appliedFilters.status ?? undefined,
+      sortBy: pageState.sorting.sortBy,
+      sortOrder: pageState.sorting.sortOrder.toUpperCase(),
     }),
-    [appliedFilters, sortState],
+    [filterBar.appliedFilters, pageState.sorting],
   )
 
   const {
     data: adjustmentsResponse,
-    isLoading,
-    isFetching,
-    error: listError,
+    isFetching: loading,
+    error: adjustmentsError,
     refetch: refetchAdjustments,
-  } = useGetStockAdjustmentsQuery(adjustmentQueryParams)
+  } = useGetStockAdjustmentsQuery(queryParams)
   const [fetchStockAdjustmentById] = useLazyGetStockAdjustmentQuery()
   const [deleteStockAdjustment] = useDeleteStockAdjustmentMutation()
   const [completeStockAdjustment] = useCompleteStockAdjustmentMutation()
   const [uncompleteStockAdjustment] = useUncompleteStockAdjustmentMutation()
-  const [fetchJournalEntries] = useLazyGetJournalEntriesQuery()
+
   const adjustments = adjustmentsResponse?.data || []
-  const pagination = adjustmentsResponse?.meta
-  const error = useMemo(() => {
-    if (!listError) return null
-    const fallback = 'Failed to fetch stock adjustments'
-    if (typeof listError !== 'object') return fallback
-    const errorData = (listError as any).data
-    if (typeof errorData === 'string') return errorData
-    return errorData?.message || fallback
-  }, [listError])
+  const total = adjustmentsResponse?.meta?.total || 0
+  const error = adjustmentsError && typeof adjustmentsError === 'object'
+    ? ((adjustmentsError as any).data?.message || (adjustmentsError as any).data || 'Failed to fetch stock adjustments')
+    : null
 
-  const [focusedAdjustmentIndex, setFocusedAdjustmentIndex] = useState(-1)
-  const adjustmentListRef = useRef<HTMLDivElement>(null)
-  const searchInputRef = useRef<HTMLInputElement>(null)
-  const [showDeletedDialog, setShowDeletedDialog] = useState(false)
-  const [deletingId, setDeletingId] = useState<string | null>(null)
-  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
-  const [adjustmentToDelete, setAdjustmentToDelete] = useState<string | null>(null)
-  const [adjustmentToDeleteName, setAdjustmentToDeleteName] = useState<string>('')
-  const [completingId, setCompletingId] = useState<string | null>(null)
-  const [completeConfirmOpen, setCompleteConfirmOpen] = useState(false)
-  const [adjustmentToComplete, setAdjustmentToComplete] = useState<string | null>(null)
-  const [adjustmentToCompleteName, setAdjustmentToCompleteName] = useState<string>('')
-  const [cancellingId, setCancellingId] = useState<string | null>(null)
-  const [cancelConfirmOpen, setCancelConfirmOpen] = useState(false)
-  const [adjustmentToCancel, setAdjustmentToCancel] = useState<string | null>(null)
-  const [adjustmentToCancelName, setAdjustmentToCancelName] = useState<string>('')
-  const [hasAutoSelected, setHasAutoSelected] = useState(false)
-  const [journalEntry, setJournalEntry] = useState<JournalEntry | null>(null)
+  const selection = useStockAdjustmentsSelection({
+    dispatch,
+    adjustments,
+    selectedAdjustment,
+    focusedAdjustmentIndex: pageState.focusedAdjustmentIndex,
+    setFocusedAdjustmentIndex: pageState.setFocusedAdjustmentIndex,
+    searchParams,
+    setSearchParams,
+    adjustmentListRef: pageState.adjustmentListRef,
+    searchInputRef: pageState.searchInputRef,
+    userHasNavigatedRef: pageState.userHasNavigatedRef,
+    setJournalEntryRef: pageState.setJournalEntryRef,
+    setJournalEntryRefLoading: pageState.setJournalEntryRefLoading,
+  })
 
-  // Fetch journal entry for completed stock adjustment
-  useEffect(() => {
-    if (selectedAdjustment?.status === 'completed') {
-      fetchJournalEntries({ sourceType: 'stock_adjustment', sourceId: selectedAdjustment.id, limit: 1 })
-        .unwrap()
-        .then((res) => {
-          const entries = res?.data || []
-          setJournalEntry(entries.length > 0 ? entries[0] : null)
-        })
-        .catch(() => setJournalEntry(null))
-    } else {
-      setJournalEntry(null)
-    }
-  }, [selectedAdjustment?.id, selectedAdjustment?.status, fetchJournalEntries])
-
-  const loadStockAdjustmentDetail = useCallback(async (id: string) => {
-    try {
-      const adjustment = await fetchStockAdjustmentById(id).unwrap()
-      dispatch(setSelectedStockAdjustment(adjustment))
-    } catch (detailError: any) {
-      console.error('Failed to fetch stock adjustment details:', detailError)
-      showError(detailError?.data?.message || detailError?.message || 'Failed to load stock adjustment details')
-    }
-  }, [dispatch, fetchStockAdjustmentById, showError])
+  const actions = useStockAdjustmentsActions({
+    dispatch,
+    navigate,
+    selectedAdjustment,
+    deleteStockAdjustment,
+    completeStockAdjustment,
+    uncompleteStockAdjustment,
+    fetchStockAdjustmentById,
+    refetchAdjustments,
+    showSuccess,
+    showError,
+    setDeleteConfirmOpen: pageState.setDeleteConfirmOpen,
+    setAdjustmentToDelete: pageState.setAdjustmentToDelete,
+    setAdjustmentToDeleteName: pageState.setAdjustmentToDeleteName,
+    setCompleteConfirmOpen: pageState.setCompleteConfirmOpen,
+    setAdjustmentToComplete: pageState.setAdjustmentToComplete,
+    setAdjustmentToCompleteName: pageState.setAdjustmentToCompleteName,
+    setRevertConfirmOpen: pageState.setRevertConfirmOpen,
+    setAdjustmentToRevert: pageState.setAdjustmentToRevert,
+    setAdjustmentToRevertName: pageState.setAdjustmentToRevertName,
+    setFocusedAdjustmentIndex: pageState.setFocusedAdjustmentIndex,
+  })
 
   const handleSort = useCallback((field: string) => {
-    setSortState((prev) => ({
-      ...prev,
+    pageState.setSorting((prev) => ({
       sortBy: field,
       sortOrder: prev.sortBy === field && prev.sortOrder === 'desc' ? 'asc' : 'desc',
     }))
-  }, [])
+  }, [pageState])
 
-  const handleAdjustmentSelect = useCallback((adjustment: StockAdjustment) => {
-    // Set the selected adjustment first (for immediate UI feedback)
-    dispatch(setSelectedStockAdjustment(adjustment))
-    const adjustmentIndex = adjustments.findIndex(a => a.id === adjustment.id)
-    setFocusedAdjustmentIndex(adjustmentIndex)
-
-    // Fetch full details including items
-    void loadStockAdjustmentDetail(adjustment.id)
-  }, [dispatch, adjustments, loadStockAdjustmentDetail])
-
-  // Auto-select newly created adjustment when navigating back from create page
-  useEffect(() => {
-    if (newAdjustmentId && adjustments.length > 0 && !hasAutoSelected) {
-      const newAdjustment = adjustments.find(a => a.id === newAdjustmentId)
-      if (newAdjustment) {
-        const newIndex = adjustments.indexOf(newAdjustment)
-        setFocusedAdjustmentIndex(newIndex)
-        setHasAutoSelected(true)
-        // Set the selected adjustment first (for immediate UI feedback)
-        dispatch(setSelectedStockAdjustment(newAdjustment))
-        // Fetch full details including items
-        void loadStockAdjustmentDetail(newAdjustmentId)
-      }
-    }
-  }, [newAdjustmentId, adjustments, hasAutoSelected, dispatch, loadStockAdjustmentDetail])
-
-  // Auto-focus first adjustment when adjustments load (only if no new adjustment to select)
-  useEffect(() => {
-    if (adjustments.length > 0 && focusedAdjustmentIndex === -1 && !newAdjustmentId) {
-      if (!selectedAdjustment && searchInputRef.current !== document.activeElement) {
-        setFocusedAdjustmentIndex(0)
-        dispatch(setSelectedStockAdjustment(adjustments[0]))
-        // Fetch full details for the first adjustment
-        void loadStockAdjustmentDetail(adjustments[0].id)
-      }
-    }
-  }, [adjustments, focusedAdjustmentIndex, selectedAdjustment, dispatch, newAdjustmentId, loadStockAdjustmentDetail])
-
-  // Clear selection when no adjustments exist
-  useEffect(() => {
-    if (adjustments.length === 0 && selectedAdjustment) {
-      dispatch(setSelectedStockAdjustment(null))
-      setFocusedAdjustmentIndex(-1)
-    }
-  }, [adjustments.length, selectedAdjustment, dispatch])
-
-  // Keyboard shortcuts
-  const handleNavigateUp = useCallback(() => {
-    if (focusedAdjustmentIndex > 0) {
-      const newIndex = focusedAdjustmentIndex - 1
-      setFocusedAdjustmentIndex(newIndex)
-      dispatch(setSelectedStockAdjustment(adjustments[newIndex]))
-      void loadStockAdjustmentDetail(adjustments[newIndex].id)
-    }
-  }, [focusedAdjustmentIndex, adjustments, dispatch, loadStockAdjustmentDetail])
-
-  const handleNavigateDown = useCallback(() => {
-    if (focusedAdjustmentIndex < adjustments.length - 1) {
-      const newIndex = focusedAdjustmentIndex + 1
-      setFocusedAdjustmentIndex(newIndex)
-      dispatch(setSelectedStockAdjustment(adjustments[newIndex]))
-      void loadStockAdjustmentDetail(adjustments[newIndex].id)
-    }
-  }, [focusedAdjustmentIndex, adjustments, dispatch, loadStockAdjustmentDetail])
-
-  const focusSearchInput = useCallback(() => {
-    searchInputRef.current?.focus()
-    searchInputRef.current?.select()
-  }, [])
-
-  const handleEdit = () => {
-    if (selectedAdjustment) {
-      // Only allow editing draft adjustments
-      if (selectedAdjustment.status !== 'draft') {
-        showError('Only draft adjustments can be edited')
-        return
-      }
-      navigate(`/inventory/stock-adjustments/${selectedAdjustment.id}/edit`)
-    }
-  }
-
-  const handleDelete = (id: string, adjustmentNumber: string) => {
-    setAdjustmentToDelete(id)
-    setAdjustmentToDeleteName(adjustmentNumber)
-    setDeleteConfirmOpen(true)
-  }
-
-  const handleConfirmDelete = async () => {
-    if (adjustmentToDelete) {
-      setDeletingId(adjustmentToDelete)
-      try {
-        // Clear selection BEFORE deleting if this adjustment is selected
-        if (selectedAdjustment?.id === adjustmentToDelete) {
-          dispatch(setSelectedStockAdjustment(null))
-          setFocusedAdjustmentIndex(-1)
-        }
-
-        await deleteStockAdjustment(adjustmentToDelete).unwrap()
-        showSuccess(`Stock adjustment "${adjustmentToDeleteName}" deleted successfully`)
-        void refetchAdjustments()
-
-        setDeleteConfirmOpen(false)
-        setAdjustmentToDelete(null)
-        setAdjustmentToDeleteName('')
-      } catch (error: any) {
-        console.error('Failed to delete stock adjustment:', error)
-        showError(error?.response?.data?.message || 'Failed to delete stock adjustment')
-        setDeleteConfirmOpen(false)
-        setAdjustmentToDelete(null)
-        setAdjustmentToDeleteName('')
-      } finally {
-        setDeletingId(null)
-      }
-    }
-  }
-
-  const handleCancelDelete = () => {
-    setDeleteConfirmOpen(false)
-    setAdjustmentToDelete(null)
-    setAdjustmentToDeleteName('')
-  }
-
-  const handleComplete = (id: string, adjustmentNumber: string) => {
-    setAdjustmentToComplete(id)
-    setAdjustmentToCompleteName(adjustmentNumber)
-    setCompleteConfirmOpen(true)
-  }
-
-  const handleConfirmComplete = async () => {
-    if (adjustmentToComplete) {
-      setCompletingId(adjustmentToComplete)
-      try {
-        await completeStockAdjustment(adjustmentToComplete).unwrap()
-        showSuccess(`Stock adjustment "${adjustmentToCompleteName}" completed successfully`)
-        void refetchAdjustments()
-        if (selectedAdjustment?.id === adjustmentToComplete) {
-          void loadStockAdjustmentDetail(adjustmentToComplete)
-        }
-        setCompleteConfirmOpen(false)
-        setAdjustmentToComplete(null)
-        setAdjustmentToCompleteName('')
-      } catch (error: any) {
-        console.error('Failed to complete stock adjustment:', error)
-        showError(error?.response?.data?.message || 'Failed to complete stock adjustment')
-        setCompleteConfirmOpen(false)
-        setAdjustmentToComplete(null)
-        setAdjustmentToCompleteName('')
-      } finally {
-        setCompletingId(null)
-      }
-    }
-  }
-
-  const handleCancelComplete = () => {
-    setCompleteConfirmOpen(false)
-    setAdjustmentToComplete(null)
-    setAdjustmentToCompleteName('')
-  }
-
-  const handleCancel = (id: string, adjustmentNumber: string) => {
-    setAdjustmentToCancel(id)
-    setAdjustmentToCancelName(adjustmentNumber)
-    setCancelConfirmOpen(true)
-  }
-
-  const handleConfirmCancel = async () => {
-    if (adjustmentToCancel) {
-      setCancellingId(adjustmentToCancel)
-      try {
-        await uncompleteStockAdjustment(adjustmentToCancel).unwrap()
-        showSuccess(`Stock adjustment "${adjustmentToCancelName}" reverted to draft successfully`)
-        void refetchAdjustments()
-        if (selectedAdjustment?.id === adjustmentToCancel) {
-          void loadStockAdjustmentDetail(adjustmentToCancel)
-        }
-        setCancelConfirmOpen(false)
-        setAdjustmentToCancel(null)
-        setAdjustmentToCancelName('')
-      } catch (error: any) {
-        console.error('Failed to revert stock adjustment:', error)
-        showError(error?.response?.data?.message || 'Failed to revert stock adjustment')
-        setCancelConfirmOpen(false)
-        setAdjustmentToCancel(null)
-        setAdjustmentToCancelName('')
-      } finally {
-        setCancellingId(null)
-      }
-    }
-  }
-
-  const handleCancelCancelDialog = () => {
-    setCancelConfirmOpen(false)
-    setAdjustmentToCancel(null)
-    setAdjustmentToCancelName('')
-  }
+  const navigateToJournalEntry = useCallback(() => {
+    if (!pageState.journalEntryRef) return
+    navigate(
+      `/accounting/journal-entries?sourceType=${pageState.journalEntryRef.sourceType}&sourceId=${pageState.journalEntryRef.sourceId}`,
+    )
+  }, [navigate, pageState.journalEntryRef])
 
   useKeyboardShortcuts({
-    onSearch: focusSearchInput,
-    onArrowUp: handleNavigateUp,
-    onArrowDown: handleNavigateDown,
+    onSearch: selection.focusSearchInput,
+    onArrowUp: selection.handleNavigateUp,
+    onArrowDown: selection.handleNavigateDown,
   })
 
   return (
-    <>
-      {/* Header */}
+    <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
       <PageHeader
         title="Stock Adjustments"
         subtitle="View and manage stock adjustment history"
         variant="workflow"
-        secondaryAction={{ label: 'View Deleted', onClick: () => setShowDeletedDialog(true) }}
+        secondaryAction={{ label: 'View Deleted', onClick: () => pageState.setShowDeletedDialog(true) }}
         primaryAction={{ label: 'New Adjustment', onClick: () => navigate('/inventory/stock-adjustments/create') }}
         toolbar={(
           <FilterBar
             config={filterConfig}
-            draftFilters={draftFilters}
-            handlers={handlers}
-            hasActiveFilters={hasActiveFilters}
-            searchInputRef={searchInputRef}
+            draftFilters={filterBar.draftFilters}
+            handlers={filterBar.handlers}
+            hasActiveFilters={filterBar.hasActiveFilters}
+            searchInputRef={pageState.searchInputRef}
+            sort={{
+              field: 'adjustmentDate',
+              sortBy: pageState.sorting.sortBy,
+              sortOrder: pageState.sorting.sortOrder,
+              onSort: handleSort,
+            }}
           />
         )}
       />
-      {/* Sort button */}
-      <Box sx={{ mb: 3, display: 'flex', justifyContent: 'flex-end' }}>
-        <Button
-          variant={sortState.sortBy === 'adjustmentDate' ? 'contained' : 'outlined'}
-          size="medium"
-          startIcon={sortState.sortBy === 'adjustmentDate' ? (sortState.sortOrder === 'desc' ? <ArrowDownIcon /> : <ArrowUpIcon />) : <SortIcon />}
-          onClick={() => handleSort('adjustmentDate')}
-          sx={{
-            height: '40px',
-            fontSize: '0.875rem',
-            minWidth: 'auto',
-            px: 2,
-          }}
-        >
-          Sort
-        </Button>
-      </Box>
-      {/* Error Display */}
+
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>
           {error}
         </Alert>
       )}
-      {/* Split Layout */}
-      <Grid container spacing={3}>
-        {/* Left Side - Adjustment List */}
-        <Grid
-          size={{
-            xs: 12,
-            md: 3
-          }}>
-          <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', flexDirection: 'column' }}>
-            <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
-              <Typography variant="tableHeader" sx={{
-                fontWeight: 600,
-                fontSize: '0.8rem',
-                textTransform: 'uppercase',
-                letterSpacing: '0.5px'
-              }}>
-                SA List ({pagination?.total || 0})
-              </Typography>
-            </Box>
 
-            <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }} ref={adjustmentListRef}>
-              {(isLoading || (isFetching && !adjustmentsResponse)) ? (
-                <ListSkeleton rows={8} columns={1} />
-              ) : (
-                <Box sx={{ flex: 1, opacity: isFetching ? 0.6 : 1, position: 'relative' }}>
-                  {isFetching ? (
-                    <CircularProgress size={16} sx={{ position: 'absolute', top: 8, right: 8, zIndex: 1 }} />
-                  ) : null}
-                  <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
-                    <Table
-                      size={TABLE_STYLES.size}
-                      sx={{
-                        '& .MuiTableCell-root': {
-                          borderBottom: TABLE_STYLES.cell.border,
-                          py: TABLE_STYLES.cell.padding.py * 0.75,
-                          px: TABLE_STYLES.cell.padding.px * 0.75,
-                        },
-                      }}
-                    >
-                      <TableBody>
-                        {adjustments.map((adjustment: StockAdjustment, index: number) => (
-                          <AdjustmentRow
-                            key={adjustment.id}
-                            adjustment={adjustment}
-                            index={index}
-                            selectedAdjustmentId={selectedAdjustment?.id}
-                            focusedAdjustmentIndex={focusedAdjustmentIndex}
-                            onAdjustmentSelect={handleAdjustmentSelect}
-                          />
-                        ))}
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
-                </Box>
-              )}
-            </Box>
-          </Paper>
-        </Grid>
-
-        {/* Right Side - SA Details */}
-        <Grid
-          size={{
-            xs: 12,
-            md: 9
-          }}>
-          {selectedAdjustment ? (
-            <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', flexDirection: 'column' }}>
-              <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  <Typography variant="tableHeader" sx={{
-                    fontWeight: 600,
-                    fontSize: '0.8rem',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px'
-                  }}>
-                    SA Details - {selectedAdjustment.adjustmentNumber}
-                  </Typography>
-                  <Chip
-                    label={selectedAdjustment.status}
-                    size="small"
-                    color={
-                      selectedAdjustment.status === 'completed' ? 'success' :
-                      selectedAdjustment.status === 'cancelled' ? 'error' :
-                      'default'
-                    }
-                    sx={{
-                      textTransform: 'capitalize',
-                      fontSize: '0.75rem',
-                      fontWeight: 600
-                    }}
-                  />
-                </Box>
-                <Box sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 0.25
-                }}>
-                  <IconButton
-                    size="small"
-                    title="Edit Adjustment"
-                    onClick={handleEdit}
-                    sx={{
-                      height: `${TABLE_STYLES.row.height * 0.75}px`,
-                      width: `${TABLE_STYLES.row.height * 0.75}px`,
-                      minHeight: 20,
-                      minWidth: 20,
-                      p: 0.125,
-                      color: 'primary.main',
-                      '&:hover': {
-                        backgroundColor: 'primary.light',
-                        color: 'primary.dark'
-                      }
-                    }}
-                  >
-                    <EditIcon sx={{
-                      fontSize: `${TABLE_STYLES.row.height * 0.5}px`
-                    }} />
-                  </IconButton>
-                  <IconButton
-                    size="small"
-                    title="Delete Adjustment"
-                    onClick={() => handleDelete(selectedAdjustment.id, selectedAdjustment.adjustmentNumber)}
-                    disabled={deletingId === selectedAdjustment.id}
-                    sx={{
-                      height: `${TABLE_STYLES.row.height * 0.75}px`,
-                      width: `${TABLE_STYLES.row.height * 0.75}px`,
-                      minHeight: 20,
-                      minWidth: 20,
-                      p: 0.125,
-                      color: 'error.main',
-                      '&:hover': {
-                        backgroundColor: 'error.light',
-                        color: 'error.dark'
-                      }
-                    }}
-                  >
-                    <DeleteIcon sx={{
-                      fontSize: `${TABLE_STYLES.row.height * 0.5}px`
-                    }} />
-                  </IconButton>
-                </Box>
-              </Box>
-
-            <Box sx={{ flex: 1, overflow: 'auto', p: TABLE_STYLES.cell.padding.px }}>
-              {/* SA Details Section */}
-              <Box>
-                <Grid container spacing={3}>
-                  {/* Adjustment Information */}
-                  <Grid
-                    size={{
-                      xs: 12,
-                      md: 6
-                    }}>
-                    <TableContainer>
-                      <Table
-                        size={TABLE_STYLES.size}
-                        sx={{
-                          tableLayout: 'fixed',
-                          '& .MuiTableCell-root': {
-                            border: 'none',
-                            py: TABLE_STYLES.cell.padding.py,
-                            px: TABLE_STYLES.cell.padding.px,
-                            '&:nth-of-type(1)': { width: '40%' },
-                            '&:nth-of-type(2)': { width: '60%' },
-                          }
-                        }}
-                      >
-                        <TableBody>
-                          {/* SA Information Section */}
-                          <TableRow>
-                            <TableCell colSpan={2} sx={{
-                              pb: TABLE_STYLES.cell.padding.py * 0.67,
-                              py: TABLE_STYLES.cell.padding.py * 0.67,
-                              borderTop: TABLE_STYLES.cell.border
-                            }}>
-                              <Typography variant="h6" sx={{
-                                fontWeight: 600,
-                                color: 'primary.main',
-                                fontSize: '0.8rem'
-                              }}>
-                                SA Information
-                              </Typography>
-                            </TableCell>
-                          </TableRow>
-                          <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                            <TableCell sx={{
-                              fontWeight: 600,
-                              color: 'text.secondary',
-                              fontSize: '0.8rem'
-                            }}>
-                              Date
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem' }}>
-                              {formatDate(selectedAdjustment.adjustmentDate)}
-                            </TableCell>
-                          </TableRow>
-                          <TableRow>
-                            <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                              Item Count
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem' }}>
-                              {selectedAdjustment.itemCount}
-                            </TableCell>
-                          </TableRow>
-                          {selectedAdjustment.status === 'completed' && (
-                            <>
-                              <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                                <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                                  Journal Entry
-                                </TableCell>
-                                <TableCell sx={{ fontSize: '0.8rem' }}>
-                                  {journalEntry ? (
-                                    <Typography
-                                      component="span"
-                                      sx={{ fontSize: '0.8rem', fontWeight: 600, color: 'primary.main', cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
-                                      onClick={() => navigate(`/accounting/journal-entries/${journalEntry.id}`)}
-                                    >
-                                      {journalEntry.referenceNumber}
-                                    </Typography>
-                                  ) : '-'}
-                                </TableCell>
-                              </TableRow>
-
-                            </>
-                          )}
-                        </TableBody>
-                      </Table>
-                    </TableContainer>
-                  </Grid>
-
-                  {/* SA Confirmation */}
-                  <Grid
-                    size={{
-                      xs: 12,
-                      md: 6
-                    }}>
-                    <TableContainer>
-                      <Table
-                        size={TABLE_STYLES.size}
-                        sx={{
-                          tableLayout: 'fixed',
-                          '& .MuiTableCell-root': {
-                            border: 'none',
-                            py: TABLE_STYLES.cell.padding.py,
-                            px: TABLE_STYLES.cell.padding.px,
-                            '&:nth-of-type(1)': { width: '40%' },
-                            '&:nth-of-type(2)': { width: '60%' },
-                          }
-                        }}
-                      >
-                        <TableBody>
-                          {/* SA Confirmation Section */}
-                          <TableRow>
-                            <TableCell colSpan={2} sx={{
-                              pb: TABLE_STYLES.cell.padding.py * 0.67,
-                              py: TABLE_STYLES.cell.padding.py * 0.67,
-                              borderTop: TABLE_STYLES.cell.border
-                            }}>
-                              <Typography variant="h6" sx={{
-                                fontWeight: 600,
-                                color: 'primary.main',
-                                fontSize: '0.8rem'
-                              }}>
-                                SA Confirmation
-                              </Typography>
-                            </TableCell>
-                          </TableRow>
-                          <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                            <TableCell sx={{
-                              fontWeight: 600,
-                              color: 'text.secondary',
-                              fontSize: '0.8rem'
-                            }}>
-                              Created At
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem' }}>
-                              {formatDate(selectedAdjustment.createdAt)}
-                            </TableCell>
-                          </TableRow>
-                          <TableRow>
-                            <TableCell sx={{ fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }}>
-                              Updated At
-                            </TableCell>
-                            <TableCell sx={{ fontSize: '0.8rem' }}>
-                              {formatDate(selectedAdjustment.updatedAt)}
-                            </TableCell>
-                          </TableRow>
-                          {(selectedAdjustment.status === 'draft' || selectedAdjustment.status === 'completed') && (
-                            <TableRow>
-                              <TableCell colSpan={2} sx={{ textAlign: 'center' }}>
-                                <Stack
-                                  direction="row"
-                                  spacing={1}
-                                  sx={{
-                                    alignItems: "center",
-                                    justifyContent: "center"
-                                  }}>
-                                  {selectedAdjustment.status === 'draft' ? (
-                                    <Button
-                                      variant="contained"
-                                      size="small"
-                                      color="primary"
-                                      onClick={() => handleComplete(selectedAdjustment.id, selectedAdjustment.adjustmentNumber)}
-                                      disabled={completingId === selectedAdjustment.id}
-                                      sx={{ minWidth: 110 }}
-                                    >
-                                      {completingId === selectedAdjustment.id ? 'Completing...' : 'Complete'}
-                                    </Button>
-                                  ) : (
-                                    <Button
-                                      variant="contained"
-                                      size="small"
-                                      color="warning"
-                                      onClick={() => handleCancel(selectedAdjustment.id, selectedAdjustment.adjustmentNumber)}
-                                      disabled={cancellingId === selectedAdjustment.id}
-                                      sx={{ minWidth: 110 }}
-                                    >
-                                      {cancellingId === selectedAdjustment.id ? 'Cancelling...' : 'Cancel'}
-                                    </Button>
-                                  )}
-                                </Stack>
-                              </TableCell>
-                            </TableRow>
-                          )}
-                        </TableBody>
-                      </Table>
-                    </TableContainer>
-                  </Grid>
-
-
-                </Grid>
-
-                {/* Page Break before SA Items */}
-                <Box sx={{
-                  borderTop: '2px solid',
-                  borderColor: 'divider',
-                  pageBreakBefore: 'always', // CSS page break for printing
-                  '@media print': {
-                    pageBreakBefore: 'always'
-                  }
-                }} />
-
-                {/* SA Items Section Header */}
-                <TableContainer>
-                  <Table
-                    size={TABLE_STYLES.size}
-                    sx={{
-                      '& .MuiTableCell-root': {
-                        border: 'none',
-                        py: TABLE_STYLES.cell.padding.py,
-                        px: TABLE_STYLES.cell.padding.px,
-                      }
-                    }}
-                  >
-                    <TableBody>
-                      <TableRow>
-                        <TableCell colSpan={3} sx={{
-                          pb: TABLE_STYLES.cell.padding.py * 0.67,
-                          py: TABLE_STYLES.cell.padding.py * 0.67,
-                          borderTop: TABLE_STYLES.cell.border
-                        }}>
-                          <Typography variant="tableHeader" sx={{
-                            fontWeight: 600,
-                            fontSize: '0.8rem',
-                            textTransform: 'uppercase',
-                            letterSpacing: '0.5px'
-                          }}>
-                            SA Items
-                          </Typography>
-                        </TableCell>
-                      </TableRow>
-                    </TableBody>
-                  </Table>
-                </TableContainer>
-
-                {/* SA Items Table */}
-                <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-                  {selectedAdjustment.items && selectedAdjustment.items.length > 0 ? (
-                    <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
-                      <Table
-                        size={TABLE_STYLES.size}
-                        sx={{
-                          '& .MuiTableCell-root': {
-                            borderBottom: TABLE_STYLES.cell.border,
-                            py: TABLE_STYLES.cell.padding.py,
-                            px: TABLE_STYLES.cell.padding.px
-                          }
-                        }}
-                      >
-                        <TableHead>
-                          <TableRow sx={{ '& .MuiTableCell-head': {
-                            fontWeight: 600,
-                            backgroundColor: 'grey.50',
-                            color: 'text.primary',
-                            fontSize: '0.8rem'
-                          } }}>
-                            <TableCell sx={{ width: '40%' }}>
-                              Product
-                            </TableCell>
-                            <TableCell align="center" sx={{ width: '20%' }}>
-                              Old Quantity
-                            </TableCell>
-                            <TableCell align="center" sx={{ width: '20%' }}>
-                              New Quantity
-                            </TableCell>
-                            <TableCell align="center" sx={{ width: '20%' }}>
-                              Difference
-                            </TableCell>
-                          </TableRow>
-                        </TableHead>
-                        <TableBody>
-                          {selectedAdjustment.items.map((item: any, index: number) => (
-                            <TableRow
-                              key={index}
-                              hover
-                              sx={{
-                                '&:hover': {
-                                  backgroundColor: 'action.hover'
-                                },
-                                transition: 'background-color 0.2s ease',
-                                height: TABLE_STYLES.row.height
-                              }}
-                            >
-                              <TableCell sx={{
-                                fontSize: '0.8rem',
-                                lineHeight: 1.2
-                              }}>
-                                {item.product?.name || 'Unknown Product'}
-                              </TableCell>
-                              <TableCell align="center" sx={{
-                                fontSize: '0.8rem',
-                                fontWeight: 400,
-                                lineHeight: 1.2,
-                                color: 'text.secondary'
-                              }}>
-                                {Number(item.oldQuantity).toLocaleString()}
-                              </TableCell>
-                              <TableCell align="center" sx={{
-                                fontSize: '0.8rem',
-                                fontWeight: 400,
-                                lineHeight: 1.2
-                              }}>
-                                {Number(item.newQuantity).toLocaleString()}
-                              </TableCell>
-                              <TableCell align="center" sx={{
-                                fontSize: '0.8rem',
-                                lineHeight: 1.2,
-                                fontWeight: 600,
-                                color: Number(item.difference) > 0
-                                  ? 'success.main'
-                                  : Number(item.difference) < 0
-                                  ? 'error.main'
-                                  : 'text.primary'
-                              }}>
-                                {Number(item.difference) > 0 ? '+' : ''}
-                                {Number(item.difference).toLocaleString()}
-                              </TableCell>
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    </TableContainer>
-                  ) : (
-                    <Alert severity="info">No items in this adjustment</Alert>
-                  )}
-                </Box>
-              </Box>
-
-              {/* Page Break after SA Items */}
-              <Box sx={{
-                borderTop: '2px solid',
-                borderColor: 'divider',
-                pageBreakBefore: 'always', // CSS page break for printing
-                '@media print': {
-                  pageBreakBefore: 'always'
-                }
-              }} />
-
-              {/* NOTES Section - below items */}
-              <Box sx={{ mt: 1 }}>
-                <Typography variant="tableHeader" sx={{
-                  fontWeight: 600,
-                  fontSize: '0.8rem',
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.5px',
-                  mb: 1
-                }}>
-                  NOTES
-                </Typography>
-
-                <Box sx={{
-                  p: 2,
-                  backgroundColor: 'grey.50',
-                  borderRadius: 1,
-                  fontSize: '0.8rem',
-                  whiteSpace: 'pre-wrap',
-                  wordBreak: 'break-word'
-                }}>
-                  {selectedAdjustment.notes || '-'}
-                </Box>
-              </Box>
-            </Box>
-            </Paper>
-          ) : (
-            <Paper sx={{ height: 'calc(100vh - 300px)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-              <Typography variant="h6" sx={{
-                color: "text.secondary"
-              }}>
-                Select an adjustment to view details
-              </Typography>
-            </Paper>
-          )}
-        </Grid>
-      </Grid>
-      {/* Deleted Stock Adjustments Dialog */}
-      <DeletedStockAdjustmentsDialog
-        open={showDeletedDialog}
-        onClose={() => setShowDeletedDialog(false)}
+      <MasterDetailWorkspace
+        isMobile={isMobile}
+        listSlot={(
+          <StockAdjustmentList
+            adjustments={adjustments}
+            loading={loading}
+            total={total}
+            selectedAdjustmentId={selectedAdjustment?.id}
+            focusedAdjustmentIndex={pageState.focusedAdjustmentIndex}
+            onSelect={selection.handleAdjustmentSelect}
+            adjustmentListRef={pageState.adjustmentListRef}
+          />
+        )}
+        headerSlot={(
+          <StockAdjustmentContextHeader
+            selectedAdjustment={selectedAdjustment}
+            journalEntryRef={pageState.journalEntryRef}
+            journalEntryRefLoading={pageState.journalEntryRefLoading}
+            onEdit={actions.handleEdit}
+            onDelete={() => selectedAdjustment && actions.handleDelete(selectedAdjustment.id, selectedAdjustment.adjustmentNumber)}
+            onComplete={() => selectedAdjustment && actions.handleComplete(selectedAdjustment.id, selectedAdjustment.adjustmentNumber)}
+            onRevert={() => selectedAdjustment && actions.handleRevert(selectedAdjustment.id, selectedAdjustment.adjustmentNumber)}
+            onNavigateToJournalEntry={navigateToJournalEntry}
+          />
+        )}
+        workspaceSlot={<StockAdjustmentWorkspaceCard selectedAdjustment={selectedAdjustment} />}
       />
-      {/* Delete Confirmation Dialog */}
-      <ConfirmationDialog
-        open={deleteConfirmOpen}
-        title="Confirm Delete"
-        message={`Are you sure you want to delete stock adjustment #${adjustmentToDeleteName}? This will move it to deleted stock adjustments.`}
-        confirmText="Delete"
-        cancelText="Cancel"
-        onConfirm={handleConfirmDelete}
-        onCancel={handleCancelDelete}
-        severity="warning"
+
+      <StockAdjustmentsDialogs
+        showDeletedDialog={pageState.showDeletedDialog}
+        onCloseDeletedDialog={() => pageState.setShowDeletedDialog(false)}
+        deleteConfirmOpen={pageState.deleteConfirmOpen}
+        adjustmentToDeleteName={pageState.adjustmentToDeleteName}
+        onConfirmDelete={() => void actions.handleConfirmDelete(pageState.adjustmentToDelete)}
+        onCancelDelete={actions.handleCancelDelete}
+        completeConfirmOpen={pageState.completeConfirmOpen}
+        adjustmentToCompleteName={pageState.adjustmentToCompleteName}
+        onConfirmComplete={() => void actions.handleConfirmComplete(pageState.adjustmentToComplete)}
+        onCancelComplete={actions.handleCancelComplete}
+        revertConfirmOpen={pageState.revertConfirmOpen}
+        adjustmentToRevertName={pageState.adjustmentToRevertName}
+        onConfirmRevert={() => void actions.handleConfirmRevert(pageState.adjustmentToRevert)}
+        onCancelRevert={actions.handleCancelRevert}
       />
-      {/* Complete Confirmation Dialog */}
-      <ConfirmationDialog
-        open={completeConfirmOpen}
-        title="Confirm Complete"
-        message={`Are you sure you want to complete stock adjustment #${adjustmentToCompleteName}? This will post the stock movements and update inventory levels. This action cannot be undone.`}
-        confirmText="Complete"
-        cancelText="Cancel"
-        onConfirm={handleConfirmComplete}
-        onCancel={handleCancelComplete}
-        severity="info"
-      />
-      {/* Cancel Confirmation Dialog */}
-      <ConfirmationDialog
-        open={cancelConfirmOpen}
-        title="Revert to Draft"
-        message={`Are you sure you want to revert stock adjustment #${adjustmentToCancelName} back to draft? This will reverse the stock movements and return inventory levels to their previous state.`}
-        confirmText="Revert to Draft"
-        cancelText="Go Back"
-        onConfirm={handleConfirmCancel}
-        onCancel={handleCancelCancelDialog}
-        severity="warning"
-      />
-    </>
-  );
+    </Box>
+  )
 }
 
 export default StockAdjustmentsPage

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -381,7 +381,7 @@ describe('CreateStockAdjustmentPage submit', { timeout: 60000 }, () => {
     })
   })
 
-  it('navigates back with the edited adjustment id in state so the list can highlight it', async () => {
+  it('navigates back with the edited adjustment id in the saId query param so the list can highlight it', async () => {
     const user = userEvent.setup()
     mockParams.mockReturnValue({ id: 'adj-1' })
     mockFetchAdjustment.mockReturnValue({
@@ -422,8 +422,7 @@ describe('CreateStockAdjustmentPage submit', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(
-        '/inventory/stock-adjustments',
-        { state: { newAdjustmentId: 'adj-1' } }
+        '/inventory/stock-adjustments?saId=adj-1'
       )
     })
   })

--- a/frontend/src/pages/inventory/__tests__/StockAdjustmentsPage.filterbar.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/StockAdjustmentsPage.filterbar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import { MemoryRouter } from 'react-router-dom'
@@ -7,18 +7,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import StockAdjustmentsPage from '../StockAdjustmentsPage'
 import inventoryReducer from '@/store/slices/inventorySlice'
 
-const { useGetStockAdjustmentsQuery } = vi.hoisted(() => ({
+const { useGetStockAdjustmentsQuery, mockFetchStockAdjustment } = vi.hoisted(() => ({
   useGetStockAdjustmentsQuery: vi.fn(() => ({
     data: { data: [], meta: { total: 0 } },
     isLoading: false,
     isFetching: false,
     refetch: vi.fn(),
   })),
+  mockFetchStockAdjustment: vi.fn(),
 }))
 
 vi.mock('@/store/api/inventoryApi', () => ({
   useGetStockAdjustmentsQuery,
-  useLazyGetStockAdjustmentQuery: vi.fn(() => [vi.fn(), { data: undefined }]),
+  useLazyGetStockAdjustmentQuery: vi.fn(() => [mockFetchStockAdjustment, { data: undefined }]),
   useCompleteStockAdjustmentMutation: vi.fn(() => [vi.fn(), {}]),
   useDeleteStockAdjustmentMutation: vi.fn(() => [vi.fn(), {}]),
   useUncompleteStockAdjustmentMutation: vi.fn(() => [vi.fn(), {}]),
@@ -52,6 +53,16 @@ function renderPage(initialUrl = '/') {
 describe('StockAdjustmentsPage FilterBar', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockFetchStockAdjustment.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({
+        id: 'adj-1',
+        adjustmentNumber: 'SA-001',
+        adjustmentDate: '2026-03-01T00:00:00.000Z',
+        itemCount: 1,
+        status: 'draft',
+        items: [],
+      }),
+    })
   })
 
   it('renders the search input', () => {
@@ -71,5 +82,42 @@ describe('StockAdjustmentsPage FilterBar', () => {
     expect(useGetStockAdjustmentsQuery).toHaveBeenLastCalledWith(
       expect.not.objectContaining({ status: expect.anything() }),
     )
+  })
+
+  it('loads the adjustment referenced by the saId search param', async () => {
+    useGetStockAdjustmentsQuery.mockReturnValue({
+      data: {
+        data: [
+          {
+            id: 'adj-1',
+            adjustmentNumber: 'SA-001',
+            adjustmentDate: '2026-03-01T00:00:00.000Z',
+            itemCount: 1,
+            status: 'draft',
+            items: [],
+          },
+          {
+            id: 'adj-2',
+            adjustmentNumber: 'SA-002',
+            adjustmentDate: '2026-03-02T00:00:00.000Z',
+            itemCount: 1,
+            status: 'draft',
+            items: [],
+          },
+        ],
+        meta: { total: 2 },
+      },
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    })
+
+    renderPage('/?saId=adj-2')
+
+    await waitFor(() => {
+      expect(mockFetchStockAdjustment).toHaveBeenCalledWith('adj-2')
+    })
+
+    expect(mockFetchStockAdjustment).not.toHaveBeenCalledWith('adj-1')
   })
 })

--- a/frontend/src/pages/inventory/components/StockAdjustmentContextHeader.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentContextHeader.tsx
@@ -1,0 +1,160 @@
+import React from 'react'
+import { default as DeleteIcon } from '@mui/icons-material/Delete'
+import { default as EditIcon } from '@mui/icons-material/Edit'
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { StockAdjustment } from '@/types'
+
+import type { StockAdjustmentsJournalEntryRef } from '../hooks/useStockAdjustmentsPageState'
+
+interface StockAdjustmentContextHeaderProps {
+  selectedAdjustment: StockAdjustment | null
+  journalEntryRef: StockAdjustmentsJournalEntryRef | null
+  journalEntryRefLoading: boolean
+  onEdit: () => void
+  onDelete: () => void
+  onComplete: () => void
+  onRevert: () => void
+  onNavigateToJournalEntry: () => void
+}
+
+const actionIconSx = {
+  height: `${TABLE_STYLES.row.height * 0.75}px`,
+  width: `${TABLE_STYLES.row.height * 0.75}px`,
+  minHeight: 20,
+  minWidth: 20,
+  p: 0.125,
+}
+
+const StockAdjustmentContextHeader: React.FC<StockAdjustmentContextHeaderProps> = ({
+  selectedAdjustment,
+  journalEntryRef,
+  journalEntryRefLoading,
+  onEdit,
+  onDelete,
+  onComplete,
+  onRevert,
+  onNavigateToJournalEntry,
+}) => {
+  if (!selectedAdjustment) {
+    return (
+      <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
+        <Typography variant="h6" sx={{ color: 'text.secondary' }}>
+          Select an adjustment to view details
+        </Typography>
+      </Paper>
+    )
+  }
+
+  const statusColor: 'default' | 'success' | 'error' =
+    selectedAdjustment.status === 'completed'
+      ? 'success'
+      : selectedAdjustment.status === 'cancelled'
+        ? 'error'
+        : 'default'
+
+  return (
+    <Paper sx={{ overflow: 'hidden' }}>
+      <Box
+        sx={{
+          p: TABLE_STYLES.cell.padding.px,
+          borderBottom: TABLE_STYLES.cell.border,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Typography
+            variant="tableHeader"
+            sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+          >
+            SA Details — {selectedAdjustment.adjustmentNumber}
+          </Typography>
+          <Chip
+            label={selectedAdjustment.status}
+            size="small"
+            color={statusColor}
+            sx={{ textTransform: 'capitalize', fontSize: '0.75rem', fontWeight: 600 }}
+          />
+        </Box>
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+          <IconButton
+            size="small"
+            title="Edit Adjustment"
+            onClick={onEdit}
+            sx={{ ...actionIconSx, color: 'primary.main' }}
+          >
+            <EditIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
+          </IconButton>
+          <IconButton
+            size="small"
+            title="Delete Adjustment"
+            onClick={onDelete}
+            sx={{ ...actionIconSx, color: 'error.main' }}
+          >
+            <DeleteIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
+          </IconButton>
+        </Box>
+      </Box>
+
+      <Box sx={{ px: TABLE_STYLES.cell.padding.px, py: 1, display: 'flex', alignItems: 'center', gap: 2 }}>
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+          {selectedAdjustment.status === 'draft' && (
+            <Button variant="contained" size="small" color="primary" onClick={onComplete} sx={{ minWidth: 110 }}>
+              Complete
+            </Button>
+          )}
+          {selectedAdjustment.status === 'completed' && (
+            <Button variant="contained" size="small" color="warning" onClick={onRevert} sx={{ minWidth: 110 }}>
+              Revert to Draft
+            </Button>
+          )}
+        </Stack>
+
+        {selectedAdjustment.status === 'completed' && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary' }}>Journal Entry:</Typography>
+            {journalEntryRefLoading ? (
+              <CircularProgress size={12} />
+            ) : journalEntryRef ? (
+              <Typography
+                component="button"
+                onClick={onNavigateToJournalEntry}
+                sx={{
+                  fontSize: '0.8rem',
+                  fontWeight: 600,
+                  color: 'primary.main',
+                  cursor: 'pointer',
+                  border: 'none',
+                  background: 'none',
+                  padding: 0,
+                  '&:hover': { textDecoration: 'underline' },
+                }}
+              >
+                {journalEntryRef.referenceNumber}
+              </Typography>
+            ) : (
+              <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}>
+                Pending
+              </Typography>
+            )}
+          </Box>
+        )}
+      </Box>
+    </Paper>
+  )
+}
+
+export default StockAdjustmentContextHeader

--- a/frontend/src/pages/inventory/components/StockAdjustmentList.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentList.tsx
@@ -1,0 +1,164 @@
+import React, { memo } from 'react'
+import {
+  Box,
+  Paper,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+} from '@mui/material'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { StockAdjustment } from '@/types'
+
+interface AdjustmentRowProps {
+  adjustment: StockAdjustment
+  index: number
+  selectedAdjustmentId: string | undefined
+  focusedAdjustmentIndex: number
+  onSelect: (adjustment: StockAdjustment) => void
+}
+
+const AdjustmentRow = memo(({
+  adjustment,
+  index,
+  selectedAdjustmentId,
+  focusedAdjustmentIndex,
+  onSelect,
+}: AdjustmentRowProps) => {
+  const isSelected = selectedAdjustmentId === adjustment.id
+  const isFocused = index === focusedAdjustmentIndex
+
+  return (
+    <TableRow
+      hover
+      onClick={() => onSelect(adjustment)}
+      data-adjustment-index={index}
+      sx={{
+        cursor: 'pointer',
+        backgroundColor: isSelected ? 'action.selected' : isFocused ? 'action.focus' : 'inherit',
+        '&:hover': {
+          backgroundColor: isSelected ? 'action.selected' : 'action.hover',
+        },
+        transition: 'background-color 0.2s ease',
+        height: TABLE_STYLES.row.height,
+        ...(isFocused && {
+          outline: '2px solid',
+          outlineColor: 'primary.main',
+          outlineOffset: '-2px',
+        }),
+      }}
+    >
+      <TableCell>
+        <Typography variant="body2" sx={{ fontWeight: 400, fontSize: '0.8rem', lineHeight: 1.2 }}>
+          {adjustment.adjustmentNumber}
+        </Typography>
+      </TableCell>
+    </TableRow>
+  )
+})
+
+AdjustmentRow.displayName = 'AdjustmentRow'
+
+interface StockAdjustmentListProps {
+  adjustments: StockAdjustment[]
+  loading: boolean
+  total: number
+  selectedAdjustmentId?: string
+  focusedAdjustmentIndex: number
+  onSelect: (adjustment: StockAdjustment) => void
+  adjustmentListRef: React.RefObject<HTMLDivElement | null>
+}
+
+const StockAdjustmentList: React.FC<StockAdjustmentListProps> = ({
+  adjustments,
+  loading,
+  total,
+  selectedAdjustmentId,
+  focusedAdjustmentIndex,
+  onSelect,
+  adjustmentListRef,
+}) => {
+  return (
+    <Paper sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Typography
+            variant="tableHeader"
+            sx={{
+              fontWeight: 600,
+              fontSize: '0.8rem',
+              textTransform: 'uppercase',
+              letterSpacing: '0.5px',
+            }}
+          >
+            Adjustments ({total})
+          </Typography>
+          {loading && adjustments.length > 0 && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                Searching...
+              </Typography>
+              <Box sx={{ width: 16, height: 16 }}>
+                <Skeleton variant="circular" width={16} height={16} />
+              </Box>
+            </Box>
+          )}
+        </Box>
+      </Box>
+      <Box
+        sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}
+        ref={adjustmentListRef}
+      >
+        <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
+          <Table
+            size={TABLE_STYLES.size}
+            sx={{
+              '& .MuiTableCell-root': {
+                borderBottom: TABLE_STYLES.cell.border,
+                py: TABLE_STYLES.cell.padding.py * 0.75,
+                px: TABLE_STYLES.cell.padding.px * 0.75,
+              },
+            }}
+          >
+            <TableBody>
+              {loading && adjustments.length === 0
+                ? [...Array(10)].map((_, i) => (
+                    <TableRow key={`skeleton-${i}`}>
+                      <TableCell>
+                        <Skeleton height={40} />
+                      </TableCell>
+                    </TableRow>
+                  ))
+                : adjustments.length === 0
+                  ? (
+                      <TableRow>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ color: 'text.secondary', textAlign: 'center', py: 2 }}>
+                            No adjustments found
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  : adjustments.map((adjustment, index) => (
+                      <AdjustmentRow
+                        key={adjustment.id}
+                        adjustment={adjustment}
+                        index={index}
+                        selectedAdjustmentId={selectedAdjustmentId}
+                        focusedAdjustmentIndex={focusedAdjustmentIndex}
+                        onSelect={onSelect}
+                      />
+                    ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+    </Paper>
+  )
+}
+
+export default StockAdjustmentList

--- a/frontend/src/pages/inventory/components/StockAdjustmentWorkspaceCard.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentWorkspaceCard.tsx
@@ -1,0 +1,211 @@
+import React from 'react'
+import {
+  Alert,
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material'
+import Grid from '@mui/material/Grid'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { StockAdjustment } from '@/types'
+import { formatDate } from '@/utils/formatters'
+
+interface StockAdjustmentWorkspaceCardProps {
+  selectedAdjustment: StockAdjustment | null
+}
+
+const detailTableSx = {
+  tableLayout: 'fixed' as const,
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const sectionHeaderCellSx = {
+  pb: TABLE_STYLES.cell.padding.py * 0.67,
+  py: TABLE_STYLES.cell.padding.py * 0.67,
+  borderTop: TABLE_STYLES.cell.border,
+}
+
+const sectionTitleSx = {
+  fontWeight: 600,
+  color: 'primary.main',
+  fontSize: '0.8rem',
+}
+
+const labelCellSx = { fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }
+const valueCellSx = { fontSize: '0.8rem' }
+
+const StockAdjustmentWorkspaceCard: React.FC<StockAdjustmentWorkspaceCardProps> = ({
+  selectedAdjustment,
+}) => {
+  if (!selectedAdjustment) {
+    return <Paper sx={{ flex: 1 }} />
+  }
+
+  return (
+    <Paper sx={{ flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+                      <Typography variant="h6" sx={sectionTitleSx}>SA Information</Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Date</TableCell>
+                    <TableCell sx={valueCellSx}>{formatDate(selectedAdjustment.adjustmentDate)}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Item Count</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedAdjustment.itemCount}</TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+                      <Typography variant="h6" sx={sectionTitleSx}>SA Confirmation</Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Created At</TableCell>
+                    <TableCell sx={valueCellSx}>{formatDate(selectedAdjustment.createdAt)}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Updated At</TableCell>
+                    <TableCell sx={valueCellSx}>{formatDate(selectedAdjustment.updatedAt)}</TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+        </Grid>
+
+        <Box sx={{ borderTop: '2px solid', borderColor: 'divider', my: 1 }} />
+
+        <Typography
+          variant="tableHeader"
+          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px', mb: 1, display: 'block' }}
+        >
+          SA Items
+        </Typography>
+
+        {selectedAdjustment.items && selectedAdjustment.items.length > 0 ? (
+          <TableContainer>
+            <Table
+              size={TABLE_STYLES.size}
+              sx={{
+                '& .MuiTableCell-root': {
+                  borderBottom: TABLE_STYLES.cell.border,
+                  py: TABLE_STYLES.cell.padding.py,
+                  px: TABLE_STYLES.cell.padding.px,
+                },
+              }}
+            >
+              <TableHead>
+                <TableRow
+                  sx={{
+                    '& .MuiTableCell-head': {
+                      fontWeight: 600,
+                      backgroundColor: 'grey.50',
+                      color: 'text.primary',
+                      fontSize: '0.8rem',
+                    },
+                  }}
+                >
+                  <TableCell sx={{ width: '40%' }}>Product</TableCell>
+                  <TableCell align="center" sx={{ width: '20%' }}>Old Quantity</TableCell>
+                  <TableCell align="center" sx={{ width: '20%' }}>New Quantity</TableCell>
+                  <TableCell align="center" sx={{ width: '20%' }}>Difference</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {selectedAdjustment.items.map((item, index) => (
+                  <TableRow
+                    key={index}
+                    hover
+                    sx={{ height: TABLE_STYLES.row.height, transition: 'background-color 0.2s ease' }}
+                  >
+                    <TableCell sx={{ fontSize: '0.8rem', lineHeight: 1.2 }}>
+                      {item.product?.name || 'Unknown Product'}
+                    </TableCell>
+                    <TableCell align="center" sx={{ fontSize: '0.8rem', color: 'text.secondary', lineHeight: 1.2 }}>
+                      {Number(item.oldQuantity).toLocaleString()}
+                    </TableCell>
+                    <TableCell align="center" sx={{ fontSize: '0.8rem', lineHeight: 1.2 }}>
+                      {Number(item.newQuantity).toLocaleString()}
+                    </TableCell>
+                    <TableCell
+                      align="center"
+                      sx={{
+                        fontSize: '0.8rem',
+                        fontWeight: 600,
+                        lineHeight: 1.2,
+                        color:
+                          Number(item.difference) > 0
+                            ? 'success.main'
+                            : Number(item.difference) < 0
+                              ? 'error.main'
+                              : 'text.primary',
+                      }}
+                    >
+                      {Number(item.difference) > 0 ? '+' : ''}
+                      {Number(item.difference).toLocaleString()}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        ) : (
+          <Alert severity="info">No items in this adjustment</Alert>
+        )}
+
+        <Box sx={{ borderTop: '2px solid', borderColor: 'divider', my: 1 }} />
+
+        <Typography
+          variant="tableHeader"
+          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px', mb: 1, display: 'block' }}
+        >
+          Notes
+        </Typography>
+        <Box
+          sx={{
+            p: 2,
+            backgroundColor: 'grey.50',
+            borderRadius: 1,
+            fontSize: '0.8rem',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          }}
+        >
+          {selectedAdjustment.notes || '—'}
+        </Box>
+      </Box>
+    </Paper>
+  )
+}
+
+export default StockAdjustmentWorkspaceCard

--- a/frontend/src/pages/inventory/components/StockAdjustmentsDialogs.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentsDialogs.tsx
@@ -57,7 +57,7 @@ const StockAdjustmentsDialogs: React.FC<StockAdjustmentsDialogsProps> = ({
       <ConfirmationDialog
         open={completeConfirmOpen}
         title="Confirm Complete"
-        message={`Are you sure you want to complete stock adjustment #${adjustmentToCompleteName}? This will post the stock movements and update inventory levels. This action cannot be undone.`}
+        message={`Are you sure you want to complete stock adjustment #${adjustmentToCompleteName}? This will post the stock movements and update inventory levels. The adjustment can be reverted to draft if needed.`}
         confirmText="Complete"
         cancelText="Cancel"
         onConfirm={onConfirmComplete}

--- a/frontend/src/pages/inventory/components/StockAdjustmentsDialogs.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentsDialogs.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+
+import ConfirmationDialog from '@/components/common/ConfirmationDialog'
+import DeletedStockAdjustmentsDialog from '@/components/inventory/DeletedStockAdjustmentsDialog'
+
+interface StockAdjustmentsDialogsProps {
+  showDeletedDialog: boolean
+  onCloseDeletedDialog: () => void
+  deleteConfirmOpen: boolean
+  adjustmentToDeleteName: string
+  onConfirmDelete: () => void
+  onCancelDelete: () => void
+  completeConfirmOpen: boolean
+  adjustmentToCompleteName: string
+  onConfirmComplete: () => void
+  onCancelComplete: () => void
+  revertConfirmOpen: boolean
+  adjustmentToRevertName: string
+  onConfirmRevert: () => void
+  onCancelRevert: () => void
+}
+
+const StockAdjustmentsDialogs: React.FC<StockAdjustmentsDialogsProps> = ({
+  showDeletedDialog,
+  onCloseDeletedDialog,
+  deleteConfirmOpen,
+  adjustmentToDeleteName,
+  onConfirmDelete,
+  onCancelDelete,
+  completeConfirmOpen,
+  adjustmentToCompleteName,
+  onConfirmComplete,
+  onCancelComplete,
+  revertConfirmOpen,
+  adjustmentToRevertName,
+  onConfirmRevert,
+  onCancelRevert,
+}) => {
+  return (
+    <>
+      <DeletedStockAdjustmentsDialog
+        open={showDeletedDialog}
+        onClose={onCloseDeletedDialog}
+      />
+
+      <ConfirmationDialog
+        open={deleteConfirmOpen}
+        title="Confirm Delete"
+        message={`Are you sure you want to delete stock adjustment #${adjustmentToDeleteName}? This will move it to deleted stock adjustments.`}
+        confirmText="Delete"
+        cancelText="Cancel"
+        onConfirm={onConfirmDelete}
+        onCancel={onCancelDelete}
+        severity="warning"
+      />
+
+      <ConfirmationDialog
+        open={completeConfirmOpen}
+        title="Confirm Complete"
+        message={`Are you sure you want to complete stock adjustment #${adjustmentToCompleteName}? This will post the stock movements and update inventory levels. This action cannot be undone.`}
+        confirmText="Complete"
+        cancelText="Cancel"
+        onConfirm={onConfirmComplete}
+        onCancel={onCancelComplete}
+        severity="info"
+      />
+
+      <ConfirmationDialog
+        open={revertConfirmOpen}
+        title="Revert to Draft"
+        message={`Are you sure you want to revert stock adjustment #${adjustmentToRevertName} back to draft? This will reverse the stock movements and return inventory levels to their previous state.`}
+        confirmText="Revert to Draft"
+        cancelText="Go Back"
+        onConfirm={onConfirmRevert}
+        onCancel={onCancelRevert}
+        severity="warning"
+      />
+    </>
+  )
+}
+
+export default StockAdjustmentsDialogs

--- a/frontend/src/pages/inventory/hooks/useStockAdjustmentsActions.ts
+++ b/frontend/src/pages/inventory/hooks/useStockAdjustmentsActions.ts
@@ -1,0 +1,200 @@
+import { useCallback } from 'react'
+import type { NavigateFunction } from 'react-router-dom'
+
+import type { AppDispatch } from '@/store'
+import { setSelectedStockAdjustment } from '@/store/slices/inventorySlice'
+import type { StockAdjustment } from '@/types'
+
+interface UseStockAdjustmentsActionsParams {
+  dispatch: AppDispatch
+  navigate: NavigateFunction
+  selectedAdjustment: StockAdjustment | null
+  deleteStockAdjustment: (id: string) => { unwrap: () => Promise<unknown> }
+  completeStockAdjustment: (id: string) => { unwrap: () => Promise<unknown> }
+  uncompleteStockAdjustment: (id: string) => { unwrap: () => Promise<unknown> }
+  fetchStockAdjustmentById: (id: string) => { unwrap: () => Promise<StockAdjustment> }
+  refetchAdjustments: () => void
+  showSuccess: (message: string) => void
+  showError: (message: string) => void
+  setDeleteConfirmOpen: (v: boolean) => void
+  setAdjustmentToDelete: (v: string | null) => void
+  setAdjustmentToDeleteName: (v: string) => void
+  setCompleteConfirmOpen: (v: boolean) => void
+  setAdjustmentToComplete: (v: string | null) => void
+  setAdjustmentToCompleteName: (v: string) => void
+  setRevertConfirmOpen: (v: boolean) => void
+  setAdjustmentToRevert: (v: string | null) => void
+  setAdjustmentToRevertName: (v: string) => void
+  setFocusedAdjustmentIndex: (v: number) => void
+}
+
+export function useStockAdjustmentsActions({
+  dispatch,
+  navigate,
+  selectedAdjustment,
+  deleteStockAdjustment,
+  completeStockAdjustment,
+  uncompleteStockAdjustment,
+  fetchStockAdjustmentById,
+  refetchAdjustments,
+  showSuccess,
+  showError,
+  setDeleteConfirmOpen,
+  setAdjustmentToDelete,
+  setAdjustmentToDeleteName,
+  setCompleteConfirmOpen,
+  setAdjustmentToComplete,
+  setAdjustmentToCompleteName,
+  setRevertConfirmOpen,
+  setAdjustmentToRevert,
+  setAdjustmentToRevertName,
+  setFocusedAdjustmentIndex,
+}: UseStockAdjustmentsActionsParams) {
+  const handleEdit = useCallback(() => {
+    if (!selectedAdjustment) return
+    if (selectedAdjustment.status !== 'draft') {
+      showError('Only draft adjustments can be edited')
+      return
+    }
+    navigate(`/inventory/stock-adjustments/${selectedAdjustment.id}/edit`)
+  }, [navigate, selectedAdjustment, showError])
+
+  const handleDelete = useCallback((id: string, adjustmentNumber: string) => {
+    setAdjustmentToDelete(id)
+    setAdjustmentToDeleteName(adjustmentNumber)
+    setDeleteConfirmOpen(true)
+  }, [setAdjustmentToDelete, setAdjustmentToDeleteName, setDeleteConfirmOpen])
+
+  const handleConfirmDelete = useCallback(async (id: string | null) => {
+    if (!id) return
+    try {
+      if (selectedAdjustment?.id === id) {
+        dispatch(setSelectedStockAdjustment(null))
+        setFocusedAdjustmentIndex(-1)
+      }
+      await deleteStockAdjustment(id).unwrap()
+      showSuccess('Stock adjustment deleted successfully')
+      refetchAdjustments()
+    } catch (error: any) {
+      showError(error?.data?.message || 'Failed to delete stock adjustment')
+    } finally {
+      setDeleteConfirmOpen(false)
+      setAdjustmentToDelete(null)
+      setAdjustmentToDeleteName('')
+    }
+  }, [
+    deleteStockAdjustment,
+    dispatch,
+    refetchAdjustments,
+    selectedAdjustment?.id,
+    setAdjustmentToDelete,
+    setAdjustmentToDeleteName,
+    setDeleteConfirmOpen,
+    setFocusedAdjustmentIndex,
+    showError,
+    showSuccess,
+  ])
+
+  const handleCancelDelete = useCallback(() => {
+    setDeleteConfirmOpen(false)
+    setAdjustmentToDelete(null)
+    setAdjustmentToDeleteName('')
+  }, [setAdjustmentToDelete, setAdjustmentToDeleteName, setDeleteConfirmOpen])
+
+  const handleComplete = useCallback((id: string, adjustmentNumber: string) => {
+    setAdjustmentToComplete(id)
+    setAdjustmentToCompleteName(adjustmentNumber)
+    setCompleteConfirmOpen(true)
+  }, [setAdjustmentToComplete, setAdjustmentToCompleteName, setCompleteConfirmOpen])
+
+  const handleConfirmComplete = useCallback(async (id: string | null) => {
+    if (!id) return
+    try {
+      await completeStockAdjustment(id).unwrap()
+      showSuccess('Stock adjustment completed successfully')
+      refetchAdjustments()
+      if (selectedAdjustment?.id === id) {
+        const fresh = await fetchStockAdjustmentById(id).unwrap()
+        dispatch(setSelectedStockAdjustment(fresh))
+      }
+    } catch (error: any) {
+      showError(error?.data?.message || 'Failed to complete stock adjustment')
+    } finally {
+      setCompleteConfirmOpen(false)
+      setAdjustmentToComplete(null)
+      setAdjustmentToCompleteName('')
+    }
+  }, [
+    completeStockAdjustment,
+    dispatch,
+    fetchStockAdjustmentById,
+    refetchAdjustments,
+    selectedAdjustment?.id,
+    setAdjustmentToComplete,
+    setAdjustmentToCompleteName,
+    setCompleteConfirmOpen,
+    showError,
+    showSuccess,
+  ])
+
+  const handleCancelComplete = useCallback(() => {
+    setCompleteConfirmOpen(false)
+    setAdjustmentToComplete(null)
+    setAdjustmentToCompleteName('')
+  }, [setAdjustmentToComplete, setAdjustmentToCompleteName, setCompleteConfirmOpen])
+
+  const handleRevert = useCallback((id: string, adjustmentNumber: string) => {
+    setAdjustmentToRevert(id)
+    setAdjustmentToRevertName(adjustmentNumber)
+    setRevertConfirmOpen(true)
+  }, [setAdjustmentToRevert, setAdjustmentToRevertName, setRevertConfirmOpen])
+
+  const handleConfirmRevert = useCallback(async (id: string | null) => {
+    if (!id) return
+    try {
+      await uncompleteStockAdjustment(id).unwrap()
+      showSuccess('Stock adjustment reverted to draft successfully')
+      refetchAdjustments()
+      if (selectedAdjustment?.id === id) {
+        const fresh = await fetchStockAdjustmentById(id).unwrap()
+        dispatch(setSelectedStockAdjustment(fresh))
+      }
+    } catch (error: any) {
+      showError(error?.data?.message || 'Failed to revert stock adjustment')
+    } finally {
+      setRevertConfirmOpen(false)
+      setAdjustmentToRevert(null)
+      setAdjustmentToRevertName('')
+    }
+  }, [
+    dispatch,
+    fetchStockAdjustmentById,
+    refetchAdjustments,
+    selectedAdjustment?.id,
+    setAdjustmentToRevert,
+    setAdjustmentToRevertName,
+    setRevertConfirmOpen,
+    showError,
+    showSuccess,
+    uncompleteStockAdjustment,
+  ])
+
+  const handleCancelRevert = useCallback(() => {
+    setRevertConfirmOpen(false)
+    setAdjustmentToRevert(null)
+    setAdjustmentToRevertName('')
+  }, [setAdjustmentToRevert, setAdjustmentToRevertName, setRevertConfirmOpen])
+
+  return {
+    handleEdit,
+    handleDelete,
+    handleConfirmDelete,
+    handleCancelDelete,
+    handleComplete,
+    handleConfirmComplete,
+    handleCancelComplete,
+    handleRevert,
+    handleConfirmRevert,
+    handleCancelRevert,
+  }
+}

--- a/frontend/src/pages/inventory/hooks/useStockAdjustmentsPageState.ts
+++ b/frontend/src/pages/inventory/hooks/useStockAdjustmentsPageState.ts
@@ -1,0 +1,73 @@
+import { useRef, useState } from 'react'
+
+export interface StockAdjustmentsSorting {
+  sortBy: string
+  sortOrder: 'asc' | 'desc'
+}
+
+export interface StockAdjustmentsJournalEntryRef {
+  referenceNumber: string
+  sourceType: string
+  sourceId: string
+}
+
+export function useStockAdjustmentsPageState() {
+  const [sorting, setSorting] = useState<StockAdjustmentsSorting>({
+    sortBy: 'adjustmentNumber',
+    sortOrder: 'asc',
+  })
+  const [focusedAdjustmentIndex, setFocusedAdjustmentIndex] = useState(-1)
+  const [showDeletedDialog, setShowDeletedDialog] = useState(false)
+  const [journalEntryRef, setJournalEntryRef] = useState<StockAdjustmentsJournalEntryRef | null>(null)
+  const [journalEntryRefLoading, setJournalEntryRefLoading] = useState(false)
+
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
+  const [adjustmentToDelete, setAdjustmentToDelete] = useState<string | null>(null)
+  const [adjustmentToDeleteName, setAdjustmentToDeleteName] = useState('')
+
+  const [completeConfirmOpen, setCompleteConfirmOpen] = useState(false)
+  const [adjustmentToComplete, setAdjustmentToComplete] = useState<string | null>(null)
+  const [adjustmentToCompleteName, setAdjustmentToCompleteName] = useState('')
+
+  const [revertConfirmOpen, setRevertConfirmOpen] = useState(false)
+  const [adjustmentToRevert, setAdjustmentToRevert] = useState<string | null>(null)
+  const [adjustmentToRevertName, setAdjustmentToRevertName] = useState('')
+
+  const adjustmentListRef = useRef<HTMLDivElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+  const userHasNavigatedRef = useRef(false)
+
+  return {
+    sorting,
+    setSorting,
+    focusedAdjustmentIndex,
+    setFocusedAdjustmentIndex,
+    showDeletedDialog,
+    setShowDeletedDialog,
+    journalEntryRef,
+    setJournalEntryRef,
+    journalEntryRefLoading,
+    setJournalEntryRefLoading,
+    deleteConfirmOpen,
+    setDeleteConfirmOpen,
+    adjustmentToDelete,
+    setAdjustmentToDelete,
+    adjustmentToDeleteName,
+    setAdjustmentToDeleteName,
+    completeConfirmOpen,
+    setCompleteConfirmOpen,
+    adjustmentToComplete,
+    setAdjustmentToComplete,
+    adjustmentToCompleteName,
+    setAdjustmentToCompleteName,
+    revertConfirmOpen,
+    setRevertConfirmOpen,
+    adjustmentToRevert,
+    setAdjustmentToRevert,
+    adjustmentToRevertName,
+    setAdjustmentToRevertName,
+    adjustmentListRef,
+    searchInputRef,
+    userHasNavigatedRef,
+  }
+}

--- a/frontend/src/pages/inventory/hooks/useStockAdjustmentsSelection.ts
+++ b/frontend/src/pages/inventory/hooks/useStockAdjustmentsSelection.ts
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, type MutableRefObject, type RefObject } from 'react'
+import type { SetURLSearchParams } from 'react-router-dom'
+
+import { useLazyGetJournalEntriesQuery } from '@/store/api/accountingApi'
+import { useLazyGetStockAdjustmentQuery } from '@/store/api/inventoryApi'
+import type { AppDispatch } from '@/store'
+import { setSelectedStockAdjustment } from '@/store/slices/inventorySlice'
+import type { StockAdjustment } from '@/types'
+
+import type { StockAdjustmentsJournalEntryRef } from './useStockAdjustmentsPageState'
+
+interface UseStockAdjustmentsSelectionParams {
+  dispatch: AppDispatch
+  adjustments: StockAdjustment[]
+  selectedAdjustment: StockAdjustment | null
+  focusedAdjustmentIndex: number
+  setFocusedAdjustmentIndex: (index: number) => void
+  searchParams: URLSearchParams
+  setSearchParams: SetURLSearchParams
+  adjustmentListRef: RefObject<HTMLDivElement | null>
+  searchInputRef: RefObject<HTMLInputElement | null>
+  userHasNavigatedRef: MutableRefObject<boolean>
+  setJournalEntryRef: (value: StockAdjustmentsJournalEntryRef | null) => void
+  setJournalEntryRefLoading: (value: boolean) => void
+}
+
+export function useStockAdjustmentsSelection({
+  dispatch,
+  adjustments,
+  selectedAdjustment,
+  focusedAdjustmentIndex,
+  setFocusedAdjustmentIndex,
+  searchParams,
+  setSearchParams,
+  adjustmentListRef,
+  searchInputRef,
+  userHasNavigatedRef,
+  setJournalEntryRef,
+  setJournalEntryRefLoading,
+}: UseStockAdjustmentsSelectionParams) {
+  const [fetchAdjustment] = useLazyGetStockAdjustmentQuery()
+  const [fetchJournalEntries] = useLazyGetJournalEntriesQuery()
+
+  useEffect(() => {
+    if (!selectedAdjustment?.id) {
+      setJournalEntryRef(null)
+      setJournalEntryRefLoading(false)
+      return
+    }
+
+    let cancelled = false
+    setJournalEntryRefLoading(true)
+
+    ;(async () => {
+      try {
+        const res = await fetchJournalEntries({
+          sourceType: 'stock_adjustment',
+          sourceId: selectedAdjustment.id,
+          sortBy: 'createdAt',
+          sortOrder: 'DESC',
+          limit: 1,
+        }).unwrap()
+
+        if (cancelled) return
+
+        const entry = res.data?.[0]
+        if (entry) {
+          setJournalEntryRef({
+            referenceNumber: entry.referenceNumber,
+            sourceType: 'stock_adjustment',
+            sourceId: selectedAdjustment.id,
+          })
+        } else {
+          setJournalEntryRef(null)
+        }
+      } catch {
+        if (!cancelled) setJournalEntryRef(null)
+      } finally {
+        if (!cancelled) setJournalEntryRefLoading(false)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [fetchJournalEntries, selectedAdjustment?.id, setJournalEntryRef, setJournalEntryRefLoading])
+
+  useEffect(() => {
+    const saId = searchParams.get('saId')
+    if (saId && adjustments.length > 0) {
+      const adjustment = adjustments.find((item) => item.id === saId)
+      if (adjustment) {
+        dispatch(setSelectedStockAdjustment(adjustment))
+        const index = adjustments.findIndex((item) => item.id === saId)
+        setFocusedAdjustmentIndex(index)
+        setSearchParams((prev) => {
+          prev.delete('saId')
+          return prev
+        }, { replace: true })
+        void fetchAdjustment(saId)
+          .unwrap()
+          .then((fresh) => {
+            dispatch(setSelectedStockAdjustment(fresh))
+          })
+          .catch(() => {
+            // Keep the lightweight list item selected when detail fetch fails.
+          })
+      }
+    }
+  }, [adjustments, dispatch, fetchAdjustment, searchParams, setFocusedAdjustmentIndex, setSearchParams])
+
+  useEffect(() => {
+    if (adjustments.length > 0 && focusedAdjustmentIndex === -1) {
+      if (selectedAdjustment) {
+        const index = adjustments.findIndex((item) => item.id === selectedAdjustment.id)
+        setFocusedAdjustmentIndex(index >= 0 ? index : 0)
+      } else if (searchInputRef.current !== document.activeElement) {
+        const saId = searchParams.get('saId')
+        if (!saId) {
+          setFocusedAdjustmentIndex(0)
+          dispatch(setSelectedStockAdjustment(adjustments[0]))
+          void fetchAdjustment(adjustments[0].id)
+            .unwrap()
+            .then((fresh) => {
+              dispatch(setSelectedStockAdjustment(fresh))
+            })
+            .catch(() => {})
+        }
+      }
+    }
+  }, [
+    adjustments,
+    dispatch,
+    fetchAdjustment,
+    focusedAdjustmentIndex,
+    searchInputRef,
+    searchParams,
+    selectedAdjustment,
+    setFocusedAdjustmentIndex,
+  ])
+
+  useEffect(() => {
+    if (adjustments.length === 0 && selectedAdjustment) {
+      dispatch(setSelectedStockAdjustment(null))
+      setFocusedAdjustmentIndex(-1)
+    }
+  }, [adjustments.length, dispatch, selectedAdjustment, setFocusedAdjustmentIndex])
+
+  useEffect(() => {
+    if (focusedAdjustmentIndex >= 0 && adjustmentListRef.current) {
+      const row = adjustmentListRef.current.querySelector(`[data-adjustment-index="${focusedAdjustmentIndex}"]`)
+      if (row instanceof HTMLElement && typeof row.scrollIntoView === 'function') {
+        row.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      }
+    }
+  }, [focusedAdjustmentIndex, adjustmentListRef])
+
+  const handleAdjustmentSelect = useCallback(async (adjustment: StockAdjustment) => {
+    const index = adjustments.findIndex((item) => item.id === adjustment.id)
+    setFocusedAdjustmentIndex(index)
+    userHasNavigatedRef.current = true
+
+    try {
+      const fresh = await fetchAdjustment(adjustment.id).unwrap()
+      dispatch(setSelectedStockAdjustment(fresh))
+    } catch {
+      dispatch(setSelectedStockAdjustment(adjustment))
+    }
+  }, [adjustments, dispatch, fetchAdjustment, setFocusedAdjustmentIndex, userHasNavigatedRef])
+
+  const handleNavigateUp = useCallback(() => {
+    if (focusedAdjustmentIndex > 0) {
+      const newIndex = focusedAdjustmentIndex - 1
+      setFocusedAdjustmentIndex(newIndex)
+      dispatch(setSelectedStockAdjustment(adjustments[newIndex]))
+      userHasNavigatedRef.current = true
+    }
+  }, [adjustments, dispatch, focusedAdjustmentIndex, setFocusedAdjustmentIndex, userHasNavigatedRef])
+
+  const handleNavigateDown = useCallback(() => {
+    if (focusedAdjustmentIndex < adjustments.length - 1) {
+      const newIndex = focusedAdjustmentIndex + 1
+      setFocusedAdjustmentIndex(newIndex)
+      dispatch(setSelectedStockAdjustment(adjustments[newIndex]))
+      userHasNavigatedRef.current = true
+    }
+  }, [adjustments, dispatch, focusedAdjustmentIndex, setFocusedAdjustmentIndex, userHasNavigatedRef])
+
+  const focusSearchInput = useCallback(() => {
+    searchInputRef.current?.focus()
+  }, [searchInputRef])
+
+  return {
+    handleAdjustmentSelect,
+    handleNavigateUp,
+    handleNavigateDown,
+    focusSearchInput,
+  }
+}


### PR DESCRIPTION
Closes #346

## Summary

- Decomposes `StockAdjustmentsPage.tsx` (1028 lines) into `useStockAdjustmentsPageState`, `useStockAdjustmentsSelection`, `useStockAdjustmentsActions`, `StockAdjustmentList`, `StockAdjustmentContextHeader`, `StockAdjustmentWorkspaceCard`, and `StockAdjustmentsDialogs` — consistent with `GoodsReceivedPage` and `ProductsPage`
- Rewrites page orchestrator to ~100 lines using `MasterDetailWorkspace`
- Moves sort button into `FilterBar` unified sort button (`adjustmentDate`)
- Replaces `location.state.newAdjustmentId` navigation with `?saId=` search param (same pattern as GRN's `?grnId=`)
- Fixes error messages from Axios shape (`error.response.data.message`) to RTK Query shape (`error.data.message`) so mutation errors now surface correctly
- Fixes complete confirmation dialog wording ("cannot be undone" → "can be reverted to draft if needed")

## Test plan

- [x] `npm run type-check` — passed
- [x] `npx vitest run src/pages/inventory/__tests__/StockAdjustmentsPage.filterbar.test.tsx` — passed
- [x] `npx vitest run src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx` — passed
- [x] `npx vitest run src/pages/inventory/` — passed (13 files, 62 tests)
- [x] `npm run lint` — passed
- [x] Manual browser verification (keyboard nav, complete/revert/delete actions, sort, `?saId=` deep link, journal entry link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)