### PR TITLE
feat(accounting): COA page refactor - simplified list, 2-col header, recent activity (issue #399)

### DIFF
--- a/backend/src/modules/accounting/controllers/chart-of-accounts.controller.ts
+++ b/backend/src/modules/accounting/controllers/chart-of-accounts.controller.ts
@@ -23,6 +23,8 @@ import {
   ChartOfAccountListResponseDto,
   ChartOfAccountHierarchyDto,
   BulkChartOfAccountsDto,
+  QueryRecentActivityDto,
+  RecentActivityItemDto,
 } from '../dto/chart-of-account.dto';
 
 @ApiTags('Chart of Accounts')
@@ -66,6 +68,22 @@ export class ChartOfAccountsController {
   })
   async getHierarchy(): Promise<ChartOfAccountHierarchyDto> {
     return this.chartOfAccountsService.getAccountHierarchy();
+  }
+
+  @Get(':id/recent-activity')
+  @ApiOperation({ summary: 'Get recent posted journal entries for an account' })
+  @ApiParam({ name: 'id', description: 'Account ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns recent activity items',
+    type: [RecentActivityItemDto],
+  })
+  @ApiResponse({ status: 404, description: 'Account not found' })
+  async getRecentActivity(
+    @Param('id') id: string,
+    @Query() query: QueryRecentActivityDto,
+  ): Promise<RecentActivityItemDto[]> {
+    return this.chartOfAccountsService.getRecentActivity(id, query.limit ?? 10);
   }
 
   @Get(':id')

--- a/backend/src/modules/accounting/dto/chart-of-account.dto.ts
+++ b/backend/src/modules/accounting/dto/chart-of-account.dto.ts
@@ -209,3 +209,33 @@ export class BulkChartOfAccountsDto {
   @IsUUID(4, { each: true })
   accountIds: string[];
 }
