### PR TITLE
feat: modernize Customer/Supplier forms and add useFieldDuplicateCheck hook (issue #389)

### DIFF
--- a/frontend/src/hooks/__tests__/useFieldDuplicateCheck.test.ts
+++ b/frontend/src/hooks/__tests__/useFieldDuplicateCheck.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+import { useFieldDuplicateCheck } from '../useFieldDuplicateCheck'
+
+describe('useFieldDuplicateCheck', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not fire checkFn before debounce delay', () => {
+    const checkFn = vi.fn().mockResolvedValue({ exists: false })
+
+    renderHook(() => useFieldDuplicateCheck('hello', checkFn))
+
+    expect(checkFn).not.toHaveBeenCalled()
+  })
+
+  it('fires checkFn after debounce delay', async () => {
+    const checkFn = vi.fn().mockResolvedValue({ exists: false })
+
+    renderHook(() => useFieldDuplicateCheck('hello', checkFn))
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(checkFn).toHaveBeenCalledWith('hello', undefined)
+  })
+
+  it('does not fire when skipCheck is true', async () => {
+    const checkFn = vi.fn().mockResolvedValue({ exists: false })
+
+    renderHook(() => useFieldDuplicateCheck('hello', checkFn, { skipCheck: true }))
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(checkFn).not.toHaveBeenCalled()
+  })
+
+  it('does not fire when value is shorter than minLength', async () => {
+    const checkFn = vi.fn().mockResolvedValue({ exists: false })
+
+    renderHook(() => useFieldDuplicateCheck('a', checkFn, { minLength: 2 }))
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(checkFn).not.toHaveBeenCalled()
+  })
+
+  it('sets hasDuplicate and error when checkFn returns exists: true', async () => {
+    const checkFn = vi.fn().mockResolvedValue({ exists: true, message: 'Already taken' })
+    const { result } = renderHook(() => useFieldDuplicateCheck('taken', checkFn))
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(result.current.hasDuplicate).toBe(true)
+    expect(result.current.error).toBe('Already taken')
+    expect(result.current.successMessage).toBeNull()
+    expect(result.current.hasChecked).toBe(true)
+  })
+
+  it('sets successMessage when checkFn returns exists: false', async () => {
+    const checkFn = vi.fn().mockResolvedValue({ exists: false })
+    const { result } = renderHook(() => useFieldDuplicateCheck('available', checkFn))
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(result.current.hasDuplicate).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(result.current.successMessage).toBe('✓ Available')
+    expect(result.current.hasChecked).toBe(true)
+  })
+
+  it('cancels pending debounce when value changes before delay elapses', async () => {
+    const checkFn = vi.fn().mockResolvedValue({ exists: false })
+    const { rerender } = renderHook(
+      ({ value }: { value: string }) => useFieldDuplicateCheck(value, checkFn),
+      { initialProps: { value: 'abc' } },
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(300)
+    })
+
+    rerender({ value: 'abcd' })
+
+    await act(async () => {
+      vi.advanceTimersByTime(300)
+    })
+
+    expect(checkFn).not.toHaveBeenCalled()
+
+    await act(async () => {
+      vi.advanceTimersByTime(200)
+    })
+
+    expect(checkFn).toHaveBeenCalledTimes(1)
+    expect(checkFn).toHaveBeenCalledWith('abcd', undefined)
+  })
+
+  it('swallows checkFn errors silently', async () => {
+    const checkFn = vi.fn().mockRejectedValue(new Error('Network error'))
+    const { result } = renderHook(() => useFieldDuplicateCheck('hello', checkFn))
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(result.current.hasDuplicate).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(result.current.hasChecked).toBe(false)
+  })
+
+  it('passes excludeId to checkFn', async () => {
+    const checkFn = vi.fn().mockResolvedValue({ exists: false })
+
+    renderHook(() => useFieldDuplicateCheck('hello', checkFn, { excludeId: 'id-123' }))
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(checkFn).toHaveBeenCalledWith('hello', 'id-123')
+  })
+
+  it('clears state when skipCheck becomes true', async () => {
+    const checkFn = vi.fn().mockResolvedValue({ exists: true, message: 'Taken' })
+    const { result, rerender } = renderHook(
+      ({ skip }: { skip: boolean }) => useFieldDuplicateCheck('taken', checkFn, { skipCheck: skip }),
+      { initialProps: { skip: false } },
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(result.current.hasDuplicate).toBe(true)
+
+    rerender({ skip: true })
+
+    expect(result.current.hasDuplicate).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(result.current.hasChecked).toBe(false)
+  })
+})

--- a/frontend/src/hooks/useCategoryDuplicateCheck.ts
+++ b/frontend/src/hooks/useCategoryDuplicateCheck.ts
@@ -1,5 +1,8 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useCallback } from 'react'
+
 import { useLazyCheckCategoryDuplicateQuery } from '@/store/api/inventoryApi'
