### PR TITLE
feat(accounting): restore COA page visual polish and consistency (issue #397)

### DIFF
--- a/frontend/src/components/common/EntityTable.tsx
+++ b/frontend/src/components/common/EntityTable.tsx
@@ -17,6 +17,7 @@ export interface ColumnConfig<T> {
   key: string
   render: (row: T) => React.ReactNode
   width?: string | number
+  raw?: boolean
 }
 
 export interface EntityTableProps<T extends { id: string }> {
@@ -81,12 +82,16 @@ const EntityRow = memo(function EntityRow<T extends { id: string }>({
     >
       {columns.map((column) => (
         <TableCell key={column.key} width={column.width}>
-          <Typography
-            variant="body2"
-            sx={{ fontWeight: 400, fontSize: '0.8rem', lineHeight: 1.2 }}
-          >
-            {column.render(row)}
-          </Typography>
+          {column.raw
+            ? column.render(row)
+            : (
+                <Typography
+                  variant="body2"
+                  sx={{ fontWeight: 400, fontSize: '0.8rem', lineHeight: 1.2 }}
+                >
+                  {column.render(row)}
+                </Typography>
+              )}
         </TableCell>
       ))}
     </TableRow>

--- a/frontend/src/pages/accounting/ChartOfAccountsPage.tsx
+++ b/frontend/src/pages/accounting/ChartOfAccountsPage.tsx
@@ -66,7 +66,7 @@ const ChartOfAccountsPage: React.FC = () => {
       <AccountMappingWarning context="system" />
       <GenericListPage
         title="Chart of Accounts"
-        subtitle={`Manage your accounting structure and account hierarchy (${filteredAccounts.length} total)`}
+        subtitle={`Manage your accounting structure and account hierarchy (${appliedFilters.search ? `${filteredAccounts.length} of ${accounts.length}` : `${accounts.length} total`})`}
         primaryAction={{
           label: 'Add Account',
           onClick: () => {

--- a/frontend/src/pages/accounting/ChartOfAccountsPage.tsx
+++ b/frontend/src/pages/accounting/ChartOfAccountsPage.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react'
 import AccountMappingWarning from '@/components/accounting/AccountMappingWarning'
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
-import { useGetChartOfAccountsQuery } from '@/store/api/accountingApi'
+import { useGetChartOfAccountsHierarchyQuery } from '@/store/api/accountingApi'
 import type { ChartOfAccount } from '@/types'
 import type { FilterBarConfig } from '@/types/filterBar.types'
 
@@ -13,23 +13,67 @@ import { ChartOfAccountsTable } from './components/ChartOfAccountsTable'
 import { ChartOfAccountWorkspaceCard } from './components/ChartOfAccountWorkspaceCard'
 import { useChartOfAccountsWorkspace } from './hooks/useChartOfAccountsWorkspace'
 
-interface CoaFilters { search: string }
-const filterConfig: FilterBarConfig<CoaFilters> = { search: { placeholder: 'Search by code or name...' }, fields: [], defaults: { search: '' } }
+interface CoaFilters {
+  search: string
+}
+
+const filterConfig: FilterBarConfig<CoaFilters> = {
+  search: { placeholder: 'Search by code or name...' },
+  fields: [],
+  defaults: { search: '' },
+}
 
 const ChartOfAccountsPage: React.FC = () => {
   const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
-  const { data: accountsResponse, isLoading, error, refetch } = useGetChartOfAccountsQuery({ page: 1, search: appliedFilters.search || undefined })
-  const accounts = (accountsResponse?.data ?? []) as ChartOfAccount[]
-  const workspace = useChartOfAccountsWorkspace(() => { void refetch() })
-  const filteredAccounts = useMemo(() => accounts, [accounts])
+  const { data: hierarchyData, isLoading, error, refetch } = useGetChartOfAccountsHierarchyQuery()
+  const workspace = useChartOfAccountsWorkspace(() => {
+    void refetch()
+  })
+
+  const accounts = useMemo(() => {
+    const result: ChartOfAccount[] = []
+
+    const walk = (nodes: ChartOfAccount[]) => {
+      for (const node of nodes) {
+        result.push(node)
+
+        if (node.children?.length) {
+          walk(node.children)
+        }
+      }
+    }
+
+    walk(hierarchyData ?? [])
+    return result
+  }, [hierarchyData])
+
+  const filteredAccounts = useMemo(
+    () =>
+      appliedFilters.search
+        ? accounts.filter((account) => {
+            const searchTerm = appliedFilters.search.toLowerCase()
+            return (
+              account.code.toLowerCase().includes(searchTerm) ||
+              account.name.toLowerCase().includes(searchTerm)
+            )
+          })
+        : accounts,
+    [accounts, appliedFilters.search],
+  )
 
   return (
     <>
       <AccountMappingWarning context="system" />
       <GenericListPage
         title="Chart of Accounts"
-        subtitle={`Manage your accounting structure and account hierarchy (${accountsResponse?.meta?.total || 0} total)`}
-        primaryAction={{ label: 'Add Account', onClick: () => { workspace.setSelected(null); workspace.setFormDialogOpen(true) } }}
+        subtitle={`Manage your accounting structure and account hierarchy (${filteredAccounts.length} total)`}
+        primaryAction={{
+          label: 'Add Account',
+          onClick: () => {
+            workspace.setSelected(null)
+            workspace.setFormDialogOpen(true)
+          },
+        }}
         secondaryAction={{ label: 'View Deleted', onClick: () => workspace.setDeletedDialogOpen(true) }}
         filterConfig={filterConfig}
         draftFilters={draftFilters}
@@ -38,10 +82,45 @@ const ChartOfAccountsPage: React.FC = () => {
         searchInputRef={workspace.searchInputRef}
         sort={{ field: 'code', sortBy: 'code', sortOrder: 'asc', onSort: () => {} }}
         error={(error as any)?.data ?? null}
-        listSlot={<ChartOfAccountsTable accounts={filteredAccounts} loading={isLoading} selectedId={workspace.selected?.id ?? null} onSelect={workspace.setSelected} listRef={workspace.listRef} />}
-        headerSlot={<ChartOfAccountContextHeader selected={workspace.selected} onEdit={() => workspace.setFormDialogOpen(true)} onDelete={() => workspace.selected && workspace.setDeleteTarget(workspace.selected)} />}
-        workspaceSlot={<ChartOfAccountWorkspaceCard selected={workspace.selected} allAccounts={accounts} />}
-        dialogs={<ChartOfAccountsDialogs formDialogOpen={workspace.formDialogOpen} selected={workspace.selected} onCloseForm={() => workspace.setFormDialogOpen(false)} onFormSuccess={() => { workspace.setFormDialogOpen(false); void refetch() }} deleteTarget={workspace.deleteTarget} onConfirmDelete={() => void workspace.handleDelete()} onCancelDelete={() => workspace.setDeleteTarget(null)} seedConfirmOpen={workspace.seedConfirmOpen} onConfirmSeed={() => void workspace.handleSeed()} onCancelSeed={() => workspace.setSeedConfirmOpen(false)} deletedDialogOpen={workspace.deletedDialogOpen} onCloseDeletedDialog={() => workspace.setDeletedDialogOpen(false)} onChanged={() => void refetch()} />}
+        listSlot={
+          <ChartOfAccountsTable
+            accounts={filteredAccounts}
+            loading={isLoading}
+            selectedId={workspace.selected?.id ?? null}
+            onSelect={workspace.setSelected}
+            listRef={workspace.listRef}
+          />
+        }
+        headerSlot={
+          <ChartOfAccountContextHeader
+            selected={workspace.selected}
+            onEdit={() => workspace.setFormDialogOpen(true)}
+            onDelete={() => workspace.selected && workspace.setDeleteTarget(workspace.selected)}
+          />
+        }
+        workspaceSlot={
+          <ChartOfAccountWorkspaceCard selected={workspace.selected} allAccounts={accounts} />
+        }
+        dialogs={
+          <ChartOfAccountsDialogs
+            formDialogOpen={workspace.formDialogOpen}
+            selected={workspace.selected}
+            onCloseForm={() => workspace.setFormDialogOpen(false)}
+            onFormSuccess={() => {
+              workspace.setFormDialogOpen(false)
+              void refetch()
+            }}
+            deleteTarget={workspace.deleteTarget}
+            onConfirmDelete={() => void workspace.handleDelete()}
+            onCancelDelete={() => workspace.setDeleteTarget(null)}
+            seedConfirmOpen={workspace.seedConfirmOpen}
+            onConfirmSeed={() => void workspace.handleSeed()}
+            onCancelSeed={() => workspace.setSeedConfirmOpen(false)}
+            deletedDialogOpen={workspace.deletedDialogOpen}
+            onCloseDeletedDialog={() => workspace.setDeletedDialogOpen(false)}
+            onChanged={() => void refetch()}
+          />
+        }
       />
     </>
   )

--- a/frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter } from 'react-router-dom'
 import ChartOfAccountsPage from '../ChartOfAccountsPage'
 
 const mockedApi = vi.hoisted(() => ({
+  useGetChartOfAccountsHierarchyQuery: vi.fn(),
   useGetChartOfAccountsQuery: vi.fn(),
   useDeleteChartOfAccountMutation: vi.fn(),
   useSeedDefaultChartOfAccountsMutation: vi.fn(),
@@ -13,23 +14,87 @@ const mockedApi = vi.hoisted(() => ({
 }))
 
 vi.mock('@/store/api/accountingApi', () => mockedApi)
-vi.mock('@/hooks/useNotification', () => ({ useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }) }))
+vi.mock('@/hooks/useNotification', () => ({
+  useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
+}))
 vi.mock('@/components/accounting/AccountMappingWarning', () => ({ default: () => null }))
 vi.mock('@/components/accounting/DeletedAccountsDialog', () => ({ default: () => null }))
+
+const mockAccount = {
+  id: '1',
+  code: '1000',
+  name: 'Cash',
+  type: 'ASSET',
+  isActive: true,
+  fullCode: '1000',
+  isParent: false,
+  currentBalance: 0,
+  isCashEquivalent: false,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+}
 
 describe('ChartOfAccountsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockedApi.useGetChartOfAccountsQuery.mockReturnValue({ data: { data: [{ id: '1', code: '1000', name: 'Assets', type: 'asset', normalBalance: 'debit', isActive: true, isSystemAccount: false, currentBalance: 0, createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' }] }, isLoading: false, refetch: vi.fn() })
+    mockedApi.useGetChartOfAccountsHierarchyQuery.mockReturnValue({
+      data: [mockAccount],
+      isLoading: false,
+      refetch: vi.fn(),
+    })
+    mockedApi.useGetChartOfAccountsQuery.mockReturnValue({
+      data: { data: [mockAccount] },
+      isLoading: false,
+      refetch: vi.fn(),
+    })
     mockedApi.useDeleteChartOfAccountMutation.mockReturnValue([vi.fn()])
     mockedApi.useSeedDefaultChartOfAccountsMutation.mockReturnValue([vi.fn()])
     mockedApi.useCreateChartOfAccountMutation.mockReturnValue([vi.fn()])
     mockedApi.useUpdateChartOfAccountMutation.mockReturnValue([vi.fn()])
   })
 
-  it('renders header and row', () => {
-    render(<BrowserRouter><ChartOfAccountsPage /></BrowserRouter>)
+  it('renders page title', () => {
+    render(
+      <BrowserRouter>
+        <ChartOfAccountsPage />
+      </BrowserRouter>,
+    )
+
     expect(screen.getByText('Chart of Accounts')).toBeInTheDocument()
+  })
+
+  it('renders account code from hierarchy data', () => {
+    render(
+      <BrowserRouter>
+        <ChartOfAccountsPage />
+      </BrowserRouter>,
+    )
+
     expect(screen.getByText('1000')).toBeInTheDocument()
+  })
+
+  it('flattens nested children into table', () => {
+    const parent = {
+      ...mockAccount,
+      id: '1',
+      code: '1000',
+      name: 'Cash',
+      children: [{ ...mockAccount, id: '2', code: '1010', name: 'CIMB', children: [] }],
+    }
+
+    mockedApi.useGetChartOfAccountsHierarchyQuery.mockReturnValue({
+      data: [parent],
+      isLoading: false,
+      refetch: vi.fn(),
+    })
+
+    render(
+      <BrowserRouter>
+        <ChartOfAccountsPage />
+      </BrowserRouter>,
+    )
+
+    expect(screen.getByText('1000')).toBeInTheDocument()
+    expect(screen.getByText('1010')).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx
@@ -42,11 +42,7 @@ describe('ChartOfAccountsPage', () => {
       isLoading: false,
       refetch: vi.fn(),
     })
-    mockedApi.useGetChartOfAccountsQuery.mockReturnValue({
-      data: { data: [mockAccount] },
-      isLoading: false,
-      refetch: vi.fn(),
-    })
+    mockedApi.useGetChartOfAccountsQuery.mockReturnValue({ data: { data: [] }, isLoading: false, refetch: vi.fn() })
     mockedApi.useDeleteChartOfAccountMutation.mockReturnValue([vi.fn()])
     mockedApi.useSeedDefaultChartOfAccountsMutation.mockReturnValue([vi.fn()])
     mockedApi.useCreateChartOfAccountMutation.mockReturnValue([vi.fn()])

--- a/frontend/src/pages/accounting/components/ChartOfAccountContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/ChartOfAccountContextHeader.tsx
@@ -4,20 +4,14 @@ import { Box, Chip, Paper, Stack, Typography } from '@mui/material'
 
 import { AppButton } from '@/components/common/AppButton'
 import { TABLE_STYLES } from '@/constants/tableStyles'
-import type { AccountType, ChartOfAccount } from '@/types'
+import type { ChartOfAccount } from '@/types'
+
+import { ACCOUNT_TYPE_COLORS } from '../utils/accountTypeColors'
 
 interface Props {
   selected: ChartOfAccount | null
   onEdit: () => void
   onDelete: () => void
-}
-
-const TYPE_COLORS: Record<AccountType, 'success' | 'error' | 'primary' | 'info' | 'warning'> = {
-  ASSET: 'success',
-  LIABILITY: 'error',
-  EQUITY: 'primary',
-  REVENUE: 'info',
-  EXPENSE: 'warning',
 }
 
 export function ChartOfAccountContextHeader({ selected, onEdit, onDelete }: Props) {
@@ -52,7 +46,7 @@ export function ChartOfAccountContextHeader({ selected, onEdit, onDelete }: Prop
           <Chip
             size="small"
             label={selected.type.charAt(0) + selected.type.slice(1).toLowerCase()}
-            color={TYPE_COLORS[selected.type]}
+            color={ACCOUNT_TYPE_COLORS[selected.type]}
             variant="outlined"
           />
         </Stack>

--- a/frontend/src/pages/accounting/components/ChartOfAccountContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/ChartOfAccountContextHeader.tsx
@@ -1,9 +1,10 @@
-import { Box, Chip, Paper, Stack, Typography } from '@mui/material'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as EditIcon } from '@mui/icons-material/Edit'
+import { Box, Chip, Paper, Stack, Typography } from '@mui/material'
 
 import { AppButton } from '@/components/common/AppButton'
-import type { ChartOfAccount } from '@/types'
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { AccountType, ChartOfAccount } from '@/types'
 
 interface Props {
   selected: ChartOfAccount | null
@@ -11,19 +12,57 @@ interface Props {
   onDelete: () => void
 }
 
+const TYPE_COLORS: Record<AccountType, 'success' | 'error' | 'primary' | 'info' | 'warning'> = {
+  ASSET: 'success',
+  LIABILITY: 'error',
+  EQUITY: 'primary',
+  REVENUE: 'info',
+  EXPENSE: 'warning',
+}
+
 export function ChartOfAccountContextHeader({ selected, onEdit, onDelete }: Props) {
-  if (!selected) return <Paper sx={{ p: 2 }}><Typography variant="body2" color="text.secondary">Select an account to view details</Typography></Paper>
+  if (!selected) {
+    return (
+      <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
+        <Typography variant="h6" sx={{ color: 'text.secondary' }}>
+          Select an account to view details
+        </Typography>
+      </Paper>
+    )
+  }
 
   return (
-    <Paper>
-      <Box sx={{ px: 2, py: 1.5, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+    <Paper sx={{ overflow: 'hidden' }}>
+      <Box
+        sx={{
+          p: TABLE_STYLES.cell.padding.px,
+          borderBottom: TABLE_STYLES.cell.border,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
         <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-          <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{selected.code} - {selected.name}</Typography>
-          <Chip size="small" label={selected.type} color="primary" variant="outlined" />
+          <Typography
+            variant="tableHeader"
+            sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+          >
+            {selected.code} - {selected.name}
+          </Typography>
+          <Chip
+            size="small"
+            label={selected.type.charAt(0) + selected.type.slice(1).toLowerCase()}
+            color={TYPE_COLORS[selected.type]}
+            variant="outlined"
+          />
         </Stack>
         <Stack direction="row" spacing={0.5}>
-          <AppButton size="small" variant="outlined" startIcon={<EditIcon />} onClick={onEdit}>Edit</AppButton>
-          <AppButton size="small" variant="danger" startIcon={<DeleteIcon />} onClick={onDelete}>Delete</AppButton>
+          <AppButton size="small" variant="outlined" startIcon={<EditIcon />} onClick={onEdit}>
+            Edit
+          </AppButton>
+          <AppButton size="small" variant="danger" startIcon={<DeleteIcon />} onClick={onDelete}>
+            Delete
+          </AppButton>
         </Stack>
       </Box>
     </Paper>

--- a/frontend/src/pages/accounting/components/ChartOfAccountWorkspaceCard.tsx
+++ b/frontend/src/pages/accounting/components/ChartOfAccountWorkspaceCard.tsx
@@ -2,28 +2,73 @@ import { Box, Paper, Table, TableBody, TableCell, TableRow, Typography } from '@
 
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { ChartOfAccount } from '@/types'
+import { formatDate } from '@/utils/formatters'
 
 interface Props {
   selected: ChartOfAccount | null
   allAccounts: ChartOfAccount[]
 }
 
-const cellSx = { border: 'none', py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px }
+const labelSx = {
+  border: 'none',
+  py: TABLE_STYLES.cell.padding.py,
+  px: TABLE_STYLES.cell.padding.px,
+  color: 'text.secondary',
+  width: '40%',
+  fontWeight: 600,
+  fontSize: '0.8rem',
+}
+
+const valueSx = {
+  border: 'none',
+  py: TABLE_STYLES.cell.padding.py,
+  px: TABLE_STYLES.cell.padding.px,
+  fontSize: '0.8rem',
+}
+
+const rows: { label: string; getValue: (account: ChartOfAccount, allAccounts: ChartOfAccount[]) => string }[] = [
+  {
+    label: 'Account Type',
+    getValue: (account) => account.type.charAt(0) + account.type.slice(1).toLowerCase(),
+  },
+  {
+    label: 'Parent Account',
+    getValue: (account, allAccounts) =>
+      account.parentId ? allAccounts.find((item) => item.id === account.parentId)?.name ?? '—' : '—',
+  },
+  { label: 'Description', getValue: (account) => account.description || '—' },
+  {
+    label: 'Balance',
+    getValue: (account) => (account.currentBalance != null ? String(account.currentBalance) : '—'),
+  },
+  { label: 'Cash Equivalent', getValue: (account) => (account.isCashEquivalent ? 'Yes' : 'No') },
+  { label: 'Created', getValue: (account) => formatDate(account.createdAt) },
+  { label: 'Updated', getValue: (account) => formatDate(account.updatedAt) },
+]
 
 export function ChartOfAccountWorkspaceCard({ selected, allAccounts }: Props) {
-  if (!selected) return <Paper sx={{ flex: 1 }} />
-  const parentName = selected.parentId ? allAccounts.find((account) => account.id === selected.parentId)?.name ?? '—' : '—'
+  if (!selected) {
+    return <Paper sx={{ flex: 1 }} />
+  }
+
   return (
     <Paper sx={{ flex: 1 }}>
-      <Box sx={{ px: 2, py: 1, borderBottom: TABLE_STYLES.cell.border }}>
-        <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>Details</Typography>
+      <Box sx={{ px: TABLE_STYLES.cell.padding.px, py: 1, borderBottom: TABLE_STYLES.cell.border }}>
+        <Typography
+          variant="tableHeader"
+          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+        >
+          Details
+        </Typography>
       </Box>
-      <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': cellSx }}>
+      <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': { border: 'none' } }}>
         <TableBody>
-          <TableRow><TableCell sx={{ ...cellSx, color: 'text.secondary', width: '35%' }}>Account Type</TableCell><TableCell>{selected.type}</TableCell></TableRow>
-          <TableRow><TableCell sx={{ ...cellSx, color: 'text.secondary' }}>Parent Account</TableCell><TableCell>{parentName}</TableCell></TableRow>
-          <TableRow><TableCell sx={{ ...cellSx, color: 'text.secondary' }}>Description</TableCell><TableCell>{selected.description || '—'}</TableCell></TableRow>
-          <TableRow><TableCell sx={{ ...cellSx, color: 'text.secondary' }}>Balance</TableCell><TableCell>{selected.currentBalance != null ? String(selected.currentBalance) : '—'}</TableCell></TableRow>
+          {rows.map(({ label, getValue }, index) => (
+            <TableRow key={label} sx={index % 2 === 1 ? { backgroundColor: 'grey.50' } : {}}>
+              <TableCell sx={labelSx}>{label}</TableCell>
+              <TableCell sx={valueSx}>{getValue(selected, allAccounts)}</TableCell>
+            </TableRow>
+          ))}
         </TableBody>
       </Table>
     </Paper>

--- a/frontend/src/pages/accounting/components/ChartOfAccountsTable.tsx
+++ b/frontend/src/pages/accounting/components/ChartOfAccountsTable.tsx
@@ -1,8 +1,10 @@
-import type { RefObject } from 'react'
+import { useRef, type RefObject } from 'react'
 import { Chip } from '@mui/material'
 
 import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
-import type { AccountType, ChartOfAccount } from '@/types'
+import type { ChartOfAccount } from '@/types'
+
+import { ACCOUNT_TYPE_COLORS } from '../utils/accountTypeColors'
 
 interface Props {
   accounts: ChartOfAccount[]
@@ -10,14 +12,6 @@ interface Props {
   selectedId: string | null
   onSelect: (item: ChartOfAccount) => void
   listRef?: RefObject<HTMLDivElement | null>
-}
-
-const TYPE_COLORS: Record<AccountType, 'success' | 'error' | 'primary' | 'info' | 'warning'> = {
-  ASSET: 'success',
-  LIABILITY: 'error',
-  EQUITY: 'primary',
-  REVENUE: 'info',
-  EXPENSE: 'warning',
 }
 
 const COLUMNS: ColumnConfig<ChartOfAccount>[] = [
@@ -30,7 +24,7 @@ const COLUMNS: ColumnConfig<ChartOfAccount>[] = [
       <Chip
         size="small"
         label={account.type.charAt(0) + account.type.slice(1).toLowerCase()}
-        color={TYPE_COLORS[account.type]}
+        color={ACCOUNT_TYPE_COLORS[account.type]}
         variant="outlined"
       />
     ),
@@ -56,6 +50,7 @@ export function ChartOfAccountsTable({
   onSelect,
   listRef,
 }: Props) {
+  const fallbackRef = useRef<HTMLDivElement | null>(null)
   return (
     <EntityTable
       rows={accounts}
@@ -66,7 +61,7 @@ export function ChartOfAccountsTable({
       selectedId={selectedId ?? undefined}
       focusedIndex={-1}
       onSelect={onSelect}
-      listRef={listRef ?? { current: null }}
+      listRef={listRef ?? fallbackRef}
       dataAttr="account"
     />
   )

--- a/frontend/src/pages/accounting/components/ChartOfAccountsTable.tsx
+++ b/frontend/src/pages/accounting/components/ChartOfAccountsTable.tsx
@@ -1,8 +1,8 @@
 import type { RefObject } from 'react'
-import { Chip, CircularProgress, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from '@mui/material'
+import { Chip } from '@mui/material'
 
-import { TABLE_STYLES } from '@/constants/tableStyles'
-import type { ChartOfAccount } from '@/types'
+import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
+import type { AccountType, ChartOfAccount } from '@/types'
 
 interface Props {
   accounts: ChartOfAccount[]
@@ -12,35 +12,62 @@ interface Props {
   listRef?: RefObject<HTMLDivElement | null>
 }
 
-export function ChartOfAccountsTable({ accounts, loading, selectedId, onSelect, listRef }: Props) {
+const TYPE_COLORS: Record<AccountType, 'success' | 'error' | 'primary' | 'info' | 'warning'> = {
+  ASSET: 'success',
+  LIABILITY: 'error',
+  EQUITY: 'primary',
+  REVENUE: 'info',
+  EXPENSE: 'warning',
+}
+
+const COLUMNS: ColumnConfig<ChartOfAccount>[] = [
+  { key: 'code', render: (account) => account.code },
+  { key: 'name', render: (account) => account.name },
+  {
+    key: 'type',
+    raw: true,
+    render: (account) => (
+      <Chip
+        size="small"
+        label={account.type.charAt(0) + account.type.slice(1).toLowerCase()}
+        color={TYPE_COLORS[account.type]}
+        variant="outlined"
+      />
+    ),
+  },
+  {
+    key: 'status',
+    raw: true,
+    render: (account) => (
+      <Chip
+        size="small"
+        label={account.isActive ? 'Active' : 'Inactive'}
+        color={account.isActive ? 'success' : 'default'}
+        variant="outlined"
+      />
+    ),
+  },
+]
+
+export function ChartOfAccountsTable({
+  accounts,
+  loading,
+  selectedId,
+  onSelect,
+  listRef,
+}: Props) {
   return (
-    <Paper ref={listRef} sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
-        <Table size={TABLE_STYLES.size} stickyHeader>
-          <TableHead>
-            <TableRow>
-              <TableCell sx={{ fontWeight: 600 }}>Code</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Name</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Type</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Status</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {loading ? (
-              <TableRow><TableCell colSpan={4} align="center" sx={{ py: 4 }}><CircularProgress /></TableCell></TableRow>
-            ) : accounts.length === 0 ? (
-              <TableRow><TableCell colSpan={4} align="center" sx={{ py: 4 }}><Typography variant="body2" color="text.secondary">No accounts found</Typography></TableCell></TableRow>
-            ) : accounts.map((account) => (
-              <TableRow key={account.id} hover selected={account.id === selectedId} onClick={() => onSelect(account)} sx={{ cursor: 'pointer', height: TABLE_STYLES.row.height }}>
-                <TableCell>{account.code}</TableCell>
-                <TableCell>{account.name}</TableCell>
-                <TableCell><Chip size="small" label={account.type.charAt(0).toUpperCase() + account.type.slice(1)} color="primary" variant="outlined" /></TableCell>
-                <TableCell><Chip size="small" label={account.isActive ? 'Active' : 'Inactive'} color={account.isActive ? 'success' : 'default'} variant="outlined" /></TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </Paper>
+    <EntityTable
+      rows={accounts}
+      columns={COLUMNS}
+      loading={loading}
+      total={accounts.length}
+      label="Accounts"
+      selectedId={selectedId ?? undefined}
+      focusedIndex={-1}
+      onSelect={onSelect}
+      listRef={listRef ?? { current: null }}
+      dataAttr="account"
+    />
   )
 }

--- a/frontend/src/pages/accounting/utils/accountTypeColors.ts
+++ b/frontend/src/pages/accounting/utils/accountTypeColors.ts
@@ -1,0 +1,9 @@
+import type { AccountType } from '@/types'
+
+export const ACCOUNT_TYPE_COLORS: Record<AccountType, 'success' | 'error' | 'primary' | 'info' | 'warning'> = {
+  ASSET: 'success',
+  LIABILITY: 'error',
+  EQUITY: 'primary',
+  REVENUE: 'info',
+  EXPENSE: 'warning',
+}


### PR DESCRIPTION
## Summary
- switch the COA page from the flat paginated endpoint to the hierarchy endpoint and flatten/search client-side
- migrate `ChartOfAccountsTable` to `EntityTable` with raw chip cells and account-type color coding
- align the COA context header and workspace card styling with the sales-page pattern and add missing detail fields

## Verification
- `cd frontend && npm run lint` ✅
- `cd frontend && npm run type-check` ✅
- `cd frontend && npx vitest run src/pages/accounting/` ✅
- `cd frontend && npm run test` ✅

## Notes
- Added a `raw?: boolean` column option to `EntityTable` so chip-based cells can render without nested typography wrappers.
- COA page test coverage now uses the hierarchy query path and verifies child-account flattening.

Closes #397
