### PR TITLE
refactor(purchasing): standardize buttons with AppButton (#368)

### DIFF
--- a/frontend/src/pages/purchasing/PurchasingPage.tsx
+++ b/frontend/src/pages/purchasing/PurchasingPage.tsx
@@ -14,7 +14,6 @@ import {
   TableRow,
   Chip,
   Alert,
-  Button,
   useTheme,
 } from '@mui/material'
 import { default as PurchasingIcon } from '@mui/icons-material/Assignment'
@@ -39,6 +38,7 @@ import { Line } from 'react-chartjs-2'
 import { formatCurrency, formatDate } from '@/utils/formatters'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { useNavigate } from 'react-router-dom'
+import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { FilterBar } from '@/components/filters/FilterBar'
 import { useFilterBar } from '@/hooks/useFilterBar'
@@ -226,7 +226,11 @@ const PurchasingPage: React.FC = () => {
         <Alert
           severity="error"
           sx={{ mb: 2 }}
-          action={<Button size="small" onClick={() => window.location.reload()}>Retry</Button>}
+          action={
+            <AppButton size="small" variant="secondary" onClick={() => window.location.reload()}>
+              Retry
+            </AppButton>
+          }
         >
           Failed to load dashboard data.
         </Alert>

--- a/frontend/src/pages/purchasing/components/GRNContextHeader.tsx
+++ b/frontend/src/pages/purchasing/components/GRNContextHeader.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { default as PrintIcon } from '@mui/icons-material/Print'
 import {
   Box,
-  IconButton,
   Paper,
   Table,
   TableBody,
@@ -14,6 +13,7 @@ import {
 import Grid from '@mui/material/Grid'
 import { useNavigate } from 'react-router-dom'
 
+import { AppButton } from '@/components/common/AppButton'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { GoodsReceivedNote } from '@/types'
 import { formatDate } from '@/utils/formatters'
@@ -26,14 +26,6 @@ interface GRNContextHeaderProps {
   journalEntryRefLoading: boolean
   onPrint: () => void
   onNavigateToJournalEntry: () => void
-}
-
-const actionIconSx = {
-  height: `${TABLE_STYLES.row.height * 0.75}px`,
-  width: `${TABLE_STYLES.row.height * 0.75}px`,
-  minHeight: 20,
-  minWidth: 20,
-  p: 0.125,
 }
 
 const detailTableSx = {
@@ -92,10 +84,16 @@ const GRNContextHeader: React.FC<GRNContextHeaderProps> = ({
         >
           GRN Details - {selectedGRN.grnNumber}
         </Typography>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
-          <IconButton size="small" title="Print GRN" onClick={onPrint} sx={{ ...actionIconSx, color: 'info.main' }}>
-            <PrintIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
-          </IconButton>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <AppButton
+            size="small"
+            variant="secondary"
+            startIcon={<PrintIcon />}
+            title="Print GRN"
+            onClick={onPrint}
+          >
+            Print
+          </AppButton>
         </Box>
       </Box>
 

--- a/frontend/src/pages/purchasing/components/PurchaseOrderContextHeader.tsx
+++ b/frontend/src/pages/purchasing/components/PurchaseOrderContextHeader.tsx
@@ -4,8 +4,6 @@ import { default as EditIcon } from '@mui/icons-material/Edit'
 import { default as PrintIcon } from '@mui/icons-material/Print'
 import {
   Box,
-  Button,
-  IconButton,
   Paper,
   Stack,
   Table,
@@ -17,6 +15,7 @@ import {
 } from '@mui/material'
 import Grid from '@mui/material/Grid'
 
+import { AppButton } from '@/components/common/AppButton'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { PurchaseOrder } from '@/types'
 import { formatCurrency, formatDate } from '@/utils/formatters'
@@ -38,14 +37,6 @@ interface PurchaseOrderContextHeaderProps {
   onOpenPaymentDialog: (order: PurchaseOrder) => void
   onReturn: () => void
   onReceive: () => void
-}
-
-const actionIconSx = {
-  height: `${TABLE_STYLES.row.height * 0.75}px`,
-  width: `${TABLE_STYLES.row.height * 0.75}px`,
-  minHeight: 20,
-  minWidth: 20,
-  p: 0.125,
 }
 
 const detailTableSx = {
@@ -118,16 +109,34 @@ const PurchaseOrderContextHeader: React.FC<PurchaseOrderContextHeaderProps> = ({
         <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
           PO Details - {selectedOrder.orderNumber}
         </Typography>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
-          <IconButton size="small" title="Edit Order" onClick={onEditClick} sx={{ ...actionIconSx, color: 'primary.main' }}>
-            <EditIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
-          </IconButton>
-          <IconButton size="small" title="Delete Order" onClick={onDeleteClick} sx={{ ...actionIconSx, color: 'error.main' }}>
-            <DeleteIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
-          </IconButton>
-          <IconButton size="small" title="Print Purchase Order" onClick={onPrint} sx={{ ...actionIconSx, color: 'info.main' }}>
-            <PrintIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
-          </IconButton>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <AppButton
+            size="small"
+            variant="secondary"
+            startIcon={<EditIcon />}
+            title="Edit Order"
+            onClick={onEditClick}
+          >
+            Edit
+          </AppButton>
+          <AppButton
+            size="small"
+            variant="danger"
+            startIcon={<DeleteIcon />}
+            title="Delete Order"
+            onClick={onDeleteClick}
+          >
+            Delete
+          </AppButton>
+          <AppButton
+            size="small"
+            variant="secondary"
+            startIcon={<PrintIcon />}
+            title="Print Purchase Order"
+            onClick={onPrint}
+          >
+            Print
+          </AppButton>
         </Box>
       </Box>
       <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
@@ -237,28 +246,33 @@ const PurchaseOrderContextHeader: React.FC<PurchaseOrderContextHeaderProps> = ({
                         direction="row"
                         spacing={1}
                         sx={{
-                          alignItems: "center",
-                          justifyContent: "center"
-                        }}>
-                        <Button
-                          variant="contained"
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                        }}
+                      >
+                        <AppButton
+                          variant={hasPayment ? 'warning' : 'primary'}
                           size="small"
-                          color={hasPayment ? 'warning' : 'primary'}
                           onClick={hasPayment ? onUnpay : () => onOpenPaymentDialog(selectedOrder)}
                           disabled={(hasPayment && isReceived) || isLoading}
                           sx={{ minWidth: 110 }}
                         >
                           {hasPayment ? 'Unpay' : 'Pay'}
-                        </Button>
+                        </AppButton>
                         {isReceived ? (
-                          <Button variant="contained" size="small" color="warning" sx={{ minWidth: 110 }} onClick={onReturn} disabled={!selectedOrder.items || selectedOrder.items.length === 0 || isLoading}>
-                            Return
-                          </Button>
-                        ) : (
-                          <Button
-                            variant="contained"
+                          <AppButton
+                            variant="warning"
                             size="small"
-                            color="success"
+                            sx={{ minWidth: 110 }}
+                            onClick={onReturn}
+                            disabled={!selectedOrder.items || selectedOrder.items.length === 0 || isLoading}
+                          >
+                            Return
+                          </AppButton>
+                        ) : (
+                          <AppButton
+                            variant="success"
+                            size="small"
                             sx={{ minWidth: 110 }}
                             onClick={onReceive}
                             disabled={
@@ -269,7 +283,7 @@ const PurchaseOrderContextHeader: React.FC<PurchaseOrderContextHeaderProps> = ({
                             }
                           >
                             Receive
-                          </Button>
+                          </AppButton>
                         )}
                       </Stack>
                     </TableCell>

--- a/frontend/src/pages/purchasing/components/SupplierContextHeader.tsx
+++ b/frontend/src/pages/purchasing/components/SupplierContextHeader.tsx
@@ -3,7 +3,6 @@ import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as EditIcon } from '@mui/icons-material/Edit'
 import {
   Box,
-  IconButton,
   Paper,
   Table,
   TableBody,
@@ -14,6 +13,7 @@ import {
 } from '@mui/material'
 import Grid from '@mui/material/Grid'
 
+import { AppButton } from '@/components/common/AppButton'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { Supplier } from '@/types'
 import { SupplierType } from '@/types'
@@ -23,14 +23,6 @@ interface SupplierContextHeaderProps {
   selectedSupplier: Supplier | null
   onEdit: () => void
   onDelete: () => void
-}
-
-const actionIconSx = {
-  height: `${TABLE_STYLES.row.height * 0.75}px`,
-  width: `${TABLE_STYLES.row.height * 0.75}px`,
-  minHeight: 20,
-  minWidth: 20,
-  p: 0.125,
 }
 
 const detailTableSx = {
@@ -94,23 +86,25 @@ const SupplierContextHeader: React.FC<SupplierContextHeaderProps> = ({
         >
           Supplier - {selectedSupplier.companyName}
         </Typography>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
-          <IconButton
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <AppButton
             size="small"
+            variant="secondary"
+            startIcon={<EditIcon />}
             title="Edit Supplier"
             onClick={onEdit}
-            sx={{ ...actionIconSx, color: 'primary.main' }}
           >
-            <EditIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
-          </IconButton>
-          <IconButton
+            Edit
+          </AppButton>
+          <AppButton
             size="small"
+            variant="danger"
+            startIcon={<DeleteIcon />}
             title="Delete Supplier"
             onClick={onDelete}
-            sx={{ ...actionIconSx, color: 'error.main' }}
           >
-            <DeleteIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
-          </IconButton>
+            Delete
+          </AppButton>
         </Box>
       </Box>
 

--- a/frontend/src/pages/purchasing/components/VendorPaymentContextHeader.tsx
+++ b/frontend/src/pages/purchasing/components/VendorPaymentContextHeader.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { default as PrintIcon } from '@mui/icons-material/Print'
 import {
   Box,
-  IconButton,
   Paper,
   Table,
   TableBody,
@@ -14,6 +13,7 @@ import {
 import Grid from '@mui/material/Grid'
 import { useNavigate } from 'react-router-dom'
 
+import { AppButton } from '@/components/common/AppButton'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { VendorPayment } from '@/types'
 import { formatCurrency, formatDate } from '@/utils/formatters'
@@ -26,14 +26,6 @@ interface VendorPaymentContextHeaderProps {
   journalEntryRefLoading: boolean
   onPrint: () => void
   onNavigateToJournalEntry: () => void
-}
-
-const actionIconSx = {
-  height: `${TABLE_STYLES.row.height * 0.75}px`,
-  width: `${TABLE_STYLES.row.height * 0.75}px`,
-  minHeight: 20,
-  minWidth: 20,
-  p: 0.125,
 }
 
 const detailTableSx = {
@@ -92,10 +84,16 @@ const VendorPaymentContextHeader: React.FC<VendorPaymentContextHeaderProps> = ({
         >
           Payment Details — {selectedPayment.paymentNumber}
         </Typography>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
-          <IconButton size="small" title="Print Payment" onClick={onPrint} sx={{ ...actionIconSx, color: 'info.main' }}>
-            <PrintIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
-          </IconButton>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <AppButton
+            size="small"
+            variant="secondary"
+            startIcon={<PrintIcon />}
+            title="Print Payment"
+            onClick={onPrint}
+          >
+            Print
+          </AppButton>
         </Box>
       </Box>
 

--- a/frontend/src/pages/purchasing/components/__tests__/GRNContextHeader.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/GRNContextHeader.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import GRNContextHeader from '../GRNContextHeader'
+
+const baseGRN = {
+  id: 'grn-1',
+  grnNumber: 'GRN-1001',
+  status: 'received' as const,
+  receivedDate: new Date('2026-04-10T00:00:00.000Z'),
+  supplier: { id: 'sup-1', companyName: 'Acme Supplies' },
+  purchaseOrder: { id: 'po-1', orderNumber: 'PO-1001' },
+  items: [],
+  totalQuantityReceived: 5,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as any
+
+describe('GRNContextHeader', () => {
+  it('shows empty state when no GRN selected', () => {
+    render(
+      <MemoryRouter>
+        <GRNContextHeader
+          selectedGRN={null}
+          journalEntryRef={null}
+          journalEntryRefLoading={false}
+          onPrint={vi.fn()}
+          onNavigateToJournalEntry={vi.fn()}
+        />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText('Select a goods received note to view details')).toBeInTheDocument()
+  })
+
+  it('renders GRN number in header', () => {
+    render(
+      <MemoryRouter>
+        <GRNContextHeader
+          selectedGRN={baseGRN}
+          journalEntryRef={null}
+          journalEntryRefLoading={false}
+          onPrint={vi.fn()}
+          onNavigateToJournalEntry={vi.fn()}
+        />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText(/GRN Details - GRN-1001/i)).toBeInTheDocument()
+  })
+
+  it('renders a labeled Print action button', () => {
+    render(
+      <MemoryRouter>
+        <GRNContextHeader
+          selectedGRN={baseGRN}
+          journalEntryRef={null}
+          journalEntryRefLoading={false}
+          onPrint={vi.fn()}
+          onNavigateToJournalEntry={vi.fn()}
+        />
+      </MemoryRouter>,
+    )
+    expect(screen.getByTitle('Print GRN')).toBeInTheDocument()
+    expect(screen.getByText('Print')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/purchasing/components/__tests__/PurchaseOrderContextHeader.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/PurchaseOrderContextHeader.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import PurchaseOrderContextHeader from '../PurchaseOrderContextHeader'
+
+const baseOrder = {
+  id: 'po-1',
+  orderNumber: 'PO-1001',
+  orderDate: new Date('2026-04-10T00:00:00.000Z'),
+  supplier: { id: 'sup-1', companyName: 'Acme Supplies' },
+  items: [{ id: 'item-1', quantity: 1, unitPrice: 100, total: 100 }],
+  totalAmount: 100,
+  paidAmount: 0,
+  subtotal: 100,
+  shippingAmount: 0,
+  goodsReceivedNotes: [],
+  vendorPayments: [],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as any
+
+const defaultProps = {
+  selectedOrder: baseOrder,
+  isLoading: false,
+  journalEntryRef: null,
+  journalEntryRefLoading: false,
+  onEditClick: vi.fn(),
+  onDeleteClick: vi.fn(),
+  onPrint: vi.fn(),
+  onNavigateToGoodsReceived: vi.fn(),
+  onNavigateToVendorPayment: vi.fn(),
+  onNavigateToJournalEntry: vi.fn(),
+  onUnpay: vi.fn(),
+  onOpenPaymentDialog: vi.fn(),
+  onReturn: vi.fn(),
+  onReceive: vi.fn(),
+}
+
+describe('PurchaseOrderContextHeader', () => {
+  it('shows empty state when no order selected', () => {
+    render(<PurchaseOrderContextHeader {...defaultProps} selectedOrder={null} />)
+    expect(screen.getByText('Select a purchase order to view details')).toBeInTheDocument()
+  })
+
+  it('renders order number in header', () => {
+    render(<PurchaseOrderContextHeader {...defaultProps} />)
+    expect(screen.getByText(/PO Details - PO-1001/i)).toBeInTheDocument()
+  })
+
+  it('renders header action buttons', () => {
+    render(<PurchaseOrderContextHeader {...defaultProps} />)
+    expect(screen.getByTitle('Edit Order')).toBeInTheDocument()
+    expect(screen.getByTitle('Delete Order')).toBeInTheDocument()
+    expect(screen.getByTitle('Print Purchase Order')).toBeInTheDocument()
+  })
+
+  it('shows Pay button when order has no payment', () => {
+    render(<PurchaseOrderContextHeader {...defaultProps} />)
+    expect(screen.getByText('Pay')).toBeInTheDocument()
+  })
+
+  it('shows Unpay button when order has a payment', () => {
+    const orderWithPayment = {
+      ...baseOrder,
+      vendorPayments: [{ id: 'vp-1', paymentNumber: 'VP-001', amount: 100 }],
+    }
+    render(<PurchaseOrderContextHeader {...defaultProps} selectedOrder={orderWithPayment} />)
+    expect(screen.getByText('Unpay')).toBeInTheDocument()
+  })
+
+  it('shows Receive button when order is not yet received', () => {
+    render(<PurchaseOrderContextHeader {...defaultProps} />)
+    expect(screen.getByText('Receive')).toBeInTheDocument()
+  })
+
+  it('shows Return button when order is received', () => {
+    const receivedOrder = {
+      ...baseOrder,
+      goodsReceivedNotes: [{ id: 'grn-1', grnNumber: 'GRN-001', status: 'received' }],
+    }
+    render(<PurchaseOrderContextHeader {...defaultProps} selectedOrder={receivedOrder} />)
+    expect(screen.getByText('Return')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/purchasing/components/__tests__/VendorPaymentContextHeader.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/VendorPaymentContextHeader.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import VendorPaymentContextHeader from '../VendorPaymentContextHeader'
+
+const basePayment = {
+  id: 'vp-1',
+  paymentNumber: 'VP-1001',
+  status: 'completed' as const,
+  paymentDate: new Date('2026-04-10T00:00:00.000Z'),
+  supplier: { id: 'sup-1', companyName: 'Acme Supplies' },
+  supplierId: 'sup-1',
+  amount: 500,
+  purchaseOrder: { id: 'po-1', orderNumber: 'PO-1001' },
+  createdAt: new Date(),
+} as any
+
+describe('VendorPaymentContextHeader', () => {
+  it('shows empty state when no payment selected', () => {
+    render(
+      <MemoryRouter>
+        <VendorPaymentContextHeader
+          selectedPayment={null}
+          journalEntryRef={null}
+          journalEntryRefLoading={false}
+          onPrint={vi.fn()}
+          onNavigateToJournalEntry={vi.fn()}
+        />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText('Select a vendor payment to view details')).toBeInTheDocument()
+  })
+
+  it('renders payment number in header', () => {
+    render(
+      <MemoryRouter>
+        <VendorPaymentContextHeader
+          selectedPayment={basePayment}
+          journalEntryRef={null}
+          journalEntryRefLoading={false}
+          onPrint={vi.fn()}
+          onNavigateToJournalEntry={vi.fn()}
+        />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText(/Payment Details.*VP-1001/i)).toBeInTheDocument()
+  })
+
+  it('renders a labeled Print action button', () => {
+    render(
+      <MemoryRouter>
+        <VendorPaymentContextHeader
+          selectedPayment={basePayment}
+          journalEntryRef={null}
+          journalEntryRefLoading={false}
+          onPrint={vi.fn()}
+          onNavigateToJournalEntry={vi.fn()}
+        />
+      </MemoryRouter>,
+    )
+    expect(screen.getByTitle('Print Payment')).toBeInTheDocument()
+    expect(screen.getByText('Print')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/sales/SalesPage.tsx
+++ b/frontend/src/pages/sales/SalesPage.tsx
@@ -3,7 +3,6 @@ import {
   Alert,
   Avatar,
   Box,
-  Button,
   Chip,
   Grid,
   Paper,
@@ -22,6 +21,7 @@ import { default as OrdersIcon } from '@mui/icons-material/Receipt'
 import { default as PaymentsIcon } from '@mui/icons-material/Payment'
 import { formatCurrency, formatDate, formatNumber } from '@/utils/formatters'
 import { TABLE_STYLES } from '@/constants/tableStyles'
+import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { FilterBar } from '@/components/filters/FilterBar'
 import { useFilterBar } from '@/hooks/useFilterBar'
@@ -193,7 +193,7 @@ const SalesPage: React.FC = () => {
         <Alert
           severity="error"
           sx={{ mb: 2 }}
-          action={<Button size="small" onClick={() => window.location.reload()}>Retry</Button>}
+          action={<AppButton size="small" variant="secondary" onClick={() => window.location.reload()}>Retry</AppButton>}
         >
           Failed to load dashboard data.
         </Alert>


### PR DESCRIPTION
## Summary
- Replace `Button`/`IconButton` with `AppButton` across all Purchasing module context headers and overview page (`PurchasingPage`, `SupplierContextHeader`, `PurchaseOrderContextHeader`, `GRNContextHeader`, `VendorPaymentContextHeader`)
- Also standardize the Retry button in `SalesPage` error alert to match (was missed in PR #369)
- Add unit tests for `PurchaseOrderContextHeader`, `GRNContextHeader`, and `VendorPaymentContextHeader` (pre-existing gap)
- Follows same pattern as Sales module AppButton standardization (PR #369)

## Test plan
- [x] All `SupplierContextHeader` unit tests pass unchanged (5 tests)
- [x] New `PurchaseOrderContextHeader` tests pass (7 tests)
- [x] New `GRNContextHeader` tests pass (3 tests)
- [x] New `VendorPaymentContextHeader` tests pass (3 tests)
- [x] Full type-check passes with 0 errors
- [x] No raw `Button`/`IconButton` remaining in target files

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)