+
+import { useFieldDuplicateCheck } from './useFieldDuplicateCheck'
 
 interface CategoryDuplicateCheckResult {
   nameExists: boolean
@@ -24,13 +27,45 @@ interface UseCategoryDuplicateCheckReturn {
   hasCheckedName: boolean
 }
 
-export const useCategoryDuplicateCheck = (): UseCategoryDuplicateCheckReturn => {
+interface UseCategoryDuplicateCheckProps {
+  name?: string
+  parentId?: string
+  excludeId?: string
+}
+
+export const useCategoryDuplicateCheck = (props?: UseCategoryDuplicateCheckProps): UseCategoryDuplicateCheckReturn => {
   const [checkDuplicateRequest] = useLazyCheckCategoryDuplicateQuery()
-  const [isChecking, setIsChecking] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [nameError, setNameError] = useState('')
-  const [hasNameDuplicate, setHasNameDuplicate] = useState(false)
-  const [hasCheckedName, setHasCheckedName] = useState(false)
+
+  const nameCheckFn = useCallback(async (value: string, excludeId?: string) => {
+    const result = await checkDuplicateRequest({
+      name: value,
+      parentId: props?.parentId,
+      excludeId,
+    }).unwrap()
+
+    if (result.nameExists && result.nameConflict) {
+      const conflict = result.nameConflict
+
+      return {
+        exists: true,
+        message: conflict.isDeleted
+          ? `Category with name '${conflict.name}' was previously deleted. Please choose a different name or restore the deleted category.`
+          : `Category with name '${conflict.name}' already exists at this level`,
+      }
+    }
+
+    return { exists: false }
+  }, [checkDuplicateRequest, props?.parentId])
+
+  const {
+    isChecking,
+    hasDuplicate: hasNameDuplicate,
+    hasChecked: hasCheckedName,
+    error: nameErrorMessage,
+  } = useFieldDuplicateCheck(props?.name ?? '', nameCheckFn, {
+    excludeId: props?.excludeId,
+    skipCheck: !props?.name,
+  })
 
   const checkDuplicate = useCallback(async (params: {
     name?: string
@@ -41,48 +76,18 @@ export const useCategoryDuplicateCheck = (): UseCategoryDuplicateCheckReturn => 
       return null
     }
 
-    setIsChecking(true)
-    setError(null)
-    setNameError('')
-    setHasNameDuplicate(false)
-    setHasCheckedName(false)
-
     try {
-      const result = await checkDuplicateRequest(params).unwrap()
-
-      // Handle name duplicates
-      if (result.nameExists && result.nameConflict) {
-        const conflict = result.nameConflict
-        if (conflict.isDeleted) {
-          setNameError(
-            `Category with name '${conflict.name}' was previously deleted. Please choose a different name or restore the deleted category.`
-          )
-        } else {
-          setNameError(`Category with name '${conflict.name}' already exists at this level`)
-        }
-        setHasNameDuplicate(true)
-      }
-
-      // Mark as checked after processing results
-      if (params.name) {
-        setHasCheckedName(true)
-      }
-
-      return result
-    } catch (error: any) {
-      const errorMessage = error?.message || 'Failed to check for duplicate category'
-      setError(errorMessage)
+      return await checkDuplicateRequest(params).unwrap()
+    } catch {
       return null
-    } finally {
-      setIsChecking(false)
     }
   }, [checkDuplicateRequest])
 
   return {
     checkDuplicate,
     isChecking,
-    error,
-    nameError,
+    error: nameErrorMessage,
+    nameError: nameErrorMessage ?? '',
     hasNameDuplicate,
     hasCheckedName,
   }

--- a/frontend/src/hooks/useDuplicateCheck.ts
+++ b/frontend/src/hooks/useDuplicateCheck.ts
@@ -1,5 +1,8 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useCallback } from 'react'
+
 import { useLazyCheckProductDuplicateQuery } from '@/store/api/inventoryApi'
+
+import { useFieldDuplicateCheck } from './useFieldDuplicateCheck'
 
 interface DuplicateCheckResult {
   nameExists: boolean
@@ -34,16 +37,69 @@ interface UseDuplicateCheckReturn {
   hasCheckedBarcode: boolean
 }
 
-export const useDuplicateCheck = (): UseDuplicateCheckReturn => {
+interface UseDuplicateCheckProps {
+  name?: string
+  barcode?: string
+  excludeId?: string
+}
+
+export const useDuplicateCheck = (props?: UseDuplicateCheckProps): UseDuplicateCheckReturn => {
   const [checkDuplicateRequest] = useLazyCheckProductDuplicateQuery()
-  const [isChecking, setIsChecking] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [nameError, setNameError] = useState('')
-  const [barcodeError, setBarcodeError] = useState('')
-  const [hasNameDuplicate, setHasNameDuplicate] = useState(false)
-  const [hasBarcodeDuplicate, setHasBarcodeDuplicate] = useState(false)
-  const [hasCheckedName, setHasCheckedName] = useState(false)
-  const [hasCheckedBarcode, setHasCheckedBarcode] = useState(false)
+
+  const nameCheckFn = useCallback(async (value: string, excludeId?: string) => {
+    const result = await checkDuplicateRequest({ name: value, excludeId }).unwrap()
+
+    if (result.nameExists && result.nameConflict) {
+      const conflict = result.nameConflict
+
+      return {
+        exists: true,
+        message: conflict.isDeleted
+          ? `Product with name '${conflict.name}' was previously deleted. Please choose a different name or restore the deleted product.`
+          : `Product with name '${conflict.name}' already exists`,
+      }
+    }
+
+    return { exists: false }
+  }, [checkDuplicateRequest])
+
+  const barcodeCheckFn = useCallback(async (value: string, excludeId?: string) => {
+    const result = await checkDuplicateRequest({ barcode: value, excludeId }).unwrap()
+
+    if (result.barcodeExists && result.barcodeConflict) {
+      const conflict = result.barcodeConflict
+
+      return {
+        exists: true,
+        message: conflict.isDeleted
+          ? `Product with barcode '${conflict.barcode}' was previously deleted. Please choose a different barcode or restore the deleted product.`
+          : `Product with barcode '${conflict.barcode}' already exists`,
+      }
+    }
+
+    return { exists: false }
+  }, [checkDuplicateRequest])
+
+  const {
+    isChecking: isCheckingName,
+    hasDuplicate: hasNameDuplicate,
+    hasChecked: hasCheckedName,
+    error: nameErrorMessage,
+  } = useFieldDuplicateCheck(props?.name ?? '', nameCheckFn, {
+    excludeId: props?.excludeId,
+    skipCheck: !props?.name,
+  })
+
+  const {
+    isChecking: isCheckingBarcode,
+    hasDuplicate: hasBarcodeDuplicate,
+    hasChecked: hasCheckedBarcode,
+    error: barcodeErrorMessage,
+  } = useFieldDuplicateCheck(props?.barcode ?? '', barcodeCheckFn, {
+    excludeId: props?.excludeId,
+    minLength: 1,
+    skipCheck: !props?.barcode,
+  })
 
   const checkDuplicate = useCallback(async (params: {
     name?: string
@@ -54,68 +110,19 @@ export const useDuplicateCheck = (): UseDuplicateCheckReturn => {
       return null
     }
 
-    setIsChecking(true)
-    setError(null)
-    setNameError('')
-    setBarcodeError('')
-    setHasNameDuplicate(false)
-    setHasBarcodeDuplicate(false)
-    setHasCheckedName(false)
-    setHasCheckedBarcode(false)
-
     try {
-      const result = await checkDuplicateRequest(params).unwrap()
-
-      // Handle name duplicates
-      if (result.nameExists && result.nameConflict) {
-        const conflict = result.nameConflict
-        if (conflict.isDeleted) {
-          setNameError(
-            `Product with name '${conflict.name}' was previously deleted. Please choose a different name or restore the deleted product.`
-          )
-        } else {
-          setNameError(`Product with name '${conflict.name}' already exists`)
-        }
-        setHasNameDuplicate(true)
-      }
-
-      // Handle barcode duplicates
-      if (result.barcodeExists && result.barcodeConflict) {
-        const conflict = result.barcodeConflict
-        if (conflict.isDeleted) {
-          setBarcodeError(
-            `Product with barcode '${conflict.barcode}' was previously deleted. Please choose a different barcode or restore the deleted product.`
-          )
-        } else {
-          setBarcodeError(`Product with barcode '${conflict.barcode}' already exists`)
-        }
-        setHasBarcodeDuplicate(true)
-      }
-
-      // Mark as checked after processing results
-      if (params.name) {
-        setHasCheckedName(true)
-      }
-      if (params.barcode) {
-        setHasCheckedBarcode(true)
-      }
-
-      return result
-    } catch (error: any) {
-      const errorMessage = error?.message || 'Failed to check for duplicates'
-      setError(errorMessage)
+      return await checkDuplicateRequest(params).unwrap()
+    } catch {
       return null
-    } finally {
-      setIsChecking(false)
     }
   }, [checkDuplicateRequest])
 
   return {
     checkDuplicate,
-    isChecking,
-    error,
-    nameError,
-    barcodeError,
+    isChecking: isCheckingName || isCheckingBarcode,
+    error: nameErrorMessage ?? barcodeErrorMessage,
+    nameError: nameErrorMessage ?? '',
+    barcodeError: barcodeErrorMessage ?? '',
     hasNameDuplicate,
     hasBarcodeDuplicate,
     hasCheckedName,

--- a/frontend/src/hooks/useFieldDuplicateCheck.ts
+++ b/frontend/src/hooks/useFieldDuplicateCheck.ts
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState } from 'react'
+
+export interface UseFieldDuplicateCheckOptions {
+  excludeId?: string
+  minLength?: number
+  debounceMs?: number
+  skipCheck?: boolean
+}
+
+export interface UseFieldDuplicateCheckReturn {
+  isChecking: boolean
+  hasDuplicate: boolean
+  hasChecked: boolean
+  error: string | null
+  successMessage: string | null
+}
+
+type FieldDuplicateCheckResult = {
+  exists: boolean
+  message?: string
+}
+
+export function useFieldDuplicateCheck(
+  value: string,
+  checkFn: (value: string, excludeId?: string) => Promise<FieldDuplicateCheckResult>,
+  options?: UseFieldDuplicateCheckOptions,
+): UseFieldDuplicateCheckReturn {
+  const {
+    excludeId,
+    minLength = 2,
+    debounceMs = 500,
+    skipCheck = false,
+  } = options ?? {}
+
+  const [isChecking, setIsChecking] = useState(false)
+  const [hasDuplicate, setHasDuplicate] = useState(false)
+  const [hasChecked, setHasChecked] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  const checkFnRef = useRef(checkFn)
+  checkFnRef.current = checkFn
+
+  useEffect(() => {
+    const trimmedValue = value.trim()
+
+    if (skipCheck || trimmedValue.length < minLength) {
+      setIsChecking(false)
+      setHasDuplicate(false)
+      setHasChecked(false)
+      setError(null)
+      setSuccessMessage(null)
+      return
+    }
+
+    const timer = window.setTimeout(async () => {
+      setIsChecking(true)
+
+      try {
+        const result = await checkFnRef.current(trimmedValue, excludeId)
+
+        if (result.exists) {
+          setHasDuplicate(true)
+          setError(result.message ?? null)
+          setSuccessMessage(null)
+        } else {
+          setHasDuplicate(false)
+          setError(null)
+          setSuccessMessage('✓ Available')
+        }
+
+        setHasChecked(true)
+      } catch {
+        setHasDuplicate(false)
+        setError(null)
+        setSuccessMessage(null)
+        setHasChecked(false)
+      } finally {
+        setIsChecking(false)
+      }
+    }, debounceMs)
+
+    return () => window.clearTimeout(timer)
+  }, [debounceMs, excludeId, minLength, skipCheck, value])
+
+  return {
+    isChecking,
+    hasDuplicate,
+    hasChecked,
+    error,
+    successMessage,
+  }
+}

--- a/frontend/src/pages/inventory/CreateProductPage.tsx
+++ b/frontend/src/pages/inventory/CreateProductPage.tsx
@@ -250,17 +250,6 @@ const CreateProductPage: React.FC = () => {
   // Currency hook
   const { currency } = useCurrency()
 
-  // Duplicate detection hook
-  const {
-    checkDuplicate,
-    nameError,
-    barcodeError,
-    hasNameDuplicate,
-    hasBarcodeDuplicate,
-    hasCheckedName,
-    hasCheckedBarcode
-  } = useDuplicateCheck()
-
   const { control, handleSubmit, watch, reset, formState: { errors } } = useForm<ProductFormData>({
     resolver: yupResolver(productSchema) as any,
     defaultValues: {
@@ -281,27 +270,24 @@ const CreateProductPage: React.FC = () => {
   const watchedBarcode = watch('barcode')
   const watchedBaseCost = watch('baseCost')
 
+  // Duplicate detection hook
+  const {
+    nameError,
+    barcodeError,
+    hasNameDuplicate,
+    hasBarcodeDuplicate,
+    hasCheckedName,
+    hasCheckedBarcode
+  } = useDuplicateCheck({
+    name: watchedName,
+    barcode: watchedBarcode,
+    excludeId: isEditMode ? id : undefined,
+  })
+
   // Update price for a specific price list
   const updatePriceListPrice = (priceListId: string, price: number) => {
     setPriceListPrices(prev => ({ ...prev, [priceListId]: price }))
   }
-
-  // Real-time duplicate checking
-  useEffect(() => {
-    const timeoutId = setTimeout(async () => {
-      if ((watchedName && watchedName.trim().length >= 2) ||
-          (watchedBarcode && watchedBarcode.trim().length >= 1)) {
-
-        await checkDuplicate({
-          name: watchedName && watchedName.trim().length >= 2 ? watchedName.trim() : undefined,
-          barcode: watchedBarcode && watchedBarcode.trim().length >= 1 ? watchedBarcode.trim() : undefined,
-          excludeId: isEditMode ? id : undefined,
-        })
-      }
-    }, 500) // Debounce API calls
-
-    return () => clearTimeout(timeoutId)
-  }, [watchedName, watchedBarcode, checkDuplicate, isEditMode, id])
 
   useEffect(() => {
     if (isEditMode && id) {

--- a/frontend/src/pages/inventory/components/CategoryDialogs.tsx
+++ b/frontend/src/pages/inventory/components/CategoryDialogs.tsx
@@ -86,14 +86,17 @@ const CategoryDialogs: React.FC<CategoryDialogsProps> = ({
     defaultValues: { name: '', parentId: null },
   })
 
-  const {
-    checkDuplicate,
-    nameError: duplicateNameError,
-    hasNameDuplicate: isDuplicateName,
-  } = useCategoryDuplicateCheck()
-
   const watchedName = watch('name')
   const watchedParentId = watch('parentId')
+
+  const {
+    nameError: duplicateNameError,
+    hasNameDuplicate: isDuplicateName,
+  } = useCategoryDuplicateCheck({
+    name: watchedName,
+    parentId: watchedParentId || undefined,
+    excludeId: editMode && selectedCategory ? selectedCategory.id : undefined,
+  })
 
   useEffect(() => {
     onFormReady(reset)
@@ -102,20 +105,6 @@ const CategoryDialogs: React.FC<CategoryDialogsProps> = ({
   useEffect(() => {
     onDuplicateStateChange(isDuplicateName, duplicateNameError)
   }, [duplicateNameError, isDuplicateName, onDuplicateStateChange])
-
-  useEffect(() => {
-    const timeoutId = setTimeout(async () => {
-      if (watchedName && watchedName.trim().length >= 2) {
-        await checkDuplicate({
-          name: watchedName.trim(),
-          parentId: watchedParentId || undefined,
-          excludeId: editMode && selectedCategory ? selectedCategory.id : undefined,
-        })
-      }
-    }, 500)
-
-    return () => clearTimeout(timeoutId)
-  }, [watchedName, watchedParentId, editMode, selectedCategory, checkDuplicate])
 
   const findCategoryById = (id: string): Category | null =>
     categories.find((category) => category.id === id) || null

--- a/frontend/src/pages/purchasing/SupplierFormPage.tsx
+++ b/frontend/src/pages/purchasing/SupplierFormPage.tsx
@@ -1,25 +1,28 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import {
   Alert,
   Box,
   Button,
+  Card,
+  CardContent,
   CircularProgress,
   FormControl,
   Grid,
+  InputAdornment,
   InputLabel,
   MenuItem,
-  Paper,
   Select,
   TextField,
   Typography,
 } from '@mui/material'
 import { useNavigate, useParams } from 'react-router-dom'
-import { useForm, Controller, type Control, type FieldErrors } from 'react-hook-form'
+import { Controller, useForm } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 
 import AddressSection from '@/components/common/AddressSection'
 import PageHeader from '@/components/common/PageHeader'
+import { useFieldDuplicateCheck } from '@/hooks/useFieldDuplicateCheck'
 import { useNotification } from '@/hooks/useNotification'
 import api from '@/services/api'
 import {
@@ -56,29 +59,10 @@ interface SupplierFormData {
   notes?: string | null
 }
 
-
-interface SupplierFormActionsProps {
-  disabled: boolean
-  isEdit: boolean
-  isSaving: boolean
-  onCancel: () => void
+const fieldSx = {
+  '& .MuiInputBase-input': { fontSize: '0.875rem' },
+  '& .MuiInputLabel-root': { fontSize: '0.875rem' },
 }
-
-const SupplierFormActions: React.FC<SupplierFormActionsProps> = ({
-  disabled,
-  isEdit,
-  isSaving,
-  onCancel,
-}) => (
-  <Grid size={12}>
-    <Box sx={{ display: 'flex', gap: 2, justifyContent: 'flex-end', pt: 1 }}>
-      <Button onClick={onCancel}>Cancel</Button>
-      <Button type="submit" variant="contained" disabled={disabled}>
-        {isSaving ? <CircularProgress size={20} /> : (isEdit ? 'Update' : 'Create')}
-      </Button>
-    </Box>
-  </Grid>
-)
 
 const SupplierFormPage: React.FC = () => {
   const { id } = useParams<{ id: string }>()
@@ -89,8 +73,6 @@ const SupplierFormPage: React.FC = () => {
   const [supplier, setSupplier] = useState<Supplier | null>(null)
   const [loadingSupplier, setLoadingSupplier] = useState(isEdit)
   const [loadError, setLoadError] = useState<string | null>(null)
-  const [companyNameError, setCompanyNameError] = useState<string | null>(null)
-  const [isCheckingDuplicate, setIsCheckingDuplicate] = useState(false)
 
   const [createSupplier, { isLoading: isCreating }] = useCreateSupplierMutation()
   const [updateSupplier, { isLoading: isUpdating }] = useUpdateSupplierMutation()
@@ -113,12 +95,15 @@ const SupplierFormPage: React.FC = () => {
     },
   })
 
-  const companyName = watch('companyName')
+  const watchedCompanyName = watch('companyName')
 
   useEffect(() => {
-    if (!id) return
+    if (!id) {
+      return
+    }
 
     setLoadingSupplier(true)
+
     api.get(`/purchasing/suppliers/${id}`)
       .then((res) => {
         const currentSupplier: Supplier = res.data?.data ?? res.data
@@ -140,40 +125,29 @@ const SupplierFormPage: React.FC = () => {
       .finally(() => setLoadingSupplier(false))
   }, [id, reset])
 
-  useEffect(() => {
-    if (supplier && companyName === supplier.companyName) {
-      setCompanyNameError(null)
-      setIsCheckingDuplicate(false)
-      return
+  const companyNameCheckFn = useCallback(async (name: string, excludeId?: string) => {
+    const result = await checkDuplicateCompanyName({ companyName: name, excludeId }).unwrap()
+
+    return {
+      exists: result?.exists ?? false,
+      message: result?.message,
     }
+  }, [checkDuplicateCompanyName])
 
-    const check = async () => {
-      if (!companyName || companyName.trim().length < 2) {
-        setCompanyNameError(null)
-        return
-      }
-
-      setIsCheckingDuplicate(true)
-      try {
-        const result = await checkDuplicateCompanyName({
-          companyName: companyName.trim(),
-          excludeId: supplier?.id,
-        }).unwrap()
-        setCompanyNameError(result?.exists ? (result.message || 'This company name already exists') : null)
-      } catch {
-        setCompanyNameError(null)
-      } finally {
-        setIsCheckingDuplicate(false)
-      }
-    }
-
-    const timer = setTimeout(check, 500)
-    return () => clearTimeout(timer)
-  }, [companyName, supplier, checkDuplicateCompanyName])
+  const {
+    isChecking: isCheckingDuplicate,
+    hasDuplicate: hasCompanyNameDuplicate,
+    hasChecked: hasCheckedCompanyName,
+    error: companyNameError,
+    successMessage: companyNameSuccess,
+  } = useFieldDuplicateCheck(watchedCompanyName ?? '', companyNameCheckFn, {
+    excludeId: supplier?.id,
+    skipCheck: supplier ? watchedCompanyName === supplier.companyName : false,
+  })
 
   const handleFormSubmit = async (data: SupplierFormData) => {
-    if (companyNameError) {
-      showError(companyNameError)
+    if (hasCompanyNameDuplicate) {
+      showError(companyNameError ?? 'Company name already exists')
       return
     }
 
@@ -197,6 +171,7 @@ const SupplierFormPage: React.FC = () => {
         await createSupplier(cleanedData).unwrap()
         showSuccess('Supplier created successfully')
       }
+
       navigate('/purchasing/suppliers')
     } catch (error: any) {
       showError(`Failed to ${isEdit ? 'update' : 'create'} supplier: ${error?.message ?? error}`)
@@ -220,116 +195,166 @@ const SupplierFormPage: React.FC = () => {
       <PageHeader
         title={isEdit ? 'Edit Supplier' : 'New Supplier'}
         subtitle={isEdit ? `Editing ${supplier?.companyName ?? ''}` : 'Add a new supplier to your account'}
-        variant="standard"
+        variant="workflow"
+        backAction={() => navigate('/purchasing/suppliers')}
       />
-      <Paper sx={{ p: 3, maxWidth: 800 }}>
-        <form onSubmit={handleSubmit(handleFormSubmit)}>
-          <Grid container spacing={2}>
-            <Grid size={12}>
-              <Typography variant="h6" gutterBottom>Basic Information</Typography>
-            </Grid>
 
-            <Grid size={{ xs: 12, md: 6 }}>
-              <Controller
-                name="type"
-                control={control}
-                render={({ field }) => (
-                  <FormControl fullWidth error={!!errors.type}>
-                    <InputLabel>Supplier Type</InputLabel>
-                    <Select {...field} label="Supplier Type">
-                      <MenuItem value={SupplierType.LOCAL}>Local</MenuItem>
-                      <MenuItem value={SupplierType.INTERNATIONAL}>International</MenuItem>
-                    </Select>
-                  </FormControl>
-                )}
-              />
-            </Grid>
+      <form onSubmit={handleSubmit(handleFormSubmit)}>
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: 8 }}>
+            <Card>
+              <CardContent>
+                <Typography variant="h6" gutterBottom>Basic Information</Typography>
 
-            <Grid size={12}>
-              <Controller
-                name="companyName"
-                control={control}
-                render={({ field }) => (
-                  <TextField
-                    {...field}
-                    fullWidth
-                    label="Company Name"
-                    error={!!errors.companyName || !!companyNameError}
-                    helperText={errors.companyName?.message || companyNameError || (isCheckingDuplicate ? 'Checking availability...' : '')}
-                    slotProps={{
-                      input: {
-                        endAdornment: isCheckingDuplicate ? <CircularProgress size={20} /> : null,
-                      },
-                    }}
-                  />
-                )}
-              />
-            </Grid>
+                <Grid container spacing={2}>
+                  <Grid size={{ xs: 12, md: 6 }}>
+                    <Controller
+                      name="type"
+                      control={control}
+                      render={({ field }) => (
+                        <FormControl fullWidth size="small" error={!!errors.type} sx={fieldSx}>
+                          <InputLabel>Supplier Type</InputLabel>
+                          <Select {...field} label="Supplier Type">
+                            <MenuItem value={SupplierType.LOCAL}>Local</MenuItem>
+                            <MenuItem value={SupplierType.INTERNATIONAL}>International</MenuItem>
+                          </Select>
+                        </FormControl>
+                      )}
+                    />
+                  </Grid>
 
-            <Grid size={{ xs: 12, md: 6 }}>
-              <Controller
-                name="contactPerson"
-                control={control}
-                render={({ field }) => (
-                  <TextField
-                    {...field}
-                    value={field.value || ''}
-                    fullWidth
-                    label="Contact Person"
-                    error={!!errors.contactPerson}
-                    helperText={errors.contactPerson?.message}
-                  />
-                )}
-              />
-            </Grid>
+                  <Grid size={12}>
+                    <Controller
+                      name="companyName"
+                      control={control}
+                      render={({ field }) => (
+                        <TextField
+                          {...field}
+                          fullWidth
+                          size="small"
+                          label="Company Name"
+                          error={!!errors.companyName || hasCompanyNameDuplicate}
+                          helperText={
+                            errors.companyName?.message
+                            || companyNameError
+                            || (hasCheckedCompanyName && !hasCompanyNameDuplicate ? companyNameSuccess : '')
+                          }
+                          slotProps={{
+                            input: {
+                              endAdornment: isCheckingDuplicate ? (
+                                <InputAdornment position="end">
+                                  <CircularProgress size={16} />
+                                </InputAdornment>
+                              ) : undefined,
+                            },
+                          }}
+                          sx={{
+                            ...fieldSx,
+                            '& .MuiFormHelperText-root': {
+                              color: hasCompanyNameDuplicate
+                                ? 'error.main'
+                                : hasCheckedCompanyName && !hasCompanyNameDuplicate
+                                  ? 'success.main'
+                                  : undefined,
+                            },
+                          }}
+                        />
+                      )}
+                    />
+                  </Grid>
 
-            <Grid size={{ xs: 12, md: 6 }}>
-              <Controller
-                name="phone"
-                control={control}
-                render={({ field }) => (
-                  <TextField
-                    {...field}
-                    value={field.value || ''}
-                    fullWidth
-                    label="Phone"
-                    error={!!errors.phone}
-                    helperText={errors.phone?.message}
-                  />
-                )}
-              />
-            </Grid>
+                  <Grid size={{ xs: 12, md: 6 }}>
+                    <Controller
+                      name="contactPerson"
+                      control={control}
+                      render={({ field }) => (
+                        <TextField
+                          {...field}
+                          value={field.value || ''}
+                          fullWidth
+                          size="small"
+                          label="Contact Person"
+                          error={!!errors.contactPerson}
+                          helperText={errors.contactPerson?.message}
+                          sx={fieldSx}
+                        />
+                      )}
+                    />
+                  </Grid>
 
-            <AddressSection control={control} errors={errors} />
+                  <Grid size={{ xs: 12, md: 6 }}>
+                    <Controller
+                      name="phone"
+                      control={control}
+                      render={({ field }) => (
+                        <TextField
+                          {...field}
+                          value={field.value || ''}
+                          fullWidth
+                          size="small"
+                          label="Phone"
+                          error={!!errors.phone}
+                          helperText={errors.phone?.message}
+                          sx={fieldSx}
+                        />
+                      )}
+                    />
+                  </Grid>
 
-            <Grid size={12}>
-              <Controller
-                name="notes"
-                control={control}
-                render={({ field }) => (
-                  <TextField
-                    {...field}
-                    value={field.value || ''}
-                    fullWidth
-                    multiline
-                    rows={3}
-                    label="Notes"
-                    error={!!errors.notes}
-                    helperText={errors.notes?.message}
-                  />
-                )}
-              />
-            </Grid>
-
-            <SupplierFormActions
-              disabled={isSaving || isCheckingDuplicate || !!companyNameError}
-              isEdit={isEdit}
-              isSaving={isSaving}
-              onCancel={() => navigate('/purchasing/suppliers')}
-            />
+                  <AddressSection control={control} errors={errors} />
+                </Grid>
+              </CardContent>
+            </Card>
           </Grid>
-        </form>
-      </Paper>
+
+          <Grid size={{ xs: 12, md: 4 }}>
+            <Card sx={{ height: '100%' }}>
+              <CardContent sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+                <Controller
+                  name="notes"
+                  control={control}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      value={field.value || ''}
+                      fullWidth
+                      multiline
+                      rows={6}
+                      size="small"
+                      label="Notes"
+                      error={!!errors.notes}
+                      helperText={errors.notes?.message}
+                      sx={{ mb: 2, ...fieldSx }}
+                    />
+                  )}
+                />
+
+                <Box sx={{ mt: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
+                  <Button
+                    variant="outlined"
+                    fullWidth
+                    onClick={() => navigate('/purchasing/suppliers')}
+                    disabled={isSaving}
+                  >
+                    Cancel
+                  </Button>
+
+                  <Button
+                    type="submit"
+                    variant="contained"
+                    fullWidth
+                    disabled={isSaving || isCheckingDuplicate || hasCompanyNameDuplicate}
+                  >
+                    {isSaving
+                      ? (isEdit ? 'Updating...' : 'Creating...')
+                      : (isEdit ? 'Update Supplier' : 'Create Supplier')}
+                  </Button>
+                </Box>
+              </CardContent>
+            </Card>
+          </Grid>
+        </Grid>
+      </form>
     </>
   )
 }

--- a/frontend/src/pages/purchasing/__tests__/SupplierFormPage.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/SupplierFormPage.test.tsx
@@ -1,0 +1,237 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+import SupplierFormPage from '../SupplierFormPage'
+import purchasingReducer from '@/store/slices/purchasingSlice'
+
+const {
+  mockNavigate,
+  mockCreateSupplier,
+  mockUpdateSupplier,
+  mockShowSuccess,
+  mockShowError,
+  mockApiGet,
+  mockCheckDuplicate,
+} = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockCreateSupplier: vi.fn(),
+  mockUpdateSupplier: vi.fn(),
+  mockShowSuccess: vi.fn(),
+  mockShowError: vi.fn(),
+  mockApiGet: vi.fn(),
+  mockCheckDuplicate: vi.fn(),
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('@/store/api/purchasingApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store/api/purchasingApi')>()
+  return {
+    ...actual,
+    useCreateSupplierMutation: vi.fn(() => [mockCreateSupplier, { isLoading: false }]),
+    useUpdateSupplierMutation: vi.fn(() => [mockUpdateSupplier, { isLoading: false }]),
+    useLazyCheckDuplicateCompanyNameQuery: vi.fn(() => [mockCheckDuplicate]),
+  }
+})
+
+vi.mock('@/hooks/useNotification', () => ({
+  useNotification: () => ({ showSuccess: mockShowSuccess, showError: mockShowError }),
+}))
+
+vi.mock('@/services/api', () => ({
+  default: { get: mockApiGet },
+}))
+
+function renderCreatePage() {
+  const store = configureStore({ reducer: { purchasing: purchasingReducer } })
+
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/purchasing/suppliers/create']}>
+        <Routes>
+          <Route path="/purchasing/suppliers/create" element={<SupplierFormPage />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+function renderEditPage(supplierId = 'sup-1') {
+  const store = configureStore({ reducer: { purchasing: purchasingReducer } })
+
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[`/purchasing/suppliers/${supplierId}/edit`]}>
+        <Routes>
+          <Route path="/purchasing/suppliers/:id/edit" element={<SupplierFormPage />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('SupplierFormPage - Create mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateSupplier.mockReturnValue({ unwrap: vi.fn().mockResolvedValue({ id: 'new-sup' }) })
+    mockUpdateSupplier.mockReturnValue({ unwrap: vi.fn().mockResolvedValue({ id: 'sup-1' }) })
+    mockCheckDuplicate.mockReturnValue({ unwrap: vi.fn().mockResolvedValue({ exists: false }) })
+  })
+
+  it('renders empty form with New Supplier heading', () => {
+    renderCreatePage()
+
+    expect(screen.getByText('New Supplier')).toBeInTheDocument()
+    expect(screen.getByLabelText(/company name/i)).toHaveValue('')
+  })
+
+  it('shows validation error when company name is empty on submit', async () => {
+    const user = userEvent.setup()
+    renderCreatePage()
+
+    await user.click(screen.getByRole('button', { name: /create/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Company name is required')).toBeInTheDocument()
+    })
+    expect(mockCreateSupplier).not.toHaveBeenCalled()
+  })
+
+  it('calls createSupplier and navigates on successful submit', async () => {
+    const user = userEvent.setup()
+    renderCreatePage()
+
+    await user.type(screen.getByLabelText(/company name/i), 'Acme Supplies')
+    await user.click(screen.getByRole('button', { name: /create/i }))
+
+    await waitFor(() => {
+      expect(mockCreateSupplier).toHaveBeenCalledWith(
+        expect.objectContaining({ companyName: 'Acme Supplies' }),
+      )
+    })
+    expect(mockNavigate).toHaveBeenCalledWith('/purchasing/suppliers')
+  })
+
+  it('navigates back on Cancel click', async () => {
+    const user = userEvent.setup()
+    renderCreatePage()
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+
+    expect(mockNavigate).toHaveBeenCalledWith('/purchasing/suppliers')
+  })
+})
+
+describe('SupplierFormPage - Edit mode', () => {
+  const mockSupplier = {
+    id: 'sup-1',
+    companyName: 'Global Parts Ltd',
+    type: 'local',
+    contactPerson: 'Jane Smith',
+    phone: '555-1234',
+    streetAddress: null,
+    city: null,
+    state: null,
+    postalCode: null,
+    country: null,
+    notes: null,
+    isActive: true,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateSupplier.mockReturnValue({ unwrap: vi.fn().mockResolvedValue({ id: 'new-sup' }) })
+    mockUpdateSupplier.mockReturnValue({ unwrap: vi.fn().mockResolvedValue({ id: 'sup-1' }) })
+    mockCheckDuplicate.mockReturnValue({ unwrap: vi.fn().mockResolvedValue({ exists: false }) })
+    mockApiGet.mockImplementation((url: string) => {
+      if (url === '/purchasing/suppliers/sup-1') {
+        return Promise.resolve({ data: { data: mockSupplier } })
+      }
+
+      return Promise.resolve({ data: { data: [] } })
+    })
+  })
+
+  it('shows Edit Supplier heading and pre-populates company name', async () => {
+    renderEditPage('sup-1')
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit Supplier')).toBeInTheDocument()
+    })
+    expect(screen.getByLabelText(/company name/i)).toHaveValue('Global Parts Ltd')
+  })
+
+  it('calls updateSupplier and navigates on successful submit', async () => {
+    const user = userEvent.setup()
+    renderEditPage('sup-1')
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/company name/i)).toHaveValue('Global Parts Ltd')
+    })
+
+    await user.clear(screen.getByLabelText(/company name/i))
+    await user.type(screen.getByLabelText(/company name/i), 'Global Parts Updated')
+    await user.click(screen.getByRole('button', { name: /update/i }))
+
+    await waitFor(() => {
+      expect(mockUpdateSupplier).toHaveBeenCalledWith({
+        id: 'sup-1',
+        data: expect.objectContaining({ companyName: 'Global Parts Updated' }),
+      })
+    })
+    expect(mockNavigate).toHaveBeenCalledWith('/purchasing/suppliers')
+  })
+})
+
+describe('SupplierFormPage - company name duplicate check', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateSupplier.mockReturnValue({ unwrap: vi.fn().mockResolvedValue({ id: 'new-sup' }) })
+  })
+
+  it('shows duplicate error when company name already exists', async () => {
+    mockCheckDuplicate.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({ exists: true, message: 'Company name already exists' }),
+    })
+
+    vi.useFakeTimers()
+    renderCreatePage()
+    fireEvent.change(screen.getByLabelText(/company name/i), { target: { value: 'Taken Corp' } })
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText('Company name already exists')).toBeInTheDocument()
+    vi.useRealTimers()
+  })
+
+  it('shows available message when company name is free', async () => {
+    mockCheckDuplicate.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({ exists: false }),
+    })
+
+    vi.useFakeTimers()
+    renderCreatePage()
+    fireEvent.change(screen.getByLabelText(/company name/i), { target: { value: 'New Corp' } })
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText('✓ Available')).toBeInTheDocument()
+    vi.useRealTimers()
+  })
+})

--- a/frontend/src/pages/sales/CustomerFormPage.tsx
+++ b/frontend/src/pages/sales/CustomerFormPage.tsx
@@ -1,7 +1,10 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import {
+  Alert,
   Box,
   Button,
+  Card,
+  CardContent,
   CircularProgress,
   FormControl,
   Grid,
@@ -11,24 +14,24 @@ import {
   Select,
   TextField,
   Typography,
-  Paper,
-  Alert,
 } from '@mui/material'
 import { useNavigate, useParams } from 'react-router-dom'
-import { useForm, Controller, type Control, type FieldErrors } from 'react-hook-form'
+import { Controller, useForm } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
+
+import AddressSection from '@/components/common/AddressSection'
+import PageHeader from '@/components/common/PageHeader'
+import PriceListSelector from '@/components/price-lists/PriceListSelector'
+import { useFieldDuplicateCheck } from '@/hooks/useFieldDuplicateCheck'
 import { useNotification } from '@/hooks/useNotification'
+import api from '@/services/api'
 import {
   useCreateCustomerMutation,
   useUpdateCustomerMutation,
 } from '@/store/api/salesApi'
 import type { Customer } from '@/types'
 import { CustomerType } from '@/types'
-import api from '@/services/api'
-import PriceListSelector from '@/components/price-lists/PriceListSelector'
-import AddressSection from '@/components/common/AddressSection'
-import PageHeader from '@/components/common/PageHeader'
 
 const customerSchema = yup.object({
   name: yup.string().required('Name is required').max(200, 'Name must be less than 200 characters'),
@@ -56,29 +59,10 @@ interface CustomerFormData {
   notes?: string | null
 }
 
-
-interface CustomerFormActionsProps {
-  disabled: boolean
-  isEdit: boolean
-  isSaving: boolean
-  onCancel: () => void
+const fieldSx = {
+  '& .MuiInputBase-input': { fontSize: '0.875rem' },
+  '& .MuiInputLabel-root': { fontSize: '0.875rem' },
 }
-
-const CustomerFormActions: React.FC<CustomerFormActionsProps> = ({
-  disabled,
-  isEdit,
-  isSaving,
-  onCancel,
-}) => (
-  <Grid size={12}>
-    <Box sx={{ display: 'flex', gap: 2, justifyContent: 'flex-end', pt: 1 }}>
-      <Button onClick={onCancel}>Cancel</Button>
-      <Button type="submit" variant="contained" disabled={disabled}>
-        {isSaving ? <CircularProgress size={20} /> : (isEdit ? 'Update' : 'Create')}
-      </Button>
-    </Box>
-  </Grid>
-)
 
 const CustomerFormPage: React.FC = () => {
   const { id } = useParams<{ id: string }>()
@@ -89,101 +73,100 @@ const CustomerFormPage: React.FC = () => {
   const [customer, setCustomer] = useState<Customer | null>(null)
   const [loadingCustomer, setLoadingCustomer] = useState(isEdit)
   const [loadError, setLoadError] = useState<string | null>(null)
-  const [isCheckingPhone, setIsCheckingPhone] = useState(false)
-  const [phoneError, setPhoneError] = useState<string | null>(null)
 
   const [createCustomer, { isLoading: isCreating }] = useCreateCustomerMutation()
   const [updateCustomer, { isLoading: isUpdating }] = useUpdateCustomerMutation()
   const isSaving = isCreating || isUpdating
 
-  const { control, handleSubmit, reset, formState: { errors } } = useForm<CustomerFormData>({
+  const { control, handleSubmit, reset, watch, formState: { errors } } = useForm<CustomerFormData>({
     resolver: yupResolver(customerSchema) as any,
     defaultValues: {
       name: '',
       type: CustomerType.BUSINESS,
-      priceListId: null,
       phone: null,
       streetAddress: null,
       city: null,
       state: null,
       postalCode: null,
       country: null,
+      priceListId: null,
       notes: null,
     },
   })
 
+  const watchedPhone = watch('phone')
+
   useEffect(() => {
-    if (!id) return
+    if (!id) {
+      return
+    }
+
     setLoadingCustomer(true)
+
     api.get(`/customers/${id}`)
       .then((res) => {
-        const c: Customer = res.data?.data ?? res.data
-        setCustomer(c)
+        const currentCustomer: Customer = res.data?.data ?? res.data
+        setCustomer(currentCustomer)
         reset({
-          name: c.name,
-          type: c.type,
-          priceListId: c.priceListId || null,
-          phone: c.phone || null,
-          streetAddress: c.streetAddress || null,
-          city: c.city || null,
-          state: c.state || null,
-          postalCode: c.postalCode || null,
-          country: c.country || null,
-          notes: c.notes || null,
+          name: currentCustomer.name,
+          type: currentCustomer.type,
+          phone: currentCustomer.phone || null,
+          streetAddress: currentCustomer.streetAddress || null,
+          city: currentCustomer.city || null,
+          state: currentCustomer.state || null,
+          postalCode: currentCustomer.postalCode || null,
+          country: currentCustomer.country || null,
+          priceListId: currentCustomer.priceListId || null,
+          notes: currentCustomer.notes || null,
         })
-
       })
       .catch(() => setLoadError('Customer not found.'))
       .finally(() => setLoadingCustomer(false))
   }, [id, reset])
 
-  const checkPhoneDuplicate = useCallback(async (phone: string) => {
-    if (!phone || phone.trim().length === 0) {
-      setPhoneError(null)
-      return
-    }
+  const phoneCheckFn = useCallback(async (phone: string, excludeId?: string) => {
     const normalizedPhone = phone.replace(/[\s\-\(\)\+]/g, '')
-    if (normalizedPhone.length === 0) {
-      setPhoneError(null)
-      return
-    }
-    setIsCheckingPhone(true)
-    setPhoneError(null)
-    try {
-      const [activeResponse, deletedResponse] = await Promise.all([
-        api.get('/customers', { params: { search: phone } }),
-        api.get('/customers/deleted', { params: { search: phone } }),
-      ])
-      const allCustomers = [
-        ...(activeResponse.data?.data || []),
-        ...(deletedResponse.data?.data || []),
-      ]
-      if (allCustomers.length > 0) {
-        const duplicateCustomer = allCustomers.find((c: Customer) => {
-          if (!c.phone) return false
-          const existing = c.phone.replace(/[\s\-\(\)\+]/g, '')
-          return existing === normalizedPhone && (!customer || c.id !== customer.id)
-        })
-        if (duplicateCustomer) {
-          setPhoneError(`Phone number already exists for customer: ${duplicateCustomer.name}`)
-        }
+    const [activeResponse, deletedResponse] = await Promise.all([
+      api.get('/customers', { params: { search: phone } }),
+      api.get('/customers/deleted', { params: { search: phone } }),
+    ])
+    const allCustomers = [
+      ...(activeResponse.data?.data || []),
+      ...(deletedResponse.data?.data || []),
+    ]
+    const duplicateCustomer = allCustomers.find((current: Customer) => {
+      if (!current.phone) {
+        return false
       }
-    } catch {
-      // ignore duplicate check errors
-    } finally {
-      setIsCheckingPhone(false)
-    }
-  }, [customer])
 
-  const debouncedPhoneCheck = useMemo(() => {
-    let timeoutId: ReturnType<typeof setTimeout>
-    return (phone: string) => {
-      clearTimeout(timeoutId)
-      timeoutId = setTimeout(() => checkPhoneDuplicate(phone), 500)
+      return current.phone.replace(/[\s\-\(\)\+]/g, '') === normalizedPhone && current.id !== excludeId
+    })
+
+    return {
+      exists: !!duplicateCustomer,
+      message: duplicateCustomer
+        ? `Phone already exists for customer: ${duplicateCustomer.name}`
+        : undefined,
     }
-  }, [checkPhoneDuplicate])
+  }, [])
+
+  const {
+    isChecking: isCheckingPhone,
+    hasDuplicate: hasPhoneDuplicate,
+    hasChecked: hasCheckedPhone,
+    error: phoneError,
+    successMessage: phoneSuccess,
+  } = useFieldDuplicateCheck(watchedPhone ?? '', phoneCheckFn, {
+    excludeId: customer?.id,
+    skipCheck: !watchedPhone,
+  })
 
   const handleFormSubmit = async (data: CustomerFormData) => {
+    if (hasPhoneDuplicate) {
+      showError(phoneError ?? 'Phone number already exists')
+      return
+    }
+
     const cleanedData = {
       ...data,
       phone: data.phone?.trim() || null,
@@ -194,6 +177,7 @@ const CustomerFormPage: React.FC = () => {
       country: data.country?.trim() || null,
       notes: data.notes?.trim() || null,
     }
+
     try {
       if (isEdit && id) {
         await updateCustomer({ id, data: cleanedData }).unwrap()
@@ -202,6 +186,7 @@ const CustomerFormPage: React.FC = () => {
         await createCustomer(cleanedData).unwrap()
         showSuccess('Customer created successfully')
       }
+
       navigate('/sales/customers')
     } catch (error) {
       showError(`Failed to ${isEdit ? 'update' : 'create'} customer: ${error}`)
@@ -225,114 +210,160 @@ const CustomerFormPage: React.FC = () => {
       <PageHeader
         title={isEdit ? 'Edit Customer' : 'New Customer'}
         subtitle={isEdit ? `Editing ${customer?.name ?? ''}` : 'Add a new customer to your account'}
-        variant="standard"
+        variant="workflow"
+        backAction={() => navigate('/sales/customers')}
       />
-      <Paper sx={{ p: 3, maxWidth: 800 }}>
-        <form onSubmit={handleSubmit(handleFormSubmit)}>
-          <Grid container spacing={2}>
-            <Grid size={12}>
-              <Typography variant="h6" gutterBottom>Basic Information</Typography>
-            </Grid>
 
-            <Grid size={{ xs: 12, md: 6 }}>
-              <Controller
-                name="type"
-                control={control}
-                render={({ field }) => (
-                  <FormControl fullWidth error={!!errors.type}>
-                    <InputLabel>Customer Type</InputLabel>
-                    <Select {...field} label="Customer Type">
-                      <MenuItem value={CustomerType.INDIVIDUAL}>Individual</MenuItem>
-                      <MenuItem value={CustomerType.BUSINESS}>Business</MenuItem>
-                    </Select>
-                  </FormControl>
-                )}
-              />
-            </Grid>
+      <form onSubmit={handleSubmit(handleFormSubmit)}>
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: 8 }}>
+            <Card>
+              <CardContent>
+                <Typography variant="h6" gutterBottom>Basic Information</Typography>
 
-            <Grid size={{ xs: 12, md: 6 }}>
-              <Controller
-                name="priceListId"
-                control={control}
-                render={({ field }) => (
-                  <PriceListSelector
-                    value={field.value}
-                    onChange={(value) => field.onChange(value)}
-                    error={errors.priceListId?.message}
-                    label="Price List"
-                  />
-                )}
-              />
-            </Grid>
+                <Grid container spacing={2}>
+                  <Grid size={{ xs: 12, md: 6 }}>
+                    <Controller
+                      name="type"
+                      control={control}
+                      render={({ field }) => (
+                        <FormControl fullWidth size="small" error={!!errors.type} sx={fieldSx}>
+                          <InputLabel>Customer Type</InputLabel>
+                          <Select {...field} label="Customer Type">
+                            <MenuItem value={CustomerType.INDIVIDUAL}>Individual</MenuItem>
+                            <MenuItem value={CustomerType.BUSINESS}>Business</MenuItem>
+                          </Select>
+                        </FormControl>
+                      )}
+                    />
+                  </Grid>
 
-            <Grid size={12}>
-              <Controller
-                name="name"
-                control={control}
-                render={({ field }) => (
-                  <TextField
-                    {...field}
-                    fullWidth
-                    label="Customer Name"
-                    error={!!errors.name}
-                    helperText={errors.name?.message}
-                  />
-                )}
-              />
-            </Grid>
+                  <Grid size={12}>
+                    <Controller
+                      name="name"
+                      control={control}
+                      render={({ field }) => (
+                        <TextField
+                          {...field}
+                          fullWidth
+                          size="small"
+                          label="Customer Name"
+                          error={!!errors.name}
+                          helperText={errors.name?.message}
+                          sx={fieldSx}
+                        />
+                      )}
+                    />
+                  </Grid>
 
-            <Grid size={{ xs: 12, md: 6 }}>
-              <Controller
-                name="phone"
-                control={control}
-                render={({ field }) => (
-                  <TextField
-                    {...field}
-                    value={field.value || ''}
-                    fullWidth
-                    label="Phone"
-                    error={!!errors.phone || !!phoneError}
-                    helperText={errors.phone?.message || phoneError}
-                    onChange={(e) => {
-                      field.onChange(e)
-                      debouncedPhoneCheck(e.target.value)
-                    }}
-                    slotProps={{
-                      input: {
-                        endAdornment: isCheckingPhone ? (
-                          <InputAdornment position="end">
-                            <CircularProgress size={20} />
-                          </InputAdornment>
-                        ) : undefined,
-                      },
-                    }}
-                  />
-                )}
-              />
-            </Grid>
+                  <Grid size={{ xs: 12, md: 6 }}>
+                    <Controller
+                      name="phone"
+                      control={control}
+                      render={({ field }) => (
+                        <TextField
+                          {...field}
+                          value={field.value || ''}
+                          fullWidth
+                          size="small"
+                          label="Phone"
+                          error={!!errors.phone || hasPhoneDuplicate}
+                          helperText={
+                            errors.phone?.message
+                            || phoneError
+                            || (hasCheckedPhone && !hasPhoneDuplicate ? phoneSuccess : '')
+                          }
+                          slotProps={{
+                            input: {
+                              endAdornment: isCheckingPhone ? (
+                                <InputAdornment position="end">
+                                  <CircularProgress size={16} />
+                                </InputAdornment>
+                              ) : undefined,
+                            },
+                          }}
+                          sx={{
+                            ...fieldSx,
+                            '& .MuiFormHelperText-root': {
+                              color: hasPhoneDuplicate
+                                ? 'error.main'
+                                : hasCheckedPhone && !hasPhoneDuplicate
+                                  ? 'success.main'
+                                  : undefined,
+                            },
+                          }}
+                        />
+                      )}
+                    />
+                  </Grid>
 
-            <AddressSection control={control} errors={errors} />
-
-            <Grid size={12}>
-              <Controller
-                name="notes"
-                control={control}
-                render={({ field }) => (
-                  <TextField {...field} value={field.value || ''} fullWidth multiline rows={3}
-                    label="Notes" error={!!errors.notes} helperText={errors.notes?.message} />
-                )}
-              />
-            </Grid>
-
-            <CustomerFormActions
-              disabled={isSaving || !!phoneError || isCheckingPhone}
-              isEdit={isEdit}
-              isSaving={isSaving}
-              onCancel={() => navigate('/sales/customers')}
-            />
+                  <AddressSection control={control} errors={errors} />
+                </Grid>
+              </CardContent>
+            </Card>
           </Grid>
-        </form>
-      </Paper>
+
+          <Grid size={{ xs: 12, md: 4 }}>
+            <Card sx={{ height: '100%' }}>
+              <CardContent sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+                <Controller
+                  name="priceListId"
+                  control={control}
+                  render={({ field }) => (
+                    <PriceListSelector
+                      value={field.value}
+                      onChange={(value) => field.onChange(value)}
+                      error={errors.priceListId?.message}
+                      label="Price List"
+                    />
+                  )}
+                />
+
+                <Controller
+                  name="notes"
+                  control={control}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      value={field.value || ''}
+                      fullWidth
+                      multiline
+                      rows={6}
+                      size="small"
+                      label="Notes"
+                      error={!!errors.notes}
+                      helperText={errors.notes?.message}
+                      sx={{ mt: 2, mb: 2, ...fieldSx }}
+                    />
+                  )}
+                />
+
+                <Box sx={{ mt: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
+                  <Button
+                    variant="outlined"
+                    fullWidth
+                    onClick={() => navigate('/sales/customers')}
+                    disabled={isSaving}
+                  >
+                    Cancel
+                  </Button>
+
+                  <Button
+                    type="submit"
+                    variant="contained"
+                    fullWidth
+                    disabled={isSaving || hasPhoneDuplicate || isCheckingPhone}
+                  >
+                    {isSaving
+                      ? (isEdit ? 'Updating...' : 'Creating...')
+                      : (isEdit ? 'Update Customer' : 'Create Customer')}
+                  </Button>
+                </Box>
+              </CardContent>
+            </Card>
+          </Grid>
+        </Grid>
+      </form>
     </>
   )
 }

--- a/frontend/src/pages/sales/__tests__/CustomerFormPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CustomerFormPage.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
@@ -195,5 +195,54 @@ describe('CustomerFormPage - Edit mode', () => {
       })
     })
     expect(mockNavigate).toHaveBeenCalledWith('/sales/customers')
+  })
+})
+
+describe('CustomerFormPage - phone duplicate check', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateCustomer.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({ id: 'new-cust' }),
+    })
+  })
+
+  it('shows phone duplicate error when a matching customer exists', async () => {
+    mockApiGet.mockImplementation((url: string) => {
+      if (url === '/customers') {
+        return Promise.resolve({
+          data: { data: [{ id: 'other-cust', name: 'Existing Corp', phone: '555-9999' }] },
+        })
+      }
+
+      return Promise.resolve({ data: { data: [] } })
+    })
+
+    vi.useFakeTimers()
+    renderCreatePage()
+    fireEvent.change(screen.getByLabelText(/phone/i), { target: { value: '555-9999' } })
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText(/phone already exists for customer: existing corp/i)).toBeInTheDocument()
+    vi.useRealTimers()
+  })
+
+  it('shows available message when phone has no match', async () => {
+    mockApiGet.mockResolvedValue({ data: { data: [] } })
+
+    vi.useFakeTimers()
+    renderCreatePage()
+    fireEvent.change(screen.getByLabelText(/phone/i), { target: { value: '555-1234' } })
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText('✓ Available')).toBeInTheDocument()
+    vi.useRealTimers()
   })
 })


### PR DESCRIPTION
## Summary

- Adds generic `useFieldDuplicateCheck` hook with internal debounce, replacing duplicated inline debounce logic across 4 forms
- Refactors `useDuplicateCheck` and `useCategoryDuplicateCheck` as thin wrappers over the new hook
- Removes inline debounce `useEffect` from `CreateProductPage` and `CategoryDialogs`
- Rewrites `CustomerFormPage` and `SupplierFormPage` with `variant='workflow'` PageHeader, 8/4 card layout, `size='small'` density, side-card actions, and `✓ Available` success feedback on duplicate-check fields
- Adds `SupplierFormPage.test.tsx` (new) and extends `CustomerFormPage.test.tsx`

Closes #389

## Test plan

- [x] `useFieldDuplicateCheck` unit tests pass (10 tests)
- [x] `CreateProductPage` tests pass (no regressions)
- [x] Inventory `CategoryDialogs` tests pass (no regressions)
- [x] `CustomerFormPage` tests pass including new phone duplicate tests (8 tests)
- [x] `SupplierFormPage` tests pass including new company name duplicate tests (8 tests)
- [x] TypeScript check passes
- [x] Lint passes
- [x] Manually verify Customer form: workflow header, card layout, phone `✓ Available` feedback
- [x] Manually verify Supplier form: workflow header, card layout, company name `✓ Available` feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)