### PR TITLE
feat(ui): standardize buttons to AppButton across 4 modules (issue #407)

### DIFF
--- a/frontend/src/components/accounting/AccountMappingDialog.tsx
+++ b/frontend/src/components/accounting/AccountMappingDialog.tsx
@@ -4,7 +4,6 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Button,
   TextField,
   FormControl,
   InputLabel,
@@ -15,6 +14,7 @@ import {
   CircularProgress,
   Alert,
 } from '@mui/material'
+import { AppButton } from '@/components/common/AppButton'
 import { useNotification } from '@/hooks/useNotification'
 import {
   useCreateAccountMappingMutation,
@@ -244,16 +244,16 @@ const AccountMappingDialog: React.FC<AccountMappingDialogProps> = ({
         </DialogContent>
 
         <DialogActions>
-          <Button onClick={onClose} disabled={submitting}>
+          <AppButton variant="secondary" onClick={onClose} disabled={submitting}>
             Cancel
-          </Button>
-          <Button
+          </AppButton>
+          <AppButton
+            variant="primary"
             type="submit"
-            variant="contained"
             disabled={submitting || loadingAccounts || !formData.accountId}
           >
             {submitting ? 'Saving...' : mapping ? 'Update' : 'Create'}
-          </Button>
+          </AppButton>
         </DialogActions>
       </form>
     </Dialog>

--- a/frontend/src/components/accounting/AccountMappingWarning.tsx
+++ b/frontend/src/components/accounting/AccountMappingWarning.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Alert, AlertTitle, Typography, Button } from '@mui/material'
+import { Alert, AlertTitle, Typography } from '@mui/material'
 import { useValidateAccountMappingsQuery } from '@/store/api/accountingApi'
 import { MappingType } from '@/types/accountMapping'
+import { AppButton } from '@/components/common/AppButton'
 
 interface AccountMappingWarningProps {
   context?: 'transaction' | 'system'
@@ -58,14 +59,14 @@ const AccountMappingWarning: React.FC<AccountMappingWarningProps> = ({
             ))}
           </ul>
         )}
-        <Button
-          variant="contained"
+        <AppButton
+          variant="primary"
           size="small"
           onClick={() => navigate('/accounting/account-mappings')}
           sx={{ mt: 1 }}
         >
           Configure Account Mappings
-        </Button>
+        </AppButton>
       </Alert>
     )
   }

--- a/frontend/src/components/accounting/AccountingEntryLink.tsx
+++ b/frontend/src/components/accounting/AccountingEntryLink.tsx
@@ -2,13 +2,13 @@ import React from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   Box,
-  Button,
   Alert,
   AlertTitle,
   Link,
   Typography,
 } from '@mui/material'
 import { default as AccountBalanceIcon } from '@mui/icons-material/AccountBalance'
