### PR TITLE
refactor(accounting): align Journal Entries components with module pattern (issue #416)

### DIFF
--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -1,9 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
-import { Stack } from '@mui/material'
-import { AppButton } from '@/components/common/AppButton'
-import { default as DeleteIcon } from '@mui/icons-material/Delete'
-import { default as PostIcon } from '@mui/icons-material/PostAdd'
+import { useLocation } from 'react-router-dom'
 
 import AccountMappingWarning from '@/components/accounting/AccountMappingWarning'
 import GenericListPage from '@/components/common/GenericListPage'
@@ -30,7 +26,6 @@ export const JournalEntriesPage: React.FC = () => {
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
 
   const location = useLocation()
-  const navigate = useNavigate()
 
   const filterConfig = useMemo<FilterBarConfig<JEFilters>>(
     () => ({
@@ -74,11 +69,10 @@ export const JournalEntriesPage: React.FC = () => {
     endDate: dateRange.toDate,
     sortBy,
     sortOrder: sortOrder.toUpperCase() as 'ASC' | 'DESC',
-  }), [appliedFilters, dateRange, sortBy, sortOrder, sourceTypeParam, sourceIdParam])
+  }), [appliedFilters, dateRange, sortBy, sortOrder, sourceIdParam, sourceTypeParam])
 
   const { data, isLoading, refetch } = useGetJournalEntriesQuery(queryArgs)
   const entries = data?.data ?? []
-  const pagination = data?.meta
   const workspace = useJournalEntriesWorkspace(() => {
     void refetch()
   })
@@ -111,29 +105,13 @@ export const JournalEntriesPage: React.FC = () => {
         hasActiveFilters={hasActiveFilters}
         searchInputRef={workspace.searchInputRef}
         sort={{ field: 'createdAt', sortBy, sortOrder, onSort: handleSort }}
-        contentSlot={workspace.selectedIds.size > 0 ? (
-          <Stack direction="row" spacing={1} sx={{ mb: 1 }}>
-            <AppButton size="small" variant="primary" startIcon={<PostIcon />} onClick={() => workspace.setBulkPostOpen(true)}>
-              Post Selected ({workspace.selectedIds.size})
-            </AppButton>
-            <AppButton size="small" variant="danger" startIcon={<DeleteIcon />} onClick={() => workspace.setBulkDeleteOpen(true)}>
-              Delete Selected ({workspace.selectedIds.size})
-            </AppButton>
-          </Stack>
-        ) : null}
         listSlot={(
           <JournalEntriesTable
             entries={entries}
             loading={isLoading}
-            total={pagination?.total ?? 0}
             selectedEntryId={workspace.selectedEntry?.id ?? null}
-            selectedIds={workspace.selectedIds}
             onSelect={workspace.handleSelect}
-            onToggleCheck={workspace.handleToggleCheck}
-            onSelectAll={() => workspace.handleSelectAll(entries)}
-            onPost={(entry) => workspace.setPostTarget(entry)}
-            onDelete={(entry) => workspace.setDeleteTarget(entry)}
-            onViewSource={(sourceType, sourceId) => workspace.navigateToSource(sourceType, sourceId)}
+            onViewSource={workspace.navigateToSource}
             listRef={workspace.listRef}
           />
         )}
@@ -144,7 +122,7 @@ export const JournalEntriesPage: React.FC = () => {
             onPost={() => workspace.selectedEntry && workspace.setPostTarget(workspace.selectedEntry)}
             onReverse={() => workspace.selectedEntry && workspace.setReverseTarget(workspace.selectedEntry)}
             onDelete={() => workspace.selectedEntry && workspace.setDeleteTarget(workspace.selectedEntry)}
-            onNavigateToSource={(path) => navigate(path)}
+            onViewSource={workspace.navigateToSource}
           />
         )}
         workspaceSlot={<JournalEntryWorkspaceCard selectedEntry={workspace.selectedEntry} />}
