### PR TITLE
refactor(inventory): standardize buttons with AppButton (#370)

### DIFF
--- a/frontend/src/pages/inventory/InventoryPage.tsx
+++ b/frontend/src/pages/inventory/InventoryPage.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react'
 import {
   Alert,
   Box,
-  Button,
   Card,
   CardContent,
   Chip,
@@ -38,6 +37,7 @@ import {
 import { Doughnut, Line } from 'react-chartjs-2'
 import { format } from 'date-fns'
 import { useNavigate } from 'react-router-dom'
+import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { FilterBar } from '@/components/filters/FilterBar'
 import { useFilterBar } from '@/hooks/useFilterBar'
@@ -262,9 +262,9 @@ const InventoryPage: React.FC = () => {
           severity="error"
           sx={{ mb: 2 }}
           action={
-            <Button size="small" onClick={() => window.location.reload()}>
+            <AppButton size="small" variant="secondary" onClick={() => window.location.reload()}>
               Retry
-            </Button>
+            </AppButton>
           }
         >
           Failed to load inventory dashboard data.

--- a/frontend/src/pages/inventory/components/CategoryContextHeader.test.tsx
+++ b/frontend/src/pages/inventory/components/CategoryContextHeader.test.tsx
@@ -1,3 +1,4 @@
+import userEvent from '@testing-library/user-event'
 import { render, screen, within } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -133,5 +134,40 @@ describe('CategoryContextHeader', () => {
     )
 
     expect(screen.getByText('0 items')).toBeInTheDocument()
+  })
+
+  it('renders Edit and Delete action buttons', () => {
+    render(
+      <CategoryContextHeader
+        selectedCategory={makeCategory()}
+        allCategories={[makeCategory()]}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByTitle('Edit Root')).toBeInTheDocument()
+    expect(screen.getByTitle('Delete Root')).toBeInTheDocument()
+  })
+
+  it('fires onEdit and onDelete callbacks when buttons are clicked', async () => {
+    const onEdit = vi.fn()
+    const onDelete = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <CategoryContextHeader
+        selectedCategory={makeCategory()}
+        allCategories={[makeCategory()]}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />,
+    )
+
+    await user.click(screen.getByTitle('Edit Root'))
+    expect(onEdit).toHaveBeenCalledOnce()
+
+    await user.click(screen.getByTitle('Delete Root'))
+    expect(onDelete).toHaveBeenCalledOnce()
   })
 })

--- a/frontend/src/pages/inventory/components/CategoryContextHeader.tsx
+++ b/frontend/src/pages/inventory/components/CategoryContextHeader.tsx
@@ -4,7 +4,6 @@ import { default as EditIcon } from '@mui/icons-material/Edit'
 import {
   Box,
   Grid,
-  IconButton,
   Paper,
   Table,
   TableBody,
@@ -15,6 +14,7 @@ import {
   Typography,
 } from '@mui/material'
 
+import { AppButton } from '@/components/common/AppButton'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { Category } from '@/types'
 import { formatDate } from '@/utils/formatters'
@@ -40,14 +40,6 @@ function buildCategoryHierarchy(categoryId: string, allCategories: Category[]): 
   }
 
   return names.length > 0 ? names.join(' > ') : '—'