+import { AppButton } from '@/components/common/AppButton'
 
 interface AccountingEntryLinkProps {
   sourceType: string
@@ -40,9 +40,9 @@ const AccountingEntryLink: React.FC<AccountingEntryLinkProps> = ({
       <Alert severity="info" sx={{ mt: 2 }}>
         <AlertTitle>Accounting Information</AlertTitle>
         {message}
-        <Button variant="text" size="small" sx={{ ml: 2 }} onClick={handleClick}>
+        <AppButton variant="text" size="small" sx={{ ml: 2 }} onClick={handleClick}>
           {label}
-        </Button>
+        </AppButton>
       </Alert>
     )
   }
@@ -112,14 +112,14 @@ const AccountingEntryLink: React.FC<AccountingEntryLinkProps> = ({
 
   // Default: button variant
   return (
-    <Button
-      variant="outlined"
+    <AppButton
+      variant="secondary"
       size="small"
       startIcon={<AccountBalanceIcon />}
       onClick={handleClick}
     >
       {label}
-    </Button>
+    </AppButton>
   )
 }
 

--- a/frontend/src/components/accounting/BankReconciliationFormDialog.tsx
+++ b/frontend/src/components/accounting/BankReconciliationFormDialog.tsx
@@ -4,7 +4,6 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Button,
   TextField,
   Box,
   FormControl,
@@ -22,6 +21,7 @@ import {
 } from '@/store/api/accountingApi';
 import { BankReconciliation, FiscalPeriodStatus } from '@/types';
 import { getErrorMessage } from '@/utils/errorMessage';
+import { AppButton } from '@/components/common/AppButton';
 
 interface BankReconciliationFormDialogProps {
   open: boolean;
@@ -222,12 +222,12 @@ const BankReconciliationFormDialog: React.FC<BankReconciliationFormDialogProps> 
         </Box>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleClose} color="inherit" disabled={submitting}>
+        <AppButton variant="secondary" onClick={handleClose} disabled={submitting}>
           Cancel
-        </Button>
-        <Button onClick={handleSubmit} variant="contained" disabled={submitting}>
+        </AppButton>
+        <AppButton variant="primary" onClick={handleSubmit} disabled={submitting}>
           {reconciliation ? 'Update' : 'Create'}
-        </Button>
+        </AppButton>
       </DialogActions>
     </Dialog>
   );

--- a/frontend/src/components/accounting/ChartOfAccountFormDialog.tsx
+++ b/frontend/src/components/accounting/ChartOfAccountFormDialog.tsx
@@ -4,7 +4,6 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Button,
   TextField,
   Grid,
   FormControl,
@@ -16,6 +15,7 @@ import {
   Typography,
   Box,
 } from '@mui/material'
+import { AppButton } from '@/components/common/AppButton'
 import { useForm, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
@@ -352,16 +352,16 @@ const ChartOfAccountFormDialog: React.FC<ChartOfAccountFormDialogProps> = ({
           </Grid>
         </DialogContent>
         <DialogActions>
-          <Button onClick={onClose} disabled={submitting}>
+          <AppButton variant="secondary" onClick={onClose} disabled={submitting}>
             Cancel
-          </Button>
-          <Button
+          </AppButton>
+          <AppButton
+            variant="primary"
             type="submit"
-            variant="contained"
             disabled={submitting}
           >
             {submitting ? 'Saving...' : account ? 'Update' : 'Create'}
-          </Button>
+          </AppButton>
         </DialogActions>
       </form>
     </Dialog>

--- a/frontend/src/components/accounting/CreateSettlementDialog.tsx
+++ b/frontend/src/components/accounting/CreateSettlementDialog.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   Box,
-  Button,
   Checkbox,
   Dialog,
   DialogActions,
@@ -20,6 +19,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
+import { AppButton } from '@/components/common/AppButton';
 import type { PaymentMethodConfig } from '@/types';
 import {
   useGetPaymentMethodsQuery,
@@ -192,14 +192,14 @@ const CreateSettlementDialog: React.FC<CreateSettlementDialogProps> = ({ open, o
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>Cancel</Button>
-        <Button
-          variant="contained"
+        <AppButton variant="secondary" onClick={onClose}>Cancel</AppButton>
+        <AppButton
+          variant="primary"
           onClick={handleSubmit}
           disabled={!paymentMethodId || !selectedIds.length}
         >
           Create Settlement
-        </Button>
+        </AppButton>
       </DialogActions>
     </Dialog>
   );

--- a/frontend/src/components/accounting/FiscalPeriodFormDialog.tsx
+++ b/frontend/src/components/accounting/FiscalPeriodFormDialog.tsx
@@ -4,7 +4,6 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Button,
   TextField,
   Box,
 } from '@mui/material'
@@ -16,6 +15,7 @@ import {
 } from '@/store/api/accountingApi'
 import { FiscalPeriod } from '@/types'
 import { getErrorMessage } from '@/utils/errorMessage'
+import { AppButton } from '@/components/common/AppButton'
 
 interface FiscalPeriodFormDialogProps {
   open: boolean
@@ -212,16 +212,16 @@ const FiscalPeriodFormDialog: React.FC<FiscalPeriodFormDialogProps> = ({
         </Box>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleClose} color="inherit" disabled={submitting}>
+        <AppButton variant="secondary" onClick={handleClose} disabled={submitting}>
           Cancel
-        </Button>
-        <Button
+        </AppButton>
+        <AppButton
+          variant="primary"
           onClick={handleSubmit}
-          variant="contained"
           disabled={submitting}
         >
           {period ? 'Update' : 'Create'}
-        </Button>
+        </AppButton>
       </DialogActions>
     </Dialog>
   )

--- a/frontend/src/components/accounting/GeneratePeriodsDialog.tsx
+++ b/frontend/src/components/accounting/GeneratePeriodsDialog.tsx
@@ -4,7 +4,6 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Button,
   TextField,
   FormControl,
   InputLabel,
@@ -14,6 +13,7 @@ import {
   Typography,
   Alert,
 } from '@mui/material'
+import { AppButton } from '@/components/common/AppButton'
 
 interface GeneratePeriodsDialogProps {
   open: boolean
@@ -130,16 +130,16 @@ const GeneratePeriodsDialog: React.FC<GeneratePeriodsDialogProps> = ({
         </Box>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleClose} color="inherit">
+        <AppButton variant="secondary" onClick={handleClose}>
           Cancel
-        </Button>
-        <Button
+        </AppButton>
+        <AppButton
+          variant="primary"
           onClick={handleSubmit}
-          variant="contained"
           disabled={!!yearError || isNaN(year)}
         >
           Generate Periods
-        </Button>
+        </AppButton>
       </DialogActions>
     </Dialog>
   );

--- a/frontend/src/components/common/AppButton.tsx
+++ b/frontend/src/components/common/AppButton.tsx
@@ -5,7 +5,15 @@ import SortIcon from '@mui/icons-material/Sort'
 import { CircularProgress } from '@mui/material'
 import Button, { type ButtonProps } from '@mui/material/Button'
 
-type AppButtonVariant = 'primary' | 'secondary' | 'outlined' | 'danger' | 'warning' | 'success'
+type AppButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'outlined'
+  | 'danger'
+  | 'warning'
+  | 'success'
+  | 'text'
+  | 'info'
 type AppButtonSize = 'filter' | 'small' | 'medium' | 'large'
 
 type SortConfig = {
@@ -65,6 +73,14 @@ export function AppButton({
       case 'success':
         muiVariant = 'contained'
         muiColor = 'success'
+        break
+      case 'text':
+        muiVariant = 'text'
+        muiColor = 'inherit'
+        break
+      case 'info':
+        muiVariant = 'contained'
+        muiColor = 'info'
         break
       case 'secondary':
       case 'outlined':

--- a/frontend/src/components/common/ConfirmationDialog.tsx
+++ b/frontend/src/components/common/ConfirmationDialog.tsx
@@ -4,7 +4,6 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Button,
   Typography,
   Box,
   useTheme
@@ -12,6 +11,7 @@ import {
 import { default as WarningIcon } from '@mui/icons-material/Warning'
 import { default as ErrorIcon } from '@mui/icons-material/Error'
 import { default as InfoIcon } from '@mui/icons-material/Info'
+import { AppButton } from '@/components/common/AppButton'
 
 interface ConfirmationDialogProps {
   open: boolean
@@ -46,17 +46,6 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
         return <InfoIcon sx={{ color: theme.palette.info.main, fontSize: 32 }} />
       default:
         return <WarningIcon sx={{ color: theme.palette.warning.main, fontSize: 32 }} />
-    }
-  }
-
-  const getSeverityColor = () => {
-    switch (severity) {
-      case 'error':
-        return theme.palette.error.main
-      case 'info':
-        return theme.palette.info.main
-      default:
-        return theme.palette.warning.main
     }
   }
 
@@ -96,28 +85,21 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
         </Typography>
       </DialogContent>
       <DialogActions sx={{ p: 3, pt: 1 }}>
-        <Button
+        <AppButton
+          variant="secondary"
           onClick={onCancel}
-          variant="outlined"
           disabled={loading}
         >
           {cancelText}
-        </Button>
-        <Button
+        </AppButton>
+        <AppButton
+          variant={severity === 'error' ? 'danger' : severity}
           onClick={onConfirm}
-          variant="contained"
-          color={severity === 'error' ? 'error' : 'warning'}
           disabled={loading}
-          sx={{
-            bgcolor: getSeverityColor(),
-            '&:hover': {
-              bgcolor: getSeverityColor(),
-              filter: 'brightness(0.9)'
-            }
-          }}
+          loading={loading}
         >
-          {loading ? 'Processing...' : confirmText}
-        </Button>
+          {confirmText}
+        </AppButton>
       </DialogActions>
     </Dialog>
   );

--- a/frontend/src/components/common/NotificationPanel.tsx
+++ b/frontend/src/components/common/NotificationPanel.tsx
@@ -10,7 +10,6 @@ import {
   ListItemIcon,
   IconButton,
   Divider,
-  Button,
   Avatar,
   Chip,
   Badge,
@@ -32,6 +31,7 @@ import { useNotifications } from '@/hooks/useNotification'
 import { useAppDispatch } from '@/hooks/useRedux'
 import { markAsRead, markAllAsRead, removeNotification } from '@/store/slices/notificationSlice'
 import type { Notification } from '@/types'
+import { AppButton } from '@/components/common/AppButton'
 
 interface NotificationPanelProps {
   anchorEl: HTMLElement | null
@@ -166,14 +166,14 @@ const NotificationPanel: React.FC<NotificationPanelProps> = ({
         </Typography>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           {unreadNotifications.length > 0 && (
-            <Button
+            <AppButton
               size="small"
               startIcon={<MarkReadIcon />}
               onClick={handleMarkAllAsRead}
               sx={{ fontSize: '0.75rem' }}
             >
               Mark all read
-            </Button>
+            </AppButton>
           )}
           <IconButton size="small" onClick={onClose}>
             <CloseIcon />
@@ -307,14 +307,14 @@ const NotificationPanel: React.FC<NotificationPanelProps> = ({
         <>
           <Divider />
           <Box sx={{ p: 2, textAlign: 'center' }}>
-            <Button
+            <AppButton
               size="small"
               onClick={onClose}
               fullWidth
               sx={{ fontSize: '0.875rem' }}
             >
               View All Notifications
-            </Button>
+            </AppButton>
           </Box>
         </>
       )}

--- a/frontend/src/components/common/TransactionForm.tsx
+++ b/frontend/src/components/common/TransactionForm.tsx
@@ -4,7 +4,6 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import {
   Autocomplete,
   Box,
-  Button,
   Card,
   CardContent,
   Grid,
@@ -19,6 +18,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material'
+import { AppButton } from '@/components/common/AppButton'
 
 type EntityLabel = 'Customer' | 'Supplier'
 
@@ -227,9 +227,13 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
               <CardContent>
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
                   <Typography variant="h6">Line Items</Typography>
-                  <Button variant="outlined" startIcon={<AddIcon />} onClick={handleAddLineItem}>
+                  <AppButton
+                    variant="secondary"
+                    startIcon={<AddIcon />}
+                    onClick={handleAddLineItem}
+                  >
                     Add Line Item
-                  </Button>
+                  </AppButton>
                 </Box>
 
                 <TableContainer component={Paper}>
@@ -292,12 +296,12 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
 
       {!hideDefaultActions ? (
         <Box sx={{ display: 'flex', gap: 2, justifyContent: 'flex-end', mt: 3 }}>
-          <Button variant="outlined" onClick={onCancel}>
+          <AppButton variant="secondary" onClick={onCancel}>
             {cancelLabel}
-          </Button>
-          <Button type="submit" variant="contained" disabled={isSubmitting}>
+          </AppButton>
+          <AppButton type="submit" variant="primary" disabled={isSubmitting}>
             {submitLabel}
-          </Button>
+          </AppButton>
         </Box>
       ) : null}
     </form>

--- a/frontend/src/pages/inventory/CreateProductPage.tsx
+++ b/frontend/src/pages/inventory/CreateProductPage.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import {
   Box,
-  Button,
   Grid,
   TextField,
   Typography,
@@ -22,6 +21,7 @@ import { useGetPriceListsQuery, useBulkUpdatePricesMutation, priceListApiSlice }
 import { useCreateProductMutation, useLazyGetProductQuery, useUpdateProductMutation } from '@/store/api/inventoryApi'
 import { useDispatch } from 'react-redux'
 import { useNotification } from '@/hooks/useNotification'
+import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import CategorySelector from '@/components/inventory/CategorySelector'
 import { Category, PriceList } from '@/types'
@@ -197,15 +197,15 @@ const ProductAdditionalInformationCard: React.FC<ProductAdditionalInformationCar
 
       <Box sx={{ mt: 'auto' }}>
         <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
-          <Button variant="outlined" fullWidth onClick={onCancel} disabled={loading}>
+          <AppButton variant="secondary" fullWidth onClick={onCancel} disabled={loading}>
             Cancel
-          </Button>
-          <Button type="submit" variant="contained" fullWidth disabled={disabled}>
+          </AppButton>
+          <AppButton variant="primary" type="submit" fullWidth disabled={disabled}>
             {loading
               ? (isEditMode ? 'Updating...' : 'Creating...')
               : (isEditMode ? 'Update Product' : 'Create Product')
             }
-          </Button>
+          </AppButton>
         </Box>
       </Box>
     </CardContent>

--- a/frontend/src/pages/inventory/HistoricalInventoryReport.tsx
+++ b/frontend/src/pages/inventory/HistoricalInventoryReport.tsx
@@ -4,7 +4,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   FormControl,
   InputLabel,
   Select,
@@ -38,6 +37,7 @@ import { default as KeyboardArrowRightIcon } from '@mui/icons-material/KeyboardA
 import { default as KeyboardArrowLeftIcon } from '@mui/icons-material/KeyboardArrowLeft'
 import { default as KeyboardDoubleArrowRightIcon } from '@mui/icons-material/KeyboardDoubleArrowRight'
 import { default as KeyboardDoubleArrowLeftIcon } from '@mui/icons-material/KeyboardDoubleArrowLeft'
+import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TABLE_STYLES } from '@/constants/tableStyles'
@@ -772,20 +772,20 @@ const HistoricalInventoryReport: React.FC = () => {
                   Report Preview ({reportData.length} records)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 
@@ -1020,13 +1020,13 @@ const HistoricalInventoryReport: React.FC = () => {
           <Typography variant="h6" sx={{ fontWeight: 600 }}>
             Select Products
           </Typography>
-          <Button
+          <AppButton
             size="small"
             onClick={handleProductDialogClose}
             sx={{ minWidth: 'auto', p: 0.5 }}
           >
             <CloseIcon />
-          </Button>
+          </AppButton>
         </DialogTitle>
         <DialogContent sx={{ p: 2, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
           <Grid container spacing={1} sx={{ flex: 1, minHeight: 0 }}>
@@ -1260,15 +1260,15 @@ const HistoricalInventoryReport: React.FC = () => {
             }}>
             {selectedProducts.length} product{selectedProducts.length !== 1 ? 's' : ''} selected
           </Typography>
-          <Button onClick={handleProductDialogClose}>
+          <AppButton variant="secondary" onClick={handleProductDialogClose}>
             Cancel
-          </Button>
-          <Button
-            variant="contained"
+          </AppButton>
+          <AppButton
+            variant="primary"
             onClick={handleProductDialogConfirm}
           >
             Apply
-          </Button>
+          </AppButton>
         </DialogActions>
       </Dialog>
     </>

--- a/frontend/src/pages/inventory/InventorySummaryReport.tsx
+++ b/frontend/src/pages/inventory/InventorySummaryReport.tsx
@@ -5,7 +5,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   FormControl,
   InputLabel,
   Select,
@@ -39,6 +38,7 @@ import { default as KeyboardArrowRightIcon } from '@mui/icons-material/KeyboardA
 import { default as KeyboardArrowLeftIcon } from '@mui/icons-material/KeyboardArrowLeft'
 import { default as KeyboardDoubleArrowRightIcon } from '@mui/icons-material/KeyboardDoubleArrowRight'
 import { default as KeyboardDoubleArrowLeftIcon } from '@mui/icons-material/KeyboardDoubleArrowLeft'
+import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDateTime } from '@/utils/formatters'
 import { TABLE_STYLES } from '@/constants/tableStyles'
@@ -938,20 +938,20 @@ const InventorySummaryReport: React.FC = () => {
                   Report Preview ({reportData.length} records)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 
@@ -1198,13 +1198,13 @@ const InventorySummaryReport: React.FC = () => {
           <Typography variant="h6" sx={{ fontWeight: 600 }}>
             Select Products
           </Typography>
-          <Button
+          <AppButton
             size="small"
             onClick={handleProductDialogClose}
             sx={{ minWidth: 'auto', p: 0.5 }}
           >
             <CloseIcon />
-          </Button>
+          </AppButton>
         </DialogTitle>
         <DialogContent sx={{ p: 2, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
           <Grid container spacing={1} sx={{ flex: 1, minHeight: 0 }}>
@@ -1438,15 +1438,15 @@ const InventorySummaryReport: React.FC = () => {
             }}>
             {selectedProducts.length} product{selectedProducts.length !== 1 ? 's' : ''} selected
           </Typography>
-          <Button onClick={handleProductDialogClose}>
+          <AppButton variant="secondary" onClick={handleProductDialogClose}>
             Cancel
-          </Button>
-          <Button
-            variant="contained"
+          </AppButton>
+          <AppButton
+            variant="primary"
             onClick={handleProductDialogConfirm}
           >
             Apply
-          </Button>
+          </AppButton>
         </DialogActions>
       </Dialog>
     </>

--- a/frontend/src/pages/inventory/MovementSummaryReport.tsx
+++ b/frontend/src/pages/inventory/MovementSummaryReport.tsx
@@ -5,7 +5,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   FormControl,
   InputLabel,
   Select,
@@ -39,6 +38,7 @@ import { default as KeyboardArrowRightIcon } from '@mui/icons-material/KeyboardA
 import { default as KeyboardArrowLeftIcon } from '@mui/icons-material/KeyboardArrowLeft'
 import { default as KeyboardDoubleArrowRightIcon } from '@mui/icons-material/KeyboardDoubleArrowRight'
 import { default as KeyboardDoubleArrowLeftIcon } from '@mui/icons-material/KeyboardDoubleArrowLeft'
+import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TABLE_STYLES } from '@/constants/tableStyles'
@@ -759,20 +759,20 @@ const MovementSummaryReport: React.FC = () => {
                   Report Preview ({reportData.length} records)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 
@@ -1012,13 +1012,13 @@ const MovementSummaryReport: React.FC = () => {
           <Typography variant="h6" sx={{ fontWeight: 600 }}>
             Select Products
           </Typography>
-          <Button
+          <AppButton
             size="small"
             onClick={handleProductDialogClose}
             sx={{ minWidth: 'auto', p: 0.5 }}
           >
             <CloseIcon />
-          </Button>
+          </AppButton>
         </DialogTitle>
         <DialogContent sx={{ p: 2, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
           <Grid container spacing={1} sx={{ flex: 1, minHeight: 0 }}>
@@ -1252,15 +1252,15 @@ const MovementSummaryReport: React.FC = () => {
             }}>
             {selectedProducts.length} product{selectedProducts.length !== 1 ? 's' : ''} selected
           </Typography>
-          <Button onClick={handleProductDialogClose}>
+          <AppButton variant="secondary" onClick={handleProductDialogClose}>
             Cancel
-          </Button>
-          <Button
-            variant="contained"
+          </AppButton>
+          <AppButton
+            variant="primary"
             onClick={handleProductDialogConfirm}
           >
             Apply
-          </Button>
+          </AppButton>
         </DialogActions>
       </Dialog>
     </>

--- a/frontend/src/pages/inventory/PriceListReport.tsx
+++ b/frontend/src/pages/inventory/PriceListReport.tsx
@@ -4,7 +4,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   FormControl,
   InputLabel,
   Select,
@@ -37,6 +36,7 @@ import { default as KeyboardArrowRightIcon } from '@mui/icons-material/KeyboardA
 import { default as KeyboardArrowLeftIcon } from '@mui/icons-material/KeyboardArrowLeft'
 import { default as KeyboardDoubleArrowRightIcon } from '@mui/icons-material/KeyboardDoubleArrowRight'
 import { default as KeyboardDoubleArrowLeftIcon } from '@mui/icons-material/KeyboardDoubleArrowLeft'
+import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDateTime } from '@/utils/formatters'
 import { TABLE_STYLES } from '@/constants/tableStyles'
@@ -799,20 +799,20 @@ const PriceListReport: React.FC = () => {
                   Report Preview ({reportData.length} records)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 
@@ -965,13 +965,13 @@ const PriceListReport: React.FC = () => {
           <Typography variant="h6" sx={{ fontWeight: 600 }}>
             Select Products
           </Typography>
-          <Button
+          <AppButton
             size="small"
             onClick={handleProductDialogClose}
             sx={{ minWidth: 'auto', p: 0.5 }}
           >
             <CloseIcon />
-          </Button>
+          </AppButton>
         </DialogTitle>
         <DialogContent sx={{ p: 2, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
           <Grid container spacing={1} sx={{ flex: 1, minHeight: 0 }}>
@@ -1205,15 +1205,15 @@ const PriceListReport: React.FC = () => {
             }}>
             {selectedProducts.length} product{selectedProducts.length !== 1 ? 's' : ''} selected
           </Typography>
-          <Button onClick={handleProductDialogClose}>
+          <AppButton variant="secondary" onClick={handleProductDialogClose}>
             Cancel
-          </Button>
-          <Button
-            variant="contained"
+          </AppButton>
+          <AppButton
+            variant="primary"
             onClick={handleProductDialogConfirm}
           >
             Apply
-          </Button>
+          </AppButton>
         </DialogActions>
       </Dialog>
     </>

--- a/frontend/src/pages/inventory/ProductCostReport.tsx
+++ b/frontend/src/pages/inventory/ProductCostReport.tsx
@@ -4,7 +4,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   FormControl,
   InputLabel,
   Select,
@@ -37,6 +36,7 @@ import { default as KeyboardArrowRightIcon } from '@mui/icons-material/KeyboardA
 import { default as KeyboardArrowLeftIcon } from '@mui/icons-material/KeyboardArrowLeft'
 import { default as KeyboardDoubleArrowRightIcon } from '@mui/icons-material/KeyboardDoubleArrowRight'
 import { default as KeyboardDoubleArrowLeftIcon } from '@mui/icons-material/KeyboardDoubleArrowLeft'
+import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { TABLE_STYLES } from '@/constants/tableStyles'
@@ -784,20 +784,20 @@ const ProductCostReport: React.FC = () => {
                   Report Preview ({reportData.length} records)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 
@@ -1016,13 +1016,13 @@ const ProductCostReport: React.FC = () => {
           <Typography variant="h6" sx={{ fontWeight: 600 }}>
             Select Products
           </Typography>
-          <Button
+          <AppButton
             size="small"
             onClick={handleProductDialogClose}
             sx={{ minWidth: 'auto', p: 0.5 }}
           >
             <CloseIcon />
-          </Button>
+          </AppButton>
         </DialogTitle>
         <DialogContent sx={{ p: 2, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
           <Grid container spacing={1} sx={{ flex: 1, minHeight: 0 }}>
@@ -1256,15 +1256,15 @@ const ProductCostReport: React.FC = () => {
             }}>
             {selectedProducts.length} product{selectedProducts.length !== 1 ? 's' : ''} selected
           </Typography>
-          <Button onClick={handleProductDialogClose}>
+          <AppButton variant="secondary" onClick={handleProductDialogClose}>
             Cancel
-          </Button>
-          <Button
-            variant="contained"
+          </AppButton>
+          <AppButton
+            variant="primary"
             onClick={handleProductDialogConfirm}
           >
             Apply
-          </Button>
+          </AppButton>
         </DialogActions>
       </Dialog>
     </>

--- a/frontend/src/pages/inventory/components/CategoryDialogs.tsx
+++ b/frontend/src/pages/inventory/components/CategoryDialogs.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react'
 import {
-  Button,
   Dialog,
   DialogActions,
   DialogContent,
@@ -14,6 +13,7 @@ import { Controller, useForm, type UseFormReset } from 'react-hook-form'
 import * as yup from 'yup'
 
 import ConfirmationDialog from '@/components/common/ConfirmationDialog'
+import { AppButton } from '@/components/common/AppButton'
 import CategorySelector from '@/components/inventory/CategorySelector'
 import DeletedCategoriesDialog from '@/components/inventory/DeletedCategoriesDialog'
 import { SmartCategoryDeleteDialog } from '@/components/inventory/SmartCategoryDeleteDialog'
@@ -159,12 +159,12 @@ const CategoryDialogs: React.FC<CategoryDialogsProps> = ({
             </Grid>
           </DialogContent>
           <DialogActions>
-            <Button onClick={onDialogClose} disabled={submitting}>
+            <AppButton variant="secondary" onClick={onDialogClose} disabled={submitting}>
               Cancel
-            </Button>
-            <Button type="submit" variant="contained" disabled={submitting}>
+            </AppButton>
+            <AppButton variant="primary" type="submit" disabled={submitting}>
               {submitting ? 'Saving...' : editMode ? 'Update' : 'Create'}
-            </Button>
+            </AppButton>
           </DialogActions>
         </form>
       </Dialog>

--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import {
   Box,
-  Button,
   Grid,
   TextField,
   Typography,
@@ -27,6 +26,7 @@ import { useForm, useFieldArray, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import { formatCurrency, getCurrentDate } from '@/utils/formatters'
+import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import TransactionForm from '@/components/common/TransactionForm'
 import { useNotification } from '@/hooks/useNotification'
@@ -466,13 +466,13 @@ const CreatePurchaseOrderPage: React.FC = () => {
               <CardContent>
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
                   <Typography variant="h6">PO Items</Typography>
-                  <Button
+                  <AppButton
+                    variant="secondary"
                     startIcon={<AddIcon />}
                     onClick={addItem}
-                    variant="outlined"
                   >
                     Add Item
-                  </Button>
+                  </AppButton>
                 </Box>
 
                 <TableContainer component={Paper} sx={{ border: `1px solid ${theme.palette.divider}` }}>
@@ -905,17 +905,17 @@ const CreatePurchaseOrderPage: React.FC = () => {
                 </Box>
 
                 <Box sx={{ display: 'flex', gap: 2, mt: 'auto' }}>
-                  <Button
-                    variant="outlined"
+                  <AppButton
+                    variant="secondary"
                     fullWidth
                     onClick={() => navigate('/purchasing/orders')}
                     disabled={loading}
                   >
                     Cancel
-                  </Button>
-                  <Button
+                  </AppButton>
+                  <AppButton
+                    variant="primary"
                     type="submit"
-                    variant="contained"
                     fullWidth
                     disabled={loading}
                   >
@@ -923,7 +923,7 @@ const CreatePurchaseOrderPage: React.FC = () => {
                       ? (isEditMode ? 'Updating...' : 'Creating...')
                       : (isEditMode ? 'Update Order' : 'Create Order')
                     }
-                  </Button>
+                  </AppButton>
                 </Box>
               </CardContent>
             </Card>

--- a/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
@@ -5,7 +5,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   IconButton,
   FormControl,
   InputLabel,
@@ -48,6 +47,7 @@ import { default as KeyboardArrowRightIcon } from '@mui/icons-material/KeyboardA
 import { default as KeyboardArrowLeftIcon } from '@mui/icons-material/KeyboardArrowLeft'
 import { default as KeyboardDoubleArrowRightIcon } from '@mui/icons-material/KeyboardDoubleArrowRight'
 import { default as KeyboardDoubleArrowLeftIcon } from '@mui/icons-material/KeyboardDoubleArrowLeft'
+import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { PRINT_STYLES } from '@/styles/printStyles'
@@ -1013,20 +1013,20 @@ const PurchaseOrderDetailsReport: React.FC = () => {
                   Report Preview ({reportData.length} records)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 
@@ -1317,13 +1317,13 @@ const PurchaseOrderDetailsReport: React.FC = () => {
           <Typography variant="h6" sx={{ fontWeight: 600 }}>
             Select Products
           </Typography>
-          <Button
+          <AppButton
             size="small"
             onClick={handleProductDialogClose}
             sx={{ minWidth: 'auto', p: 0.5 }}
           >
             <CloseIcon />
-          </Button>
+          </AppButton>
         </DialogTitle>
         <DialogContent sx={{ p: 2, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
           <Grid container spacing={1} sx={{ flex: 1, minHeight: 0 }}>
@@ -1557,15 +1557,15 @@ const PurchaseOrderDetailsReport: React.FC = () => {
             }}>
             {selectedProducts.length} product{selectedProducts.length !== 1 ? 's' : ''} selected
           </Typography>
-          <Button onClick={handleProductDialogClose}>
+          <AppButton variant="secondary" onClick={handleProductDialogClose}>
             Cancel
-          </Button>
-          <Button
-            variant="contained"
+          </AppButton>
+          <AppButton
+            variant="primary"
             onClick={handleProductDialogConfirm}
           >
             Apply
-          </Button>
+          </AppButton>
         </DialogActions>
       </Dialog>
     </>

--- a/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
@@ -5,7 +5,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   FormControl,
   InputLabel,
   Select,
@@ -40,6 +39,7 @@ import { default as KeyboardArrowRightIcon } from '@mui/icons-material/KeyboardA
 import { default as KeyboardArrowLeftIcon } from '@mui/icons-material/KeyboardArrowLeft'
 import { default as KeyboardDoubleArrowRightIcon } from '@mui/icons-material/KeyboardDoubleArrowRight'
 import { default as KeyboardDoubleArrowLeftIcon } from '@mui/icons-material/KeyboardDoubleArrowLeft'
+import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { PRINT_STYLES } from '@/styles/printStyles'
@@ -938,20 +938,20 @@ const PurchaseOrderStatusReport: React.FC = () => {
                   Report Preview ({reportData.length} records)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 
@@ -1254,13 +1254,13 @@ const PurchaseOrderStatusReport: React.FC = () => {
           <Typography variant="h6" sx={{ fontWeight: 600 }}>
             Select Products
           </Typography>
-          <Button
+          <AppButton
             size="small"
             onClick={handleProductDialogClose}
             sx={{ minWidth: 'auto', p: 0.5 }}
           >
             <CloseIcon />
-          </Button>
+          </AppButton>
         </DialogTitle>
         <DialogContent sx={{ p: 2, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
           <Grid container spacing={1} sx={{ flex: 1, minHeight: 0 }}>
@@ -1494,15 +1494,15 @@ const PurchaseOrderStatusReport: React.FC = () => {
             }}>
             {selectedProducts.length} product{selectedProducts.length !== 1 ? 's' : ''} selected
           </Typography>
-          <Button onClick={handleProductDialogClose}>
+          <AppButton variant="secondary" onClick={handleProductDialogClose}>
             Cancel
-          </Button>
-          <Button
-            variant="contained"
+          </AppButton>
+          <AppButton
+            variant="primary"
             onClick={handleProductDialogConfirm}
           >
             Apply
-          </Button>
+          </AppButton>
         </DialogActions>
       </Dialog>
     </>

--- a/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
@@ -5,7 +5,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   FormControl,
   InputLabel,
   Select,
@@ -30,6 +29,7 @@ import { default as ExcelIcon } from '@mui/icons-material/TableChart'
 import { default as RefreshIcon } from '@mui/icons-material/Refresh'
 import { default as GenerateIcon } from '@mui/icons-material/PlayArrow'
 import { default as PurchaseOrderIcon } from '@mui/icons-material/Summarize'
+import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
@@ -816,20 +816,20 @@ const PurchaseOrderSummary: React.FC = () => {
                   Report Preview ({reportData.length} records)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 

--- a/frontend/src/pages/purchasing/SupplierFormPage.tsx
+++ b/frontend/src/pages/purchasing/SupplierFormPage.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useState } from 'react'
 import {
   Alert,
   Box,
-  Button,
   Card,
   CardContent,
   CircularProgress,
@@ -21,6 +20,7 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 
 import AddressSection from '@/components/common/AddressSection'
+import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { useFieldDuplicateCheck } from '@/hooks/useFieldDuplicateCheck'
 import { useNotification } from '@/hooks/useNotification'
@@ -330,25 +330,25 @@ const SupplierFormPage: React.FC = () => {
                 />
 
                 <Box sx={{ mt: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
-                  <Button
-                    variant="outlined"
+                  <AppButton
+                    variant="secondary"
                     fullWidth
                     onClick={() => navigate('/purchasing/suppliers')}
                     disabled={isSaving}
                   >
                     Cancel
-                  </Button>
+                  </AppButton>
 
-                  <Button
+                  <AppButton
+                    variant="primary"
                     type="submit"
-                    variant="contained"
                     fullWidth
                     disabled={isSaving || isCheckingDuplicate || hasCompanyNameDuplicate}
                   >
                     {isSaving
                       ? (isEdit ? 'Updating...' : 'Creating...')
                       : (isEdit ? 'Update Supplier' : 'Create Supplier')}
-                  </Button>
+                  </AppButton>
                 </Box>
               </CardContent>
             </Card>

--- a/frontend/src/pages/purchasing/VendorPaymentDetailsReport.tsx
+++ b/frontend/src/pages/purchasing/VendorPaymentDetailsReport.tsx
@@ -4,7 +4,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   FormControl,
   InputLabel,
   Select,
@@ -28,6 +27,7 @@ import { default as ExcelIcon } from '@mui/icons-material/TableChart'
 import { default as RefreshIcon } from '@mui/icons-material/Refresh'
 import { default as GenerateIcon } from '@mui/icons-material/PlayArrow'
 import { default as PaymentIcon } from '@mui/icons-material/MonetizationOn'
+import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { PRINT_STYLES } from '@/styles/printStyles'
@@ -674,20 +674,20 @@ const VendorPaymentDetailsReport: React.FC = () => {
                   Report Preview ({reportData.length} payments)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 

--- a/frontend/src/pages/purchasing/VendorProductListReport.tsx
+++ b/frontend/src/pages/purchasing/VendorProductListReport.tsx
@@ -5,7 +5,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   FormControl,
   InputLabel,
   Select,
@@ -40,6 +39,7 @@ import { default as KeyboardArrowRightIcon } from '@mui/icons-material/KeyboardA
 import { default as KeyboardArrowLeftIcon } from '@mui/icons-material/KeyboardArrowLeft'
 import { default as KeyboardDoubleArrowRightIcon } from '@mui/icons-material/KeyboardDoubleArrowRight'
 import { default as KeyboardDoubleArrowLeftIcon } from '@mui/icons-material/KeyboardDoubleArrowLeft'
+import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { PRINT_STYLES } from '@/styles/printStyles'
@@ -903,20 +903,20 @@ const VendorProductListReport: React.FC = () => {
                   Report Preview ({reportData.length} records)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 
@@ -1084,13 +1084,13 @@ const VendorProductListReport: React.FC = () => {
           <Typography variant="h6" sx={{ fontWeight: 600 }}>
             Select Products
           </Typography>
-          <Button
+          <AppButton
             size="small"
             onClick={handleProductDialogClose}
             sx={{ minWidth: 'auto', p: 0.5 }}
           >
             <CloseIcon />
-          </Button>
+          </AppButton>
         </DialogTitle>
         <DialogContent sx={{ p: 2, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
           <Grid container spacing={1} sx={{ flex: 1, minHeight: 0 }}>
@@ -1324,15 +1324,15 @@ const VendorProductListReport: React.FC = () => {
             }}>
             {selectedProducts.length} product{selectedProducts.length !== 1 ? 's' : ''} selected
           </Typography>
-          <Button onClick={handleProductDialogClose}>
+          <AppButton variant="secondary" onClick={handleProductDialogClose}>
             Cancel
-          </Button>
-          <Button
-            variant="contained"
+          </AppButton>
+          <AppButton
+            variant="primary"
             onClick={handleProductDialogConfirm}
           >
             Apply
-          </Button>
+          </AppButton>
         </DialogActions>
       </Dialog>
     </>

--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -3,7 +3,6 @@ import { useStore } from 'react-redux'
 import { useNavigate, useParams } from 'react-router-dom'
 import {
   Box,
-  Button,
   Grid,
   TextField,
   Typography,
@@ -30,6 +29,7 @@ import * as yup from 'yup'
 import { useCreateSalesOrderMutation, useUpdateSalesOrderMutation, useLazyGetSalesOrderQuery, useGetCustomersQuery } from '@/store/api/salesApi'
 import { patchSalesOrderCaches } from '@/store/api/salesOrderCache'
 import { formatCurrency, getCurrentDate } from '@/utils/formatters'
+import { AppButton } from '@/components/common/AppButton'
 import { useNotification } from '@/hooks/useNotification'
 import { useProductSearch } from '@/hooks/useProductSearch'
 import { useAppDispatch } from '@/hooks/useRedux'
@@ -545,13 +545,13 @@ const CreateSalesOrderPage: React.FC = () => {
                 <CardContent>
                   <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
                     <Typography variant="h6">SO Items</Typography>
-                    <Button
+                    <AppButton
+                      variant="secondary"
                       startIcon={<AddIcon />}
                       onClick={addItem}
-                      variant="outlined"
                     >
                       Add Item
-                    </Button>
+                    </AppButton>
                   </Box>
 
                   <TableContainer component={Paper} sx={{ border: `1px solid ${theme.palette.divider}` }}>
@@ -998,17 +998,17 @@ const CreateSalesOrderPage: React.FC = () => {
                   </Box>
 
                   <Box sx={{ display: 'flex', gap: 2, mt: 'auto' }}>
-                    <Button
-                      variant="outlined"
+                    <AppButton
+                      variant="secondary"
                       fullWidth
                       onClick={() => navigate('/sales/orders')}
                       disabled={loading}
                     >
                       Cancel
-                    </Button>
-                    <Button
+                    </AppButton>
+                    <AppButton
+                      variant="primary"
                       type="submit"
-                      variant="contained"
                       fullWidth
                       disabled={loading}
                     >
@@ -1016,7 +1016,7 @@ const CreateSalesOrderPage: React.FC = () => {
                         ? (isEditMode ? 'Updating...' : 'Creating...')
                         : (isEditMode ? 'Update Order' : 'Create Order')
                       }
-                    </Button>
+                    </AppButton>
                   </Box>
                 </CardContent>
               </Card>

--- a/frontend/src/pages/sales/CustomerFormPage.tsx
+++ b/frontend/src/pages/sales/CustomerFormPage.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useState } from 'react'
 import {
   Alert,
   Box,
-  Button,
   Card,
   CardContent,
   CircularProgress,
@@ -21,6 +20,7 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 
 import AddressSection from '@/components/common/AddressSection'
+import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import PriceListSelector from '@/components/price-lists/PriceListSelector'
 import { useFieldDuplicateCheck } from '@/hooks/useFieldDuplicateCheck'
@@ -339,25 +339,25 @@ const CustomerFormPage: React.FC = () => {
                 />
 
                 <Box sx={{ mt: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
-                  <Button
-                    variant="outlined"
+                  <AppButton
+                    variant="secondary"
                     fullWidth
                     onClick={() => navigate('/sales/customers')}
                     disabled={isSaving}
                   >
                     Cancel
-                  </Button>
+                  </AppButton>
 
-                  <Button
+                  <AppButton
+                    variant="primary"
                     type="submit"
-                    variant="contained"
                     fullWidth
                     disabled={isSaving || hasPhoneDuplicate || isCheckingPhone}
                   >
                     {isSaving
                       ? (isEdit ? 'Updating...' : 'Creating...')
                       : (isEdit ? 'Update Customer' : 'Create Customer')}
-                  </Button>
+                  </AppButton>
                 </Box>
               </CardContent>
             </Card>

--- a/frontend/src/pages/sales/CustomerOrderHistory.tsx
+++ b/frontend/src/pages/sales/CustomerOrderHistory.tsx
@@ -4,7 +4,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   FormControl,
   InputLabel,
   Select,
@@ -30,6 +29,7 @@ import {
   Divider,
 } from '@mui/material'
 import { alpha } from '@mui/material/styles'
+import { AppButton } from '@/components/common/AppButton'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
 import { default as ExcelIcon } from '@mui/icons-material/TableChart'
 import { default as RefreshIcon } from '@mui/icons-material/Refresh'
@@ -1116,20 +1116,20 @@ const CustomerOrderHistory: React.FC = () => {
                   Report Preview ({reportData.length} orders)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 
@@ -1447,13 +1447,13 @@ const CustomerOrderHistory: React.FC = () => {
           <Typography variant="h6" sx={{ fontWeight: 600 }}>
             Select Products
           </Typography>
-          <Button
+          <AppButton
             size="small"
             onClick={handleProductDialogClose}
             sx={{ minWidth: 'auto', p: 0.5 }}
           >
             <CloseIcon />
-          </Button>
+          </AppButton>
         </DialogTitle>
         <DialogContent sx={{ p: 2, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
           <Grid container spacing={1} sx={{ flex: 1, minHeight: 0 }}>
@@ -1687,12 +1687,12 @@ const CustomerOrderHistory: React.FC = () => {
             }}>
             {selectedProducts.length} product{selectedProducts.length !== 1 ? 's' : ''} selected
           </Typography>
-          <Button onClick={handleProductDialogClose}>
+          <AppButton variant="secondary" onClick={handleProductDialogClose}>
             Cancel
-          </Button>
-          <Button onClick={handleProductDialogClose} variant="contained">
+          </AppButton>
+          <AppButton variant="primary" onClick={handleProductDialogClose}>
             Done
-          </Button>
+          </AppButton>
         </DialogActions>
       </Dialog>
     </>

--- a/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
@@ -4,7 +4,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   FormControl,
   InputLabel,
   Select,
@@ -26,6 +25,7 @@ import {
   Checkbox,
 } from '@mui/material'
 import { alpha } from '@mui/material/styles'
+import { AppButton } from '@/components/common/AppButton'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
 import { default as ExcelIcon } from '@mui/icons-material/TableChart'
 import { default as RefreshIcon } from '@mui/icons-material/Refresh'
@@ -847,20 +847,20 @@ const CustomerPaymentByOrder: React.FC = () => {
                   Report Preview ({reportData.length} orders)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 

--- a/frontend/src/pages/sales/CustomerPaymentDetails.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentDetails.tsx
@@ -4,7 +4,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   FormControl,
   InputLabel,
   Select,
@@ -23,6 +22,7 @@ import {
   useMediaQuery,
 } from '@mui/material'
 import { alpha } from '@mui/material/styles'
+import { AppButton } from '@/components/common/AppButton'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
 import { default as ExcelIcon } from '@mui/icons-material/TableChart'
 import { default as RefreshIcon } from '@mui/icons-material/Refresh'
@@ -755,20 +755,20 @@ const CustomerPaymentDetails: React.FC = () => {
                   Report Preview ({reportData.length} payments)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 

--- a/frontend/src/pages/sales/CustomerPaymentSummary.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentSummary.tsx
@@ -4,7 +4,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   FormControl,
   InputLabel,
   Select,
@@ -26,6 +25,7 @@ import {
   Checkbox,
 } from '@mui/material'
 import { alpha } from '@mui/material/styles'
+import { AppButton } from '@/components/common/AppButton'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
 import { default as ExcelIcon } from '@mui/icons-material/TableChart'
 import { default as RefreshIcon } from '@mui/icons-material/Refresh'
@@ -737,20 +737,20 @@ const CustomerPaymentSummary: React.FC = () => {
                   Report Preview ({reportData.length} customers)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 

--- a/frontend/src/pages/sales/ProductCustomerReport.tsx
+++ b/frontend/src/pages/sales/ProductCustomerReport.tsx
@@ -4,7 +4,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   FormControl,
   InputLabel,
   Select,
@@ -29,6 +28,7 @@ import {
   IconButton,
 } from '@mui/material'
 import { alpha } from '@mui/material/styles'
+import { AppButton } from '@/components/common/AppButton'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
 import { default as ExcelIcon } from '@mui/icons-material/TableChart'
 import { default as RefreshIcon } from '@mui/icons-material/Refresh'
@@ -1064,20 +1064,20 @@ const ProductCustomerReport: React.FC = () => {
                   Report Preview ({reportData.length} records)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 
@@ -1393,13 +1393,13 @@ const ProductCustomerReport: React.FC = () => {
           <Typography variant="h6" sx={{ fontWeight: 600 }}>
             Select Products
           </Typography>
-          <Button
+          <AppButton
             size="small"
             onClick={handleProductDialogClose}
             sx={{ minWidth: 'auto', p: 0.5 }}
           >
             <CloseIcon />
-          </Button>
+          </AppButton>
         </DialogTitle>
         <DialogContent sx={{ p: 2, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
           <Grid container spacing={1} sx={{ flex: 1, minHeight: 0 }}>
@@ -1633,12 +1633,12 @@ const ProductCustomerReport: React.FC = () => {
             }}>
             {selectedProducts.length} product{selectedProducts.length !== 1 ? 's' : ''} selected
           </Typography>
-          <Button onClick={handleProductDialogClose}>
+          <AppButton variant="secondary" onClick={handleProductDialogClose}>
             Cancel
-          </Button>
-          <Button onClick={handleProductDialogClose} variant="contained">
+          </AppButton>
+          <AppButton variant="primary" onClick={handleProductDialogClose}>
             Done
-          </Button>
+          </AppButton>
         </DialogActions>
       </Dialog>
     </>

--- a/frontend/src/pages/sales/SalesByProductDetails.tsx
+++ b/frontend/src/pages/sales/SalesByProductDetails.tsx
@@ -4,7 +4,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   IconButton,
   FormControl,
   InputLabel,
@@ -37,6 +36,7 @@ import {
   OutlinedInput,
 } from '@mui/material'
 import { alpha } from '@mui/material/styles'
+import { AppButton } from '@/components/common/AppButton'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
 import { default as ExcelIcon } from '@mui/icons-material/TableChart'
 import { default as RefreshIcon } from '@mui/icons-material/Refresh'
@@ -1086,20 +1086,20 @@ const SalesByProductDetails: React.FC = () => {
                   Report Preview ({reportData.length} transactions)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 
@@ -1440,13 +1440,13 @@ const SalesByProductDetails: React.FC = () => {
           <Typography variant="h6" sx={{ fontWeight: 600 }}>
             Select Products
           </Typography>
-          <Button
+          <AppButton
             size="small"
             onClick={handleProductDialogClose}
             sx={{ minWidth: 'auto', p: 0.5 }}
           >
             <CloseIcon />
-          </Button>
+          </AppButton>
         </DialogTitle>
         <DialogContent sx={{ p: 2, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
           <Grid container spacing={1} sx={{ flex: 1, minHeight: 0 }}>
@@ -1680,16 +1680,16 @@ const SalesByProductDetails: React.FC = () => {
             }}>
             {selectedProducts.length} product{selectedProducts.length !== 1 ? 's' : ''} selected
           </Typography>
-          <Button onClick={handleProductDialogClose}>
+          <AppButton variant="secondary" onClick={handleProductDialogClose}>
             Cancel
-          </Button>
-          <Button
-            variant="contained"
+          </AppButton>
+          <AppButton
+            variant="primary"
             onClick={handleProductDialogConfirm}
             disabled={selectedProducts.length === 0}
           >
             Apply
-          </Button>
+          </AppButton>
         </DialogActions>
       </Dialog>
     </>

--- a/frontend/src/pages/sales/SalesByProductSummary.tsx
+++ b/frontend/src/pages/sales/SalesByProductSummary.tsx
@@ -4,7 +4,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   IconButton,
   FormControl,
   InputLabel,
@@ -37,6 +36,7 @@ import {
   OutlinedInput,
 } from '@mui/material'
 import { alpha } from '@mui/material/styles'
+import { AppButton } from '@/components/common/AppButton'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
 import { default as ExcelIcon } from '@mui/icons-material/TableChart'
 import { default as RefreshIcon } from '@mui/icons-material/Refresh'
@@ -1041,20 +1041,20 @@ const SalesByProductSummary: React.FC = () => {
                   Report Preview ({reportData.length} products)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 
@@ -1442,13 +1442,13 @@ const SalesByProductSummary: React.FC = () => {
           <Typography variant="h6" sx={{ fontWeight: 600 }}>
             Select Products
           </Typography>
-          <Button
+          <AppButton
             size="small"
             onClick={handleProductDialogClose}
             sx={{ minWidth: 'auto', p: 0.5 }}
           >
             <CloseIcon />
-          </Button>
+          </AppButton>
         </DialogTitle>
         <DialogContent sx={{ p: 2, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
           <Grid container spacing={1} sx={{ flex: 1, minHeight: 0 }}>
@@ -1682,16 +1682,16 @@ const SalesByProductSummary: React.FC = () => {
             }}>
             {selectedProducts.length} product{selectedProducts.length !== 1 ? 's' : ''} selected
           </Typography>
-          <Button onClick={handleProductDialogClose}>
+          <AppButton variant="secondary" onClick={handleProductDialogClose}>
             Cancel
-          </Button>
-          <Button
-            variant="contained"
+          </AppButton>
+          <AppButton
+            variant="primary"
             onClick={handleProductDialogConfirm}
             disabled={selectedProducts.length === 0}
           >
             Apply
-          </Button>
+          </AppButton>
         </DialogActions>
       </Dialog>
     </>

--- a/frontend/src/pages/sales/SalesOrderProfitReport.tsx
+++ b/frontend/src/pages/sales/SalesOrderProfitReport.tsx
@@ -4,7 +4,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   FormControl,
   InputLabel,
   Select,
@@ -24,6 +23,7 @@ import {
   Chip,
 } from '@mui/material'
 import { alpha } from '@mui/material/styles'
+import { AppButton } from '@/components/common/AppButton'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
 import { default as ExcelIcon } from '@mui/icons-material/TableChart'
 import { default as RefreshIcon } from '@mui/icons-material/Refresh'
@@ -834,20 +834,20 @@ const SalesOrderProfitReport: React.FC = () => {
                   Report Preview ({reportData.length} orders)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 

--- a/frontend/src/pages/sales/SalesOrderSummary.tsx
+++ b/frontend/src/pages/sales/SalesOrderSummary.tsx
@@ -4,7 +4,6 @@ import {
   Typography,
   Paper,
   Grid,
-  Button,
   FormControl,
   InputLabel,
   Select,
@@ -24,6 +23,7 @@ import {
   Chip,
 } from '@mui/material'
 import { alpha } from '@mui/material/styles'
+import { AppButton } from '@/components/common/AppButton'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
 import { default as ExcelIcon } from '@mui/icons-material/TableChart'
 import { default as RefreshIcon } from '@mui/icons-material/Refresh'
@@ -886,20 +886,20 @@ const SalesOrderSummary: React.FC = () => {
                   Report Preview ({reportData.length} orders)
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    size="small"
+                  <AppButton
+                    size="filter"
                     startIcon={<ExcelIcon />}
                     onClick={handleExportExcel}
                   >
                     Excel
-                  </Button>
-                  <Button
-                    size="small"
+                  </AppButton>
+                  <AppButton
+                    size="filter"
                     startIcon={<PdfIcon />}
                     onClick={handleExportPDF}
                   >
                     PDF
-                  </Button>
+                  </AppButton>
                 </Box>
               </Box>
 

--- a/frontend/src/pages/sales/components/OrdersDialogs.tsx
+++ b/frontend/src/pages/sales/components/OrdersDialogs.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import {
   Alert,
   Box,
-  Button,
   Card,
   CardContent,
   Dialog,
@@ -21,6 +20,7 @@ import {
 import Grid from '@mui/material/Grid'
 
 import AccountingEntryLink from '@/components/accounting/AccountingEntryLink'
+import { AppButton } from '@/components/common/AppButton'
 import ConfirmationDialog from '@/components/common/ConfirmationDialog'
 import PaymentDialog from '@/components/sales/PaymentDialog'
 import BlockedSalesOrderDialog from '@/components/sales/BlockedSalesOrderDialog'
@@ -246,7 +246,7 @@ const OrdersDialogs: React.FC<OrdersDialogsProps> = ({
           )}
         </DialogContent>
         <DialogActions>
-          <Button onClick={onCloseViewDialog}>Close</Button>
+          <AppButton variant="secondary" onClick={onCloseViewDialog}>Close</AppButton>
         </DialogActions>
       </Dialog>
       {selectedOrder && (


### PR DESCRIPTION
## Summary
- Extends `AppButton` with two new semantic variants: `text` and `info`
- Migrates 37 files across Accounting, Sales, Purchasing, and Inventory modules from raw MUI `Button` to `AppButton`
- Simplifies `ConfirmationDialog` confirm button: replaces dynamic color + sx override with `variant` derived from `severity`

## Files Changed
- `frontend/src/components/common/AppButton.tsx` — new `text` and `info` variants
- 37 component/page files — import + JSX substitution only, no logic changes

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `grep` for remaining raw MUI `Button` in target modules returns no matches
- [x] Manual: Cancel/Submit buttons work in ChartOfAccountFormDialog
- [x] Manual: ConfirmationDialog shows correct colors for warning, error, info severity
- [x] Manual: Export (Excel/PDF) buttons work on a report page
- [x] Manual: Form cancel/submit work on CreateSalesOrderPage

Closes #407