### PR TITLE
refactor(inventory): use AppButton in Stock Adjustment page (#361)

### DIFF
--- a/frontend/src/components/common/AppButton.tsx
+++ b/frontend/src/components/common/AppButton.tsx
@@ -5,7 +5,7 @@ import SortIcon from '@mui/icons-material/Sort'
 import { CircularProgress } from '@mui/material'
 import Button, { type ButtonProps } from '@mui/material/Button'
 
-type AppButtonVariant = 'primary' | 'secondary' | 'outlined' | 'danger'
+type AppButtonVariant = 'primary' | 'secondary' | 'outlined' | 'danger' | 'warning' | 'success'
 type AppButtonSize = 'filter' | 'small' | 'medium' | 'large'
 
 type SortConfig = {
@@ -57,6 +57,14 @@ export function AppButton({
       case 'danger':
         muiVariant = 'contained'
         muiColor = 'error'
+        break
+      case 'warning':
+        muiVariant = 'contained'
+        muiColor = 'warning'
+        break
+      case 'success':
+        muiVariant = 'contained'
+        muiColor = 'success'
         break
       case 'secondary':
       case 'outlined':

--- a/frontend/src/components/common/__tests__/AppButton.test.tsx
+++ b/frontend/src/components/common/__tests__/AppButton.test.tsx
@@ -36,6 +36,20 @@ describe('AppButton - variants', () => {
     expect(btn.className).toMatch(/MuiButton-contained/)
     expect(btn.className).toMatch(/MuiButton-colorError/)
   })
+
+  it('renders warning as contained colorWarning', () => {
+    wrap(<AppButton variant="warning">Revert</AppButton>)
+    const btn = screen.getByRole('button', { name: 'Revert' })
+    expect(btn.className).toMatch(/MuiButton-contained/)
+    expect(btn.className).toMatch(/MuiButton-colorWarning/)
+  })
+
+  it('renders success as contained colorSuccess', () => {
+    wrap(<AppButton variant="success">Restore</AppButton>)
+    const btn = screen.getByRole('button', { name: 'Restore' })
+    expect(btn.className).toMatch(/MuiButton-contained/)
+    expect(btn.className).toMatch(/MuiButton-colorSuccess/)
+  })
 })
 
 describe('AppButton - size=filter', () => {

--- a/frontend/src/components/inventory/DeletedStockAdjustmentsDialog.tsx
+++ b/frontend/src/components/inventory/DeletedStockAdjustmentsDialog.tsx
@@ -4,7 +4,6 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Button,
   Table,
   TableBody,
   TableCell,
@@ -37,6 +36,7 @@ import {
   usePermanentDeleteStockAdjustmentMutation,
   useRestoreStockAdjustmentMutation,
 } from '@/store/api/inventoryApi'
+import { AppButton } from '@/components/common/AppButton'
 import { useNotification } from '@/hooks/useNotification'
 import type { StockAdjustment } from '@/types'
 import { formatDate } from '@/utils/formatters'
@@ -281,26 +281,24 @@ const DeletedStockAdjustmentsDialog: React.FC<DeletedStockAdjustmentsDialogProps
 
               {selectedCount > 0 && (
                 <>
-                  <Button
-                    variant="contained"
-                    color="success"
+                  <AppButton
+                    variant="success"
                     startIcon={<RestoreIcon />}
                     onClick={() => setShowBulkRestoreConfirm(true)}
                     disabled={bulkRestoring}
                     sx={{ whiteSpace: 'nowrap' }}
                   >
                     Restore Selected ({selectedCount})
-                  </Button>
-                  <Button
-                    variant="contained"
-                    color="error"
+                  </AppButton>
+                  <AppButton
+                    variant="danger"
                     startIcon={<DeleteIcon />}
                     onClick={() => setShowBulkDeleteConfirm(true)}
                     disabled={bulkDeleting}
                     sx={{ whiteSpace: 'nowrap' }}
                   >
                     Delete Selected ({selectedCount})
-                  </Button>
+                  </AppButton>
                 </>
               )}
             </Box>
@@ -554,9 +552,9 @@ const DeletedStockAdjustmentsDialog: React.FC<DeletedStockAdjustmentsDialogProps
               {selectedCount > 0 ? `${selectedCount} selected` : `${filteredAdjustments.length} total`}
             </Typography>
           </Box>
-          <Button onClick={onClose} variant="outlined">
+          <AppButton variant="outlined" onClick={onClose}>
             Close
-          </Button>
+          </AppButton>
         </DialogActions>
       </Dialog>
       {/* Bulk Restore Confirmation Dialog */}
@@ -568,17 +566,16 @@ const DeletedStockAdjustmentsDialog: React.FC<DeletedStockAdjustmentsDialogProps
           </Typography>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setShowBulkRestoreConfirm(false)} disabled={bulkRestoring}>
+          <AppButton variant="outlined" onClick={() => setShowBulkRestoreConfirm(false)} disabled={bulkRestoring}>
             Cancel
-          </Button>
-          <Button
+          </AppButton>
+          <AppButton
             onClick={handleBulkRestore}
-            variant="contained"
-            color="success"
-            disabled={bulkRestoring}
+            variant="success"
+            loading={bulkRestoring}
           >
-            {bulkRestoring ? 'Restoring...' : 'Restore'}
-          </Button>
+            Restore
+          </AppButton>
         </DialogActions>
       </Dialog>
       {/* Bulk Delete Confirmation Dialog */}
@@ -593,17 +590,16 @@ const DeletedStockAdjustmentsDialog: React.FC<DeletedStockAdjustmentsDialogProps
           </Typography>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setShowBulkDeleteConfirm(false)} disabled={bulkDeleting}>
+          <AppButton variant="outlined" onClick={() => setShowBulkDeleteConfirm(false)} disabled={bulkDeleting}>
             Cancel
-          </Button>
-          <Button
+          </AppButton>
+          <AppButton
             onClick={handleBulkDelete}
-            variant="contained"
-            color="error"
-            disabled={bulkDeleting}
+            variant="danger"
+            loading={bulkDeleting}
           >
-            {bulkDeleting ? 'Deleting...' : 'Permanently Delete'}
-          </Button>
+            Permanently Delete
+          </AppButton>
         </DialogActions>
       </Dialog>
       {/* Single Delete Confirmation Dialog */}
@@ -618,17 +614,20 @@ const DeletedStockAdjustmentsDialog: React.FC<DeletedStockAdjustmentsDialogProps
           </Typography>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setShowDeleteConfirm(null)} disabled={!!deletingId}>
-            Cancel
-          </Button>
-          <Button
-            onClick={() => showDeleteConfirm && handlePermanentDelete(showDeleteConfirm)}
-            variant="contained"
-            color="error"
+          <AppButton
+            variant="outlined"
+            onClick={() => setShowDeleteConfirm(null)}
             disabled={!!deletingId}
           >
-            {deletingId ? 'Deleting...' : 'Permanently Delete'}
-          </Button>
+            Cancel
+          </AppButton>
+          <AppButton
+            onClick={() => showDeleteConfirm && handlePermanentDelete(showDeleteConfirm)}
+            variant="danger"
+            loading={!!deletingId}
+          >
+            Permanently Delete
+          </AppButton>
         </DialogActions>
       </Dialog>
     </>

--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import {
   Box,
-  Button,
   Grid,
   TextField,
   Typography,
@@ -26,6 +25,7 @@ import { useForm, useFieldArray, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import { ApiService } from '@/services/api'
+import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import {
   useLazyGetStockAdjustmentQuery,
@@ -343,13 +343,13 @@ const CreateStockAdjustmentPage: React.FC = () => {
               <CardContent>
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
                   <Typography variant="h6">Adjustment Items</Typography>
-                  <Button
+                  <AppButton
+                    variant="outlined"
                     startIcon={<AddIcon />}
                     onClick={addItem}
-                    variant="outlined"
                   >
                     Add Item
-                  </Button>
+                  </AppButton>
                 </Box>
 
                 <TableContainer component={Paper} sx={{ border: `1px solid ${theme.palette.divider}` }}>
@@ -593,20 +593,20 @@ const CreateStockAdjustmentPage: React.FC = () => {
           {/* Action Buttons */}
           <Grid size={12}>
             <Box sx={{ display: 'flex', gap: 2, justifyContent: 'flex-end' }}>
-              <Button
+              <AppButton
                 variant="outlined"
                 onClick={() => navigate('/inventory/stock-adjustments')}
                 disabled={loading}
               >
                 Cancel
-              </Button>
-              <Button
+              </AppButton>
+              <AppButton
+                variant="primary"
                 type="submit"
-                variant="contained"
-                disabled={loading}
+                loading={loading}
               >
-                {loading ? (isEditMode ? 'Updating...' : 'Creating...') : (isEditMode ? 'Update Adjustment' : 'Create Adjustment')}
-              </Button>
+                {isEditMode ? 'Update Adjustment' : 'Create Adjustment'}
+              </AppButton>
             </Box>
           </Grid>
           </Grid>

--- a/frontend/src/pages/inventory/components/StockAdjustmentContextHeader.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentContextHeader.tsx
@@ -3,7 +3,6 @@ import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as EditIcon } from '@mui/icons-material/Edit'
 import {
   Box,
-  Button,
   Chip,
   CircularProgress,
   IconButton,
@@ -18,6 +17,7 @@ import {
 } from '@mui/material'
 import Grid from '@mui/material/Grid'
 
+import { AppButton } from '@/components/common/AppButton'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { StockAdjustment } from '@/types'
 import { formatCurrency, formatDate } from '@/utils/formatters'
@@ -224,30 +224,28 @@ const StockAdjustmentContextHeader: React.FC<StockAdjustmentContextHeaderProps> 
                   )}
                   <TableRow>
                     <TableCell colSpan={2} sx={{ textAlign: 'center' }}>
-                      <Stack direction="row" spacing={1} sx={{ alignItems: 'center', justifyContent: 'center' }}>
-                        {selectedAdjustment.status === 'draft' && (
-                          <Button
-                            variant="contained"
-                            size="small"
-                            color="primary"
-                            onClick={onComplete}
-                            sx={{ minWidth: 110 }}
-                          >
-                            Complete
-                          </Button>
-                        )}
-                        {selectedAdjustment.status === 'completed' && (
-                          <Button
-                            variant="contained"
-                            size="small"
-                            color="warning"
-                            onClick={onRevert}
-                            sx={{ minWidth: 110 }}
-                          >
-                            Revert to Draft
-                          </Button>
-                        )}
-                      </Stack>
+                        <Stack direction="row" spacing={1} sx={{ alignItems: 'center', justifyContent: 'center' }}>
+                          {selectedAdjustment.status === 'draft' && (
+                            <AppButton
+                              variant="primary"
+                              size="small"
+                              onClick={onComplete}
+                              sx={{ minWidth: 110 }}
+                            >
+                              Complete
+                            </AppButton>
+                          )}
+                          {selectedAdjustment.status === 'completed' && (
+                            <AppButton
+                              variant="warning"
+                              size="small"
+                              onClick={onRevert}
+                              sx={{ minWidth: 110 }}
+                            >
+                              Revert to Draft
+                            </AppButton>
+                          )}
+                        </Stack>
                     </TableCell>
                   </TableRow>
                 </TableBody>


### PR DESCRIPTION
## Summary
- Adds `warning` and `success` variants to `AppButton` (`AppButton.tsx`)
- Replaces raw MUI `Button` with `AppButton` in `StockAdjustmentContextHeader`, `CreateStockAdjustmentPage`, and `DeletedStockAdjustmentsDialog`
- Uses `AppButton`'s `loading` prop on submit/action buttons instead of manual disabled+text-swap

## Test Plan
- [x] `AppButton.test.tsx` — 27 tests pass
- [x] `StockAdjustmentPanels.test.tsx` — pass
- [x] `CreateStockAdjustmentPage.test.tsx` — pass
- [x] `StockAdjustmentsPage.filterbar.test.tsx` — pass
- [x] `npm run type-check` — no errors
- [x] No `Button` from `@mui/material` remains in scope files

Closes #361