### PR TITLE
fix: GRN numbering now uses Document Numbers settings (issue #391)

### DIFF
--- a/backend/src/modules/purchasing/services/goods-received-note.service.spec.ts
+++ b/backend/src/modules/purchasing/services/goods-received-note.service.spec.ts
@@ -356,6 +356,39 @@ describe('GoodsReceivedNoteService', () => {
       // Verify accounting entry was posted
       expect(accountingService.postGoodsReceivedEntry).toHaveBeenCalled();
     });
+
+    it('should use the document number returned by settingsService', async () => {
+      const fullGrn = {
+        ...mockGrn,
+        supplier: mockPurchaseOrder.supplier,
+        purchaseOrder: mockPurchaseOrder,
+      } as GoodsReceivedNote;
+
+      grnRepository.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(fullGrn)
+        .mockResolvedValueOnce(fullGrn);
+
+      settingsService.generateDocumentNumber.mockResolvedValue('GRN-26-007');
+      grnRepository.create.mockReturnValue({ ...mockGrn, grnNumber: 'GRN-26-007' } as GoodsReceivedNote);
+
+      await service.create(createDto);
+
+      expect(settingsService.generateDocumentNumber).toHaveBeenCalledWith('Goods Received');
+      expect(grnRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ grnNumber: 'GRN-26-007' }),
+      );
+    });
+
+    it('should throw BadRequestException when settingsService.generateDocumentNumber fails', async () => {
+      grnRepository.findOne.mockResolvedValueOnce(null);
+      settingsService.generateDocumentNumber.mockRejectedValue(
+        new Error("Document number config for 'Goods Received' not found"),
+      );
+
+      await expect(service.create(createDto)).rejects.toThrow('Failed to create goods received note');
+      expect(grnRepository.save).not.toHaveBeenCalled();
+    });
   });
 
   describe('findAll', () => {

--- a/backend/src/modules/purchasing/services/goods-received-note.service.ts
+++ b/backend/src/modules/purchasing/services/goods-received-note.service.ts
@@ -66,42 +66,6 @@ export class GoodsReceivedNoteService extends BaseCrudService<
   }
 
   /**
-   * Generate sequential GRN number in format GRN-000001
-   * Checks both active and soft-deleted GRNs to ensure unique numbering
-   */
-  private async generateSequentialGrnNumber(): Promise<string> {
-    // Use document number settings to generate GRN number
-    try {
-      const grnNumber = await this.settingsService.generateDocumentNumber('Goods Received');
-      this.logger.log(`Generated GRN number: ${grnNumber}`);
-      return grnNumber;
-    } catch (error) {
-      this.logger.error(`Error generating GRN number: ${error.message}`);
-      // Fallback to legacy method
-      const grns = await this.grnRepository.find({
-        select: ['grnNumber'],
-        withDeleted: true,
-      });
-
-      let maxNumber = 0;
-      for (const grn of grns) {
-        const match = grn.grnNumber.match(/^GRN-(\d+)$/);
-        if (match) {
-          const num = parseInt(match[1]);
-          if (num > maxNumber) {
-            maxNumber = num;
-          }
-        }
-      }
-
-      const nextNumber = maxNumber + 1;
-      const fallbackNumber = `GRN-${nextNumber.toString().padStart(6, '0')}`;
-      this.logger.log(`Fallback GRN number: ${fallbackNumber}`);
-      return fallbackNumber;
-    }
-  }
-
-  /**
    * Create a new goods received note
    */
   async create(
@@ -131,8 +95,7 @@ export class GoodsReceivedNoteService extends BaseCrudService<
     }
 
     try {
-      // Generate sequential GRN number
-      const grnNumber = await this.generateSequentialGrnNumber();
+      const grnNumber = await this.settingsService.generateDocumentNumber('Goods Received');
 
       // Create GRN entity first (without items)
       const grn = this.grnRepository.create({

--- a/backend/src/modules/purchasing/services/purchase-order.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.ts
@@ -1200,23 +1200,7 @@ export class PurchaseOrderService extends BaseCrudService<
     username?: string,
   ): Promise<void> {
     try {
-      // Generate sequential GRN number
-      const grns = await this.grnRepository.find({
-        select: ['grnNumber'],
-        withDeleted: true,
-      });
-
-      let maxNumber = 0;
-      for (const grn of grns) {
-        const match = grn.grnNumber.match(/^GRN-(\d+)$/);
-        if (match) {
-          const num = parseInt(match[1]);
-          if (num > maxNumber) {
-            maxNumber = num;
-          }
-        }
-      }
-      const grnNumber = `GRN-${(maxNumber + 1).toString().padStart(6, '0')}`;
+      const grnNumber = await this.settingsService.generateDocumentNumber('Goods Received');
 
       // Fetch full PO with relations for GRN creation
       const fullPO = await this.purchaseOrderRepository.findOne({

--- a/backend/src/modules/settings/settings.service.spec.ts
+++ b/backend/src/modules/settings/settings.service.spec.ts
@@ -1,0 +1,56 @@
+import { SettingsService } from './settings.service';
+
+describe('SettingsService', () => {
+  const createQueryBuilderMock = (result: unknown) => ({
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    getOne: jest.fn().mockResolvedValue(result),
+  });
+
+  it('syncDocumentNumbersWithDatabase uses the larger of current-year and legacy GRN sequences', async () => {
+    const documentNumberSettingRepository = {
+      find: jest.fn().mockResolvedValue([
+        { documentName: 'Goods Received', prefix: 'GRN' },
+      ]),
+      update: jest.fn().mockResolvedValue(undefined),
+    };
+    const currentYearQueryBuilder = createQueryBuilderMock({ grnNumber: 'GRN-26-007' });
+    const legacyQueryBuilder = createQueryBuilderMock({ grnNumber: 'GRN-123456' });
+    const goodsReceivedNoteRepository = {
+      createQueryBuilder: jest.fn()
+        .mockReturnValueOnce(currentYearQueryBuilder)
+        .mockReturnValueOnce(legacyQueryBuilder),
+    };
+
+    const service = new SettingsService(
+      {} as any,
+      {} as any,
+      documentNumberSettingRepository as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      goodsReceivedNoteRepository as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+
+    await service.syncDocumentNumbersWithDatabase();
+
+    expect(currentYearQueryBuilder.where).toHaveBeenCalledWith(
+      'grn.grnNumber LIKE :p',
+      { p: 'GRN-26-%' },
+    );
+    expect(legacyQueryBuilder.where).toHaveBeenCalledWith("grn.grnNumber ~ '^GRN-\\\\d+$'");
+    expect(documentNumberSettingRepository.update).toHaveBeenCalledWith(
+      { documentName: 'Goods Received' },
+      { nextNumber: 123457, lastResetYear: 26 },
+    );
+  });
+});

--- a/backend/src/modules/settings/settings.service.ts
+++ b/backend/src/modules/settings/settings.service.ts
@@ -580,6 +580,18 @@ export class SettingsService {
                 .limit(1)
                 .getOne();
               if (r?.grnNumber) maxNumber = parseInt(r.grnNumber.split('-')[2], 10) || 0;
+
+              const legacy = await this.goodsReceivedNoteRepository
+                .createQueryBuilder('grn')
+                .select('grn.grnNumber')
+                .where("grn.grnNumber ~ '^GRN-\\\\d+$'")
+                .orderBy('grn.grnNumber', 'DESC')
+                .limit(1)
+                .getOne();
+              if (legacy?.grnNumber) {
+                const legacyNum = parseInt(legacy.grnNumber.split('-')[1], 10) || 0;
+                maxNumber = Math.max(maxNumber, legacyNum);
+              }
               break;
             }
             case 'Vendor Payments': {


### PR DESCRIPTION
## Summary
- Removed legacy `GRN-XXXXXX` fallback from `GoodsReceivedNoteService` — misconfigured settings now surface as an error instead of silently producing wrong-format numbers
- Removed duplicate legacy GRN number generation from `PurchaseOrderService.createDraftGrn` — this was the root cause of numbers like `GRN-000005` being produced after the first fix
- Updated `syncDocumentNumbersWithDatabase` to scan legacy `GRN-XXXXXX` format numbers so `nextNumber` is set correctly when syncing

## Test Plan
- [x] Run Settings → Document Numbers → Sync to advance `nextNumber` past existing legacy GRNs
- [x] Create a new Purchase Order — the auto-created draft GRN should use `GRN-YY-NNN` format
- [x] Verify `cd backend && npx jest src/modules/purchasing/ --no-coverage` passes
- [x] Verify `cd backend && npx jest src/modules/settings/ --no-coverage` passes

Closes #391