### PR TITLE
feat(inventory): add Period filter to Stock Adjustments page

### DIFF
--- a/docs/superpowers/specs/2026-04-14-stock-adjustments-period-filter-design.md
+++ b/docs/superpowers/specs/2026-04-14-stock-adjustments-period-filter-design.md
@@ -1,0 +1,71 @@
+# Stock Adjustments Period Filter — Design Spec
+
+**Issue**: #365
+**Date**: 2026-04-14
+
+## Overview
+
+Add a Period (date range) filter to the Stock Adjustments page, matching the existing pattern used by `InvoicesPage` and `OrdersPage`.
+
+## Backend
+
+No changes required. `GET /inventory/stock-adjustments` already accepts `fromDate` and `toDate` query params, and the service filters by `adjustmentDate` using `BETWEEN`, `>=`, or `<=` as appropriate.
+
+## Frontend Changes
+
+### `StockAdjustmentsPage.tsx`
+
+**Imports** — add:
+- `PeriodValue` from `@/types/filterBar.types`
+- `getPeriodDateRange, getStartOfWeek` from `@/utils/dateRange`
+
+**`StockAdjustmentFilters` interface** — add:
+```ts
+period: PeriodValue
+```
+
+**`filterConfig`** — add period field (before status) and default:
+```ts
+fields: [
+  { field: 'period', label: 'Period', type: 'period' },
+  { field: 'status', label: 'Status', type: 'stock-adjustment-status' },
+],
+defaults: {
+  search: '',
+  period: { key: null, from: null, to: null },
+  status: null,
+},
+```
+
+**`dateRange` memo** — identical to `InvoicesPage`:
+```ts
+const weekStartsOn = getStartOfWeek()
+const dateRange = useMemo(() => {
+  const period = filterBar.appliedFilters.period
+  if (!period || period.key === null) return { fromDate: undefined, toDate: undefined }
+  if (period.key === 'custom') return { fromDate: period.from ?? undefined, toDate: period.to ?? undefined }
+  const range = getPeriodDateRange(period.key, weekStartsOn)
+  return { fromDate: range.from, toDate: range.to }
+}, [filterBar.appliedFilters.period, weekStartsOn])
+```
+
+**`queryParams` memo** — add:
+```ts
+fromDate: dateRange.fromDate,
+toDate: dateRange.toDate,
+```
+
+### `StockAdjustmentsPage.filterbar.test.tsx`
+
+Add three test cases to the existing `describe` block:
+
+1. **Default — no dates sent**: when no period is selected, `useGetStockAdjustmentsQuery` is not called with `fromDate` or `toDate`.
+2. **Preset period resolves to dates**: with `?period=this_week` in the URL, query receives `fromDate` and `toDate` matching `/^\d{4}-\d{2}-\d{2}$/`.
+3. **No period — no dates**: (same as default, mirrors Orders test naming convention).
+
+## Success Criteria
+
+- Users can select predefined periods (Today, This Week, This Month, etc.) or a custom date range.
+- The list updates automatically when the period changes.
+- The filter state is correctly managed and can be reset (sends no `fromDate`/`toDate`).
+- URL param `?period=this_week` (and `custom` with `from`/`to`) round-trips correctly via `useFilterBar`.

--- a/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
@@ -17,7 +17,8 @@ import {
   useUncompleteStockAdjustmentMutation,
 } from '@/store/api/inventoryApi'
 import { selectSelectedStockAdjustment } from '@/store/slices/inventorySlice'
-import type { FilterBarConfig } from '@/types/filterBar.types'
+import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
+import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
 
 import StockAdjustmentContextHeader from './components/StockAdjustmentContextHeader'
 import StockAdjustmentList from './components/StockAdjustmentList'
@@ -29,6 +30,7 @@ import { useStockAdjustmentsSelection } from './hooks/useStockAdjustmentsSelecti
 
 interface StockAdjustmentFilters {
   search: string
+  period: PeriodValue
   status: 'draft' | 'completed' | 'cancelled' | null
 }
 
@@ -46,23 +48,41 @@ const StockAdjustmentsPage: React.FC = () => {
     () => ({
       search: { placeholder: 'Search by adjustment number or notes...' },
       fields: [
+        { field: 'period', label: 'Period', type: 'period' },
         { field: 'status', label: 'Status', type: 'stock-adjustment-status' },
       ],
-      defaults: { search: '', status: null },
+      defaults: { search: '', period: { key: null, from: null, to: null }, status: null },
     }),
     [],
   )
 
   const filterBar = useFilterBar(filterConfig)
