### PR TITLE
refactor(accounting): normalize JE list and details UI with Sales module (issue #420)

### DIFF
--- a/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
@@ -97,4 +97,16 @@ describe('JournalEntriesPage', () => {
     })
     expect(mockNavigate).not.toHaveBeenCalled()
   })
+
+  it('renders journal entry details without chip styling', async () => {
+    const { container } = render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+
+    fireEvent.click(screen.getByText('JE-001'))
+
+    await waitFor(() => {
+      expect(screen.getByText('JE Details - JE-001')).toBeInTheDocument()
+    })
+
+    expect(container.querySelector('.MuiChip-root')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
@@ -71,7 +71,10 @@ describe('JournalEntriesPage', () => {
       isLoading: false,
       refetch: vi.fn(),
     })
-    mockedApi.useLazyGetJournalEntryQuery.mockReturnValue([vi.fn().mockResolvedValue({ id: '1' })])
+    mockedApi.useLazyGetJournalEntryQuery.mockReturnValue([
+      vi.fn().mockResolvedValue({ data: mockEntry }),
+      { data: mockEntry, isLoading: false, isFetching: false },
+    ])
     mockedApi.useDeleteJournalEntryMutation.mockReturnValue([vi.fn()])
     mockedApi.usePostJournalEntryMutation.mockReturnValue([vi.fn()])
     mockedApi.useReverseJournalEntryMutation.mockReturnValue([vi.fn()])

--- a/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
@@ -1,19 +1,10 @@
 import { useRef, type RefObject } from 'react'
-import { Typography } from '@mui/material'
 
 import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
 import { JournalEntry } from '@/types'
 
 const COLUMNS: ColumnConfig<JournalEntry>[] = [
-  {
-    key: 'referenceNumber',
-    raw: true,
-    render: (entry) => (
-      <Typography variant="body2" sx={{ fontWeight: 500, color: 'primary.main', fontSize: '0.8rem' }}>
-        {entry.referenceNumber}
-      </Typography>
-    ),
-  },
+  { key: 'referenceNumber', render: (entry) => entry.referenceNumber },
 ]
 
 interface Props {

--- a/frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx
@@ -1,4 +1,4 @@
-import { Box, Chip, Link, Paper, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material'
+import { Box, Link, Paper, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material'
 import Grid from '@mui/material/Grid'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as EditIcon } from '@mui/icons-material/Edit'
@@ -51,12 +51,6 @@ const sectionHeaderCellSx = {
   pb: TABLE_STYLES.cell.padding.py * 0.67,
   py: TABLE_STYLES.cell.padding.py * 0.67,
   borderTop: TABLE_STYLES.cell.border,
-}
-
-function statusColor(status: JournalEntryStatus) {
-  if (status === JournalEntryStatus.POSTED) return 'success' as const
-  if (status === JournalEntryStatus.REVERSED) return 'error' as const
-  return 'default' as const
 }
 
 interface Props {
@@ -154,10 +148,7 @@ export function JournalEntryContextHeader({
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
                     <TableCell sx={labelCellSx}>Type</TableCell>
                     <TableCell sx={valueCellSx}>
-                      <Chip
-                        size="small"
-                        label={ENTRY_TYPE_LABELS[selectedEntry.sourceType ?? ''] ?? 'Manual Entry'}
-                      />
+                      {ENTRY_TYPE_LABELS[selectedEntry.sourceType ?? ''] ?? 'Manual Entry'}
                     </TableCell>
                   </TableRow>
                   <TableRow>
@@ -192,9 +183,7 @@ export function JournalEntryContextHeader({
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
                     <TableCell sx={labelCellSx}>Status</TableCell>
-                    <TableCell sx={valueCellSx}>
-                      <Chip label={selectedEntry.status} color={statusColor(selectedEntry.status)} size="small" />
-                    </TableCell>
+                    <TableCell sx={valueCellSx}>{selectedEntry.status}</TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell sx={labelCellSx}>Debits</TableCell>
@@ -207,9 +196,7 @@ export function JournalEntryContextHeader({
                   {!isBalanced && (
                     <TableRow>
                       <TableCell sx={labelCellSx}>Balance</TableCell>
-                      <TableCell sx={valueCellSx}>
-                        <Chip label="Unbalanced" color="warning" size="small" />
-                      </TableCell>
+                      <TableCell sx={valueCellSx}>Unbalanced</TableCell>
                     </TableRow>
                   )}
                 </TableBody>


### PR DESCRIPTION
## Summary

- `JournalEntriesTable`: removed custom `Typography` render (fontWeight 500, primary color) from `referenceNumber` column — now uses `EntityTable` default formatting (fontWeight 400, standard text color), matching `OrdersTable`
- `JournalEntryContextHeader`: replaced `Chip` components for Type, Status, and Balance (unbalanced) with plain text using existing `valueCellSx` — matching `OrderContextHeader` pattern
- `JournalEntriesPage.test.tsx`: fixed lazy query mock to return full entry object (RTK Query tuple shape) for test robustness

Closes #420

## Test plan

- [x] `cd frontend && npx vitest run src/pages/accounting/components/JournalEntriesTable.test.tsx` — 3 passed
- [x] `cd frontend && npx vitest run src/pages/accounting/__tests__/JournalEntriesPage.test.tsx` — 4 passed
- [x] `cd frontend && npx vitest run src/pages/accounting` — 18 passed
- [x] `cd frontend && npm run type-check` — passed
- [x] `cd frontend && npm run lint` — passed