### PR TITLE
fix(layout): scrollable list panels, fixed page header (#403)

### DIFF
--- a/frontend/src/components/common/MainLayout.tsx
+++ b/frontend/src/components/common/MainLayout.tsx
@@ -34,7 +34,7 @@ const MainLayout: React.FC = () => {
   }
 
   return (
-    <Box sx={{ display: 'flex', minHeight: '100vh' }}>
+    <Box sx={{ display: 'flex', minHeight: '100vh', height: '100vh' }}>
       <TopBar collapsed={collapsed} onMobileMenuOpen={handleDrawerToggle} />
 
       <Box

--- a/frontend/src/components/common/MainLayout.tsx
+++ b/frontend/src/components/common/MainLayout.tsx
@@ -89,7 +89,7 @@ const MainLayout: React.FC = () => {
           px: { xs: 2, sm: 3 },
           pb: 3,
           bgcolor: 'background.default',
-          minHeight: '100vh',
+          height: '100%',
           overflow: 'hidden',
           maxWidth: '100%',
         }}

--- a/frontend/src/components/common/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/common/__tests__/MainLayout.test.tsx
@@ -39,4 +39,16 @@ describe('MainLayout', () => {
 
     expect(screen.getByRole('main')).toHaveStyle({ paddingTop: '88px' })
   })
+
+  it('constrains the main content area to the layout height', () => {
+    render(
+      <Provider store={makeStore()}>
+        <MemoryRouter>
+          <MainLayout />
+        </MemoryRouter>
+      </Provider>
+    )
+
+    expect(screen.getByRole('main')).toHaveStyle({ height: '100%' })
+  })
 })


### PR DESCRIPTION
## Summary

- Pin outer shell `Box` in `MainLayout.tsx` to `height: 100vh` (alongside existing `minHeight: 100vh`) so it always fills the viewport
- Change `<main>` Box from `minHeight: 100vh` to `height: 100%` so it fills its parent without growing beyond the viewport
- The flex chain below (`GenericListPage → MasterDetailWorkspace → EntityTable`) already had correct `flex: 1 / minHeight: 0 / overflow: auto` — no changes needed there
- Add regression test to lock in the `height: 100%` constraint on the main content area

## Result

- All `GenericListPage`-based pages (COA, Inventory, Sales, Purchasing): list panel scrolls independently, page header + filter bar stay fixed
- Short pages (Customers, Settings, Dashboard): continue to fill the full viewport height

Closes #403

## Test plan

- [x] COA list scrolls independently; page header + filter bar stay fixed
- [x] Inventory, Sales, Purchasing list pages behave the same
- [x] Short pages (Customers, Settings, Dashboard) fill the full viewport
- [x] Mobile stacked layout renders correctly at < 960px

🤖 Generated with [Claude Code](https://claude.com/claude-code)