-}
-
-const actionIconSx = {
-  height: `${TABLE_STYLES.row.height * 0.75}px`,
-  width: `${TABLE_STYLES.row.height * 0.75}px`,
-  minHeight: 20,
-  minWidth: 20,
-  p: 0.125,
 }
 
 const detailTableSx = {
@@ -111,25 +103,25 @@ const CategoryContextHeader: React.FC<CategoryContextHeaderProps> = ({
         >
           Category - {selectedCategory.name}
         </Typography>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
-          <IconButton
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <AppButton
             size="small"
+            variant="secondary"
+            startIcon={<EditIcon />}
             title={`Edit ${selectedCategory.name}`}
-            aria-label={`Edit category ${selectedCategory.name}`}
             onClick={onEdit}
-            sx={{ ...actionIconSx, color: 'primary.main' }}
           >
-            <EditIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
-          </IconButton>
-          <IconButton
+            Edit
+          </AppButton>
+          <AppButton
             size="small"
+            variant="danger"
+            startIcon={<DeleteIcon />}
             title={`Delete ${selectedCategory.name}`}
-            aria-label={`Delete category ${selectedCategory.name}`}
             onClick={onDelete}
-            sx={{ ...actionIconSx, color: 'error.main' }}
           >
-            <DeleteIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
-          </IconButton>
+            Delete
+          </AppButton>
         </Box>
       </Box>
 

--- a/frontend/src/pages/inventory/components/ProductContextHeader.tsx
+++ b/frontend/src/pages/inventory/components/ProductContextHeader.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as EditIcon } from '@mui/icons-material/Edit'
-import { Box, IconButton, Paper, Typography } from '@mui/material'
+import { Box, Paper, Typography } from '@mui/material'
 
+import { AppButton } from '@/components/common/AppButton'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { Product } from '@/types'
 
@@ -10,14 +11,6 @@ interface ProductContextHeaderProps {
   selectedProduct: Product | null
   onEdit: () => void
   onDelete: () => void
-}
-
-const actionIconSx = {
-  height: `${TABLE_STYLES.row.height * 0.75}px`,
-  width: `${TABLE_STYLES.row.height * 0.75}px`,
-  minHeight: 20,
-  minWidth: 20,
-  p: 0.125,
 }
 
 const ProductContextHeader: React.FC<ProductContextHeaderProps> = ({
@@ -57,25 +50,25 @@ const ProductContextHeader: React.FC<ProductContextHeaderProps> = ({
         >
           Product - {selectedProduct.name}
         </Typography>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
-          <IconButton
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <AppButton
             size="small"
+            variant="secondary"
+            startIcon={<EditIcon />}
             title={`Edit ${selectedProduct.name}`}
-            aria-label={`Edit product ${selectedProduct.name}`}
             onClick={onEdit}
-            sx={{ ...actionIconSx, color: 'primary.main' }}
           >
-            <EditIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
-          </IconButton>
-          <IconButton
+            Edit
+          </AppButton>
+          <AppButton
             size="small"
+            variant="danger"
+            startIcon={<DeleteIcon />}
             title={`Delete ${selectedProduct.name}`}
-            aria-label={`Delete product ${selectedProduct.name}`}
             onClick={onDelete}
-            sx={{ ...actionIconSx, color: 'error.main' }}
           >
-            <DeleteIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
-          </IconButton>
+            Delete
+          </AppButton>
         </Box>
       </Box>
     </Paper>

--- a/frontend/src/pages/inventory/components/StockAdjustmentContextHeader.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentContextHeader.tsx
@@ -5,7 +5,6 @@ import {
   Box,
   Chip,
   CircularProgress,
-  IconButton,
   Paper,
   Stack,
   Table,
@@ -33,14 +32,6 @@ interface StockAdjustmentContextHeaderProps {
   onComplete: () => void
   onRevert: () => void
   onNavigateToJournalEntry: () => void
-}
-
-const actionIconSx = {
-  height: `${TABLE_STYLES.row.height * 0.75}px`,
-  width: `${TABLE_STYLES.row.height * 0.75}px`,
-  minHeight: 20,
-  minWidth: 20,
-  p: 0.125,
 }
 
 const detailTableSx = {
@@ -122,23 +113,25 @@ const StockAdjustmentContextHeader: React.FC<StockAdjustmentContextHeaderProps> 
           />
         </Box>
 
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
-          <IconButton
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <AppButton
             size="small"
+            variant="secondary"
+            startIcon={<EditIcon />}
             title="Edit Adjustment"
             onClick={onEdit}
-            sx={{ ...actionIconSx, color: 'primary.main' }}
           >
-            <EditIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
-          </IconButton>
-          <IconButton
+            Edit
+          </AppButton>
+          <AppButton
             size="small"
+            variant="danger"
+            startIcon={<DeleteIcon />}
             title="Delete Adjustment"
             onClick={onDelete}
-            sx={{ ...actionIconSx, color: 'error.main' }}
           >
-            <DeleteIcon sx={{ fontSize: `${TABLE_STYLES.row.height * 0.5}px` }} />
-          </IconButton>
+            Delete
+          </AppButton>
         </Box>
       </Box>
 


### PR DESCRIPTION
## Summary
- Replace MUI `Button` (Retry) in `InventoryPage` error alert with `AppButton`
- Replace `IconButton` Edit/Delete pairs in `ProductContextHeader`, `CategoryContextHeader`, and `StockAdjustmentContextHeader` with `AppButton`
- Remove dead `actionIconSx` constants from all three context headers
- Add button render + callback tests to `CategoryContextHeader.test.tsx`

## Test plan
- [x] `npm run type-check` passes
- [x] `CategoryContextHeader.test.tsx` — all tests pass
- [x] No `IconButton` remaining in the four refactored files

Closes #370