+
+export class QueryRecentActivityDto {
+  @ApiPropertyOptional({ description: 'Number of recent entries to return', minimum: 1, maximum: 50, default: 10 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(50)
+  limit?: number = 10;
+}
+
+export class RecentActivityItemDto {
+  @ApiProperty({ description: 'Journal entry date' })
+  date: string;
+
+  @ApiProperty({ description: 'Journal entry reference number' })
+  reference: string;
+
+  @ApiProperty({ description: 'Journal entry description' })
+  description: string;
+
+  @ApiPropertyOptional({ description: 'Debit amount (null if credit entry)' })
+  debit: number | null;
+
+  @ApiPropertyOptional({ description: 'Credit amount (null if debit entry)' })
+  credit: number | null;
+
+  @ApiProperty({ description: 'Running balance after this entry' })
+  balance: number;
+}

--- a/backend/src/modules/accounting/dto/chart-of-account.dto.ts
+++ b/backend/src/modules/accounting/dto/chart-of-account.dto.ts
@@ -235,7 +235,4 @@ export class RecentActivityItemDto {
 
   @ApiPropertyOptional({ description: 'Credit amount (null if debit entry)' })
   credit: number | null;
-
-  @ApiProperty({ description: 'Running balance after this entry' })
-  balance: number;
 }

--- a/backend/src/modules/accounting/services/chart-of-accounts.service.spec.ts
+++ b/backend/src/modules/accounting/services/chart-of-accounts.service.spec.ts
@@ -76,6 +76,7 @@ describe('ChartOfAccountsService', () => {
           provide: getRepositoryToken(JournalEntryLine),
           useValue: {
             count: jest.fn(),
+            createQueryBuilder: jest.fn(),
           },
         },
         {
@@ -602,6 +603,60 @@ describe('ChartOfAccountsService', () => {
       await expect(service.getChildren('non-existent-id')).rejects.toThrow(
         NotFoundException,
       );
+    });
+  });
+
+  describe('getRecentActivity', () => {
+    const accountId = '123e4567-e89b-12d3-a456-426614174000';
+
+    it('should throw NotFoundException when account does not exist', async () => {
+      accountRepository.findOne.mockResolvedValue(null);
+      await expect(service.getRecentActivity(accountId, 10)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should return empty array when no journal entry lines exist', async () => {
+      accountRepository.findOne.mockResolvedValue(mockAccount as ChartOfAccount);
+      const mockQb = {
+        leftJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+      journalEntryLineRepository.createQueryBuilder = jest.fn().mockReturnValue(mockQb);
+      const result = await service.getRecentActivity(accountId, 10);
+      expect(result).toEqual([]);
+    });
+
+    it('should return mapped activity items', async () => {
+      accountRepository.findOne.mockResolvedValue(mockAccount as ChartOfAccount);
+      const mockQb = {
+        leftJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          {
+            date: '2026-01-15',
+            reference: 'JE-2026-001',
+            description: 'Test entry',
+            debit: '100.0000',
+            credit: '0.0000',
+          },
+        ]),
+      };
+      journalEntryLineRepository.createQueryBuilder = jest.fn().mockReturnValue(mockQb);
+      const result = await service.getRecentActivity(accountId, 10);
+      expect(result).toHaveLength(1);
+      expect(result[0].reference).toBe('JE-2026-001');
+      expect(result[0].debit).toBe(100);
+      expect(result[0].credit).toBeNull();
     });
   });
 

--- a/backend/src/modules/accounting/services/chart-of-accounts.service.ts
+++ b/backend/src/modules/accounting/services/chart-of-accounts.service.ts
@@ -21,6 +21,7 @@ import {
   ChartOfAccountResponseDto,
   ChartOfAccountListResponseDto,
   ChartOfAccountHierarchyDto,
+  RecentActivityItemDto,
 } from '../dto/chart-of-account.dto';
 import { AuditLogService } from '../../audit-logs/services';
 
@@ -508,6 +509,39 @@ export class ChartOfAccountsService {
     });
 
     return children.map((child) => this.toResponseDto(child));
+  }
+
+  async getRecentActivity(id: string, limit: number): Promise<RecentActivityItemDto[]> {
+    const account = await this.accountRepository.findOne({ where: { id } });
+    if (!account) {
+      throw new NotFoundException(`Account with ID '${id}' not found`);
+    }
+
+    const rows = await this.journalEntryLineRepository
+      .createQueryBuilder('jel')
+      .leftJoin('jel.journalEntry', 'je')
+      .where('jel.accountId = :id', { id })
+      .andWhere('je.status = :status', { status: 'POSTED' })
+      .orderBy('je.date', 'DESC')
+      .addOrderBy('jel.id', 'DESC')
+      .limit(limit)
+      .select([
+        'je.date AS date',
+        'je.referenceNumber AS reference',
+        'je.description AS description',
+        'jel.debitAmount AS debit',
+        'jel.creditAmount AS credit',
+      ])
+      .getRawMany();
+
+    return rows.map((row) => ({
+      date: row.date instanceof Date ? row.date.toISOString().split('T')[0] : String(row.date).split('T')[0],
+      reference: row.reference,
+      description: row.description ?? '',
+      debit: Number(row.debit) > 0 ? Number(row.debit) : null,
+      credit: Number(row.credit) > 0 ? Number(row.credit) : null,
+      balance: 0,
+    }));
   }
 
   /**

--- a/backend/src/modules/accounting/services/chart-of-accounts.service.ts
+++ b/backend/src/modules/accounting/services/chart-of-accounts.service.ts
@@ -540,7 +540,6 @@ export class ChartOfAccountsService {
       description: row.description ?? '',
       debit: Number(row.debit) > 0 ? Number(row.debit) : null,
       credit: Number(row.credit) > 0 ? Number(row.credit) : null,
-      balance: 0,
     }));
   }
 

--- a/frontend/src/pages/accounting/ChartOfAccountsPage.tsx
+++ b/frontend/src/pages/accounting/ChartOfAccountsPage.tsx
@@ -98,9 +98,7 @@ const ChartOfAccountsPage: React.FC = () => {
             onDelete={() => workspace.selected && workspace.setDeleteTarget(workspace.selected)}
           />
         }
-        workspaceSlot={
-          <ChartOfAccountWorkspaceCard selected={workspace.selected} allAccounts={accounts} />
-        }
+        workspaceSlot={<ChartOfAccountWorkspaceCard selected={workspace.selected} />}
         dialogs={
           <ChartOfAccountsDialogs
             formDialogOpen={workspace.formDialogOpen}

--- a/frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx
@@ -11,6 +11,7 @@ const mockedApi = vi.hoisted(() => ({
   useSeedDefaultChartOfAccountsMutation: vi.fn(),
   useCreateChartOfAccountMutation: vi.fn(),
   useUpdateChartOfAccountMutation: vi.fn(),
+  useGetChartOfAccountRecentActivityQuery: vi.fn(),
 }))
 
 vi.mock('@/store/api/accountingApi', () => mockedApi)
@@ -47,6 +48,10 @@ describe('ChartOfAccountsPage', () => {
     mockedApi.useSeedDefaultChartOfAccountsMutation.mockReturnValue([vi.fn()])
     mockedApi.useCreateChartOfAccountMutation.mockReturnValue([vi.fn()])
     mockedApi.useUpdateChartOfAccountMutation.mockReturnValue([vi.fn()])
+    mockedApi.useGetChartOfAccountRecentActivityQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+    })
   })
 
   it('renders page title', () => {

--- a/frontend/src/pages/accounting/components/ChartOfAccountContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/ChartOfAccountContextHeader.tsx
@@ -1,10 +1,23 @@
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as EditIcon } from '@mui/icons-material/Edit'
-import { Box, Chip, Paper, Stack, Typography } from '@mui/material'
+import {
+  Box,
+  Chip,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+} from '@mui/material'
+import Grid from '@mui/material/Grid'
 
 import { AppButton } from '@/components/common/AppButton'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { ChartOfAccount } from '@/types'
+import { formatDate } from '@/utils/formatters'
 
 import { ACCOUNT_TYPE_COLORS } from '../utils/accountTypeColors'
 
@@ -12,6 +25,27 @@ interface Props {
   selected: ChartOfAccount | null
   onEdit: () => void
   onDelete: () => void
+}
+
+const detailTableSx = {
+  tableLayout: 'fixed',
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const labelCellSx = {
+  fontWeight: 600,
+  color: 'text.secondary',
+  fontSize: '0.8rem',
+}
+
+const valueCellSx = {
+  fontSize: '0.8rem',
 }
 
 export function ChartOfAccountContextHeader({ selected, onEdit, onDelete }: Props) {
@@ -24,6 +58,8 @@ export function ChartOfAccountContextHeader({ selected, onEdit, onDelete }: Prop
       </Paper>
     )
   }
+
+  const parentName = selected.parent?.name ?? '-'
 
   return (
     <Paper sx={{ overflow: 'hidden' }}>
@@ -43,12 +79,6 @@ export function ChartOfAccountContextHeader({ selected, onEdit, onDelete }: Prop
           >
             {selected.code} - {selected.name}
           </Typography>
-          <Chip
-            size="small"
-            label={selected.type.charAt(0) + selected.type.slice(1).toLowerCase()}
-            color={ACCOUNT_TYPE_COLORS[selected.type]}
-            variant="outlined"
-          />
         </Stack>
         <Stack direction="row" spacing={0.5}>
           <AppButton size="small" variant="outlined" startIcon={<EditIcon />} onClick={onEdit}>
@@ -58,6 +88,102 @@ export function ChartOfAccountContextHeader({ selected, onEdit, onDelete }: Prop
             Delete
           </AppButton>
         </Stack>
+      </Box>
+
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell
+                      colSpan={2}
+                      sx={{
+                        pb: TABLE_STYLES.cell.padding.py * 0.67,
+                        py: TABLE_STYLES.cell.padding.py * 0.67,
+                        borderTop: TABLE_STYLES.cell.border,
+                      }}
+                    >
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Account Information
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Code</TableCell>
+                    <TableCell sx={valueCellSx}>{selected.code}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Name</TableCell>
+                    <TableCell sx={valueCellSx}>{selected.name}</TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Account Type</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      <Chip
+                        size="small"
+                        label={selected.type.charAt(0) + selected.type.slice(1).toLowerCase()}
+                        color={ACCOUNT_TYPE_COLORS[selected.type]}
+                        variant="outlined"
+                      />
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Parent Account</TableCell>
+                    <TableCell sx={valueCellSx}>{parentName}</TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Cash Equivalent</TableCell>
+                    <TableCell sx={valueCellSx}>{selected.isCashEquivalent ? 'Yes' : 'No'}</TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell
+                      colSpan={2}
+                      sx={{
+                        pb: TABLE_STYLES.cell.padding.py * 0.67,
+                        py: TABLE_STYLES.cell.padding.py * 0.67,
+                        borderTop: TABLE_STYLES.cell.border,
+                      }}
+                    >
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Status & Dates
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Status</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      <Chip
+                        size="small"
+                        label={selected.isActive ? 'Active' : 'Inactive'}
+                        color={selected.isActive ? 'success' : 'default'}
+                        variant="outlined"
+                      />
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Last Updated</TableCell>
+                    <TableCell sx={valueCellSx}>{formatDate(selected.updatedAt)}</TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Created</TableCell>
+                    <TableCell sx={valueCellSx}>{formatDate(selected.createdAt)}</TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+        </Grid>
       </Box>
     </Paper>
   )

--- a/frontend/src/pages/accounting/components/ChartOfAccountContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/ChartOfAccountContextHeader.tsx
@@ -59,7 +59,7 @@ export function ChartOfAccountContextHeader({ selected, onEdit, onDelete }: Prop
     )
   }
 
-  const parentName = selected.parent?.name ?? '-'
+  const parentName = selected.parent?.name ?? '—'
 
   return (
     <Paper sx={{ overflow: 'hidden' }}>
@@ -77,7 +77,7 @@ export function ChartOfAccountContextHeader({ selected, onEdit, onDelete }: Prop
             variant="tableHeader"
             sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
           >
-            {selected.code} - {selected.name}
+            {selected.code} — {selected.name}
           </Typography>
         </Stack>
         <Stack direction="row" spacing={0.5}>

--- a/frontend/src/pages/accounting/components/ChartOfAccountWorkspaceCard.tsx
+++ b/frontend/src/pages/accounting/components/ChartOfAccountWorkspaceCard.tsx
@@ -44,8 +44,8 @@ const tdSx = {
   border: 'none',
 }
 
-function SubAccountsTable({ children }: { children: ChartOfAccount[] }) {
-  if (children.length === 0) {
+function SubAccountsTable({ accounts }: { accounts: ChartOfAccount[] }) {
+  if (accounts.length === 0) {
     return (
       <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
         <Typography variant="body2" sx={{ color: 'text.secondary', fontStyle: 'italic' }}>
@@ -65,7 +65,7 @@ function SubAccountsTable({ children }: { children: ChartOfAccount[] }) {
         </TableRow>
       </TableHead>
       <TableBody>
-        {children.map((child, index) => (
+        {accounts.map((child, index) => (
           <TableRow key={child.id} sx={index % 2 === 1 ? { backgroundColor: 'grey.50' } : {}}>
             <TableCell sx={tdSx}>{child.code}</TableCell>
             <TableCell sx={tdSx}>{child.name}</TableCell>
@@ -129,10 +129,10 @@ function RecentActivityTable({ accountId }: { accountId: string }) {
               {item.description}
             </TableCell>
             <TableCell sx={{ ...tdSx, textAlign: 'right' }}>
-              {item.debit != null ? formatCurrency(item.debit) : '-'}
+              {item.debit != null ? formatCurrency(item.debit) : '—'}
             </TableCell>
             <TableCell sx={{ ...tdSx, textAlign: 'right' }}>
-              {item.credit != null ? formatCurrency(item.credit) : '-'}
+              {item.credit != null ? formatCurrency(item.credit) : '—'}
             </TableCell>
           </TableRow>
         ))}
@@ -160,7 +160,7 @@ export function ChartOfAccountWorkspaceCard({ selected }: Props) {
         </Typography>
       </Box>
       {isHeader ? (
-        <SubAccountsTable children={selected.children ?? []} />
+        <SubAccountsTable accounts={selected.children ?? []} />
       ) : (
         <RecentActivityTable accountId={selected.id} />
       )}

--- a/frontend/src/pages/accounting/components/ChartOfAccountWorkspaceCard.tsx
+++ b/frontend/src/pages/accounting/components/ChartOfAccountWorkspaceCard.tsx
@@ -1,76 +1,169 @@
-import { Box, Paper, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
+import {
+  Box,
+  Chip,
+  Paper,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material'
 
 import { TABLE_STYLES } from '@/constants/tableStyles'
+import { useGetChartOfAccountRecentActivityQuery } from '@/store/api/accountingApi'
 import type { ChartOfAccount } from '@/types'
-import { formatDate } from '@/utils/formatters'
+import { formatCurrency, formatDate } from '@/utils/formatters'
+
+import { ACCOUNT_TYPE_COLORS } from '../utils/accountTypeColors'
 
 interface Props {
   selected: ChartOfAccount | null
-  allAccounts: ChartOfAccount[]
 }
 
-const labelSx = {
-  border: 'none',
-  py: TABLE_STYLES.cell.padding.py,
+const headerSx = {
   px: TABLE_STYLES.cell.padding.px,
-  color: 'text.secondary',
-  width: '40%',
+  py: 1,
+  borderBottom: TABLE_STYLES.cell.border,
+}
+
+const thSx = {
   fontWeight: 600,
-  fontSize: '0.8rem',
-}
-
-const valueSx = {
-  border: 'none',
+  fontSize: '0.75rem',
+  color: 'text.secondary',
   py: TABLE_STYLES.cell.padding.py,
   px: TABLE_STYLES.cell.padding.px,
-  fontSize: '0.8rem',
+  borderBottom: TABLE_STYLES.cell.border,
 }
 
-const rows: { label: string; getValue: (account: ChartOfAccount, allAccounts: ChartOfAccount[]) => string }[] = [
-  {
-    label: 'Account Type',
-    getValue: (account) => account.type.charAt(0) + account.type.slice(1).toLowerCase(),
-  },
-  {
-    label: 'Parent Account',
-    getValue: (account, allAccounts) =>
-      account.parentId ? allAccounts.find((item) => item.id === account.parentId)?.name ?? '—' : '—',
-  },
-  { label: 'Description', getValue: (account) => account.description || '—' },
-  {
-    label: 'Balance',
-    getValue: (account) => (account.currentBalance != null ? String(account.currentBalance) : '—'),
-  },
-  { label: 'Cash Equivalent', getValue: (account) => (account.isCashEquivalent ? 'Yes' : 'No') },
-  { label: 'Created', getValue: (account) => formatDate(account.createdAt) },
-  { label: 'Updated', getValue: (account) => formatDate(account.updatedAt) },
-]
+const tdSx = {
+  fontSize: '0.8rem',
+  py: TABLE_STYLES.cell.padding.py,
+  px: TABLE_STYLES.cell.padding.px,
+  border: 'none',
+}
 
-export function ChartOfAccountWorkspaceCard({ selected, allAccounts }: Props) {
+function SubAccountsTable({ children }: { children: ChartOfAccount[] }) {
+  if (children.length === 0) {
+    return (
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <Typography variant="body2" sx={{ color: 'text.secondary', fontStyle: 'italic' }}>
+          No sub-accounts.
+        </Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <Table size={TABLE_STYLES.size}>
+      <TableHead>
+        <TableRow>
+          <TableCell sx={thSx}>Code</TableCell>
+          <TableCell sx={thSx}>Name</TableCell>
+          <TableCell sx={thSx}>Type</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {children.map((child, index) => (
+          <TableRow key={child.id} sx={index % 2 === 1 ? { backgroundColor: 'grey.50' } : {}}>
+            <TableCell sx={tdSx}>{child.code}</TableCell>
+            <TableCell sx={tdSx}>{child.name}</TableCell>
+            <TableCell sx={{ ...tdSx }}>
+              <Chip
+                size="small"
+                label={child.type.charAt(0) + child.type.slice(1).toLowerCase()}
+                color={ACCOUNT_TYPE_COLORS[child.type]}
+                variant="outlined"
+              />
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+function RecentActivityTable({ accountId }: { accountId: string }) {
+  const { data: activity = [], isLoading } = useGetChartOfAccountRecentActivityQuery(
+    { id: accountId, limit: 10 },
+  )
+
+  if (isLoading) {
+    return (
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        {[...Array(5)].map((_, i) => (
+          <Skeleton key={i} variant="text" height={28} />
+        ))}
+      </Box>
+    )
+  }
+
+  if (activity.length === 0) {
+    return (
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <Typography variant="body2" sx={{ color: 'text.secondary', fontStyle: 'italic' }}>
+          No recent activity.
+        </Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <Table size={TABLE_STYLES.size}>
+      <TableHead>
+        <TableRow>
+          <TableCell sx={thSx}>Date</TableCell>
+          <TableCell sx={thSx}>Reference</TableCell>
+          <TableCell sx={thSx}>Description</TableCell>
+          <TableCell sx={{ ...thSx, textAlign: 'right' }}>Debit</TableCell>
+          <TableCell sx={{ ...thSx, textAlign: 'right' }}>Credit</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {activity.map((item, index) => (
+          <TableRow key={`${item.reference}-${index}`} sx={index % 2 === 1 ? { backgroundColor: 'grey.50' } : {}}>
+            <TableCell sx={tdSx}>{formatDate(item.date)}</TableCell>
+            <TableCell sx={tdSx}>{item.reference}</TableCell>
+            <TableCell sx={{ ...tdSx, maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {item.description}
+            </TableCell>
+            <TableCell sx={{ ...tdSx, textAlign: 'right' }}>
+              {item.debit != null ? formatCurrency(item.debit) : '-'}
+            </TableCell>
+            <TableCell sx={{ ...tdSx, textAlign: 'right' }}>
+              {item.credit != null ? formatCurrency(item.credit) : '-'}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+export function ChartOfAccountWorkspaceCard({ selected }: Props) {
   if (!selected) {
     return <Paper sx={{ flex: 1 }} />
   }
 
+  const isHeader = (selected.children?.length ?? 0) > 0
+  const sectionTitle = isHeader ? 'Sub-Accounts' : 'Recent Activity'
+
   return (
     <Paper sx={{ flex: 1 }}>
-      <Box sx={{ px: TABLE_STYLES.cell.padding.px, py: 1, borderBottom: TABLE_STYLES.cell.border }}>
+      <Box sx={headerSx}>
         <Typography
           variant="tableHeader"
           sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
         >
-          Details
+          {sectionTitle}
         </Typography>
       </Box>
-      <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': { border: 'none' } }}>
-        <TableBody>
-          {rows.map(({ label, getValue }, index) => (
-            <TableRow key={label} sx={index % 2 === 1 ? { backgroundColor: 'grey.50' } : {}}>
-              <TableCell sx={labelSx}>{label}</TableCell>
-              <TableCell sx={valueSx}>{getValue(selected, allAccounts)}</TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+      {isHeader ? (
+        <SubAccountsTable children={selected.children ?? []} />
+      ) : (
+        <RecentActivityTable accountId={selected.id} />
+      )}
     </Paper>
   )
 }

--- a/frontend/src/pages/accounting/components/ChartOfAccountsTable.tsx
+++ b/frontend/src/pages/accounting/components/ChartOfAccountsTable.tsx
@@ -1,10 +1,7 @@
 import { useRef, type RefObject } from 'react'
-import { Chip } from '@mui/material'
 
 import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
 import type { ChartOfAccount } from '@/types'
-
-import { ACCOUNT_TYPE_COLORS } from '../utils/accountTypeColors'
 
 interface Props {
   accounts: ChartOfAccount[]
@@ -17,30 +14,6 @@ interface Props {
 const COLUMNS: ColumnConfig<ChartOfAccount>[] = [
   { key: 'code', render: (account) => account.code },
   { key: 'name', render: (account) => account.name },
-  {
-    key: 'type',
-    raw: true,
-    render: (account) => (
-      <Chip
-        size="small"
-        label={account.type.charAt(0) + account.type.slice(1).toLowerCase()}
-        color={ACCOUNT_TYPE_COLORS[account.type]}
-        variant="outlined"
-      />
-    ),
-  },
-  {
-    key: 'status',
-    raw: true,
-    render: (account) => (
-      <Chip
-        size="small"
-        label={account.isActive ? 'Active' : 'Inactive'}
-        color={account.isActive ? 'success' : 'default'}
-        variant="outlined"
-      />
-    ),
-  },
 ]
 
 export function ChartOfAccountsTable({

--- a/frontend/src/store/api/accountingApi.ts
+++ b/frontend/src/store/api/accountingApi.ts
@@ -729,6 +729,7 @@ export const {
   useGetChartOfAccountsQuery,
   useGetChartOfAccountsHierarchyQuery,
   useGetChartOfAccountQuery,
+  useGetChartOfAccountRecentActivityQuery,
   useLazyGetChartOfAccountQuery,
   useGetDeletedChartOfAccountsQuery,
   useGetJournalEntriesQuery,

--- a/frontend/src/store/api/accountingApi.ts
+++ b/frontend/src/store/api/accountingApi.ts
@@ -11,6 +11,7 @@ import type {
   PaginatedResponse,
   PaymentMethodConfig,
   PendingSettlementSummary,
+  RecentActivityItem,
   Settlement,
 } from '@/types'
 import type {
@@ -253,6 +254,10 @@ export const accountingApiSlice = createApi({
       query: (id) => ({ url: `/accounting/chart-of-accounts/${id}` }),
       transformResponse: normalizeSingle<ChartOfAccount>,
       providesTags: (_result, _error, id) => [{ type: 'ChartOfAccount', id }],
+    }),
+    getChartOfAccountRecentActivity: builder.query<RecentActivityItem[], { id: string; limit?: number }>({
+      query: ({ id, limit = 10 }) => ({ url: `/accounting/chart-of-accounts/${id}/recent-activity`, params: { limit } }),
+      providesTags: (_result, _error, { id }) => [{ type: 'ChartOfAccount', id }],
     }),
     getDeletedChartOfAccounts: builder.query<PaginatedResponse<ChartOfAccount>, Record<string, unknown> | undefined>({
       query: (params) => ({ url: '/accounting/chart-of-accounts/deleted', params: params ?? {} }),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -679,6 +679,15 @@ export interface ChartOfAccount {
   deletedAt?: Date | string;
 }
 
+export interface RecentActivityItem {
+  date: string;
+  reference: string;
+  description: string;
+  debit: number | null;
+  credit: number | null;
+  balance: number;
+}
+
 export enum JournalEntryStatus {
   DRAFT = 'DRAFT',
   POSTED = 'POSTED',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -685,7 +685,6 @@ export interface RecentActivityItem {
   description: string;
   debit: number | null;
   credit: number | null;
-  balance: number;
 }
 
 export enum JournalEntryStatus {


### PR DESCRIPTION
## Summary

- Strips master list to Code + Name only for faster scanning
- Redesigns context header as a 2-column grid (Account Info + Status & Dates), matching Invoice page pattern
- Adds `GET /accounting/chart-of-accounts/:id/recent-activity` backend endpoint returning the 10 most recent posted journal entries for an account
- Replaces static workspace detail card with context-aware content: sub-accounts table for header accounts, recent activity table for leaf accounts

## Test Plan

- [x] Select a leaf account — workspace shows Recent Activity table (or "No recent activity" if none)
- [x] Select a header account (one with children) — workspace shows Sub-Accounts table
- [x] Verify context header shows 2-column layout with Account Info and Status & Dates
- [x] Verify master list shows only Code and Name columns
- [x] `cd backend && npx jest src/modules/accounting/ --no-coverage`
- [x] `cd frontend && npx vitest run src/pages/accounting/`

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)