### PR TITLE
fix(inventory): add dedicated category products endpoint to fix workspace card error

### DIFF
--- a/backend/src/modules/inventory/controllers/category.controller.ts
+++ b/backend/src/modules/inventory/controllers/category.controller.ts
@@ -32,6 +32,7 @@ import {
   BulkUpdateCategoriesDto,
   CategoryStatsDto,
   CategoryAncestorsDto,
+  CategoryProductDto,
 } from '../dto/category.dto';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 
@@ -141,6 +142,20 @@ export class CategoryController {
     @Query('excludeId') excludeId?: string,
   ) {
     return this.categoryService.checkDuplicate({ name, parentId, excludeId });
+  }
+
+  @Get(':id/products')
+  @ApiOperation({ summary: 'Get products in a category' })
+  @ApiResponse({
+    status: 200,
+    description: 'Category products retrieved successfully',
+  })
+  @ApiResponse({ status: 404, description: 'Category not found' })
+  @ApiParam({ name: 'id', description: 'Category ID' })
+  async getCategoryProducts(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<{ data: CategoryProductDto[] }> {
+    return this.categoryService.getCategoryProducts(id);
   }
 
   @Get(':id')

--- a/backend/src/modules/inventory/dto/category.dto.ts
+++ b/backend/src/modules/inventory/dto/category.dto.ts
@@ -235,3 +235,14 @@ class CategoryPathUpdateDto {
   @IsBoolean()
   forceRecalculate?: boolean;
 }
+
+export class CategoryProductDto {
+  @ApiProperty({ description: 'Product ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Product name' })
+  name: string;
+
+  @ApiProperty({ description: 'Current stock quantity' })
+  stockQuantity: number;
+}

--- a/backend/src/modules/inventory/services/category.service.spec.ts
+++ b/backend/src/modules/inventory/services/category.service.spec.ts
@@ -1,3 +1,4 @@
+import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -10,6 +11,7 @@ import { CategoryService } from './category.service';
 describe('CategoryService', () => {
   let service: CategoryService;
   let categoryRepository: jest.Mocked<Repository<Category>>;
+  let productRepository: jest.Mocked<Repository<Product>>;
 
   const createCategory = (id: string, overrides: Partial<Category> = {}): Category =>
     ({
@@ -57,6 +59,7 @@ describe('CategoryService', () => {
           provide: getRepositoryToken(Product),
           useValue: {
             count: jest.fn().mockResolvedValue(0),
+            find: jest.fn(),
           },
         },
         {
@@ -70,6 +73,7 @@ describe('CategoryService', () => {
 
     service = module.get(CategoryService);
     categoryRepository = module.get(getRepositoryToken(Category));
+    productRepository = module.get(getRepositoryToken(Product));
   });
 
   it('findDeleted applies parentId filtering through the shared query builder path', async () => {
@@ -84,6 +88,44 @@ describe('CategoryService', () => {
     expect(categoryRepository.createQueryBuilder).toHaveBeenCalledWith('category');
     expect(qb.andWhere).toHaveBeenCalledWith('category.parentId = :parentId', {
       parentId: 'parent-1',
+    });
+  });
+
+  describe('getCategoryProducts', () => {
+    it('returns products for a valid category', async () => {
+      categoryRepository.findOne.mockResolvedValue({ id: 'cat-1', name: 'Hardware' } as any);
+      productRepository.find.mockResolvedValue([
+        { id: 'prod-1', name: 'Widget', stockQuantity: 5 },
+        { id: 'prod-2', name: 'Bolt', stockQuantity: 0 },
+      ] as any);
+
+      const result = await service.getCategoryProducts('cat-1');
+
+      expect(result).toEqual({
+        data: [
+          { id: 'prod-1', name: 'Widget', stockQuantity: 5 },
+          { id: 'prod-2', name: 'Bolt', stockQuantity: 0 },
+        ],
+      });
+      expect(productRepository.find).toHaveBeenCalledWith({
+        where: { categoryId: 'cat-1' },
+        select: ['id', 'name', 'stockQuantity'],
+      });
+    });
+
+    it('returns empty data array for a category with no products', async () => {
+      categoryRepository.findOne.mockResolvedValue({ id: 'cat-2', name: 'Empty' } as any);
+      productRepository.find.mockResolvedValue([] as any);
+
+      const result = await service.getCategoryProducts('cat-2');
+
+      expect(result).toEqual({ data: [] });
+    });
+
+    it('throws NotFoundException for an unknown category ID', async () => {
+      categoryRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getCategoryProducts('no-such-id')).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/backend/src/modules/inventory/services/category.service.ts
+++ b/backend/src/modules/inventory/services/category.service.ts
@@ -30,6 +30,7 @@ import {
   BulkUpdateCategoriesDto,
   CategoryStatsDto,
   CategoryAncestorsDto,
+  CategoryProductDto,
 } from '../dto/category.dto';
 import { ValidationUtil, BulkOperationUtil, BulkOperationResponse } from '../../../common/utils/validation.util';
 import { AuditLogService } from '../../audit-logs/services';
@@ -227,6 +228,21 @@ export class CategoryService extends BaseCrudService<
         hasPreviousPage: page > 1,
       },
     };
+  }
+
+  async getCategoryProducts(id: string): Promise<{ data: CategoryProductDto[] }> {
+    const category = await this.categoryRepository.findOne({ where: { id } });
+
+    if (!category) {
+      throw new NotFoundException(`Category with id ${id} not found`);
+    }
+
+    const products = await this.productRepository.find({
+      where: { categoryId: id },
+      select: ['id', 'name', 'stockQuantity'],
+    });
+
+    return { data: products as CategoryProductDto[] };
   }
 
   /**

--- a/frontend/src/pages/inventory/components/CategoryWorkspaceCard.test.tsx
+++ b/frontend/src/pages/inventory/components/CategoryWorkspaceCard.test.tsx
@@ -5,11 +5,11 @@ import CategoryWorkspaceCard from './CategoryWorkspaceCard'
 
 import type { Category } from '@/types'
 
-const mockUseGetProductsQuery = vi.hoisted(() => vi.fn())
+const mockUseGetCategoryProductsQuery = vi.hoisted(() => vi.fn())
 const mockUseGetRegionalSettingsQuery = vi.hoisted(() => vi.fn())
 
 vi.mock('@/store/api/inventoryApi', () => ({
-  useGetProductsQuery: mockUseGetProductsQuery,
+  useGetCategoryProductsQuery: mockUseGetCategoryProductsQuery,
 }))
 
 vi.mock('@/store/api/settingsApi', () => ({
@@ -40,13 +40,13 @@ const makeProduct = (overrides: Partial<{ id: string; name: string; stockQuantit
 
 describe('CategoryWorkspaceCard', () => {
   beforeEach(() => {
-    mockUseGetProductsQuery.mockReset()
+    mockUseGetCategoryProductsQuery.mockReset()
     mockUseGetRegionalSettingsQuery.mockReset()
     mockUseGetRegionalSettingsQuery.mockReturnValue({ data: { lowStockThreshold: 10 } })
   })
 
   it('renders a products table and notes section instead of tab panels', () => {
-    mockUseGetProductsQuery.mockReturnValue({
+    mockUseGetCategoryProductsQuery.mockReturnValue({
       data: { data: [makeProduct({ name: 'Widget', stockQuantity: 3 })] },
       isLoading: false,
       isError: false,
@@ -66,7 +66,7 @@ describe('CategoryWorkspaceCard', () => {
   })
 
   it('skips the products query when no category is selected', () => {
-    mockUseGetProductsQuery.mockReturnValue({
+    mockUseGetCategoryProductsQuery.mockReturnValue({
       data: undefined,
       isLoading: false,
       isError: false,
@@ -74,7 +74,19 @@ describe('CategoryWorkspaceCard', () => {
 
     render(<CategoryWorkspaceCard selectedCategory={null} />)
 
-    expect(mockUseGetProductsQuery).toHaveBeenCalledWith({ categoryId: '' }, { skip: true })
+    expect(mockUseGetCategoryProductsQuery).toHaveBeenCalledWith('', { skip: true })
     expect(screen.queryByText('Category Products')).not.toBeInTheDocument()
+  })
+
+  it('shows error alert when query fails', () => {
+    mockUseGetCategoryProductsQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    })
+
+    render(<CategoryWorkspaceCard selectedCategory={makeCategory()} />)
+
+    expect(screen.getByText('Failed to load products.')).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/inventory/components/CategoryWorkspaceCard.tsx
+++ b/frontend/src/pages/inventory/components/CategoryWorkspaceCard.tsx
@@ -15,7 +15,7 @@ import {
 } from '@mui/material'
 
 import { TABLE_STYLES } from '@/constants/tableStyles'
-import { useGetProductsQuery } from '@/store/api/inventoryApi'
+import { useGetCategoryProductsQuery } from '@/store/api/inventoryApi'
 import { useGetRegionalSettingsQuery } from '@/store/api/settingsApi'
 import type { Category } from '@/types'
 import { getStockStatus } from '@/utils/stockUtils'
@@ -26,8 +26,8 @@ interface CategoryWorkspaceCardProps {
 
 const CategoryWorkspaceCard: React.FC<CategoryWorkspaceCardProps> = ({ selectedCategory }) => {
   const categoryId = selectedCategory?.id ?? ''
-  const { data: productsResponse, isLoading, isError } = useGetProductsQuery(
-    { categoryId },
+  const { data: productsResponse, isLoading, isError } = useGetCategoryProductsQuery(
+    categoryId,
     { skip: !categoryId },
   )
   const { data: regionalSettings } = useGetRegionalSettingsQuery()

--- a/frontend/src/store/api/inventoryApi.ts
+++ b/frontend/src/store/api/inventoryApi.ts
@@ -5,6 +5,12 @@ import type { Category, PaginatedResponse, Product, StockAdjustment, StockMoveme
 import { axiosBaseQuery } from './baseQuery'
 import { normalizePaginated, normalizeSingle } from './normalizers'
 
+export interface CategoryProduct {
+  id: string
+  name: string
+  stockQuantity: number
+}
+
 export const inventoryApiSlice = createApi({
   reducerPath: 'inventoryApi',
   baseQuery: axiosBaseQuery(),
@@ -82,6 +88,10 @@ export const inventoryApiSlice = createApi({
       query: (params) => ({ url: '/inventory/categories', params: { includeProductCount: true, ...(params ?? {}) } }),
       transformResponse: (response: any) => (Array.isArray(response) ? response : response?.data ?? []),
       providesTags: ['Category'],
+    }),
+    getCategoryProducts: builder.query<{ data: CategoryProduct[] }, string>({
+      query: (categoryId) => ({ url: `/inventory/categories/${categoryId}/products` }),
+      providesTags: (_result, _error, categoryId) => [{ type: 'Category', id: categoryId }],
     }),
     createCategory: builder.mutation<Category, Partial<Category>>({
       query: (body) => ({ url: '/inventory/categories', method: 'POST', data: body }),
@@ -228,6 +238,7 @@ export const {
   useBulkPermanentDeleteProductsMutation,
   useLazyCheckProductDuplicateQuery,
   useGetCategoriesQuery,
+  useGetCategoryProductsQuery,
   useCreateCategoryMutation,
   useUpdateCategoryMutation,
   useDeleteCategoryMutation,


### PR DESCRIPTION
## Summary
- Adds `GET /inventory/categories/:id/products` endpoint returning lightweight `{ id, name, stockQuantity }` rows — no price list joins
- `CategoryWorkspaceCard` now uses the new `useGetCategoryProductsQuery` hook instead of the heavier `useGetProductsQuery`
- Fixes the 500 error caused by complex price list joins in `ProductService.applyQueryBuilder` when called from the workspace card

## Test Plan
- [x] Navigate to Inventory > Categories, select a category — products table should load correctly
- [x] Select a category with no products — "No products in this category." message shown
- [x] Backend: `npx jest src/modules/inventory --no-coverage` — 30/30 pass
- [x] Frontend: `npx vitest run src/pages/inventory` — 55/55 pass

Closes #379