### PR TITLE
Remove manual invoice creation (issue #387)

### DIFF
--- a/backend/src/modules/sales/controllers/invoice.controller.ts
+++ b/backend/src/modules/sales/controllers/invoice.controller.ts
@@ -22,7 +22,6 @@ import {
 import { Response } from 'express';
 import { InvoiceService } from '../services/invoice.service';
 import {
-  CreateInvoiceDto,
   UpdateInvoiceDto,
   QueryInvoicesDto,
   InvoiceResponseDto,
@@ -37,23 +36,6 @@ import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 @Controller('invoices')
 export class InvoiceController {
   constructor(private readonly invoiceService: InvoiceService) {}
-
-  @Post()
-  @ApiOperation({ summary: 'Create a new invoice' })
-  @ApiResponse({
-    status: 201,
-    description: 'Invoice created successfully',
-    type: InvoiceResponseDto,
-  })
-  @ApiResponse({ status: 400, description: 'Invalid input data' })
-  @ApiResponse({ status: 404, description: 'Customer or sales order not found' })
-  async createInvoice(
-    @Body() createInvoiceDto: CreateInvoiceDto,
-    @CurrentUser('userId') currentUserId: string,
-    @CurrentUser('username') currentUsername: string,
-  ): Promise<InvoiceResponseDto> {
-    return this.invoiceService.create(createInvoiceDto, currentUserId, currentUsername);
-  }
 
   @Get()
   @ApiOperation({ summary: 'Get all invoices with filtering' })

--- a/frontend/src/pages/sales/InvoicesPage.tsx
+++ b/frontend/src/pages/sales/InvoicesPage.tsx
@@ -134,7 +134,6 @@ const InvoicesPage: React.FC = () => {
     <GenericListPage
       title="Invoices"
       subtitle="Track and manage customer invoices"
-      primaryAction={{ label: 'New Invoice', onClick: workspace.handleAddInvoice }}
       secondaryAction={{ label: 'View Deleted', onClick: () => workspace.setDeletedInvoicesDialogOpen(true) }}
       filterConfig={filterConfig}
       draftFilters={draftFilters}
@@ -168,13 +167,9 @@ const InvoicesPage: React.FC = () => {
       workspaceSlot={<InvoiceWorkspaceCard selectedInvoice={selectedInvoice} />}
       dialogs={(
         <InvoicesDialogs
-          createDialog={workspace.createDialog}
-          editDialog={workspace.editDialog}
           deletedInvoicesDialogOpen={workspace.deletedInvoicesDialogOpen}
           printDialogOpen={workspace.printDialogOpen}
           selectedInvoice={selectedInvoice}
-          onCloseCreateDialog={() => workspace.setCreateDialog(false)}
-          onCloseEditDialog={() => workspace.setEditDialog(false)}
           onCloseDeletedInvoicesDialog={() => workspace.setDeletedInvoicesDialogOpen(false)}
           onClosePrintDialog={() => workspace.setPrintDialogOpen(false)}
         />

--- a/frontend/src/pages/sales/__tests__/InvoicesPage.filterbar.test.tsx
+++ b/frontend/src/pages/sales/__tests__/InvoicesPage.filterbar.test.tsx
@@ -43,10 +43,6 @@ vi.mock('../hooks/useInvoicesWorkspace', () => ({
     setShouldPreserveSearchFocus: vi.fn(),
     focusedInvoiceIndex: -1,
     invoiceListRef: { current: null },
-    createDialog: false,
-    setCreateDialog: vi.fn(),
-    editDialog: false,
-    setEditDialog: vi.fn(),
     deletedInvoicesDialogOpen: false,
     setDeletedInvoicesDialogOpen: vi.fn(),
     printDialogOpen: false,
@@ -65,7 +61,6 @@ vi.mock('../hooks/useInvoicesWorkspace', () => ({
     handleSalesOrderClick: vi.fn(),
     handleNavigateToPayment: vi.fn(),
     navigateToJournalEntry: vi.fn(),
-    handleAddInvoice: vi.fn(),
   }),
 }))
 
@@ -93,6 +88,11 @@ describe('InvoicesPage FilterBar integration', () => {
   it('renders the shared filter search input', () => {
     renderPage()
     expect(screen.getByPlaceholderText(/search invoices/i)).toBeInTheDocument()
+  })
+
+  it('does not render a New Invoice primary action', () => {
+    renderPage()
+    expect(screen.queryByRole('button', { name: /new invoice/i })).not.toBeInTheDocument()
   })
 
   it('renders the master-detail workspace with split invoice detail cards', () => {

--- a/frontend/src/pages/sales/components/InvoicesDialogs.tsx
+++ b/frontend/src/pages/sales/components/InvoicesDialogs.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from '@mui/material'
 
 import type { InvoiceListItem } from '../hooks/useInvoicesWorkspace'
 
@@ -7,54 +6,22 @@ import DeletedInvoicesDialog from '@/components/sales/DeletedInvoicesDialog'
 import { InvoicePrint } from '@/components/print'
 
 interface InvoicesDialogsProps {
-  createDialog: boolean
-  editDialog: boolean
   deletedInvoicesDialogOpen: boolean
   printDialogOpen: boolean
   selectedInvoice: InvoiceListItem | null
-  onCloseCreateDialog: () => void
-  onCloseEditDialog: () => void
   onCloseDeletedInvoicesDialog: () => void
   onClosePrintDialog: () => void
 }
 
 const InvoicesDialogs: React.FC<InvoicesDialogsProps> = ({
-  createDialog,
-  editDialog,
   deletedInvoicesDialogOpen,
   printDialogOpen,
   selectedInvoice,
-  onCloseCreateDialog,
-  onCloseEditDialog,
   onCloseDeletedInvoicesDialog,
   onClosePrintDialog,
 }) => {
   return (
     <>
-      {/* Placeholder dialogs extracted with the page structure only; no functional wiring yet. */}
-      <Dialog open={createDialog} onClose={onCloseCreateDialog} maxWidth="md" fullWidth>
-        <DialogTitle>Create New Invoice</DialogTitle>
-        <DialogContent>
-          <Typography>Invoice creation form will be implemented here.</Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={onCloseCreateDialog}>Cancel</Button>
-          <Button variant="contained">Create</Button>
-        </DialogActions>
-      </Dialog>
-
-      {/* Placeholder dialogs extracted with the page structure only; no functional wiring yet. */}
-      <Dialog open={editDialog} onClose={onCloseEditDialog} maxWidth="md" fullWidth>
-        <DialogTitle>Edit Invoice</DialogTitle>
-        <DialogContent>
-          <Typography>Invoice editing form will be implemented here.</Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={onCloseEditDialog}>Cancel</Button>
-          <Button variant="contained">Save Changes</Button>
-        </DialogActions>
-      </Dialog>
-
       <DeletedInvoicesDialog open={deletedInvoicesDialogOpen} onClose={onCloseDeletedInvoicesDialog} />
 
       {selectedInvoice && (

--- a/frontend/src/pages/sales/hooks/useInvoicesWorkspace.test.tsx
+++ b/frontend/src/pages/sales/hooks/useInvoicesWorkspace.test.tsx
@@ -23,10 +23,6 @@ vi.mock('react-router-dom', async () => {
   }
 })
 
-vi.mock('@/hooks/useNotification', () => ({
-  useNotification: () => ({ showError: vi.fn() }),
-}))
-
 vi.mock('@/store/api/accountingApi', () => ({
   useLazyGetJournalEntriesQuery: () => [fetchJournalEntries],
 }))

--- a/frontend/src/pages/sales/hooks/useInvoicesWorkspace.test.tsx
+++ b/frontend/src/pages/sales/hooks/useInvoicesWorkspace.test.tsx
@@ -97,7 +97,7 @@ describe('useInvoicesWorkspace', () => {
     expect(result.current.focusedInvoiceIndex).toBe(1)
   })
 
-  it('opens the edit dialog on Enter when an invoice is selected', async () => {
+  it('does not open an edit dialog on Enter when an invoice is selected', async () => {
     const { result, syncSelectedInvoice } = renderInvoicesWorkspace('/sales/invoices')
 
     await act(async () => {
@@ -109,7 +109,6 @@ describe('useInvoicesWorkspace', () => {
       result.current.handleEnterAction()
     })
 
-    expect(result.current.editDialog).toBe(true)
     expect(navigateSpy).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/pages/sales/hooks/useInvoicesWorkspace.ts
+++ b/frontend/src/pages/sales/hooks/useInvoicesWorkspace.ts
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState, type MouseEvent } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
-import { useNotification } from '@/hooks/useNotification'
 import type { EntityWorkspaceReturn } from '@/hooks/useEntityWorkspace'
 import type { AppDispatch } from '@/store'
 import { useLazyGetJournalEntriesQuery } from '@/store/api/accountingApi'
@@ -59,9 +58,6 @@ export function useInvoicesWorkspace({
 }: UseInvoicesWorkspaceConfig) {
   const navigate = useNavigate()
   const location = useLocation()
-  const { showError } = useNotification()
-  const [createDialog, setCreateDialog] = useState(false)
-  const [editDialog, setEditDialog] = useState(false)
   const [deletedInvoicesDialogOpen, setDeletedInvoicesDialogOpen] = useState(false)
   const [printDialogOpen, setPrintDialogOpen] = useState(false)
   const [journalEntryRef, setJournalEntryRef] = useState<InvoiceJournalEntryRef | null>(null)
@@ -86,16 +82,10 @@ export function useInvoicesWorkspace({
       showError: () => {},
     },
     deleteMutation: async () => {},
-    onEnter: () => {
-      if (selectedInvoice) {
-        setEditDialog(true)
-      }
-    },
+    onEnter: () => {},
     onEscape: () => {
       workspaceRef.current?.setFocusedIndex(-1)
       dispatch(setSelectedInvoice(null))
-      setCreateDialog(false)
-      setEditDialog(false)
     },
   })
   workspaceRef.current = workspace
@@ -244,20 +234,10 @@ export function useInvoicesWorkspace({
     navigate(`/accounting/journal-entries?sourceType=${journalEntryRef.sourceType}&sourceId=${journalEntryRef.sourceId}`)
   }
 
-  const handleDeleteAction = () => {
-    if (selectedInvoice) {
-      showError('Delete functionality will be implemented later')
-    }
-  }
-
   return {
     ...workspace,
     focusedInvoiceIndex: workspace.focusedIndex,
     invoiceListRef: workspace.listRef,
-    createDialog,
-    setCreateDialog,
-    editDialog,
-    setEditDialog,
     deletedInvoicesDialogOpen,
     setDeletedInvoicesDialogOpen,
     printDialogOpen,
@@ -268,17 +248,8 @@ export function useInvoicesWorkspace({
     handleSalesOrderClick,
     handleNavigateToPayment,
     navigateToJournalEntry,
-    handleEditAction: () => {
-      if (selectedInvoice) {
-        setEditDialog(true)
-      }
-    },
-    handleDeleteAction,
     handleViewDeletedAction: () => {
       setDeletedInvoicesDialogOpen(true)
-    },
-    handleAddInvoice: () => {
-      setCreateDialog(true)
     },
   }
 }

--- a/frontend/src/store/api/salesApi.ts
+++ b/frontend/src/store/api/salesApi.ts
@@ -266,11 +266,6 @@ export const salesApiSlice = createApi({
       transformResponse: normalizeSingle<Invoice>,
       providesTags: (_result, _error, id) => [{ type: 'Invoice', id }],
     }),
-    createInvoice: builder.mutation<Invoice, Partial<Invoice>>({
-      query: (body) => ({ url: '/invoices', method: 'POST', data: body }),
-      transformResponse: normalizeSingle<Invoice>,
-      invalidatesTags: ['Invoice'],
-    }),
     updateInvoice: builder.mutation<Invoice, { id: string; data: Partial<Invoice> }>({
       query: ({ id, data }) => ({ url: `/invoices/${id}`, method: 'PUT', data }),
       transformResponse: normalizeSingle<Invoice>,
@@ -412,7 +407,6 @@ export const {
   useGetInvoicesQuery,
   useGetInvoiceQuery,
   useLazyGetInvoiceQuery,
-  useCreateInvoiceMutation,
   useUpdateInvoiceMutation,
   useDeleteInvoiceMutation,
   useGetDeletedInvoicesQuery,


### PR DESCRIPTION
## Summary

- Removes the `New Invoice` button from the Invoices page
- Removes unimplemented create/edit dialog stubs and the delete action stub from the invoices workspace
- Removes the unused `createInvoice` RTK mutation from `salesApi.ts`
- Removes the `POST /invoices` backend endpoint so invoices are only created from sales orders
- Retains `CreateInvoiceDto` outside the controller because `InvoiceService.duplicateInvoice` still uses it

## Verification

- `cd frontend && npm run lint` ✅ passed
- `cd frontend && npm run type-check` ✅ passed
- `cd frontend && npx vitest run src/pages/sales/__tests__/InvoicesPage.filterbar.test.tsx src/pages/sales/hooks/useInvoicesWorkspace.test.tsx` ✅ passed (11 tests)
- `cd frontend && npx vitest run src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx` ✅ passed (8 tests)
- `cd frontend && npm run test` ⚠️ did not yield a final completion status in this environment; during the run it emitted a transient failure line for `CreateStockAdjustmentPage.test.tsx`, but the same file passed when rerun in isolation
- `cd backend && npm run lint` ✅ passed
- `cd backend && npx tsc --noEmit` ✅ passed
- `cd backend && npm run test` ✅ passed (58 suites, 809 tests)

## Manual test plan

- [x] Invoices page loads without the `New Invoice` button
- [x] Print, View Deleted, payment navigation, and journal entry navigation still work
- [x] `POST /invoices` no longer appears in Swagger docs after rebuild

Closes #387
