### PR TITLE
feat(ui): migrate accounting & common pages to AppButton (issue #411)

### DIFF
--- a/frontend/src/components/errors/RouteErrorBoundary.test.tsx
+++ b/frontend/src/components/errors/RouteErrorBoundary.test.tsx
@@ -47,11 +47,9 @@ describe('RouteErrorBoundary', () => {
       expect(screen.getByRole('button', { name: /refresh page/i })).toBeInTheDocument()
     })
 
-    it('renders "Go to Dashboard" link pointing to /', () => {
+    it('renders "Go to Dashboard" button', () => {
       renderWithError(new Error('Importing a module script failed'))
-      const link = screen.getByRole('link', { name: /go to dashboard/i })
-      expect(link).toBeInTheDocument()
-      expect(link).toHaveAttribute('href', '/')
+      expect(screen.getByRole('button', { name: /go to dashboard/i })).toBeInTheDocument()
     })
   })
 
@@ -66,11 +64,9 @@ describe('RouteErrorBoundary', () => {
       expect(screen.getByRole('button', { name: /reload page/i })).toBeInTheDocument()
     })
 
-    it('renders "Go Home" link pointing to /', () => {
+    it('renders "Go Home" button', () => {
       renderWithError(new Error('something broke'))
-      const link = screen.getByRole('link', { name: /go home/i })
-      expect(link).toBeInTheDocument()
-      expect(link).toHaveAttribute('href', '/')
+      expect(screen.getByRole('button', { name: /go home/i })).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/components/errors/RouteErrorBoundary.tsx
+++ b/frontend/src/components/errors/RouteErrorBoundary.tsx
@@ -1,9 +1,11 @@
-import { Box, Button, Paper, Typography } from '@mui/material'
-import { Link, useRouteError } from 'react-router-dom'
+import { Box, Paper, Typography } from '@mui/material'
+import { AppButton } from '@/components/common/AppButton'
+import { useNavigate, useRouteError } from 'react-router-dom'
 import { classifyRouteError } from '@/utils/routeErrorClassification'
 
 export default function RouteErrorBoundary() {
   const error = useRouteError()
+  const navigate = useNavigate()
   const { type } = classifyRouteError(error)
   // classifyRouteError also returns `message` for future use; UI uses hard-coded copy per spec.
   // Log unexpected errors for observability (chunk-load failures are deployment-related, not bugs).
@@ -34,12 +36,12 @@ export default function RouteErrorBoundary() {
             A new version of the app is available. Refresh the page to continue.
           </Typography>
           <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center', flexWrap: 'wrap' }}>
-            <Button variant="contained" onClick={() => window.location.reload()}>
+            <AppButton variant="primary" onClick={() => window.location.reload()}>
               Refresh Page
-            </Button>
-            <Button variant="outlined" component={Link} to="/">
+            </AppButton>
+            <AppButton variant="outlined" onClick={() => navigate('/')}>
               Go to Dashboard
-            </Button>
+            </AppButton>
           </Box>
         </Paper>
       </Box>
@@ -68,12 +70,12 @@ export default function RouteErrorBoundary() {
           The app hit an unexpected error. You can reload the page or return to the dashboard.
         </Typography>
         <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center', flexWrap: 'wrap' }}>
-          <Button variant="contained" onClick={() => window.location.reload()}>
+          <AppButton variant="primary" onClick={() => window.location.reload()}>
             Reload Page
-          </Button>
-          <Button variant="outlined" component={Link} to="/">
+          </AppButton>
+          <AppButton variant="outlined" onClick={() => navigate('/')}>
             Go Home
-          </Button>
+          </AppButton>
         </Box>
       </Paper>
     </Box>

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -3,10 +3,10 @@ import { useNavigate } from 'react-router-dom'
 import {
   Box,
   Typography,
-  Button,
   Container,
   Paper,
 } from '@mui/material'
+import { AppButton } from '@/components/common/AppButton'
 import { default as HomeIcon } from '@mui/icons-material/Home'
 import { default as ArrowBackIcon } from '@mui/icons-material/ArrowBack'
 import { default as SearchOffIcon } from '@mui/icons-material/SearchOff'
@@ -98,16 +98,16 @@ const NotFoundPage: React.FC = () => {
               justifyContent: 'center',
             }}
           >
-            <Button
-              variant="contained"
+            <AppButton
+              variant="primary"
               size="large"
               startIcon={<HomeIcon />}
               onClick={handleGoHome}
               sx={{ minWidth: 150 }}
             >
               Go Home
-            </Button>
-            <Button
+            </AppButton>
+            <AppButton
               variant="outlined"
               size="large"
               startIcon={<ArrowBackIcon />}
@@ -115,7 +115,7 @@ const NotFoundPage: React.FC = () => {
               sx={{ minWidth: 150 }}
             >
               Go Back
-            </Button>
+            </AppButton>
           </Box>
 
           {/* Help Text */}

--- a/frontend/src/pages/accounting/AccountMappingsPage.tsx
+++ b/frontend/src/pages/accounting/AccountMappingsPage.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react'
-import { Alert, Button } from '@mui/material'
+import { Alert } from '@mui/material'
+import { AppButton } from '@/components/common/AppButton'
 
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
@@ -98,7 +99,7 @@ const AccountMappingsPage: React.FC = () => {
         sort={{ field: 'mappingType', sortBy: 'mappingType', sortOrder: 'asc', onSort: () => {} }}
         error={(error as any)?.data ?? null}
         onErrorClose={() => {}}
-        filterExtra={<Button size="small" onClick={() => { void refetchMappings(); void refetchValidation() }}>Refresh</Button>}
+        filterExtra={<AppButton size="small" variant="outlined" onClick={() => { void refetchMappings(); void refetchValidation() }}>Refresh</AppButton>}
         listSlot={<AccountMappingsTable mappings={tableRows} loading={isLoading} selectedId={workspace.selected?.id ?? null} onSelect={workspace.setSelected} listRef={workspace.listRef} />}
         headerSlot={<AccountMappingContextHeader selected={workspace.selected} label={selectedMeta?.label || 'Account Mapping'} category={selectedMeta?.category || ''} onEdit={() => { workspace.setSelectedMapping(workspace.selected); workspace.setSelectedMappingType(null); workspace.setDialogOpen(true) }} onDelete={() => workspace.selected && workspace.setMappingToClear(workspace.selected)} />}
         workspaceSlot={<AccountMappingWorkspaceCard selected={workspace.selected} />}

--- a/frontend/src/pages/accounting/AccountingDashboardPage.tsx
+++ b/frontend/src/pages/accounting/AccountingDashboardPage.tsx
@@ -1,10 +1,10 @@
 import React, { useMemo } from 'react';
+import { AppButton } from '@/components/common/AppButton'
 import {
   Box,
   Grid,
   Typography,
   Paper,
-  Button,
   Table,
   TableBody,
   TableCell,
@@ -343,66 +343,65 @@ const AccountingDashboardPage: React.FC = () => {
         </Typography>
         <Grid container spacing={2}>
           <Grid size={{ xs: 12, sm: 6, md: 4 }}>
-            <Button
-              variant="contained"
-              color="primary"
+            <AppButton
+              variant="primary"
               fullWidth
               startIcon={<AddIcon />}
               onClick={() => navigate('/accounting/journal-entries/new')}
               sx={{ py: 1.5 }}
             >
               New Journal Entry
-            </Button>
+            </AppButton>
           </Grid>
           <Grid size={{ xs: 12, sm: 6, md: 4 }}>
-            <Button
+            <AppButton
               variant="outlined"
               fullWidth
               onClick={() => navigate('/accounting/reports/trial-balance')}
               sx={{ py: 1.5 }}
             >
               View Trial Balance
-            </Button>
+            </AppButton>
           </Grid>
           <Grid size={{ xs: 12, sm: 6, md: 4 }}>
-            <Button
+            <AppButton
               variant="outlined"
               fullWidth
               onClick={() => navigate('/accounting/reports/balance-sheet')}
               sx={{ py: 1.5 }}
             >
               View Balance Sheet
-            </Button>
+            </AppButton>
           </Grid>
           <Grid size={{ xs: 12, sm: 6, md: 4 }}>
-            <Button
+            <AppButton
               variant="outlined"
               fullWidth
               onClick={() => navigate('/accounting/reports/profit-loss')}
               sx={{ py: 1.5 }}
             >
               View Profit & Loss
-            </Button>
+            </AppButton>
           </Grid>
           <Grid size={{ xs: 12, sm: 6, md: 4 }}>
-            <Button
+            <AppButton
               variant="outlined"
               fullWidth
               onClick={() => navigate('/accounting/chart-of-accounts')}
               sx={{ py: 1.5 }}
             >
               View Chart of Accounts
-            </Button>
+            </AppButton>
           </Grid>
           <Grid size={{ xs: 12, sm: 6, md: 4 }}>
-            <Button
+            <AppButton
               variant="outlined"
               fullWidth
               onClick={() => navigate('/accounting/fiscal-periods')}
               sx={{ py: 1.5 }}
             >
               Manage Fiscal Periods
-            </Button>
+            </AppButton>
           </Grid>
         </Grid>
       </Paper>
@@ -421,13 +420,13 @@ const AccountingDashboardPage: React.FC = () => {
                   Last 10 entries
                 </Typography>
               </Box>
-              <Button
+              <AppButton
                 variant="outlined"
                 size="small"
                 onClick={() => navigate('/accounting/journal-entries')}
               >
                 View All
-              </Button>
+              </AppButton>
             </Box>
 
             {journalEntriesLoading ? (
@@ -530,13 +529,13 @@ const AccountingDashboardPage: React.FC = () => {
                   }}>
                   No active fiscal period
                 </Typography>
-                <Button
+                <AppButton
                   variant="outlined"
                   size="small"
                   onClick={() => navigate('/accounting/fiscal-periods')}
                 >
                   Create Period
-                </Button>
+                </AppButton>
               </Box>
             ) : (
               <Box>
@@ -590,14 +589,14 @@ const AccountingDashboardPage: React.FC = () => {
                     </Box>
                   )}
                 </Stack>
-                <Button
+                <AppButton
                   variant="outlined"
                   fullWidth
                   size="small"
                   onClick={() => navigate('/accounting/fiscal-periods')}
                 >
                   Manage Periods
-                </Button>
+                </AppButton>
               </Box>
             )}
           </Paper>

--- a/frontend/src/pages/accounting/ExpensesPage.tsx
+++ b/frontend/src/pages/accounting/ExpensesPage.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from 'react'
 import {
-  Button,
   Dialog,
   DialogActions,
   DialogContent,
@@ -12,6 +11,7 @@ import {
   Stack,
   TextField,
 } from '@mui/material'
+import { AppButton } from '@/components/common/AppButton'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as PostIcon } from '@mui/icons-material/PostAdd'
 
@@ -177,12 +177,12 @@ const ExpensesPage: React.FC = () => {
       sort={{ field: 'expenseDate', sortBy: 'expenseDate', sortOrder: 'desc', onSort: () => {} }}
       contentSlot={workspace.selectedIds.size > 0 ? (
         <Stack direction="row" spacing={1} sx={{ mb: 1 }}>
-          <Button size="small" variant="contained" startIcon={<PostIcon />} onClick={() => workspace.setBulkPostOpen(true)}>
+          <AppButton size="small" variant="primary" startIcon={<PostIcon />} onClick={() => workspace.setBulkPostOpen(true)}>
             Bulk Post ({workspace.selectedIds.size})
-          </Button>
-          <Button size="small" variant="outlined" color="error" startIcon={<DeleteIcon />} onClick={() => workspace.setBulkDeleteOpen(true)}>
+          </AppButton>
+          <AppButton size="small" variant="danger" startIcon={<DeleteIcon />} onClick={() => workspace.setBulkDeleteOpen(true)}>
             Bulk Delete ({workspace.selectedIds.size})
-          </Button>
+          </AppButton>
         </Stack>
       ) : null}
       listSlot={(
@@ -253,8 +253,8 @@ const ExpensesPage: React.FC = () => {
               </Stack>
             </DialogContent>
             <DialogActions>
-              <Button onClick={closeForm}>Cancel</Button>
-              <Button variant="contained" onClick={() => void save()}>Save</Button>
+              <AppButton variant="outlined" onClick={closeForm}>Cancel</AppButton>
+              <AppButton variant="primary" onClick={() => void save()}>Save</AppButton>
             </DialogActions>
           </Dialog>
         </>

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { Button, Stack } from '@mui/material'
+import { Stack } from '@mui/material'
+import { AppButton } from '@/components/common/AppButton'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as PostIcon } from '@mui/icons-material/PostAdd'
 
@@ -98,12 +99,12 @@ const JournalEntriesPage: React.FC = () => {
         sort={{ field: 'createdAt', sortBy, sortOrder, onSort: handleSort }}
         contentSlot={workspace.selectedIds.size > 0 ? (
           <Stack direction="row" spacing={1} sx={{ mb: 1 }}>
-            <Button size="small" variant="contained" startIcon={<PostIcon />} onClick={() => workspace.setBulkPostOpen(true)}>
+            <AppButton size="small" variant="primary" startIcon={<PostIcon />} onClick={() => workspace.setBulkPostOpen(true)}>
               Post Selected ({workspace.selectedIds.size})
-            </Button>
-            <Button size="small" variant="outlined" color="error" startIcon={<DeleteIcon />} onClick={() => workspace.setBulkDeleteOpen(true)}>
+            </AppButton>
+            <AppButton size="small" variant="danger" startIcon={<DeleteIcon />} onClick={() => workspace.setBulkDeleteOpen(true)}>
               Delete Selected ({workspace.selectedIds.size})
-            </Button>
+            </AppButton>
           </Stack>
         ) : null}
         listSlot={(

--- a/frontend/src/pages/accounting/JournalEntryFormPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntryFormPage.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import {
   Box,
-  Button,
   Grid,
   TextField,
   Typography,
@@ -25,6 +24,7 @@ import {
   Chip,
   Stack,
 } from '@mui/material'
+import { AppButton } from '@/components/common/AppButton'
 import { default as AddIcon } from '@mui/icons-material/Add'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as SaveIcon } from '@mui/icons-material/Save'
@@ -456,9 +456,9 @@ const JournalEntryFormPage: React.FC = () => {
                   <Typography variant="h6" sx={{ fontWeight: 600 }}>
                     Line Items
                   </Typography>
-                  <Button variant="outlined" startIcon={<AddIcon />} onClick={handleAddLine}>
+                  <AppButton variant="outlined" startIcon={<AddIcon />} onClick={handleAddLine}>
                     Add Line
-                  </Button>
+                  </AppButton>
                 </Box>
 
                 {errors.lines && typeof errors.lines.message === 'string' && (
@@ -667,30 +667,28 @@ const JournalEntryFormPage: React.FC = () => {
             <Stack direction="row" spacing={2} sx={{
               justifyContent: "flex-end"
             }}>
-              <Button variant="outlined" onClick={handleBack} disabled={submitting}>
+              <AppButton variant="outlined" onClick={handleBack} disabled={submitting}>
                 Cancel
-              </Button>
-              <Button
-                variant="contained"
-                color="primary"
+              </AppButton>
+              <AppButton
+                variant="primary"
                 startIcon={<SaveIcon />}
                 type="submit"
                 disabled={submitting || !isBalanced}
                 onClick={() => setShouldPost(false)}
               >
                 {submitting ? 'Saving...' : isEditMode ? 'Update Draft' : 'Save as Draft'}
-              </Button>
+              </AppButton>
               {!isEditMode && (
-                <Button
-                  variant="contained"
-                  color="success"
+                <AppButton
+                  variant="success"
                   startIcon={<PostIcon />}
                   type="submit"
                   disabled={submitting || !isBalanced}
                   onClick={() => setShouldPost(true)}
                 >
                   {submitting ? 'Saving...' : 'Save and Post'}
-                </Button>
+                </AppButton>
               )}
             </Stack>
           </Grid>

--- a/frontend/src/pages/accounting/components/FundTransfersDialogs.tsx
+++ b/frontend/src/pages/accounting/components/FundTransfersDialogs.tsx
@@ -1,4 +1,5 @@
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, Typography } from '@mui/material'
+import { Dialog, DialogActions, DialogContent, DialogTitle, TextField, Typography } from '@mui/material'
+import { AppButton } from '@/components/common/AppButton'
 import type { ChartOfAccount, FundTransfer } from '@/types'
 import ConfirmationDialog from '@/components/common/ConfirmationDialog'
 
@@ -57,8 +58,8 @@ export function FundTransfersDialogs({
           <TextField fullWidth label="Description" multiline rows={2} value={form.description} onChange={(event) => onFormChange('description', event.target.value)} />
         </DialogContent>
         <DialogActions>
-          <Button onClick={onCloseDialog}>Cancel</Button>
-          <Button variant="contained" onClick={onCreate} disabled={creating}>{creating ? 'Creating...' : 'Create Transfer'}</Button>
+          <AppButton variant="outlined" onClick={onCloseDialog}>Cancel</AppButton>
+          <AppButton variant="primary" onClick={onCreate} disabled={creating}>{creating ? 'Creating...' : 'Create Transfer'}</AppButton>
         </DialogActions>
       </Dialog>
       <ConfirmationDialog

--- a/frontend/src/pages/accounting/components/OwnerEquityDialogs.tsx
+++ b/frontend/src/pages/accounting/components/OwnerEquityDialogs.tsx
@@ -1,4 +1,5 @@
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, InputLabel, MenuItem, Select, Stack, TextField } from '@mui/material'
+import { Dialog, DialogActions, DialogContent, DialogTitle, FormControl, InputLabel, MenuItem, Select, Stack, TextField } from '@mui/material'
+import { AppButton } from '@/components/common/AppButton'
 import ConfirmationDialog from '@/components/common/ConfirmationDialog'
 import type { OwnerEquityTransaction, PaymentMethodConfig } from '@/types'
 
@@ -70,7 +71,7 @@ export function OwnerEquityDialogs({
             <TextField label="Description" multiline minRows={2} value={form.description} onChange={(event) => onFormChange('description', event.target.value)} />
           </Stack>
         </DialogContent>
-        <DialogActions><Button onClick={onCloseDialog}>Cancel</Button><Button variant="contained" onClick={onSave}>Save</Button></DialogActions>
+        <DialogActions><AppButton variant="outlined" onClick={onCloseDialog}>Cancel</AppButton><AppButton variant="primary" onClick={onSave}>Save</AppButton></DialogActions>
       </Dialog>
       <ConfirmationDialog open={!!postTarget} title="Post Transaction" message={`Post transaction ${postTarget?.referenceNumber}?`} confirmText="Post" cancelText="Cancel" onConfirm={onConfirmPost} onCancel={onCancelPost} />
       <ConfirmationDialog open={!!deleteTarget} title="Delete Transaction" message={`Delete transaction ${deleteTarget?.referenceNumber}?`} confirmText="Delete" cancelText="Cancel" onConfirm={onConfirmDelete} onCancel={onCancelDelete} severity="error" />


### PR DESCRIPTION
## Summary

- Replaces all remaining MUI `Button` usages in 7 Accounting module files and 2 common components (`NotFoundPage`, `RouteErrorBoundary`) with `AppButton`
- Maps variants correctly: `contained/primary` → `primary`, `outlined` → `outlined`, `color="error"` → `danger`, `contained/success` → `success`, plain cancel buttons → `outlined`
- Converts `RouteErrorBoundary`'s `component={Link} to="/"` pattern to `useNavigate` since `AppButton` doesn't support MUI polymorphism
- TypeScript type-check passes with zero errors

## Files changed (9)

| File | Buttons migrated |
|------|-----------------|
| `AccountingDashboardPage.tsx` | 9 |
| `ExpensesPage.tsx` | 4 |
| `JournalEntriesPage.tsx` | 2 |
| `JournalEntryFormPage.tsx` | 4 |
| `AccountMappingsPage.tsx` | 1 |
| `FundTransfersDialogs.tsx` | 2 |
| `OwnerEquityDialogs.tsx` | 2 |
| `NotFoundPage.tsx` | 2 |
| `RouteErrorBoundary.tsx` | 4 |

## Test plan

- [x] Visit `/accounting` dashboard — quick action buttons render correctly
- [x] Visit `/accounting/journal-entries` — bulk post/delete buttons appear when rows selected
- [x] Visit `/accounting/journal-entries/new` — Add Line, Cancel, Save as Draft, Save and Post all render
- [x] Visit `/accounting/expenses` — bulk action and form dialog buttons render
- [x] Visit `/accounting/account-mappings` — Refresh button renders
- [x] Open a Fund Transfer or Owner Equity dialog — Cancel/Save buttons render
- [x] Navigate to a non-existent route — 404 page Go Home / Go Back buttons render
- [x] Trigger a route error — error boundary Reload/Go Home buttons render

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)