+  const weekStartsOn = getStartOfWeek()
+  const dateRange = useMemo(() => {
+    const period = filterBar.appliedFilters.period
+
+    if (!period || period.key === null) {
+      return { fromDate: undefined, toDate: undefined }
+    }
+
+    if (period.key === 'custom') {
+      return { fromDate: period.from ?? undefined, toDate: period.to ?? undefined }
+    }
+
+    const range = getPeriodDateRange(period.key, weekStartsOn)
+    return { fromDate: range.from, toDate: range.to }
+  }, [filterBar.appliedFilters.period, weekStartsOn])
 
   const queryParams = useMemo(
     () => ({
       search: filterBar.appliedFilters.search || undefined,
       status: filterBar.appliedFilters.status ?? undefined,
+      fromDate: dateRange.fromDate,
+      toDate: dateRange.toDate,
       sortBy: pageState.sorting.sortBy,
       sortOrder: pageState.sorting.sortOrder.toUpperCase(),
     }),
-    [filterBar.appliedFilters, pageState.sorting],
+    [filterBar.appliedFilters, dateRange, pageState.sorting],
   )
 
   const {

--- a/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
@@ -56,10 +56,10 @@ const StockAdjustmentsPage: React.FC = () => {
     [],
   )
 
-  const filterBar = useFilterBar(filterConfig)
+  const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
   const weekStartsOn = getStartOfWeek()
   const dateRange = useMemo(() => {
-    const period = filterBar.appliedFilters.period
+    const period = appliedFilters.period
 
     if (!period || period.key === null) {
       return { fromDate: undefined, toDate: undefined }
@@ -71,18 +71,18 @@ const StockAdjustmentsPage: React.FC = () => {
 
     const range = getPeriodDateRange(period.key, weekStartsOn)
     return { fromDate: range.from, toDate: range.to }
-  }, [filterBar.appliedFilters.period, weekStartsOn])
+  }, [appliedFilters.period, weekStartsOn])
 
   const queryParams = useMemo(
     () => ({
-      search: filterBar.appliedFilters.search || undefined,
-      status: filterBar.appliedFilters.status ?? undefined,
+      search: appliedFilters.search || undefined,
+      status: appliedFilters.status ?? undefined,
       fromDate: dateRange.fromDate,
       toDate: dateRange.toDate,
       sortBy: pageState.sorting.sortBy,
       sortOrder: pageState.sorting.sortOrder.toUpperCase(),
     }),
-    [filterBar.appliedFilters, dateRange, pageState.sorting],
+    [appliedFilters, dateRange, pageState.sorting],
   )
 
   const {
@@ -171,9 +171,9 @@ const StockAdjustmentsPage: React.FC = () => {
         toolbar={(
           <FilterBar
             config={filterConfig}
-            draftFilters={filterBar.draftFilters}
-            handlers={filterBar.handlers}
-            hasActiveFilters={filterBar.hasActiveFilters}
+            draftFilters={draftFilters}
+            handlers={handlers}
+            hasActiveFilters={hasActiveFilters}
             searchInputRef={pageState.searchInputRef}
             sort={{
               field: 'adjustmentNumber',

--- a/frontend/src/pages/inventory/__tests__/StockAdjustmentsPage.filterbar.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/StockAdjustmentsPage.filterbar.test.tsx
@@ -120,4 +120,39 @@ describe('StockAdjustmentsPage FilterBar', () => {
 
     expect(mockFetchStockAdjustment).not.toHaveBeenCalledWith('adj-1')
   })
+
+  it('sends no fromDate or toDate when period is not selected (default)', () => {
+    renderPage()
+
+    expect(useGetStockAdjustmentsQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        fromDate: undefined,
+        toDate: undefined,
+      }),
+    )
+  })
+
+  it('restores period=this_week from URL and resolves to fromDate/toDate in the query', () => {
+    renderPage('/?period=this_week')
+
+    expect(useGetStockAdjustmentsQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        fromDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        toDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      }),
+    )
+  })
+
+  it('sends no fromDate or toDate when period is reset to null', () => {
+    renderPage('/?period=this_week')
+
+    renderPage('/')
+
+    expect(useGetStockAdjustmentsQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        fromDate: undefined,
+        toDate: undefined,
+      }),
+    )
+  })
 })


### PR DESCRIPTION
## Summary

- Adds a Period (date range) filter to the Stock Adjustments page, matching the pattern used by `InvoicesPage` and `OrdersPage`
- Resolves the selected period to `fromDate`/`toDate` via `getPeriodDateRange` and passes them to the existing `useGetStockAdjustmentsQuery` call
- No backend changes required — `GET /inventory/stock-adjustments` already supports `fromDate`/`toDate`

## Test plan

- [ ] 7/7 tests pass: `npx vitest run src/pages/inventory/__tests__/StockAdjustmentsPage.filterbar.test.tsx`
- [ ] Type-check passes: `npm run type-check`
- [ ] Period filter renders in the FilterBar before the Status filter
- [ ] Selecting a preset period (e.g. This Week) updates the list
- [ ] Selecting a custom date range updates the list
- [ ] Resetting filters clears the period and removes date params from the query

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)