### PR TITLE
refactor(accounting): reduce JournalEntriesTable to single referenceNumber column (issue #418)

### DIFF
--- a/frontend/src/__tests__/integration/accounting-auto-posting.integration.test.tsx
+++ b/frontend/src/__tests__/integration/accounting-auto-posting.integration.test.tsx
@@ -301,7 +301,7 @@ describe('Accounting Auto-Posting Integration Tests', () => {
       })
     })
 
-    it('displays both manual and auto-posted entries with correct type labels', async () => {
+    it('displays all entries as reference numbers in the list', async () => {
       renderJournalEntriesPage()
 
       await waitFor(() => {
@@ -309,23 +309,9 @@ describe('Accounting Auto-Posting Integration Tests', () => {
         expect(screen.getByText('JE-2026-002')).toBeInTheDocument()
         expect(screen.getByText('JE-2026-003')).toBeInTheDocument()
       })
-
-      expect(screen.getByText('Manual Entry')).toBeInTheDocument()
-      expect(screen.getByText('Sales Order')).toBeInTheDocument()
-      expect(screen.getByText('Customer Payment')).toBeInTheDocument()
     })
 
-    it('shows "View Transaction" link only for auto-posted entries', async () => {
-      renderJournalEntriesPage()
-
-      await waitFor(() => {
-        expect(screen.getByText('JE-2026-002')).toBeInTheDocument()
-      })
-
-      expect(screen.getAllByText('View Transaction')).toHaveLength(2)
-    })
-
-    it('navigates to source transaction when clicking View Transaction', async () => {
+    it('shows source link in context header when an auto-posted entry is selected', async () => {
       const user = createUser()
 
       renderJournalEntriesPage()
@@ -334,7 +320,29 @@ describe('Accounting Auto-Posting Integration Tests', () => {
         expect(screen.getByText('JE-2026-002')).toBeInTheDocument()
       })
 
-      await user.click(screen.getAllByText('View Transaction')[0])
+      await user.click(screen.getByText('JE-2026-002'))
+
+      await waitFor(() => {
+        expect(screen.getByText('View Sales Order')).toBeInTheDocument()
+      })
+    })
+
+    it('navigates to source transaction when clicking source link in context header', async () => {
+      const user = createUser()
+
+      renderJournalEntriesPage()
+
+      await waitFor(() => {
+        expect(screen.getByText('JE-2026-002')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByText('JE-2026-002'))
+
+      await waitFor(() => {
+        expect(screen.getByText('View Sales Order')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByText('View Sales Order'))
 
       expect(mockNavigate).toHaveBeenCalledWith('/sales/orders?highlight=so-123')
     })

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -113,7 +113,6 @@ export const JournalEntriesPage: React.FC = () => {
             total={pagination?.total ?? entries.length}
             selectedEntryId={workspace.selectedEntry?.id ?? null}
             onSelect={workspace.handleSelect}
-            onViewSource={workspace.navigateToSource}
             listRef={workspace.listRef}
           />
         )}

--- a/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
@@ -1,29 +1,20 @@
 import { useRef, type RefObject } from 'react'
-import { Chip, Link, Typography } from '@mui/material'
+import { Typography } from '@mui/material'
 
 import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
-import { JournalEntry, JournalEntryStatus } from '@/types'
-import { formatCurrency, formatDate } from '@/utils/formatters'
+import { JournalEntry } from '@/types'
 
-const ENTRY_TYPE_LABELS: Record<string, string> = {
-  manual: 'Manual Entry',
-  sales_order: 'Sales Order',
-  payment: 'Customer Payment',
-  settlement: 'Settlement',
-  goods_received_note: 'Goods Receipt',
-  vendor_payment: 'Vendor Payment',
-  stock_adjustment: 'Stock Adjustment',
-  owner_equity_transaction: 'Owner Equity',
-  expense: 'Expense',
-  opening_balance: 'Opening Balance',
-  fund_transfer: 'Fund Transfer',
-}
-
-function statusColor(status: JournalEntryStatus) {
-  if (status === JournalEntryStatus.POSTED) return 'success' as const
-  if (status === JournalEntryStatus.REVERSED) return 'error' as const
-  return 'default' as const
-}
+const COLUMNS: ColumnConfig<JournalEntry>[] = [
+  {
+    key: 'referenceNumber',
+    raw: true,
+    render: (entry) => (
+      <Typography variant="body2" sx={{ fontWeight: 500, color: 'primary.main', fontSize: '0.8rem' }}>
+        {entry.referenceNumber}
+      </Typography>
+    ),
+  },
+]
 
 interface Props {
   entries: JournalEntry[]
@@ -31,7 +22,6 @@ interface Props {
   total: number
   selectedEntryId: string | null
   onSelect: (entry: JournalEntry) => void
-  onViewSource?: (sourceType: string, sourceId: string) => void
   listRef?: RefObject<HTMLDivElement | null>
 }
 
@@ -41,77 +31,14 @@ export function JournalEntriesTable({
   total,
   selectedEntryId,
   onSelect,
-  onViewSource,
   listRef,
 }: Props) {
   const fallbackRef = useRef<HTMLDivElement | null>(null)
 
-  const columns: ColumnConfig<JournalEntry>[] = [
-    {
-      key: 'referenceNumber',
-      raw: true,
-      render: (entry) => (
-        <Typography variant="body2" sx={{ fontWeight: 500, color: 'primary.main', fontSize: '0.8rem' }}>
-          {entry.referenceNumber}
-        </Typography>
-      ),
-    },
-    {
-      key: 'entryDate',
-      render: (entry) => formatDate(entry.entryDate),
-    },
-    {
-      key: 'description',
-      render: (entry) => entry.description,
-    },
-    {
-      key: 'sourceType',
-      raw: true,
-      render: (entry) => (
-        <Chip label={ENTRY_TYPE_LABELS[entry.sourceType ?? ''] ?? 'Manual Entry'} size="small" />
-      ),
-    },
-    {
-      key: 'source',
-      raw: true,
-      render: (entry) => (
-        entry.sourceType && entry.sourceType !== 'manual' && entry.sourceId && onViewSource
-          ? (
-              <Link
-                component="button"
-                variant="body2"
-                onClick={(event) => {
-                  event.stopPropagation()
-                  onViewSource(entry.sourceType!, entry.sourceId!)
-                }}
-              >
-                View Transaction
-              </Link>
-            )
-          : null
-      ),
-    },
-    {
-      key: 'totalDebits',
-      render: (entry) => formatCurrency(entry.totalDebits),
-    },
-    {
-      key: 'totalCredits',
-      render: (entry) => formatCurrency(entry.totalCredits),
-    },
-    {
-      key: 'status',
-      raw: true,
-      render: (entry) => (
-        <Chip label={entry.status} color={statusColor(entry.status)} size="small" />
-      ),
-    },
-  ]
-
   return (
     <EntityTable
       rows={entries}
-      columns={columns}
+      columns={COLUMNS}
       loading={loading}
       total={total}
       label="Journal Entries"


### PR DESCRIPTION
## Summary

- Reduces `JournalEntriesTable` to a single `referenceNumber` column, matching the `OrdersTable` / `ProductsTable` ultra-minimalist pattern
- Removes `onViewSource` prop from `JournalEntriesTable` (source link already present in `JournalEntryContextHeader`)
- Removes all now-unused imports: `Chip`, `Link`, `formatCurrency`, `formatDate`, `ENTRY_TYPE_LABELS`, `statusColor`

All removed data (date, description, type, source, debits, credits, status) is confirmed available in `JournalEntryContextHeader` and `JournalEntryWorkspaceCard`.

Closes #418

## Test Plan
- [x] `JournalEntriesTable` unit tests pass (3/3)
- [x] `JournalEntriesPage` tests pass (3/3)
- [x] Full accounting test suite passes (18 files, 106 tests)
- [x] TypeScript check clean (no errors)
- [x] No remaining `onViewSource` references on `JournalEntriesTable`