### PR TITLE
feat(accounting): add account type, status filters and sort to COA page

### DIFF
--- a/frontend/src/components/filters/FilterAccountType.tsx
+++ b/frontend/src/components/filters/FilterAccountType.tsx
@@ -1,0 +1,27 @@
+import { FilterSelect } from './FilterSelect'
+
+const OPTIONS = [
+  { value: 'ASSET', label: 'Asset' },
+  { value: 'LIABILITY', label: 'Liability' },
+  { value: 'EQUITY', label: 'Equity' },
+  { value: 'REVENUE', label: 'Revenue' },
+  { value: 'EXPENSE', label: 'Expense' },
+]
+
+interface Props {
+  field: string
+  value: string | null
+  onChange: (value: string | null) => void
+}
+
+export function FilterAccountType({ field, value, onChange }: Props) {
+  return (
+    <FilterSelect
+      field={field}
+      label="Account Type"
+      value={value}
+      options={OPTIONS}
+      onChange={onChange}
+    />
+  )
+}

--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -1,5 +1,6 @@
 import { CircularProgress, Stack } from '@mui/material'
 
+import { FilterAccountType } from './FilterAccountType'
 import { FilterCategory } from './FilterCategory'
 import { FilterExpenseStatus } from './FilterExpenseStatus'
 import { FilterBankReconciliationStatus } from './FilterBankReconciliationStatus'
