### PR TITLE
refactor(accounting): align JournalEntriesPage with standard page format

### DIFF
--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -25,26 +25,29 @@ interface JEFilters {
   period: PeriodValue
 }
 
-const filterConfig: FilterBarConfig<JEFilters> = {
-  search: { placeholder: 'Search by reference or description...' },
-  fields: [
-    { field: 'period', label: 'Period', type: 'period' },
-    { field: 'status', label: 'Status', type: 'journal-entry-status' },
-    { field: 'entryType', label: 'Entry Type', type: 'journal-entry-type' },
-  ],
-  defaults: {
-    search: '',
-    status: null,
-    entryType: null,
-    period: { key: null, from: null, to: null },
-  },
-}
-
 export const JournalEntriesPage: React.FC = () => {
   const location = useLocation()
   const navigate = useNavigate()
   const [sortBy, setSortBy] = useState('createdAt')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
+
+  const filterConfig = useMemo<FilterBarConfig<JEFilters>>(
+    () => ({
+      search: { placeholder: 'Search by reference or description...' },
+      fields: [
+        { field: 'period', label: 'Period', type: 'period' },
+        { field: 'status', label: 'Status', type: 'journal-entry-status' },
+        { field: 'entryType', label: 'Entry Type', type: 'journal-entry-type' },
+      ],
+      defaults: {
+        search: '',
+        status: null,
+        entryType: null,
+        period: { key: null, from: null, to: null },
+      },
+    }),
+    [],
+  )
 
   const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
 

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -40,7 +40,7 @@ const filterConfig: FilterBarConfig<JEFilters> = {
   },
 }
 
-const JournalEntriesPage: React.FC = () => {
+export const JournalEntriesPage: React.FC = () => {
   const location = useLocation()
   const navigate = useNavigate()
   const [sortBy, setSortBy] = useState('createdAt')
@@ -89,7 +89,7 @@ const JournalEntriesPage: React.FC = () => {
       <AccountMappingWarning context="system" />
       <GenericListPage
         title="Journal Entries"
-        subtitle={`Manage and post accounting journal entries (${pagination?.total ?? 0} total)`}
+        subtitle="Manage and post accounting journal entries"
         primaryAction={{ label: 'New Journal Entry', onClick: workspace.navigateToCreate }}
         filterConfig={filterConfig}
         draftFilters={draftFilters}

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -26,10 +26,11 @@ interface JEFilters {
 }
 
 export const JournalEntriesPage: React.FC = () => {
-  const location = useLocation()
-  const navigate = useNavigate()
   const [sortBy, setSortBy] = useState('createdAt')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
+
+  const location = useLocation()
+  const navigate = useNavigate()
 
   const filterConfig = useMemo<FilterBarConfig<JEFilters>>(
     () => ({
@@ -82,6 +83,16 @@ export const JournalEntriesPage: React.FC = () => {
     void refetch()
   })
 
+  const filterHandlers = useMemo(() => ({
+    ...handlers,
+    onSearchChange: (value: string) => {
+      handlers.onSearchChange(value)
+      window.setTimeout(() => {
+        workspace.searchInputRef.current?.focus()
+      }, 0)
+    },
+  }), [handlers, workspace])
+
   const handleSort = useCallback((field: string) => {
     setSortOrder((prev) => (sortBy === field && prev === 'desc' ? 'asc' : 'desc'))
     setSortBy(field)
@@ -96,7 +107,7 @@ export const JournalEntriesPage: React.FC = () => {
         primaryAction={{ label: 'New Journal Entry', onClick: workspace.navigateToCreate }}
         filterConfig={filterConfig}
         draftFilters={draftFilters}
-        handlers={handlers}
+        handlers={filterHandlers}
         hasActiveFilters={hasActiveFilters}
         searchInputRef={workspace.searchInputRef}
         sort={{ field: 'createdAt', sortBy, sortOrder, onSort: handleSort }}


### PR DESCRIPTION
## Summary
- Added named export `export const JournalEntriesPage` (default export kept for router compatibility)
- Made subtitle static: "Manage and post accounting journal entries"
- Moved `filterConfig` inside component body, wrapped in `useMemo`
- Added `filterHandlers` memo to preserve search input focus after filtering (via `searchInputRef` focus, as `useJournalEntriesWorkspace` does not expose `setShouldPreserveSearchFocus`)
- Reordered hooks to standard sequence: React → router → RTK Query → custom

Closes #414

## Test plan
- [x] TypeScript check passes
- [x] 3/3 `JournalEntriesPage` tests pass
- [x] 18 accounting test files (106 tests) pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)