### PR TITLE
refactor(inventory): stock adjustment UI polish (#359)

### DIFF
--- a/frontend/src/pages/inventory/components/StockAdjustmentContextHeader.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentContextHeader.tsx
@@ -9,11 +9,18 @@ import {
   IconButton,
   Paper,
   Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
   Typography,
 } from '@mui/material'
+import Grid from '@mui/material/Grid'
 
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { StockAdjustment } from '@/types'
+import { formatCurrency, formatDate } from '@/utils/formatters'
 
 import type { StockAdjustmentsJournalEntryRef } from '../hooks/useStockAdjustmentsPageState'
 
@@ -35,6 +42,32 @@ const actionIconSx = {
   minWidth: 20,
   p: 0.125,
 }
+
+const detailTableSx = {
+  tableLayout: 'fixed' as const,
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const sectionHeaderCellSx = {
+  pb: TABLE_STYLES.cell.padding.py * 0.67,
+  py: TABLE_STYLES.cell.padding.py * 0.67,
+  borderTop: TABLE_STYLES.cell.border,
+}
+
+const sectionTitleSx = {
+  fontWeight: 600,
+  color: 'primary.main',
+  fontSize: '0.8rem',
+}
+
+const labelCellSx = { fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }
+const valueCellSx = { fontSize: '0.8rem' }
 
 const StockAdjustmentContextHeader: React.FC<StockAdjustmentContextHeaderProps> = ({
   selectedAdjustment,
@@ -109,49 +142,119 @@ const StockAdjustmentContextHeader: React.FC<StockAdjustmentContextHeaderProps> 
         </Box>
       </Box>
 
-      <Box sx={{ px: TABLE_STYLES.cell.padding.px, py: 1, display: 'flex', alignItems: 'center', gap: 2 }}>
-        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-          {selectedAdjustment.status === 'draft' && (
-            <Button variant="contained" size="small" color="primary" onClick={onComplete} sx={{ minWidth: 110 }}>
-              Complete
-            </Button>
-          )}
-          {selectedAdjustment.status === 'completed' && (
-            <Button variant="contained" size="small" color="warning" onClick={onRevert} sx={{ minWidth: 110 }}>
-              Revert to Draft
-            </Button>
-          )}
-        </Stack>
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+                      <Typography variant="h6" sx={sectionTitleSx}>
+                        SA Information
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Date</TableCell>
+                    <TableCell sx={valueCellSx}>{formatDate(selectedAdjustment.adjustmentDate)}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Item Count</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedAdjustment.itemCount}</TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Total Value</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(selectedAdjustment.totalValue)}</TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
 
-        {selectedAdjustment.status === 'completed' && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary' }}>Journal Entry:</Typography>
-            {journalEntryRefLoading ? (
-              <CircularProgress size={12} />
-            ) : journalEntryRef ? (
-              <Typography
-                component="button"
-                onClick={onNavigateToJournalEntry}
-                sx={{
-                  fontSize: '0.8rem',
-                  fontWeight: 600,
-                  color: 'primary.main',
-                  cursor: 'pointer',
-                  border: 'none',
-                  background: 'none',
-                  padding: 0,
-                  '&:hover': { textDecoration: 'underline' },
-                }}
-              >
-                {journalEntryRef.referenceNumber}
-              </Typography>
-            ) : (
-              <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}>
-                Pending
-              </Typography>
-            )}
-          </Box>
-        )}
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+                      <Typography variant="h6" sx={sectionTitleSx}>
+                        SA Confirmation
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Created At</TableCell>
+                    <TableCell sx={valueCellSx}>{formatDate(selectedAdjustment.createdAt)}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Updated At</TableCell>
+                    <TableCell sx={valueCellSx}>{formatDate(selectedAdjustment.updatedAt)}</TableCell>
+                  </TableRow>
+                  {selectedAdjustment.status === 'completed' && (
+                    <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                      <TableCell sx={labelCellSx}>Journal Entry</TableCell>
+                      <TableCell sx={valueCellSx}>
+                        {journalEntryRefLoading ? (
+                          <CircularProgress size={12} />
+                        ) : journalEntryRef ? (
+                          <Typography
+                            component="button"
+                            onClick={onNavigateToJournalEntry}
+                            sx={{
+                              fontSize: '0.8rem',
+                              fontWeight: 600,
+                              color: 'primary.main',
+                              cursor: 'pointer',
+                              border: 'none',
+                              background: 'none',
+                              padding: 0,
+                              '&:hover': { textDecoration: 'underline' },
+                            }}
+                          >
+                            {journalEntryRef.referenceNumber}
+                          </Typography>
+                        ) : (
+                          <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}>
+                            Pending
+                          </Typography>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  <TableRow>
+                    <TableCell colSpan={2} sx={{ textAlign: 'center' }}>
+                      <Stack direction="row" spacing={1} sx={{ alignItems: 'center', justifyContent: 'center' }}>
+                        {selectedAdjustment.status === 'draft' && (
+                          <Button
+                            variant="contained"
+                            size="small"
+                            color="primary"
+                            onClick={onComplete}
+                            sx={{ minWidth: 110 }}
+                          >
+                            Complete
+                          </Button>
+                        )}
+                        {selectedAdjustment.status === 'completed' && (
+                          <Button
+                            variant="contained"
+                            size="small"
+                            color="warning"
+                            onClick={onRevert}
+                            sx={{ minWidth: 110 }}
+                          >
+                            Revert to Draft
+                          </Button>
+                        )}
+                      </Stack>
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+        </Grid>
       </Box>
     </Paper>
   )

--- a/frontend/src/pages/inventory/components/StockAdjustmentPanels.test.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentPanels.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import StockAdjustmentContextHeader from './StockAdjustmentContextHeader'
+import StockAdjustmentWorkspaceCard from './StockAdjustmentWorkspaceCard'
+
+import type { StockAdjustment } from '@/types'
+
+const makeAdjustment = (overrides: Partial<StockAdjustment> = {}): StockAdjustment => ({
+  id: 'adj-1',
+  adjustmentNumber: 'SA-001',
+  adjustmentDate: new Date('2026-03-01T00:00:00.000Z'),
+  status: 'completed',
+  notes: 'Cycle count variance',
+  itemCount: 2,
+  totalValue: 125.5,
+  items: [
+    {
+      id: 'item-1',
+      product: { id: 'prod-1', name: 'Widget A' },
+      oldQuantity: 10,
+      newQuantity: 13,
+      difference: 3,
+      totalValue: 37.5,
+      isIncrease: true,
+      isDecrease: false,
+      absoluteDifference: 3,
+    },
+  ],
+  createdAt: new Date('2026-03-02T00:00:00.000Z'),
+  updatedAt: new Date('2026-03-03T00:00:00.000Z'),
+  ...overrides,
+})
+
+describe('Stock adjustment detail panels', () => {
+  it('renders the context header as an info grid with confirmation actions and journal entry link', () => {
+    const onNavigateToJournalEntry = vi.fn()
+
+    render(
+      <StockAdjustmentContextHeader
+        selectedAdjustment={makeAdjustment()}
+        journalEntryRef={{ id: 'je-1', referenceNumber: 'JE-001' }}
+        journalEntryRefLoading={false}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onComplete={vi.fn()}
+        onRevert={vi.fn()}
+        onNavigateToJournalEntry={onNavigateToJournalEntry}
+      />,
+    )
+
+    expect(screen.getByText('SA Information')).toBeInTheDocument()
+    expect(screen.getByText('SA Confirmation')).toBeInTheDocument()
+    expect(screen.getByText('Total Value')).toBeInTheDocument()
+    expect(screen.getByText('RM 125.50')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Revert to Draft' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'JE-001' }))
+    expect(onNavigateToJournalEntry).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the workspace card with items first and notes only when present', () => {
+    const { rerender } = render(<StockAdjustmentWorkspaceCard selectedAdjustment={makeAdjustment()} />)
+
+    expect(screen.getByText('SA Items')).toBeInTheDocument()
+    expect(screen.queryByText('SA Information')).not.toBeInTheDocument()
+    expect(screen.queryByText('SA Confirmation')).not.toBeInTheDocument()
+    expect(screen.getByText('Notes')).toBeInTheDocument()
+    expect(screen.getByText('Cycle count variance')).toBeInTheDocument()
+
+    const row = screen.getByText('Widget A').closest('tr')
+    expect(row).not.toBeNull()
+    expect(within(row as HTMLTableRowElement).getByText('+3')).toBeInTheDocument()
+
+    rerender(<StockAdjustmentWorkspaceCard selectedAdjustment={makeAdjustment({ notes: '' })} />)
+
+    expect(screen.queryByText('Notes')).not.toBeInTheDocument()
+    expect(screen.queryByText('Cycle count variance')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/inventory/components/StockAdjustmentWorkspaceCard.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentWorkspaceCard.tsx
@@ -11,41 +11,13 @@ import {
   TableRow,
   Typography,
 } from '@mui/material'
-import Grid from '@mui/material/Grid'
 
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { StockAdjustment } from '@/types'
-import { formatDate } from '@/utils/formatters'
 
 interface StockAdjustmentWorkspaceCardProps {
   selectedAdjustment: StockAdjustment | null
 }
-
-const detailTableSx = {
-  tableLayout: 'fixed' as const,
-  '& .MuiTableCell-root': {
-    border: 'none',
-    py: TABLE_STYLES.cell.padding.py,
-    px: TABLE_STYLES.cell.padding.px,
-    '&:nth-of-type(1)': { width: '40%' },
-    '&:nth-of-type(2)': { width: '60%' },
-  },
-}
-
-const sectionHeaderCellSx = {
-  pb: TABLE_STYLES.cell.padding.py * 0.67,
-  py: TABLE_STYLES.cell.padding.py * 0.67,
-  borderTop: TABLE_STYLES.cell.border,
-}
-
-const sectionTitleSx = {
-  fontWeight: 600,
-  color: 'primary.main',
-  fontSize: '0.8rem',
-}
-
-const labelCellSx = { fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }
-const valueCellSx = { fontSize: '0.8rem' }
 
 const StockAdjustmentWorkspaceCard: React.FC<StockAdjustmentWorkspaceCardProps> = ({
   selectedAdjustment,
@@ -55,154 +27,136 @@ const StockAdjustmentWorkspaceCard: React.FC<StockAdjustmentWorkspaceCardProps> 
   }
 
   return (
-    <Paper sx={{ flex: 1, overflow: 'auto', display: 'flex', flexDirection: 'column' }}>
-      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
-        <Grid container spacing={3}>
-          <Grid size={{ xs: 12, md: 6 }}>
-            <TableContainer>
-              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
-                <TableBody>
-                  <TableRow>
-                    <TableCell colSpan={2} sx={sectionHeaderCellSx}>
-                      <Typography variant="h6" sx={sectionTitleSx}>SA Information</Typography>
-                    </TableCell>
-                  </TableRow>
-                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                    <TableCell sx={labelCellSx}>Date</TableCell>
-                    <TableCell sx={valueCellSx}>{formatDate(selectedAdjustment.adjustmentDate)}</TableCell>
-                  </TableRow>
-                  <TableRow>
-                    <TableCell sx={labelCellSx}>Item Count</TableCell>
-                    <TableCell sx={valueCellSx}>{selectedAdjustment.itemCount}</TableCell>
-                  </TableRow>
-                </TableBody>
-              </Table>
-            </TableContainer>
-          </Grid>
-
-          <Grid size={{ xs: 12, md: 6 }}>
-            <TableContainer>
-              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
-                <TableBody>
-                  <TableRow>
-                    <TableCell colSpan={2} sx={sectionHeaderCellSx}>
-                      <Typography variant="h6" sx={sectionTitleSx}>SA Confirmation</Typography>
-                    </TableCell>
-                  </TableRow>
-                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
-                    <TableCell sx={labelCellSx}>Created At</TableCell>
-                    <TableCell sx={valueCellSx}>{formatDate(selectedAdjustment.createdAt)}</TableCell>
-                  </TableRow>
-                  <TableRow>
-                    <TableCell sx={labelCellSx}>Updated At</TableCell>
-                    <TableCell sx={valueCellSx}>{formatDate(selectedAdjustment.updatedAt)}</TableCell>
-                  </TableRow>
-                </TableBody>
-              </Table>
-            </TableContainer>
-          </Grid>
-        </Grid>
-
-        <Box sx={{ borderTop: '2px solid', borderColor: 'divider', my: 1 }} />
-
+    <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
         <Typography
           variant="tableHeader"
-          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px', mb: 1, display: 'block' }}
+          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
         >
           SA Items
         </Typography>
+      </Box>
 
-        {selectedAdjustment.items && selectedAdjustment.items.length > 0 ? (
-          <TableContainer>
-            <Table
-              size={TABLE_STYLES.size}
-              sx={{
-                '& .MuiTableCell-root': {
-                  borderBottom: TABLE_STYLES.cell.border,
-                  py: TABLE_STYLES.cell.padding.py,
-                  px: TABLE_STYLES.cell.padding.px,
-                },
-              }}
-            >
-              <TableHead>
-                <TableRow
-                  sx={{
-                    '& .MuiTableCell-head': {
-                      fontWeight: 600,
-                      backgroundColor: 'grey.50',
-                      color: 'text.primary',
-                      fontSize: '0.8rem',
-                    },
-                  }}
-                >
-                  <TableCell sx={{ width: '40%' }}>Product</TableCell>
-                  <TableCell align="center" sx={{ width: '20%' }}>Old Quantity</TableCell>
-                  <TableCell align="center" sx={{ width: '20%' }}>New Quantity</TableCell>
-                  <TableCell align="center" sx={{ width: '20%' }}>Difference</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {selectedAdjustment.items.map((item, index) => (
+      <Box
+        sx={{
+          flex: 1,
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
+          p: TABLE_STYLES.cell.padding.px,
+        }}
+      >
+        <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          {selectedAdjustment.items && selectedAdjustment.items.length > 0 ? (
+            <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
+              <Table
+                size={TABLE_STYLES.size}
+                sx={{
+                  '& .MuiTableCell-root': {
+                    borderBottom: TABLE_STYLES.cell.border,
+                    py: TABLE_STYLES.cell.padding.py,
+                    px: TABLE_STYLES.cell.padding.px,
+                  },
+                }}
+              >
+                <TableHead>
                   <TableRow
-                    key={index}
-                    hover
-                    sx={{ height: TABLE_STYLES.row.height, transition: 'background-color 0.2s ease' }}
-                  >
-                    <TableCell sx={{ fontSize: '0.8rem', lineHeight: 1.2 }}>
-                      {item.product?.name || 'Unknown Product'}
-                    </TableCell>
-                    <TableCell align="center" sx={{ fontSize: '0.8rem', color: 'text.secondary', lineHeight: 1.2 }}>
-                      {Number(item.oldQuantity).toLocaleString()}
-                    </TableCell>
-                    <TableCell align="center" sx={{ fontSize: '0.8rem', lineHeight: 1.2 }}>
-                      {Number(item.newQuantity).toLocaleString()}
-                    </TableCell>
-                    <TableCell
-                      align="center"
-                      sx={{
-                        fontSize: '0.8rem',
+                    sx={{
+                      '& .MuiTableCell-head': {
                         fontWeight: 600,
-                        lineHeight: 1.2,
-                        color:
-                          Number(item.difference) > 0
-                            ? 'success.main'
-                            : Number(item.difference) < 0
-                              ? 'error.main'
-                              : 'text.primary',
-                      }}
-                    >
-                      {Number(item.difference) > 0 ? '+' : ''}
-                      {Number(item.difference).toLocaleString()}
+                        backgroundColor: 'grey.50',
+                        color: 'text.primary',
+                        fontSize: '0.8rem',
+                      },
+                    }}
+                  >
+                    <TableCell sx={{ width: '40%' }}>Product</TableCell>
+                    <TableCell align="center" sx={{ width: '20%' }}>
+                      Old Quantity
+                    </TableCell>
+                    <TableCell align="center" sx={{ width: '20%' }}>
+                      New Quantity
+                    </TableCell>
+                    <TableCell align="center" sx={{ width: '20%' }}>
+                      Difference
                     </TableCell>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
-        ) : (
-          <Alert severity="info">No items in this adjustment</Alert>
-        )}
-
-        <Box sx={{ borderTop: '2px solid', borderColor: 'divider', my: 1 }} />
-
-        <Typography
-          variant="tableHeader"
-          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px', mb: 1, display: 'block' }}
-        >
-          Notes
-        </Typography>
-        <Box
-          sx={{
-            p: 2,
-            backgroundColor: 'grey.50',
-            borderRadius: 1,
-            fontSize: '0.8rem',
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-word',
-          }}
-        >
-          {selectedAdjustment.notes || '—'}
+                </TableHead>
+                <TableBody>
+                  {selectedAdjustment.items.map((item, index) => (
+                    <TableRow
+                      key={index}
+                      hover
+                      sx={{ height: TABLE_STYLES.row.height, transition: 'background-color 0.2s ease' }}
+                    >
+                      <TableCell sx={{ fontSize: '0.8rem', lineHeight: 1.2 }}>
+                        {item.product?.name || 'Unknown Product'}
+                      </TableCell>
+                      <TableCell
+                        align="center"
+                        sx={{ fontSize: '0.8rem', color: 'text.secondary', lineHeight: 1.2 }}
+                      >
+                        {Number(item.oldQuantity).toLocaleString()}
+                      </TableCell>
+                      <TableCell align="center" sx={{ fontSize: '0.8rem', lineHeight: 1.2 }}>
+                        {Number(item.newQuantity).toLocaleString()}
+                      </TableCell>
+                      <TableCell
+                        align="center"
+                        sx={{
+                          fontSize: '0.8rem',
+                          fontWeight: 600,
+                          lineHeight: 1.2,
+                          color:
+                            Number(item.difference) > 0
+                              ? 'success.main'
+                              : Number(item.difference) < 0
+                                ? 'error.main'
+                                : 'text.primary',
+                        }}
+                      >
+                        {Number(item.difference) > 0 ? '+' : ''}
+                        {Number(item.difference).toLocaleString()}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          ) : (
+            <Alert severity="info">No items in this adjustment</Alert>
+          )}
         </Box>
+
+        {selectedAdjustment.notes && (
+          <Box sx={{ mt: 1 }}>
+            <Typography
+              variant="tableHeader"
+              sx={{
+                fontWeight: 600,
+                fontSize: '0.8rem',
+                textTransform: 'uppercase',
+                letterSpacing: '0.5px',
+                mb: 1,
+                display: 'block',
+              }}
+            >
+              Notes
+            </Typography>
+            <Box
+              sx={{
+                p: 2,
+                backgroundColor: 'grey.50',
+                borderRadius: 1,
+                fontSize: '0.8rem',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+              }}
+            >
+              {selectedAdjustment.notes}
+            </Box>
+          </Box>
+        )}
       </Box>
     </Paper>
   )


### PR DESCRIPTION
## Summary
- `StockAdjustmentContextHeader` now uses the two-column info grid pattern (matching SO/PO), with SA Information on the left and SA Confirmation + action content (Complete/Revert button, Journal Entry link) on the right — standalone action strip removed
- `StockAdjustmentWorkspaceCard` restructured to match `PurchaseOrderWorkspaceCard`: items-first layout with scrollable table body, Notes rendered only when present (no "—" fallback)
- Added focused regression test at `frontend/src/pages/inventory/components/StockAdjustmentPanels.test.tsx`

## Test Plan
- [x] `npx vitest run src/pages/inventory/components/StockAdjustmentPanels.test.tsx` passes
- [x] `npx vitest run src/pages/inventory/__tests__/StockAdjustmentsPage.filterbar.test.tsx` passes
- [x] `npx vitest run src/pages/inventory/` passes (14 files, 64 tests)
- [x] `npm run lint` passes
- [x] `npm run type-check` passes
- [x] Visually verify SA detail view matches SO/PO layout

Closes #359