### PR TITLE
chore(deps): update @mui/x-date-pickers, eslint-plugin-react-hooks, typescript

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erp-backend",
-  "version": "1.76.0",
+  "version": "1.76.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-backend",
-      "version": "1.76.0",
+      "version": "1.76.1",
       "license": "MIT",
       "dependencies": {
         "@nestjs/bull": "^11.0.3",
@@ -69,7 +69,7 @@
         "ts-loader": "^9.5.4",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "6.0.2"
+        "typescript": "6.0.3"
       }
     },
     "node_modules/@angular-devkit/core": {
@@ -12233,9 +12233,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -86,7 +86,7 @@
     "ts-loader": "^9.5.4",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "6.0.2"
+    "typescript": "6.0.3"
   },
   "overrides": {
     "body-parser": "2.2.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "erp-frontend",
-  "version": "1.76.0",
+  "version": "1.76.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-frontend",
-      "version": "1.76.0",
+      "version": "1.76.1",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@hookform/resolvers": "5.2.2",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
-        "@mui/x-date-pickers": "9.0.0",
+        "@mui/x-date-pickers": "9.0.2",
         "@reduxjs/toolkit": "^2.11.2",
         "@tanstack/react-query": "^5.96.0",
         "@tanstack/react-query-devtools": "^5.96.0",
@@ -49,13 +49,13 @@
         "@vitest/coverage-v8": "^4.1.2",
         "@vitest/ui": "^4.1.2",
         "eslint": "^10.2.0",
-        "eslint-plugin-react-hooks": "7.1.0-canary-98ce535f-20260226",
+        "eslint-plugin-react-hooks": "7.1.0",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.3.0",
         "jsdom": "29.0.2",
         "msw": "^2.12.10",
         "react-transition-group": "^4.4.5",
-        "typescript": "6.0.2",
+        "typescript": "6.0.3",
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.3",
         "vitest": "^4.1.2"
@@ -1320,9 +1320,9 @@
       }
     },
     "node_modules/@mui/x-date-pickers": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-9.0.0.tgz",
-      "integrity": "sha512-g6Rx+PgzVw+ErhoEVq0Zcf7+v9VQBiiKKyvVr5wuVvKa+8wqBkdM2BSJ18pS1HLmhVI/0O3kLrGpNYDyC58Kiw==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-9.0.2.tgz",
+      "integrity": "sha512-rnyc2wFPnprTS5i8Lq9aX2Rlx+ZRvNZERTd7sPMErf/8HnMCYzxwErITbd+TuImlvo2vaLF1gNynqT8AJMusYw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.6",
@@ -2989,6 +2989,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3355,9 +3364,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.1.0-canary-98ce535f-20260226",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.0-canary-98ce535f-20260226.tgz",
-      "integrity": "sha512-QJWpoDJWXiP+8J2ej02OPLBUU3w+LjpOaIvsgDqk70zeLVEKzdo5N/Migg5kNDPyt2U/6a8LdHqNd1STEOVlCg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.0.tgz",
+      "integrity": "sha512-LDicyhrRFrIaheDYryeM2W8gWyZXnAs4zIr2WVPiOSeTmIu2RjR4x/9N0xLaRWZ+9hssBDGo3AadcohuzAvSvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5886,9 +5895,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6377,15 +6386,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "@hookform/resolvers": "5.2.2",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
-    "@mui/x-date-pickers": "9.0.0",
+    "@mui/x-date-pickers": "9.0.2",
     "@reduxjs/toolkit": "^2.11.2",
     "@tanstack/react-query": "^5.96.0",
     "@tanstack/react-query-devtools": "^5.96.0",
@@ -57,13 +57,13 @@
     "@vitest/coverage-v8": "^4.1.2",
     "@vitest/ui": "^4.1.2",
     "eslint": "^10.2.0",
-    "eslint-plugin-react-hooks": "7.1.0-canary-98ce535f-20260226",
+    "eslint-plugin-react-hooks": "7.1.0",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.3.0",
     "jsdom": "29.0.2",
     "msw": "^2.12.10",
     "react-transition-group": "^4.4.5",
-    "typescript": "6.0.2",
+    "typescript": "6.0.3",
     "typescript-eslint": "^8.58.0",
     "vite": "^8.0.3",
     "vitest": "^4.1.2"
@@ -74,7 +74,7 @@
   },
   "overrides": {
     "qs": "6.14.2",
-    "eslint-plugin-react-hooks": "7.1.0-canary-98ce535f-20260226",
+    "eslint-plugin-react-hooks": "7.1.0",
     "flatted": "3.4.2"
   }
 }


### PR DESCRIPTION
## Summary

- typescript 6.0.2 -> 6.0.3 in backend and frontend
- @mui/x-date-pickers 9.0.0 -> 9.0.2 in frontend
- eslint-plugin-react-hooks 7.1.0-canary-98ce535f-20260226 -> 7.1.0 in frontend, including the package override

## Verification

Passed:
- `cd backend && npm run build`
- `cd backend && npm run lint`
- `cd backend && npm run test`
- `cd frontend && npm run type-check`
- `cd frontend && npm run lint`
- `cd /home/blur/erp2 && docker compose up -d`
- `cd /home/blur/erp2 && docker compose ps`

Pending / not completed in this environment:
- Manual UI spot-check of the date picker focus/blur and AM/PM behavior

Additional note:
- `cd frontend && npm run test` was started as an extra safeguard, remained CPU-active for over 9 minutes without producing a terminal result, and was stopped without a pass/fail conclusion.

Closes #377