@@ -153,19 +131,13 @@ export const JournalEntriesPage: React.FC = () => {
             postTarget={workspace.postTarget}
             deleteTarget={workspace.deleteTarget}
             reverseTarget={workspace.reverseTarget}
-            bulkPostIds={workspace.bulkPostOpen ? workspace.selectedIds : new Set<string>()}
-            bulkDeleteIds={workspace.bulkDeleteOpen ? workspace.selectedIds : new Set<string>()}
             actionLoading={workspace.actionLoading}
             onConfirmPost={workspace.handleConfirmPost}
             onConfirmDelete={workspace.handleConfirmDelete}
             onConfirmReverse={workspace.handleConfirmReverse}
-            onConfirmBulkPost={workspace.handleBulkPost}
-            onConfirmBulkDelete={workspace.handleBulkDelete}
             onCancelPost={() => workspace.setPostTarget(null)}
             onCancelDelete={() => workspace.setDeleteTarget(null)}
             onCancelReverse={() => workspace.setReverseTarget(null)}
-            onCancelBulkPost={() => workspace.setBulkPostOpen(false)}
-            onCancelBulkDelete={() => workspace.setBulkDeleteOpen(false)}
           />
         )}
       />

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -73,6 +73,7 @@ export const JournalEntriesPage: React.FC = () => {
 
   const { data, isLoading, refetch } = useGetJournalEntriesQuery(queryArgs)
   const entries = data?.data ?? []
+  const pagination = data?.meta
   const workspace = useJournalEntriesWorkspace(() => {
     void refetch()
   })
@@ -109,6 +110,7 @@ export const JournalEntriesPage: React.FC = () => {
           <JournalEntriesTable
             entries={entries}
             loading={isLoading}
+            total={pagination?.total ?? entries.length}
             selectedEntryId={workspace.selectedEntry?.id ?? null}
             onSelect={workspace.handleSelect}
             onViewSource={workspace.navigateToSource}

--- a/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
@@ -15,7 +15,7 @@ vi.mock('@/utils/formatters', async () => {
     ...actual,
     formatCurrency: (value: number) => `$${value}`,
     formatDate: (date: string) => date,
-    getCurrentDate: () => '2026-04-19',
+    getCurrentDate: () => '2026-04-22',
   }
 })
 vi.mock('@/utils/dateRange', () => ({
@@ -28,8 +28,6 @@ const mockedApi = vi.hoisted(() => ({
   useLazyGetJournalEntryQuery: vi.fn(),
   useDeleteJournalEntryMutation: vi.fn(),
   usePostJournalEntryMutation: vi.fn(),
-  useBulkPostJournalEntriesMutation: vi.fn(),
-  useBulkDeleteJournalEntriesMutation: vi.fn(),
   useReverseJournalEntryMutation: vi.fn(),
 }))
 
@@ -76,8 +74,6 @@ describe('JournalEntriesPage', () => {
     mockedApi.useLazyGetJournalEntryQuery.mockReturnValue([vi.fn().mockResolvedValue({ id: '1' })])
     mockedApi.useDeleteJournalEntryMutation.mockReturnValue([vi.fn()])
     mockedApi.usePostJournalEntryMutation.mockReturnValue([vi.fn()])
-    mockedApi.useBulkPostJournalEntriesMutation.mockReturnValue([vi.fn()])
-    mockedApi.useBulkDeleteJournalEntriesMutation.mockReturnValue([vi.fn()])
     mockedApi.useReverseJournalEntryMutation.mockReturnValue([vi.fn()])
   })
 
@@ -91,13 +87,13 @@ describe('JournalEntriesPage', () => {
     expect(screen.getByText('JE-001')).toBeInTheDocument()
   })
 
-  it('clicking a row selects it instead of navigating', async () => {
+  it('clicking a row selects it and shows details in the context header', async () => {
     render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
 
     fireEvent.click(screen.getByText('JE-001'))
 
     await waitFor(() => {
-      expect(screen.getAllByText('JE-001').length).toBeGreaterThan(1)
+      expect(screen.getByText('JE Details - JE-001')).toBeInTheDocument()
     })
     expect(mockNavigate).not.toHaveBeenCalled()
   })

--- a/frontend/src/pages/accounting/components/JournalEntriesDialogs.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesDialogs.tsx
@@ -8,38 +8,26 @@ interface Props {
   postTarget: JournalEntry | null
   deleteTarget: JournalEntry | null
   reverseTarget: JournalEntry | null
-  bulkPostIds: Set<string>
-  bulkDeleteIds: Set<string>
   actionLoading: boolean
   onConfirmPost: () => void
   onConfirmDelete: () => void
   onConfirmReverse: (reverseDate: string) => void
-  onConfirmBulkPost: () => void
-  onConfirmBulkDelete: () => void
   onCancelPost: () => void
   onCancelDelete: () => void
   onCancelReverse: () => void
-  onCancelBulkPost: () => void
-  onCancelBulkDelete: () => void
 }
 
 export function JournalEntriesDialogs({
   postTarget,
   deleteTarget,
   reverseTarget,
-  bulkPostIds,
-  bulkDeleteIds,
   actionLoading,
   onConfirmPost,
   onConfirmDelete,
   onConfirmReverse,
-  onConfirmBulkPost,
-  onConfirmBulkDelete,
   onCancelPost,
   onCancelDelete,
   onCancelReverse,
-  onCancelBulkPost,
-  onCancelBulkDelete,
 }: Props) {
   const [reverseDate] = useState(getCurrentDate())
 
@@ -73,27 +61,6 @@ export function JournalEntriesDialogs({
         cancelText="Cancel"
         onConfirm={() => onConfirmReverse(reverseDate)}
         onCancel={onCancelReverse}
-        loading={actionLoading}
-      >
-      </ConfirmationDialog>
-      <ConfirmationDialog
-        open={bulkPostIds.size > 0}
-        title="Bulk Post Entries"
-        message={`Post ${bulkPostIds.size} selected journal entries?`}
-        confirmText="Post"
-        cancelText="Cancel"
-        onConfirm={onConfirmBulkPost}
-        onCancel={onCancelBulkPost}
-        loading={actionLoading}
-      />
-      <ConfirmationDialog
-        open={bulkDeleteIds.size > 0}
-        title="Bulk Delete Entries"
-        message={`Delete ${bulkDeleteIds.size} selected journal entries?`}
-        confirmText="Delete"
-        cancelText="Cancel"
-        onConfirm={onConfirmBulkDelete}
-        onCancel={onCancelBulkDelete}
         loading={actionLoading}
       />
     </>

--- a/frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx
@@ -41,6 +41,7 @@ describe('JournalEntriesTable', () => {
   const defaultProps = {
     entries: [],
     loading: false,
+    total: 0,
     selectedEntryId: null,
     onSelect: vi.fn(),
   }

--- a/frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx
@@ -9,8 +9,18 @@ vi.mock('@/utils/formatters', () => ({
   formatDate: (date: string) => date,
 }))
 
-vi.mock('@/components/common/AppButton', () => ({
-  AppButton: ({ onClick, children, startIcon }: any) => <button onClick={onClick}>{children}{startIcon}</button>,
+vi.mock('@/components/common/EntityTable', () => ({
+  default: ({ rows, loading, label, onSelect }: any) => (
+    <div>
+      {loading && <div>Loading...</div>}
+      {rows.length === 0 && <div>No {label} found</div>}
+      {rows.map((row: any) => (
+        <div key={row.id} onClick={() => onSelect(row)} data-testid={`row-${row.id}`}>
+          {row.referenceNumber}
+        </div>
+      ))}
+    </div>
+  ),
 }))
 
 const makeEntry = (overrides = {}) => ({
@@ -21,9 +31,9 @@ const makeEntry = (overrides = {}) => ({
   status: JournalEntryStatus.DRAFT,
   totalDebits: 100,
   totalCredits: 100,
-  isBalanced: true,
   sourceType: 'manual',
   sourceId: null,
+  lines: [],
   ...overrides,
 })
 
@@ -31,29 +41,23 @@ describe('JournalEntriesTable', () => {
   const defaultProps = {
     entries: [],
     loading: false,
-    total: 0,
     selectedEntryId: null,
-    selectedIds: new Set<string>(),
     onSelect: vi.fn(),
-    onToggleCheck: vi.fn(),
-    onSelectAll: vi.fn(),
-    onPost: vi.fn(),
-    onDelete: vi.fn(),
   }
 
   it('shows empty state when no entries', () => {
     render(<JournalEntriesTable {...defaultProps} />)
-    expect(screen.getByText('No journal entries found')).toBeInTheDocument()
+    expect(screen.getByText('No Journal Entries found')).toBeInTheDocument()
   })
 
   it('renders entry rows', () => {
-    render(<JournalEntriesTable {...defaultProps} entries={[makeEntry()]} total={1} />)
+    render(<JournalEntriesTable {...defaultProps} entries={[makeEntry()]} />)
     expect(screen.getByText('JE-001')).toBeInTheDocument()
   })
 
   it('calls onSelect when row is clicked', () => {
     const onSelect = vi.fn()
-    render(<JournalEntriesTable {...defaultProps} entries={[makeEntry()]} total={1} onSelect={onSelect} />)
+    render(<JournalEntriesTable {...defaultProps} entries={[makeEntry()]} onSelect={onSelect} />)
     fireEvent.click(screen.getByText('JE-001'))
     expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: '1' }))
   })

--- a/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
@@ -1,27 +1,9 @@
-import type { RefObject } from 'react'
-import { Checkbox, Chip, CircularProgress, Link, Paper, Stack, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tooltip, Typography } from '@mui/material'
-import { default as DeleteIcon } from '@mui/icons-material/Delete'
-import { default as PostIcon } from '@mui/icons-material/PostAdd'
+import { useRef, type RefObject } from 'react'
+import { Chip, Link, Typography } from '@mui/material'
 
-import { AppButton } from '@/components/common/AppButton'
-import { TABLE_STYLES } from '@/constants/tableStyles'
+import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
 import { JournalEntry, JournalEntryStatus } from '@/types'
 import { formatCurrency, formatDate } from '@/utils/formatters'
-
-interface Props {
-  entries: JournalEntry[]
-  loading: boolean
-  total: number
-  selectedEntryId: string | null
-  selectedIds: Set<string>
-  onSelect: (entry: JournalEntry) => void
-  onToggleCheck: (id: string) => void
-  onSelectAll: () => void
-  onPost: (entry: JournalEntry) => void
-  onDelete: (entry: JournalEntry) => void
-  onViewSource: (sourceType: string, sourceId: string) => void
-  listRef?: RefObject<HTMLDivElement | null>
-}
 
 const ENTRY_TYPE_LABELS: Record<string, string> = {
   manual: 'Manual Entry',
@@ -43,130 +25,99 @@ function statusColor(status: JournalEntryStatus) {
   return 'default' as const
 }
 
+interface Props {
+  entries: JournalEntry[]
+  loading: boolean
+  selectedEntryId: string | null
+  onSelect: (entry: JournalEntry) => void
+  onViewSource?: (sourceType: string, sourceId: string) => void
+  listRef?: RefObject<HTMLDivElement | null>
+}
+
 export function JournalEntriesTable({
   entries,
   loading,
   selectedEntryId,
-  selectedIds,
   onSelect,
-  onToggleCheck,
-  onSelectAll,
-  onPost,
-  onDelete,
   onViewSource,
   listRef,
 }: Props) {
-  const selectableEntries = entries.filter((entry) => entry.status === JournalEntryStatus.DRAFT)
-  const allSelected = selectableEntries.length > 0 && selectedIds.size === selectableEntries.length
-  const someSelected = selectedIds.size > 0 && selectedIds.size < selectableEntries.length
+  const fallbackRef = useRef<HTMLDivElement | null>(null)
+
+  const columns: ColumnConfig<JournalEntry>[] = [
+    {
+      key: 'referenceNumber',
+      raw: true,
+      render: (entry) => (
+        <Typography variant="body2" sx={{ fontWeight: 500, color: 'primary.main', fontSize: '0.8rem' }}>
+          {entry.referenceNumber}
+        </Typography>
+      ),
+    },
+    {
+      key: 'entryDate',
+      render: (entry) => formatDate(entry.entryDate),
+    },
+    {
+      key: 'description',
+      render: (entry) => entry.description,
+    },
+    {
+      key: 'sourceType',
+      raw: true,
+      render: (entry) => (
+        <Chip label={ENTRY_TYPE_LABELS[entry.sourceType ?? ''] ?? 'Manual Entry'} size="small" />
+      ),
+    },
+    {
+      key: 'source',
+      raw: true,
+      render: (entry) => (
+        entry.sourceType && entry.sourceType !== 'manual' && entry.sourceId && onViewSource
+          ? (
+              <Link
+                component="button"
+                variant="body2"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onViewSource(entry.sourceType!, entry.sourceId!)
+                }}
+              >
+                View Transaction
+              </Link>
+            )
+          : null
+      ),
+    },
+    {
+      key: 'totalDebits',
+      render: (entry) => formatCurrency(entry.totalDebits),
+    },
+    {
+      key: 'totalCredits',
+      render: (entry) => formatCurrency(entry.totalCredits),
+    },
+    {
+      key: 'status',
+      raw: true,
+      render: (entry) => (
+        <Chip label={entry.status} color={statusColor(entry.status)} size="small" />
+      ),
+    },
+  ]
 
   return (
-    <Paper ref={listRef} sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
-        <Table size={TABLE_STYLES.size} stickyHeader>
-          <TableHead>
-            <TableRow>
-              <TableCell padding="checkbox">
-                <Checkbox indeterminate={someSelected} checked={allSelected} onChange={onSelectAll} />
-              </TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Reference</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Date</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Description</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Type</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Source</TableCell>
-              <TableCell sx={{ fontWeight: 600 }} align="right">Debits</TableCell>
-              <TableCell sx={{ fontWeight: 600 }} align="right">Credits</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Status</TableCell>
-              <TableCell sx={{ fontWeight: 600 }} align="center">Actions</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {loading ? (
-              <TableRow>
-                <TableCell colSpan={10} align="center" sx={{ py: 4 }}>
-                  <CircularProgress />
-                </TableCell>
-              </TableRow>
-            ) : entries.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={10} align="center" sx={{ py: 4 }}>
-                  <Typography variant="body2" color="text.secondary">No journal entries found</Typography>
-                </TableCell>
-              </TableRow>
-            ) : entries.map((entry) => (
-              <TableRow
-                key={entry.id}
-                hover
-                selected={entry.id === selectedEntryId}
-                onClick={() => onSelect(entry)}
-                sx={{ cursor: 'pointer', height: TABLE_STYLES.row.height }}
-              >
-                <TableCell padding="checkbox" onClick={(event) => event.stopPropagation()}>
-                  <Checkbox
-                    disabled={entry.status !== JournalEntryStatus.DRAFT}
-                    checked={selectedIds.has(entry.id)}
-                    onChange={() => onToggleCheck(entry.id)}
-                  />
-                </TableCell>
-                <TableCell>
-                  <Typography variant="body2" sx={{ fontWeight: 500, color: 'primary.main' }}>
-                    {entry.referenceNumber}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="body2">{formatDate(entry.entryDate)}</Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="body2" sx={{ maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                    {entry.description}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Chip label={ENTRY_TYPE_LABELS[entry.sourceType ?? ''] ?? 'Manual Entry'} size="small" />
-                </TableCell>
-                <TableCell onClick={(event) => event.stopPropagation()}>
-                  {entry.sourceType && entry.sourceType !== 'manual' && entry.sourceId && (
-                    <Link
-                      component="button"
-                      variant="body2"
-                      onClick={() => onViewSource(entry.sourceType!, entry.sourceId!)}
-                    >
-                      View Transaction
-                    </Link>
-                  )}
-                </TableCell>
-                <TableCell align="right">
-                  <Typography variant="body2">{formatCurrency(entry.totalDebits)}</Typography>
-                </TableCell>
-                <TableCell align="right">
-                  <Typography variant="body2">{formatCurrency(entry.totalCredits)}</Typography>
-                </TableCell>
-                <TableCell>
-                  <Chip label={entry.status} color={statusColor(entry.status)} size="small" />
-                </TableCell>
-                <TableCell align="center" onClick={(event) => event.stopPropagation()}>
-                  <Stack direction="row" spacing={0.5} sx={{ justifyContent: 'center' }}>
-                    {entry.status === JournalEntryStatus.DRAFT && (
-                      <>
-                        <Tooltip title="Post">
-                          <span>
-                            <AppButton size="small" variant="success" onClick={() => onPost(entry)} startIcon={<PostIcon fontSize="small" />} />
-                          </span>
-                        </Tooltip>
-                        <Tooltip title="Delete">
-                          <span>
-                            <AppButton size="small" variant="danger" onClick={() => onDelete(entry)} startIcon={<DeleteIcon fontSize="small" />} />
-                          </span>
-                        </Tooltip>
-                      </>
-                    )}
-                  </Stack>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </Paper>
+    <EntityTable
+      rows={entries}
+      columns={columns}
+      loading={loading}
+      total={entries.length}
+      label="Journal Entries"
+      selectedId={selectedEntryId ?? undefined}
+      focusedIndex={-1}
+      onSelect={onSelect}
+      listRef={listRef ?? fallbackRef}
+      dataAttr="entry"
+    />
   )
 }

--- a/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
@@ -28,6 +28,7 @@ function statusColor(status: JournalEntryStatus) {
 interface Props {
   entries: JournalEntry[]
   loading: boolean
+  total: number
   selectedEntryId: string | null
   onSelect: (entry: JournalEntry) => void
   onViewSource?: (sourceType: string, sourceId: string) => void
@@ -37,6 +38,7 @@ interface Props {
 export function JournalEntriesTable({
   entries,
   loading,
+  total,
   selectedEntryId,
   onSelect,
   onViewSource,
@@ -111,7 +113,7 @@ export function JournalEntriesTable({
       rows={entries}
       columns={columns}
       loading={loading}
-      total={entries.length}
+      total={total}
       label="Journal Entries"
       selectedId={selectedEntryId ?? undefined}
       focusedIndex={-1}

--- a/frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx
@@ -1,4 +1,5 @@
-import { Box, Chip, Link, Paper, Stack, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
+import { Box, Chip, Link, Paper, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material'
+import Grid from '@mui/material/Grid'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as EditIcon } from '@mui/icons-material/Edit'
 import { default as PostIcon } from '@mui/icons-material/PostAdd'
@@ -8,6 +9,8 @@ import { AppButton } from '@/components/common/AppButton'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { JournalEntry, JournalEntryStatus } from '@/types'
 import { formatCurrency, formatDate } from '@/utils/formatters'
+
+import { SOURCE_ROUTES } from '../hooks/useJournalEntriesWorkspace'
 
 const ENTRY_TYPE_LABELS: Record<string, string> = {
   manual: 'Manual Entry',
@@ -23,15 +26,37 @@ const ENTRY_TYPE_LABELS: Record<string, string> = {
   fund_transfer: 'Fund Transfer',
 }
 
-const SOURCE_ROUTES: Record<string, (id: string) => string> = {
-  sales_order: (id) => `/sales/orders?highlight=${id}`,
-  payment: (id) => `/sales/payments?highlight=${id}`,
-  goods_received_note: (id) => `/purchasing/goods-received?grnId=${id}`,
-  vendor_payment: (id) => `/purchasing/vendor-payments?vpId=${id}`,
-  expense: () => `/accounting/expenses`,
-  owner_equity_transaction: () => `/accounting/owner-equity`,
-  fund_transfer: () => `/accounting/fund-transfers`,
-  stock_adjustment: (id) => `/inventory/stock-adjustments/${id}/edit`,
+const detailTableSx = {
+  tableLayout: 'fixed',
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const labelCellSx = {
+  fontWeight: 600,
+  color: 'text.secondary',
+  fontSize: '0.8rem',
+}
+
+const valueCellSx = {
+  fontSize: '0.8rem',
+}
+
+const sectionHeaderCellSx = {
+  pb: TABLE_STYLES.cell.padding.py * 0.67,
+  py: TABLE_STYLES.cell.padding.py * 0.67,
+  borderTop: TABLE_STYLES.cell.border,
+}
+
+function statusColor(status: JournalEntryStatus) {
+  if (status === JournalEntryStatus.POSTED) return 'success' as const
+  if (status === JournalEntryStatus.REVERSED) return 'error' as const
+  return 'default' as const
 }
 
 interface Props {
@@ -40,22 +65,23 @@ interface Props {
   onPost: () => void
   onReverse: () => void
   onDelete: () => void
-  onNavigateToSource: (path: string) => void
+  onViewSource: (sourceType: string, sourceId: string) => void
 }
 
-const cellSx = { border: 'none', py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px }
-
-function statusColor(status: JournalEntryStatus) {
-  if (status === JournalEntryStatus.POSTED) return 'success' as const
-  if (status === JournalEntryStatus.REVERSED) return 'error' as const
-  return 'default' as const
-}
-
-export function JournalEntryContextHeader({ selectedEntry, onEdit, onPost, onReverse, onDelete, onNavigateToSource }: Props) {
+export function JournalEntryContextHeader({
+  selectedEntry,
+  onEdit,
+  onPost,
+  onReverse,
+  onDelete,
+  onViewSource,
+}: Props) {
   if (!selectedEntry) {
     return (
-      <Paper sx={{ p: 2 }}>
-        <Typography variant="body2" color="text.secondary">Select a journal entry to view details</Typography>
+      <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
+        <Typography variant="h6" sx={{ color: 'text.secondary' }}>
+          Select a journal entry to view details
+        </Typography>
       </Paper>
     )
   }
@@ -63,63 +89,135 @@ export function JournalEntryContextHeader({ selectedEntry, onEdit, onPost, onRev
   const isDraft = selectedEntry.status === JournalEntryStatus.DRAFT
   const isPosted = selectedEntry.status === JournalEntryStatus.POSTED
   const isBalanced = Math.abs(selectedEntry.totalDebits - selectedEntry.totalCredits) < 0.01
+  const hasSource = selectedEntry.sourceType && selectedEntry.sourceId && SOURCE_ROUTES[selectedEntry.sourceType]
 
   return (
-    <Paper sx={{ p: 0 }}>
-      <Box sx={{ px: 2, pt: 1.5, pb: 1, borderBottom: TABLE_STYLES.cell.border }}>
-        <Stack direction="row" sx={{ justifyContent: 'space-between', alignItems: 'center' }}>
-          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{selectedEntry.referenceNumber}</Typography>
-            <Chip label={selectedEntry.status} color={statusColor(selectedEntry.status)} size="small" />
-            {selectedEntry.sourceType && (
-              <Chip label={ENTRY_TYPE_LABELS[selectedEntry.sourceType] ?? selectedEntry.sourceType} size="small" variant="outlined" />
-            )}
-            {!isBalanced && <Chip label="Unbalanced" color="warning" size="small" />}
-          </Stack>
-          <Stack direction="row" spacing={0.5}>
-            {isDraft && (
-              <>
-                <AppButton size="small" variant="outlined" startIcon={<EditIcon />} onClick={onEdit}>Edit</AppButton>
-                <AppButton size="small" variant="success" startIcon={<PostIcon />} onClick={onPost} disabled={!isBalanced}>Post</AppButton>
-                <AppButton size="small" variant="danger" startIcon={<DeleteIcon />} onClick={onDelete}>Delete</AppButton>
-              </>
-            )}
-            {isPosted && (
-              <AppButton size="small" variant="warning" startIcon={<ReverseIcon />} onClick={onReverse}>Reverse</AppButton>
-            )}
-          </Stack>
-        </Stack>
-      </Box>
-      <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': cellSx }}>
-        <TableBody>
-          <TableRow>
-            <TableCell sx={{ ...cellSx, color: 'text.secondary', width: 120 }}>Date</TableCell>
-            <TableCell>{formatDate(selectedEntry.entryDate)}</TableCell>
-            <TableCell sx={{ ...cellSx, color: 'text.secondary', width: 120 }}>Debits</TableCell>
-            <TableCell align="right">{formatCurrency(selectedEntry.totalDebits)}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell sx={{ ...cellSx, color: 'text.secondary' }}>Description</TableCell>
-            <TableCell>{selectedEntry.description}</TableCell>
-            <TableCell sx={{ ...cellSx, color: 'text.secondary' }}>Credits</TableCell>
-            <TableCell align="right">{formatCurrency(selectedEntry.totalCredits)}</TableCell>
-          </TableRow>
-          {selectedEntry.sourceType && selectedEntry.sourceId && SOURCE_ROUTES[selectedEntry.sourceType] && (
-            <TableRow>
-              <TableCell sx={{ ...cellSx, color: 'text.secondary' }}>Source</TableCell>
-              <TableCell colSpan={3}>
-                <Link
-                  component="button"
-                  variant="body2"
-                  onClick={() => onNavigateToSource(SOURCE_ROUTES[selectedEntry.sourceType!]!(selectedEntry.sourceId!))}
-                >
-                  View {ENTRY_TYPE_LABELS[selectedEntry.sourceType] ?? selectedEntry.sourceType}
-                </Link>
-              </TableCell>
-            </TableRow>
+    <Paper sx={{ overflow: 'hidden' }}>
+      <Box
+        sx={{
+          p: TABLE_STYLES.cell.padding.px,
+          borderBottom: TABLE_STYLES.cell.border,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Typography
+          variant="tableHeader"
+          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+        >
+          JE Details - {selectedEntry.referenceNumber}
+        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          {isDraft && (
+            <>
+              <AppButton size="small" variant="outlined" startIcon={<EditIcon />} onClick={onEdit}>
+                Edit
+              </AppButton>
+              <AppButton size="small" variant="success" startIcon={<PostIcon />} onClick={onPost} disabled={!isBalanced}>
+                Post
+              </AppButton>
+              <AppButton size="small" variant="danger" startIcon={<DeleteIcon />} onClick={onDelete}>
+                Delete
+              </AppButton>
+            </>
           )}
-        </TableBody>
-      </Table>
+          {isPosted && (
+            <AppButton size="small" variant="warning" startIcon={<ReverseIcon />} onClick={onReverse}>
+              Reverse
+            </AppButton>
+          )}
+        </Box>
+      </Box>
+
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Entry Information
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Date</TableCell>
+                    <TableCell sx={valueCellSx}>{formatDate(selectedEntry.entryDate)}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Description</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedEntry.description}</TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Type</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      <Chip
+                        size="small"
+                        label={ENTRY_TYPE_LABELS[selectedEntry.sourceType ?? ''] ?? 'Manual Entry'}
+                      />
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Source</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {hasSource ? (
+                        <Link
+                          component="button"
+                          variant="body2"
+                          onClick={() => onViewSource(selectedEntry.sourceType!, selectedEntry.sourceId!)}
+                        >
+                          View {ENTRY_TYPE_LABELS[selectedEntry.sourceType!] ?? selectedEntry.sourceType}
+                        </Link>
+                      ) : '—'}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Financials
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Status</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      <Chip label={selectedEntry.status} color={statusColor(selectedEntry.status)} size="small" />
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Debits</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(selectedEntry.totalDebits)}</TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Credits</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(selectedEntry.totalCredits)}</TableCell>
+                  </TableRow>
+                  {!isBalanced && (
+                    <TableRow>
+                      <TableCell sx={labelCellSx}>Balance</TableCell>
+                      <TableCell sx={valueCellSx}>
+                        <Chip label="Unbalanced" color="warning" size="small" />
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+        </Grid>
+      </Box>
     </Paper>
   )
 }

--- a/frontend/src/pages/accounting/components/JournalEntryWorkspaceCard.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntryWorkspaceCard.tsx
@@ -16,7 +16,7 @@ export function JournalEntryWorkspaceCard({ selectedEntry }: Props) {
 
   return (
     <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <Box sx={{ px: 2, py: 1, borderBottom: TABLE_STYLES.cell.border }}>
+      <Box sx={{ px: TABLE_STYLES.cell.padding.px, py: 1, borderBottom: TABLE_STYLES.cell.border }}>
         <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
           Ledger Lines
         </Typography>

--- a/frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
@@ -3,27 +3,33 @@ import { useNavigate } from 'react-router-dom'
 
 import { useNotification } from '@/hooks/useNotification'
 import {
-  useBulkDeleteJournalEntriesMutation,
-  useBulkPostJournalEntriesMutation,
   useDeleteJournalEntryMutation,
   useLazyGetJournalEntryQuery,
   usePostJournalEntryMutation,
   useReverseJournalEntryMutation,
 } from '@/store/api/accountingApi'
-import { JournalEntry, JournalEntryStatus } from '@/types'
+import { JournalEntry } from '@/types'
 import { getErrorMessage } from '@/utils/errorMessage'
+
+export const SOURCE_ROUTES: Record<string, (id: string) => string> = {
+  sales_order: (id) => `/sales/orders?highlight=${id}`,
+  payment: (id) => `/sales/payments?highlight=${id}`,
+  goods_received_note: (id) => `/purchasing/goods-received?grnId=${id}`,
+  vendor_payment: (id) => `/purchasing/vendor-payments?vpId=${id}`,
+  expense: () => '/accounting/expenses',
+  owner_equity_transaction: () => '/accounting/owner-equity',
+  fund_transfer: () => '/accounting/fund-transfers',
+  stock_adjustment: (id) => `/inventory/stock-adjustments/${id}/edit`,
+}
 
 export function useJournalEntriesWorkspace(refetch: () => void) {
   const navigate = useNavigate()
   const { showSuccess, showError } = useNotification()
 
   const [selectedEntry, setSelectedEntry] = useState<JournalEntry | null>(null)
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [postTarget, setPostTarget] = useState<JournalEntry | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<JournalEntry | null>(null)
   const [reverseTarget, setReverseTarget] = useState<JournalEntry | null>(null)
-  const [bulkPostOpen, setBulkPostOpen] = useState(false)
-  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false)
   const [actionLoading, setActionLoading] = useState(false)
   const searchInputRef = useRef<HTMLInputElement | null>(null)
   const listRef = useRef<HTMLDivElement | null>(null)
@@ -32,8 +38,6 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
   const [postJournalEntry] = usePostJournalEntryMutation()
   const [reverseJournalEntry] = useReverseJournalEntryMutation()
   const [deleteJournalEntry] = useDeleteJournalEntryMutation()
-  const [bulkPostJournalEntries] = useBulkPostJournalEntriesMutation()
-  const [bulkDeleteJournalEntries] = useBulkDeleteJournalEntriesMutation()
 
   const handleSelect = useCallback(async (entry: JournalEntry) => {
     setSelectedEntry(entry)
@@ -41,24 +45,10 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
       const fresh = await fetchEntry(entry.id).unwrap()
       setSelectedEntry(fresh)
     }
-    catch { /* keep list-row data */ }
+    catch {
+      /* keep list-row data */
+    }
   }, [fetchEntry])
-
-  const handleToggleCheck = useCallback((id: string) => {
-    setSelectedIds((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }, [])
-
-  const handleSelectAll = useCallback((entries: JournalEntry[]) => {
-    const drafts = entries
-      .filter((entry) => entry.status === JournalEntryStatus.DRAFT)
-      .map((entry) => entry.id)
-    setSelectedIds((prev) => (prev.size === drafts.length ? new Set() : new Set(drafts)))
-  }, [])
 
   const handleConfirmPost = useCallback(async () => {
     if (!postTarget) return
@@ -76,7 +66,7 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
     finally {
       setActionLoading(false)
     }
-  }, [postTarget, postJournalEntry, showSuccess, showError, refetch])
+  }, [postTarget, postJournalEntry, refetch, showError, showSuccess])
 
   const handleConfirmReverse = useCallback(async (reverseDate: string) => {
     if (!reverseTarget) return
@@ -94,7 +84,7 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
     finally {
       setActionLoading(false)
     }
-  }, [reverseTarget, reverseJournalEntry, showSuccess, showError, refetch])
+  }, [refetch, reverseJournalEntry, reverseTarget, showError, showSuccess])
 
   const handleConfirmDelete = useCallback(async () => {
     if (!deleteTarget) return
@@ -112,82 +102,27 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
     finally {
       setActionLoading(false)
     }
-  }, [deleteTarget, deleteJournalEntry, showSuccess, showError, refetch])
-
-  const handleBulkPost = useCallback(async () => {
-    setActionLoading(true)
-    try {
-      const result = await bulkPostJournalEntries(Array.from(selectedIds)).unwrap()
-      showSuccess(`Posted ${result.succeeded.length} entries`)
-      if (result.failed.length > 0) showError(`${result.failed.length} entries failed`)
-      setSelectedIds(new Set())
-      setBulkPostOpen(false)
-      refetch()
-    }
-    catch (error: unknown) {
-      showError(getErrorMessage(error, 'Bulk post failed'))
-    }
-    finally {
-      setActionLoading(false)
-    }
-  }, [selectedIds, bulkPostJournalEntries, showSuccess, showError, refetch])
-
-  const handleBulkDelete = useCallback(async () => {
-    setActionLoading(true)
-    try {
-      const result = await bulkDeleteJournalEntries(Array.from(selectedIds)).unwrap()
-      showSuccess(`Deleted ${result.succeeded.length} entries`)
-      if (result.failed.length > 0) showError(`${result.failed.length} entries failed`)
-      setSelectedIds(new Set())
-      setBulkDeleteOpen(false)
-      refetch()
-    }
-    catch (error: unknown) {
-      showError(getErrorMessage(error, 'Bulk delete failed'))
-    }
-    finally {
-      setActionLoading(false)
-    }
-  }, [selectedIds, bulkDeleteJournalEntries, showSuccess, showError, refetch])
+  }, [deleteJournalEntry, deleteTarget, refetch, showError, showSuccess])
 
   return {
     selectedEntry,
-    selectedIds,
     postTarget,
     setPostTarget,
     deleteTarget,
     setDeleteTarget,
     reverseTarget,
     setReverseTarget,
-    bulkPostOpen,
-    setBulkPostOpen,
-    bulkDeleteOpen,
-    setBulkDeleteOpen,
     actionLoading,
     searchInputRef,
     listRef,
     handleSelect,
-    handleToggleCheck,
-    handleSelectAll,
     handleConfirmPost,
     handleConfirmReverse,
     handleConfirmDelete,
-    handleBulkPost,
-    handleBulkDelete,
     navigateToEdit: (entry: JournalEntry) => navigate(`/accounting/journal-entries/${entry.id}/edit`),
     navigateToCreate: () => navigate('/accounting/journal-entries/new'),
     navigateToSource: (sourceType: string, sourceId: string) => {
-      const routes: Record<string, (id: string) => string> = {
-        sales_order: (id) => `/sales/orders?highlight=${id}`,
-        payment: (id) => `/sales/payments?highlight=${id}`,
-        goods_received_note: (id) => `/purchasing/goods-received?grnId=${id}`,
-        vendor_payment: (id) => `/purchasing/vendor-payments?vpId=${id}`,
-        expense: () => `/accounting/expenses`,
-        owner_equity_transaction: () => `/accounting/owner-equity`,
-        fund_transfer: () => `/accounting/fund-transfers`,
-        stock_adjustment: (id) => `/inventory/stock-adjustments/${id}/edit`,
-      }
-      const route = routes[sourceType]
+      const route = SOURCE_ROUTES[sourceType]
       if (route) navigate(route(sourceId))
     },
   }


### PR DESCRIPTION
## Summary
- Replaced `JournalEntriesTable` custom table with `EntityTable` — no checkboxes, no per-row actions
- Removed all bulk post/delete state and handlers from hook, page, and dialogs
- Rewrote `JournalEntryContextHeader` to use two-column Grid layout with `detailTableSx`/`labelCellSx`/`valueCellSx` matching Sales/COA pattern
- Deduplicated `SOURCE_ROUTES` — defined once in the hook, exported for header use
- Aligned `JournalEntryWorkspaceCard` header padding
- Fixed `EntityTable` header count to use server total instead of client page count

Closes #416

## Test plan
- [x] All existing tests pass
- [x] Type-check clean
- [x] Journal Entries page loads and displays entries
- [x] Clicking a row shows details in context header
- [x] Post/Delete/Reverse actions work from context header
- [x] Navigate-to-source link works from context header and table

🤖 Generated with [Claude Code](https://claude.com/claude-code)