@@ -354,6 +355,17 @@ function renderQuickField<TFilters extends object>(
   if (field.type === 'fund-transfer-status') {
     return (
       <FilterFundTransferStatus
+        key={fieldKey}
+        field={fieldKey}
+        value={(value as string | null) ?? null}
+        onChange={onChange}
+      />
+    )
+  }
+
+  if (field.type === 'account-type') {
+    return (
+      <FilterAccountType
         key={fieldKey}
         field={fieldKey}
         value={(value as string | null) ?? null}

--- a/frontend/src/hooks/useFilterBar.ts
+++ b/frontend/src/hooks/useFilterBar.ts
@@ -44,7 +44,8 @@ function getDefaults<TFilters extends object>(
       field.type === 'fiscal-period-status' ||
       field.type === 'bank-reconciliation-status' ||
       field.type === 'settlement-status' ||
-      field.type === 'fund-transfer-status'
+      field.type === 'fund-transfer-status' ||
+      field.type === 'account-type'
     ) {
       defaults[key] = null
     }

--- a/frontend/src/pages/accounting/ChartOfAccountsPage.tsx
+++ b/frontend/src/pages/accounting/ChartOfAccountsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 
 import AccountMappingWarning from '@/components/accounting/AccountMappingWarning'
 import GenericListPage from '@/components/common/GenericListPage'
@@ -15,12 +15,17 @@ import { useChartOfAccountsWorkspace } from './hooks/useChartOfAccountsWorkspace
 
 interface CoaFilters {
   search: string
+  accountType: string | null
+  isActive: string | null
 }
 
 const filterConfig: FilterBarConfig<CoaFilters> = {
   search: { placeholder: 'Search by code or name...' },
-  fields: [],
-  defaults: { search: '' },
+  fields: [
+    { field: 'accountType', label: 'Account Type', type: 'account-type' },
+    { field: 'isActive', label: 'Status', type: 'status' },
+  ],
+  defaults: { search: '', accountType: null, isActive: null },
 }
 
 const ChartOfAccountsPage: React.FC = () => {
@@ -29,6 +34,7 @@ const ChartOfAccountsPage: React.FC = () => {
   const workspace = useChartOfAccountsWorkspace(() => {
     void refetch()
   })
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
 
   const accounts = useMemo(() => {
     const result: ChartOfAccount[] = []
@@ -47,26 +53,40 @@ const ChartOfAccountsPage: React.FC = () => {
     return result
   }, [hierarchyData])
 
-  const filteredAccounts = useMemo(
-    () =>
-      appliedFilters.search
-        ? accounts.filter((account) => {
-            const searchTerm = appliedFilters.search.toLowerCase()
-            return (
-              account.code.toLowerCase().includes(searchTerm) ||
-              account.name.toLowerCase().includes(searchTerm)
-            )
-          })
-        : accounts,
-    [accounts, appliedFilters.search],
-  )
+  const filteredAccounts = useMemo(() => {
+    let result = accounts
+
+    if (appliedFilters.search) {
+      const searchTerm = appliedFilters.search.toLowerCase()
+      result = result.filter(
+        (account) =>
+          account.code.toLowerCase().includes(searchTerm) ||
+          account.name.toLowerCase().includes(searchTerm),
+      )
+    }
+
+    if (appliedFilters.accountType) {
+      result = result.filter((account) => account.type === appliedFilters.accountType)
+    }
+
+    if (appliedFilters.isActive) {
+      const isActive = appliedFilters.isActive === 'active'
+      result = result.filter((account) => account.isActive === isActive)
+    }
+
+    return [...result].sort((left, right) =>
+      sortOrder === 'asc'
+        ? left.code.localeCompare(right.code)
+        : right.code.localeCompare(left.code),
+    )
+  }, [accounts, appliedFilters, sortOrder])
 
   return (
     <>
       <AccountMappingWarning context="system" />
       <GenericListPage
         title="Chart of Accounts"
-        subtitle={`Manage your accounting structure and account hierarchy (${appliedFilters.search ? `${filteredAccounts.length} of ${accounts.length}` : `${accounts.length} total`})`}
+        subtitle={`Manage your accounting structure and account hierarchy (${hasActiveFilters ? `${filteredAccounts.length} of ${accounts.length}` : `${accounts.length} total`})`}
         primaryAction={{
           label: 'Add Account',
           onClick: () => {
@@ -80,7 +100,12 @@ const ChartOfAccountsPage: React.FC = () => {
         handlers={handlers}
         hasActiveFilters={hasActiveFilters}
         searchInputRef={workspace.searchInputRef}
-        sort={{ field: 'code', sortBy: 'code', sortOrder: 'asc', onSort: () => {} }}
+        sort={{
+          field: 'code',
+          sortBy: 'code',
+          sortOrder,
+          onSort: () => setSortOrder((prev) => (prev === 'asc' ? 'desc' : 'asc')),
+        }}
         error={(error as any)?.data ?? null}
         listSlot={
           <ChartOfAccountsTable

--- a/frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router-dom'
 
 import ChartOfAccountsPage from '../ChartOfAccountsPage'
@@ -35,14 +36,50 @@ const mockAccount = {
   updatedAt: '2024-01-01T00:00:00Z',
 }
 
+const mockLiabilityAccount = {
+  ...mockAccount,
+  id: '2',
+  code: '2000',
+  name: 'Accounts Payable',
+  type: 'LIABILITY',
+}
+
+const mockInactiveAccount = {
+  ...mockAccount,
+  id: '3',
+  code: '3000',
+  name: 'Old Revenue',
+  type: 'REVENUE',
+  isActive: false,
+}
+
+function setup(accounts = [mockAccount]) {
+  mockedApi.useGetChartOfAccountsHierarchyQuery.mockReturnValue({
+    data: accounts,
+    isLoading: false,
+    refetch: vi.fn(),
+  })
+}
+
+function renderPage() {
+  return render(
+    <BrowserRouter>
+      <ChartOfAccountsPage />
+    </BrowserRouter>,
+  )
+}
+
+function getRenderedAccountCodes() {
+  return Array.from(document.querySelectorAll('tr[data-account-index] td:first-child')).map((cell) =>
+    cell.textContent?.trim() ?? '',
+  )
+}
+
 describe('ChartOfAccountsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockedApi.useGetChartOfAccountsHierarchyQuery.mockReturnValue({
-      data: [mockAccount],
-      isLoading: false,
-      refetch: vi.fn(),
-    })
+    window.history.replaceState(null, '', '/')
+    setup([mockAccount])
     mockedApi.useGetChartOfAccountsQuery.mockReturnValue({ data: { data: [] }, isLoading: false, refetch: vi.fn() })
     mockedApi.useDeleteChartOfAccountMutation.mockReturnValue([vi.fn()])
     mockedApi.useSeedDefaultChartOfAccountsMutation.mockReturnValue([vi.fn()])
@@ -55,22 +92,12 @@ describe('ChartOfAccountsPage', () => {
   })
 
   it('renders page title', () => {
-    render(
-      <BrowserRouter>
-        <ChartOfAccountsPage />
-      </BrowserRouter>,
-    )
-
+    renderPage()
     expect(screen.getByText('Chart of Accounts')).toBeInTheDocument()
   })
 
   it('renders account code from hierarchy data', () => {
-    render(
-      <BrowserRouter>
-        <ChartOfAccountsPage />
-      </BrowserRouter>,
-    )
-
+    renderPage()
     expect(screen.getByText('1000')).toBeInTheDocument()
   })
 
@@ -82,20 +109,76 @@ describe('ChartOfAccountsPage', () => {
       name: 'Cash',
       children: [{ ...mockAccount, id: '2', code: '1010', name: 'CIMB', children: [] }],
     }
+    setup([parent])
 
-    mockedApi.useGetChartOfAccountsHierarchyQuery.mockReturnValue({
-      data: [parent],
-      isLoading: false,
-      refetch: vi.fn(),
-    })
-
-    render(
-      <BrowserRouter>
-        <ChartOfAccountsPage />
-      </BrowserRouter>,
-    )
+    renderPage()
 
     expect(screen.getByText('1000')).toBeInTheDocument()
     expect(screen.getByText('1010')).toBeInTheDocument()
+  })
+
+  it('filters by account type and hides non-matching accounts', async () => {
+    setup([mockAccount, mockLiabilityAccount])
+    const user = userEvent.setup()
+
+    renderPage()
+
+    expect(screen.getByText('1000')).toBeInTheDocument()
+    expect(screen.getByText('2000')).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('Account Type'))
+    await user.click(screen.getByRole('option', { name: 'Asset' }))
+
+    expect(screen.getByText('1000')).toBeInTheDocument()
+    expect(screen.queryByText('2000')).not.toBeInTheDocument()
+  })
+
+  it('filters by active status and hides inactive accounts', async () => {
+    setup([mockAccount, mockInactiveAccount])
+    const user = userEvent.setup()
+
+    renderPage()
+
+    expect(screen.getByText('1000')).toBeInTheDocument()
+    expect(screen.getByText('3000')).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('Status'))
+    await user.click(screen.getByRole('option', { name: 'Active' }))
+
+    expect(screen.getByText('1000')).toBeInTheDocument()
+    expect(screen.queryByText('3000')).not.toBeInTheDocument()
+  })
+
+  it('combines account type and status filters', async () => {
+    const activeAsset = { ...mockAccount, id: '1', code: '1000', type: 'ASSET', isActive: true }
+    const inactiveAsset = { ...mockAccount, id: '2', code: '1100', type: 'ASSET', isActive: false }
+    const activeLiability = { ...mockAccount, id: '3', code: '2000', type: 'LIABILITY', isActive: true }
+    setup([activeAsset, inactiveAsset, activeLiability])
+    const user = userEvent.setup()
+
+    renderPage()
+
+    await user.click(screen.getByLabelText('Account Type'))
+    await user.click(screen.getByRole('option', { name: 'Asset' }))
+
+    await user.click(screen.getByLabelText('Status'))
+    await user.click(screen.getByRole('option', { name: 'Active' }))
+
+    expect(screen.getByText('1000')).toBeInTheDocument()
+    expect(screen.queryByText('1100')).not.toBeInTheDocument()
+    expect(screen.queryByText('2000')).not.toBeInTheDocument()
+  })
+
+  it('toggles sort order for account codes', async () => {
+    setup([mockLiabilityAccount, mockAccount])
+    const user = userEvent.setup()
+
+    renderPage()
+
+    expect(getRenderedAccountCodes()).toEqual(['1000', '2000'])
+
+    await user.click(screen.getByRole('button', { name: /sort/i }))
+
+    expect(getRenderedAccountCodes()).toEqual(['2000', '1000'])
   })
 })

--- a/frontend/src/types/filterBar.types.ts
+++ b/frontend/src/types/filterBar.types.ts
@@ -36,6 +36,7 @@ export type FilterFieldType =
   | 'bank-reconciliation-status'
   | 'settlement-status'
   | 'fund-transfer-status'
+  | 'account-type'
 
 interface BaseFilterFieldConfig<TFilters, K extends keyof TFilters> {
   field: K
@@ -181,6 +182,11 @@ export interface FundTransferStatusFilterFieldConfig<TFilters, K extends keyof T
   type: 'fund-transfer-status'
 }
 
+export interface AccountTypeFilterFieldConfig<TFilters, K extends keyof TFilters>
+  extends BaseFilterFieldConfig<TFilters, K> {
+  type: 'account-type'
+}
+
 export type FilterFieldConfig<TFilters> =
   | StatusFilterFieldConfig<TFilters, keyof TFilters>
   | UserStatusFilterFieldConfig<TFilters, keyof TFilters>
@@ -209,6 +215,7 @@ export type FilterFieldConfig<TFilters> =
   | BankReconciliationStatusFilterFieldConfig<TFilters, keyof TFilters>
   | SettlementStatusFilterFieldConfig<TFilters, keyof TFilters>
   | FundTransferStatusFilterFieldConfig<TFilters, keyof TFilters>
+  | AccountTypeFilterFieldConfig<TFilters, keyof TFilters>
 
 export interface FilterBarConfig<TFilters> {
   search?: {

--- a/frontend/src/utils/filterBar.url.ts
+++ b/frontend/src/utils/filterBar.url.ts
@@ -89,7 +89,8 @@ export function serializeFilters<TFilters extends object>(
       field.type === 'fiscal-period-status' ||
       field.type === 'bank-reconciliation-status' ||
       field.type === 'settlement-status' ||
-      field.type === 'fund-transfer-status'
+      field.type === 'fund-transfer-status' ||
+      field.type === 'account-type'
 
     if (isSingleValueField) {
       if (value !== null && value !== undefined && value !== defaultValue) {
@@ -174,7 +175,8 @@ export function parseFilters<TFilters extends object>(
       field.type === 'fiscal-period-status' ||
       field.type === 'bank-reconciliation-status' ||
       field.type === 'settlement-status' ||
-      field.type === 'fund-transfer-status'
+      field.type === 'fund-transfer-status' ||
+      field.type === 'account-type'
 
     if (isSingleValueField) {
       const raw = searchParams.get(key)
@@ -240,6 +242,9 @@ export function parseFilters<TFilters extends object>(
       } else if (field.type === 'settlement-status' || field.type === 'fund-transfer-status') {
         const VALID_COMPLETION_STATUS = ['pending', 'completed', 'cancelled']
         result[fieldKey] = VALID_COMPLETION_STATUS.includes(raw) ? raw : (defaultValue ?? null)
+      } else if (field.type === 'account-type') {
+        const VALID_ACCOUNT_TYPE = ['ASSET', 'LIABILITY', 'EQUITY', 'REVENUE', 'EXPENSE']
+        result[fieldKey] = VALID_ACCOUNT_TYPE.includes(raw) ? raw : (defaultValue ?? null)
       } else {
         result[fieldKey] = raw
       }


### PR DESCRIPTION
## Summary
- Adds new `account-type` filter type to the shared FilterBar system (types, hook, URL serialization, renderer)
- Introduces `FilterAccountType` component; reuses existing `status` type for Active/Inactive filter
- Updates `ChartOfAccountsPage` with Account Type + Active Status dropdowns, working sort toggle by account code, and correct "X of Y" subtitle when filters are active

## Test Plan
- [x] Account Type dropdown filters the list to matching accounts only
- [x] Status dropdown filters active/inactive accounts correctly
- [x] Combined filters work together
- [x] Sort button toggles between code asc/desc
- [x] Reset button clears all filters
- [x] All existing and new Vitest tests pass (`npm run test`)
- [x] TypeScript check passes (`npm run type-check`)

Closes #405