### PR TITLE
feat(accounting): refactor JE and COA pages to project workspace standards (issue #424)

### DIFF
--- a/frontend/src/__tests__/integration/accounting-auto-posting.integration.test.tsx
+++ b/frontend/src/__tests__/integration/accounting-auto-posting.integration.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
 import { BrowserRouter, MemoryRouter, Route, Routes } from 'react-router-dom'
 import { JournalEntryStatus } from '@/types'
 
@@ -67,6 +69,7 @@ import AccountMappingWarning from '@/components/accounting/AccountMappingWarning
 import AccountingEntryLink from '@/components/accounting/AccountingEntryLink'
 import AccountMappingsPage from '@/pages/accounting/AccountMappingsPage'
 import JournalEntriesPage from '@/pages/accounting/JournalEntriesPage'
+import accountingReducer from '@/store/slices/accountingSlice'
 
 const createUser = () => {
   return (userEvent as any).setup ? (userEvent as any).setup() : userEvent
@@ -77,12 +80,20 @@ const renderWithRouter = (component: React.ReactElement) => {
 }
 
 const renderJournalEntriesPage = (initialEntryUrl = '/accounting/journal-entries') => {
+  const store = configureStore({
+    reducer: {
+      accounting: accountingReducer,
+    },
+  })
+
   return render(
-    <MemoryRouter initialEntries={[initialEntryUrl]}>
-      <Routes>
-        <Route path="*" element={<JournalEntriesPage />} />
-      </Routes>
-    </MemoryRouter>,
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[initialEntryUrl]}>
+        <Routes>
+          <Route path="*" element={<JournalEntriesPage />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
   )
 }
 

--- a/frontend/src/pages/accounting/ChartOfAccountsPage.tsx
+++ b/frontend/src/pages/accounting/ChartOfAccountsPage.tsx
@@ -3,7 +3,9 @@ import React, { useMemo, useState } from 'react'
 import AccountMappingWarning from '@/components/accounting/AccountMappingWarning'
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import { useGetChartOfAccountsHierarchyQuery } from '@/store/api/accountingApi'
+import { selectSelectedAccount } from '@/store/slices/accountingSlice'
 import type { ChartOfAccount } from '@/types'
 import type { FilterBarConfig } from '@/types/filterBar.types'
 
@@ -29,11 +31,10 @@ const filterConfig: FilterBarConfig<CoaFilters> = {
 }
 
 const ChartOfAccountsPage: React.FC = () => {
+  const dispatch = useAppDispatch()
+  const selectedAccount = useAppSelector(selectSelectedAccount)
   const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
   const { data: hierarchyData, isLoading, error, refetch } = useGetChartOfAccountsHierarchyQuery()
-  const workspace = useChartOfAccountsWorkspace(() => {
-    void refetch()
-  })
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
 
   const accounts = useMemo(() => {
@@ -81,6 +82,15 @@ const ChartOfAccountsPage: React.FC = () => {
     )
   }, [accounts, appliedFilters, sortOrder])
 
+  const workspace = useChartOfAccountsWorkspace({
+    dispatch,
+    accounts: filteredAccounts,
+    selectedAccount,
+    refetch: () => {
+      void refetch()
+    },
+  })
+
   return (
     <>
       <AccountMappingWarning context="system" />
@@ -111,23 +121,24 @@ const ChartOfAccountsPage: React.FC = () => {
           <ChartOfAccountsTable
             accounts={filteredAccounts}
             loading={isLoading}
-            selectedId={workspace.selected?.id ?? null}
-            onSelect={workspace.setSelected}
+            selectedId={selectedAccount?.id ?? null}
+            focusedIndex={workspace.focusedIndex}
+            onSelect={workspace.handleSelect}
             listRef={workspace.listRef}
           />
         }
         headerSlot={
           <ChartOfAccountContextHeader
-            selected={workspace.selected}
+            selected={selectedAccount}
             onEdit={() => workspace.setFormDialogOpen(true)}
-            onDelete={() => workspace.selected && workspace.setDeleteTarget(workspace.selected)}
+            onDelete={() => selectedAccount && workspace.setDeleteTarget(selectedAccount)}
           />
         }
-        workspaceSlot={<ChartOfAccountWorkspaceCard selected={workspace.selected} />}
+        workspaceSlot={<ChartOfAccountWorkspaceCard selected={selectedAccount} />}
         dialogs={
           <ChartOfAccountsDialogs
             formDialogOpen={workspace.formDialogOpen}
-            selected={workspace.selected}
+            selected={selectedAccount}
             onCloseForm={() => workspace.setFormDialogOpen(false)}
             onFormSuccess={() => {
               workspace.setFormDialogOpen(false)

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -4,7 +4,9 @@ import { useLocation } from 'react-router-dom'
 import AccountMappingWarning from '@/components/accounting/AccountMappingWarning'
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import { useGetJournalEntriesQuery } from '@/store/api/accountingApi'
+import { selectSelectedJournalEntry } from '@/store/slices/accountingSlice'
 import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
 import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
 
@@ -25,6 +27,8 @@ export const JournalEntriesPage: React.FC = () => {
   const [sortBy, setSortBy] = useState('createdAt')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
 
+  const dispatch = useAppDispatch()
+  const selectedEntry = useAppSelector(selectSelectedJournalEntry)
   const location = useLocation()
 
   const filterConfig = useMemo<FilterBarConfig<JEFilters>>(
@@ -74,17 +78,20 @@ export const JournalEntriesPage: React.FC = () => {
   const { data, isLoading, refetch } = useGetJournalEntriesQuery(queryArgs)
   const entries = data?.data ?? []
   const pagination = data?.meta
-  const workspace = useJournalEntriesWorkspace(() => {
-    void refetch()
+  const workspace = useJournalEntriesWorkspace({
+    dispatch,
+    entries,
+    selectedEntry,
+    refetch: () => {
+      void refetch()
+    },
   })
 
   const filterHandlers = useMemo(() => ({
     ...handlers,
     onSearchChange: (value: string) => {
       handlers.onSearchChange(value)
-      window.setTimeout(() => {
-        workspace.searchInputRef.current?.focus()
-      }, 0)
+      workspace.setShouldPreserveSearchFocus(true)
     },
   }), [handlers, workspace])
 
@@ -111,22 +118,23 @@ export const JournalEntriesPage: React.FC = () => {
             entries={entries}
             loading={isLoading}
             total={pagination?.total ?? entries.length}
-            selectedEntryId={workspace.selectedEntry?.id ?? null}
+            selectedEntryId={selectedEntry?.id ?? null}
+            focusedIndex={workspace.focusedIndex}
             onSelect={workspace.handleSelect}
             listRef={workspace.listRef}
           />
         )}
         headerSlot={(
           <JournalEntryContextHeader
-            selectedEntry={workspace.selectedEntry}
-            onEdit={() => workspace.selectedEntry && workspace.navigateToEdit(workspace.selectedEntry)}
-            onPost={() => workspace.selectedEntry && workspace.setPostTarget(workspace.selectedEntry)}
-            onReverse={() => workspace.selectedEntry && workspace.setReverseTarget(workspace.selectedEntry)}
-            onDelete={() => workspace.selectedEntry && workspace.setDeleteTarget(workspace.selectedEntry)}
+            selectedEntry={selectedEntry}
+            onEdit={() => selectedEntry && workspace.navigateToEdit(selectedEntry)}
+            onPost={() => selectedEntry && workspace.setPostTarget(selectedEntry)}
+            onReverse={() => selectedEntry && workspace.setReverseTarget(selectedEntry)}
+            onDelete={() => selectedEntry && workspace.setDeleteTarget(selectedEntry)}
             onViewSource={workspace.navigateToSource}
           />
         )}
-        workspaceSlot={<JournalEntryWorkspaceCard selectedEntry={workspace.selectedEntry} />}
+        workspaceSlot={<JournalEntryWorkspaceCard selectedEntry={selectedEntry} />}
         dialogs={(
           <JournalEntriesDialogs
             postTarget={workspace.postTarget}

--- a/frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
 import { BrowserRouter } from 'react-router-dom'
 
 import ChartOfAccountsPage from '../ChartOfAccountsPage'
+import accountingReducer from '@/store/slices/accountingSlice'
 
 const mockedApi = vi.hoisted(() => ({
   useGetChartOfAccountsHierarchyQuery: vi.fn(),
@@ -61,11 +64,17 @@ function setup(accounts = [mockAccount]) {
   })
 }
 
+function makeStore() {
+  return configureStore({ reducer: { accounting: accountingReducer } })
+}
+
 function renderPage() {
   return render(
-    <BrowserRouter>
-      <ChartOfAccountsPage />
-    </BrowserRouter>,
+    <Provider store={makeStore()}>
+      <BrowserRouter>
+        <ChartOfAccountsPage />
+      </BrowserRouter>
+    </Provider>,
   )
 }
 
@@ -98,7 +107,7 @@ describe('ChartOfAccountsPage', () => {
 
   it('renders account code from hierarchy data', () => {
     renderPage()
-    expect(screen.getByText('1000')).toBeInTheDocument()
+    expect(getRenderedAccountCodes()).toContain('1000')
   })
 
   it('flattens nested children into table', () => {
@@ -113,8 +122,7 @@ describe('ChartOfAccountsPage', () => {
 
     renderPage()
 
-    expect(screen.getByText('1000')).toBeInTheDocument()
-    expect(screen.getByText('1010')).toBeInTheDocument()
+    expect(getRenderedAccountCodes()).toEqual(expect.arrayContaining(['1000', '1010']))
   })
 
   it('filters by account type and hides non-matching accounts', async () => {
@@ -123,14 +131,13 @@ describe('ChartOfAccountsPage', () => {
 
     renderPage()
 
-    expect(screen.getByText('1000')).toBeInTheDocument()
-    expect(screen.getByText('2000')).toBeInTheDocument()
+    expect(getRenderedAccountCodes()).toEqual(expect.arrayContaining(['1000', '2000']))
 
     await user.click(screen.getByLabelText('Account Type'))
     await user.click(screen.getByRole('option', { name: 'Asset' }))
 
-    expect(screen.getByText('1000')).toBeInTheDocument()
-    expect(screen.queryByText('2000')).not.toBeInTheDocument()
+    expect(getRenderedAccountCodes()).toContain('1000')
+    expect(getRenderedAccountCodes()).not.toContain('2000')
   })
 
   it('filters by active status and hides inactive accounts', async () => {
@@ -139,14 +146,13 @@ describe('ChartOfAccountsPage', () => {
 
     renderPage()
 
-    expect(screen.getByText('1000')).toBeInTheDocument()
-    expect(screen.getByText('3000')).toBeInTheDocument()
+    expect(getRenderedAccountCodes()).toEqual(expect.arrayContaining(['1000', '3000']))
 
     await user.click(screen.getByLabelText('Status'))
     await user.click(screen.getByRole('option', { name: 'Active' }))
 
-    expect(screen.getByText('1000')).toBeInTheDocument()
-    expect(screen.queryByText('3000')).not.toBeInTheDocument()
+    expect(getRenderedAccountCodes()).toContain('1000')
+    expect(getRenderedAccountCodes()).not.toContain('3000')
   })
 
   it('combines account type and status filters', async () => {
@@ -164,9 +170,9 @@ describe('ChartOfAccountsPage', () => {
     await user.click(screen.getByLabelText('Status'))
     await user.click(screen.getByRole('option', { name: 'Active' }))
 
-    expect(screen.getByText('1000')).toBeInTheDocument()
-    expect(screen.queryByText('1100')).not.toBeInTheDocument()
-    expect(screen.queryByText('2000')).not.toBeInTheDocument()
+    expect(getRenderedAccountCodes()).toContain('1000')
+    expect(getRenderedAccountCodes()).not.toContain('1100')
+    expect(getRenderedAccountCodes()).not.toContain('2000')
   })
 
   it('toggles sort order for account codes', async () => {

--- a/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
 import { BrowserRouter } from 'react-router-dom'
 
 import JournalEntriesPage from '../JournalEntriesPage'
+import accountingReducer from '@/store/slices/accountingSlice'
 import { JournalEntryStatus } from '@/types'
 
 vi.mock('@/hooks/useNotification', () => ({
@@ -63,6 +66,20 @@ const mockEntry = {
   updatedAt: '2026-01-01',
 }
 
+function makeStore() {
+  return configureStore({ reducer: { accounting: accountingReducer } })
+}
+
+function renderPage() {
+  return render(
+    <Provider store={makeStore()}>
+      <BrowserRouter>
+        <JournalEntriesPage />
+      </BrowserRouter>
+    </Provider>,
+  )
+}
+
 describe('JournalEntriesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -81,17 +98,17 @@ describe('JournalEntriesPage', () => {
   })
 
   it('renders the page title', () => {
-    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    renderPage()
     expect(screen.getByText('Journal Entries')).toBeInTheDocument()
   })
 
   it('renders journal entry rows', () => {
-    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    renderPage()
     expect(screen.getByText('JE-001')).toBeInTheDocument()
   })
 
   it('clicking a row selects it and shows details in the context header', async () => {
-    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    renderPage()
 
     fireEvent.click(screen.getByText('JE-001'))
 
@@ -102,7 +119,7 @@ describe('JournalEntriesPage', () => {
   })
 
   it('renders journal entry details without chip styling', async () => {
-    const { container } = render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    const { container } = renderPage()
 
     fireEvent.click(screen.getByText('JE-001'))
 

--- a/frontend/src/pages/accounting/components/ChartOfAccountsTable.tsx
+++ b/frontend/src/pages/accounting/components/ChartOfAccountsTable.tsx
@@ -7,6 +7,7 @@ interface Props {
   accounts: ChartOfAccount[]
   loading: boolean
   selectedId: string | null
+  focusedIndex: number
   onSelect: (item: ChartOfAccount) => void
   listRef?: RefObject<HTMLDivElement | null>
 }
@@ -20,6 +21,7 @@ export function ChartOfAccountsTable({
   accounts,
   loading,
   selectedId,
+  focusedIndex,
   onSelect,
   listRef,
 }: Props) {
@@ -32,7 +34,7 @@ export function ChartOfAccountsTable({
       total={accounts.length}
       label="Accounts"
       selectedId={selectedId ?? undefined}
-      focusedIndex={-1}
+      focusedIndex={focusedIndex}
       onSelect={onSelect}
       listRef={listRef ?? fallbackRef}
       dataAttr="account"

--- a/frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx
@@ -10,12 +10,17 @@ vi.mock('@/utils/formatters', () => ({
 }))
 
 vi.mock('@/components/common/EntityTable', () => ({
-  default: ({ rows, loading, label, onSelect }: any) => (
+  default: ({ rows, loading, label, onSelect, focusedIndex }: any) => (
     <div>
       {loading && <div>Loading...</div>}
       {rows.length === 0 && <div>No {label} found</div>}
-      {rows.map((row: any) => (
-        <div key={row.id} onClick={() => onSelect(row)} data-testid={`row-${row.id}`}>
+      {rows.map((row: any, index: number) => (
+        <div
+          key={row.id}
+          onClick={() => onSelect(row)}
+          data-testid={`row-${row.id}`}
+          data-focused={index === focusedIndex ? 'true' : 'false'}
+        >
           {row.referenceNumber}
         </div>
       ))}
@@ -61,5 +66,17 @@ describe('JournalEntriesTable', () => {
     render(<JournalEntriesTable {...defaultProps} entries={[makeEntry()]} onSelect={onSelect} />)
     fireEvent.click(screen.getByText('JE-001'))
     expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: '1' }))
+  })
+
+  it('passes focusedIndex to EntityTable', () => {
+    render(
+      <JournalEntriesTable
+        {...defaultProps}
+        entries={[makeEntry()]}
+        focusedIndex={0}
+      />,
+    )
+
+    expect(screen.getByTestId('row-1')).toHaveAttribute('data-focused', 'true')
   })
 })

--- a/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
@@ -12,6 +12,7 @@ interface Props {
   loading: boolean
   total: number
   selectedEntryId: string | null
+  focusedIndex: number
   onSelect: (entry: JournalEntry) => void
   listRef?: RefObject<HTMLDivElement | null>
 }
@@ -21,6 +22,7 @@ export function JournalEntriesTable({
   loading,
   total,
   selectedEntryId,
+  focusedIndex,
   onSelect,
   listRef,
 }: Props) {
@@ -34,7 +36,7 @@ export function JournalEntriesTable({
       total={total}
       label="Journal Entries"
       selectedId={selectedEntryId ?? undefined}
-      focusedIndex={-1}
+      focusedIndex={focusedIndex}
       onSelect={onSelect}
       listRef={listRef ?? fallbackRef}
       dataAttr="entry"

--- a/frontend/src/pages/accounting/hooks/useChartOfAccountsWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useChartOfAccountsWorkspace.ts
@@ -1,20 +1,59 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
+import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import { useNotification } from '@/hooks/useNotification'
+import type { AppDispatch } from '@/store'
 import { useDeleteChartOfAccountMutation, useSeedDefaultChartOfAccountsMutation } from '@/store/api/accountingApi'
+import { setSelectedAccount } from '@/store/slices/accountingSlice'
 import type { ChartOfAccount } from '@/types'
 
-export function useChartOfAccountsWorkspace(refetch: () => void) {
+interface UseChartOfAccountsWorkspaceConfig {
+  dispatch: AppDispatch
+  accounts: ChartOfAccount[]
+  selectedAccount: ChartOfAccount | null
+  refetch: () => void
+}
+
+export function useChartOfAccountsWorkspace({
+  dispatch,
+  accounts,
+  selectedAccount,
+  refetch,
+}: UseChartOfAccountsWorkspaceConfig) {
+  const navigate = useNavigate()
   const { showSuccess, showError } = useNotification()
-  const [selected, setSelected] = useState<ChartOfAccount | null>(null)
   const [formDialogOpen, setFormDialogOpen] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<ChartOfAccount | null>(null)
   const [seedConfirmOpen, setSeedConfirmOpen] = useState(false)
   const [deletedDialogOpen, setDeletedDialogOpen] = useState(false)
-  const searchInputRef = useRef<HTMLInputElement | null>(null)
-  const listRef = useRef<HTMLDivElement | null>(null)
   const [deleteChartOfAccount] = useDeleteChartOfAccountMutation()
   const [seedDefaultChartOfAccounts] = useSeedDefaultChartOfAccountsMutation()
+
+  const workspace = useEntityWorkspace({
+    entities: accounts,
+    selectedEntity: selectedAccount,
+    selectEntity: (account) => dispatch(setSelectedAccount(account)),
+    refetch,
+    navigate,
+    routes: {
+      create: '',
+      edit: () => '',
+    },
+    notifications: { showSuccess: () => {}, showError: () => {} },
+    deleteMutation: async () => {},
+    onEnter: () => {
+      if (selectedAccount) {
+        setFormDialogOpen(true)
+      }
+    },
+    onEscape: () => {
+      workspace.setFocusedIndex(-1)
+      dispatch(setSelectedAccount(null))
+      setFormDialogOpen(false)
+      setDeleteTarget(null)
+    },
+  })
 
   const handleDelete = useCallback(async () => {
     if (!deleteTarget) return
@@ -22,12 +61,14 @@ export function useChartOfAccountsWorkspace(refetch: () => void) {
       await deleteChartOfAccount(deleteTarget.id).unwrap()
       showSuccess(`Account "${deleteTarget.name}" deleted successfully`)
       setDeleteTarget(null)
-      if (selected?.id === deleteTarget.id) setSelected(null)
+      if (selectedAccount?.id === deleteTarget.id) {
+        dispatch(setSelectedAccount(null))
+      }
       refetch()
     } catch (error: any) {
       showError(error || 'Failed to delete account')
     }
-  }, [deleteChartOfAccount, deleteTarget, refetch, selected?.id, showError, showSuccess])
+  }, [deleteChartOfAccount, deleteTarget, dispatch, refetch, selectedAccount?.id, showError, showSuccess])
 
   const handleSeed = useCallback(async () => {
     try {
@@ -41,5 +82,19 @@ export function useChartOfAccountsWorkspace(refetch: () => void) {
     }
   }, [refetch, seedDefaultChartOfAccounts, showError, showSuccess])
 
-  return { selected, setSelected, formDialogOpen, setFormDialogOpen, deleteTarget, setDeleteTarget, seedConfirmOpen, setSeedConfirmOpen, deletedDialogOpen, setDeletedDialogOpen, searchInputRef, listRef, handleDelete, handleSeed }
+  return {
+    ...workspace,
+    selected: selectedAccount,
+    setSelected: (account: ChartOfAccount | null) => dispatch(setSelectedAccount(account)),
+    formDialogOpen,
+    setFormDialogOpen,
+    deleteTarget,
+    setDeleteTarget,
+    seedConfirmOpen,
+    setSeedConfirmOpen,
+    deletedDialogOpen,
+    setDeletedDialogOpen,
+    handleDelete,
+    handleSeed,
+  }
 }

--- a/frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
@@ -1,14 +1,17 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import { useNotification } from '@/hooks/useNotification'
+import type { AppDispatch } from '@/store'
 import {
   useDeleteJournalEntryMutation,
   useLazyGetJournalEntryQuery,
   usePostJournalEntryMutation,
   useReverseJournalEntryMutation,
 } from '@/store/api/accountingApi'
-import { JournalEntry } from '@/types'
+import { setSelectedJournalEntry } from '@/store/slices/accountingSlice'
+import type { JournalEntry } from '@/types'
 import { getErrorMessage } from '@/utils/errorMessage'
 
 export const SOURCE_ROUTES: Record<string, (id: string) => string> = {
@@ -22,33 +25,70 @@ export const SOURCE_ROUTES: Record<string, (id: string) => string> = {
   stock_adjustment: (id) => `/inventory/stock-adjustments/${id}/edit`,
 }
 
-export function useJournalEntriesWorkspace(refetch: () => void) {
+interface UseJournalEntriesWorkspaceConfig {
+  dispatch: AppDispatch
+  entries: JournalEntry[]
+  selectedEntry: JournalEntry | null
+  refetch: () => void
+}
+
+export function useJournalEntriesWorkspace({
+  dispatch,
+  entries,
+  selectedEntry,
+  refetch,
+}: UseJournalEntriesWorkspaceConfig) {
   const navigate = useNavigate()
   const { showSuccess, showError } = useNotification()
 
-  const [selectedEntry, setSelectedEntry] = useState<JournalEntry | null>(null)
   const [postTarget, setPostTarget] = useState<JournalEntry | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<JournalEntry | null>(null)
   const [reverseTarget, setReverseTarget] = useState<JournalEntry | null>(null)
   const [actionLoading, setActionLoading] = useState(false)
-  const searchInputRef = useRef<HTMLInputElement | null>(null)
-  const listRef = useRef<HTMLDivElement | null>(null)
 
   const [fetchEntry] = useLazyGetJournalEntryQuery()
   const [postJournalEntry] = usePostJournalEntryMutation()
   const [reverseJournalEntry] = useReverseJournalEntryMutation()
   const [deleteJournalEntry] = useDeleteJournalEntryMutation()
 
-  const handleSelect = useCallback(async (entry: JournalEntry) => {
-    setSelectedEntry(entry)
+  const selectAndLoadEntry = useCallback(async (entry: JournalEntry) => {
+    dispatch(setSelectedJournalEntry(entry))
     try {
       const fresh = await fetchEntry(entry.id).unwrap()
-      setSelectedEntry(fresh)
+      dispatch(setSelectedJournalEntry(fresh))
     }
     catch {
       /* keep list-row data */
     }
-  }, [fetchEntry])
+  }, [dispatch, fetchEntry])
+
+  const workspace = useEntityWorkspace({
+    entities: entries,
+    selectedEntity: selectedEntry,
+    selectEntity: (entry) => {
+      if (entry) {
+        void selectAndLoadEntry(entry)
+        return
+      }
+
+      dispatch(setSelectedJournalEntry(null))
+    },
+    refetch,
+    navigate,
+    routes: {
+      create: '/accounting/journal-entries/new',
+      edit: (id) => `/accounting/journal-entries/${id}/edit`,
+    },
+    notifications: { showSuccess: () => {}, showError: () => {} },
+    deleteMutation: async () => {},
+    onEscape: () => {
+      workspace.setFocusedIndex(-1)
+      dispatch(setSelectedJournalEntry(null))
+      setPostTarget(null)
+      setDeleteTarget(null)
+      setReverseTarget(null)
+    },
+  })
 
   const handleConfirmPost = useCallback(async () => {
     if (!postTarget) return
@@ -57,7 +97,7 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
       await postJournalEntry(postTarget.id).unwrap()
       showSuccess(`Journal entry ${postTarget.referenceNumber} posted`)
       setPostTarget(null)
-      setSelectedEntry(null)
+      dispatch(setSelectedJournalEntry(null))
       refetch()
     }
     catch (error: unknown) {
@@ -66,7 +106,7 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
     finally {
       setActionLoading(false)
     }
-  }, [postTarget, postJournalEntry, refetch, showError, showSuccess])
+  }, [dispatch, postTarget, postJournalEntry, refetch, showError, showSuccess])
 
   const handleConfirmReverse = useCallback(async (reverseDate: string) => {
     if (!reverseTarget) return
@@ -75,7 +115,7 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
       const result = await reverseJournalEntry({ id: reverseTarget.id, reverseDate }).unwrap()
       showSuccess(`Journal entry ${reverseTarget.referenceNumber} reversed`)
       setReverseTarget(null)
-      setSelectedEntry(result)
+      dispatch(setSelectedJournalEntry(result))
       refetch()
     }
     catch (error: unknown) {
@@ -84,7 +124,7 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
     finally {
       setActionLoading(false)
     }
-  }, [refetch, reverseJournalEntry, reverseTarget, showError, showSuccess])
+  }, [dispatch, refetch, reverseJournalEntry, reverseTarget, showError, showSuccess])
 
   const handleConfirmDelete = useCallback(async () => {
     if (!deleteTarget) return
@@ -93,7 +133,7 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
       await deleteJournalEntry(deleteTarget.id).unwrap()
       showSuccess(`Journal entry ${deleteTarget.referenceNumber} deleted`)
       setDeleteTarget(null)
-      setSelectedEntry(null)
+      dispatch(setSelectedJournalEntry(null))
       refetch()
     }
     catch (error: unknown) {
@@ -102,9 +142,10 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
     finally {
       setActionLoading(false)
     }
-  }, [deleteJournalEntry, deleteTarget, refetch, showError, showSuccess])
+  }, [deleteJournalEntry, deleteTarget, dispatch, refetch, showError, showSuccess])
 
   return {
+    ...workspace,
     selectedEntry,
     postTarget,
     setPostTarget,
@@ -113,9 +154,6 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
     reverseTarget,
     setReverseTarget,
     actionLoading,
-    searchInputRef,
-    listRef,
-    handleSelect,
     handleConfirmPost,
     handleConfirmReverse,
     handleConfirmDelete,

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -16,6 +16,7 @@ import purchasingSlice from './slices/purchasingSlice'
 import backupSlice from './slices/backupSlice'
 import auditLogSlice from './slices/auditLogSlice'
 import priceListSlice from './slices/priceListSlice'
+import accountingSlice from './slices/accountingSlice'
 import { auditLogApiSlice } from './api/auditLogApi'
 import { backupApiSlice } from './api/backupApi'
 import { priceListApiSlice } from './api/priceListApi'
@@ -39,6 +40,7 @@ const rootReducer = combineReducers({
   backup: backupSlice,
   auditLogs: auditLogSlice,
   priceLists: priceListSlice,
+  accounting: accountingSlice,
   [auditLogApiSlice.reducerPath]: auditLogApiSlice.reducer,
   [backupApiSlice.reducerPath]: backupApiSlice.reducer,
   [priceListApiSlice.reducerPath]: priceListApiSlice.reducer,

--- a/frontend/src/store/slices/__tests__/accountingSlice.test.ts
+++ b/frontend/src/store/slices/__tests__/accountingSlice.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import accountingReducer, {
+  setSelectedAccount,
+  setSelectedJournalEntry,
+} from '@/store/slices/accountingSlice'
+
+describe('accountingSlice', () => {
+  it('sets selectedJournalEntry', () => {
+    const entry = { id: 'je-1', referenceNumber: 'JE-001' } as any
+    const state = accountingReducer(undefined, setSelectedJournalEntry(entry))
+
+    expect(state.selectedJournalEntry).toEqual(entry)
+  })
+
+  it('clears selectedJournalEntry', () => {
+    const entry = { id: 'je-1', referenceNumber: 'JE-001' } as any
+    const withEntry = accountingReducer(undefined, setSelectedJournalEntry(entry))
+    const cleared = accountingReducer(withEntry, setSelectedJournalEntry(null))
+
+    expect(cleared.selectedJournalEntry).toBeNull()
+  })
+
+  it('sets selectedAccount', () => {
+    const account = { id: 'acc-1', code: '1000', name: 'Cash' } as any
+    const state = accountingReducer(undefined, setSelectedAccount(account))
+
+    expect(state.selectedAccount).toEqual(account)
+  })
+
+  it('clears selectedAccount', () => {
+    const account = { id: 'acc-1', code: '1000', name: 'Cash' } as any
+    const withAccount = accountingReducer(undefined, setSelectedAccount(account))
+    const cleared = accountingReducer(withAccount, setSelectedAccount(null))
+
+    expect(cleared.selectedAccount).toBeNull()
+  })
+})

--- a/frontend/src/store/slices/accountingSlice.ts
+++ b/frontend/src/store/slices/accountingSlice.ts
@@ -1,0 +1,34 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+
+import type { RootState } from '@/store'
+import type { ChartOfAccount, JournalEntry } from '@/types'
+
+interface AccountingState {
+  selectedJournalEntry: JournalEntry | null
+  selectedAccount: ChartOfAccount | null
+}
+
+const initialState: AccountingState = {
+  selectedJournalEntry: null,
+  selectedAccount: null,
+}
+
+const accountingSlice = createSlice({
+  name: 'accounting',
+  initialState,
+  reducers: {
+    setSelectedJournalEntry: (state, action: PayloadAction<JournalEntry | null>) => {
+      state.selectedJournalEntry = action.payload
+    },
+    setSelectedAccount: (state, action: PayloadAction<ChartOfAccount | null>) => {
+      state.selectedAccount = action.payload
+    },
+  },
+})
+
+export const { setSelectedJournalEntry, setSelectedAccount } = accountingSlice.actions
+
+export const selectSelectedJournalEntry = (state: RootState) => state.accounting.selectedJournalEntry
+export const selectSelectedAccount = (state: RootState) => state.accounting.selectedAccount
+
+export default accountingSlice.reducer


### PR DESCRIPTION
## Summary

- Adds `accountingSlice` with `selectedJournalEntry` and `selectedAccount` in Redux (matching `salesSlice`/`purchasingSlice` pattern)
- Refactors `useJournalEntriesWorkspace` and `useChartOfAccountsWorkspace` to internally wrap `useEntityWorkspace`, replacing ad-hoc local state
- JE selection now lazy-fetches full entry detail on each click/arrow-nav (matching `useOrdersWorkspace`)
- COA `Enter` key opens the edit form dialog; `Escape` clears selection
- Threads real `focusedIndex` through `JournalEntriesTable` and `ChartOfAccountsTable` (was hardcoded `-1`)
- Replaces manual `setTimeout` search focus hack in JE page with `setShouldPreserveSearchFocus`
- Updates page tests to provide Redux store via `Provider`; adds `accountingSlice` unit tests

Closes #424

## Test plan

- [x] `accountingSlice.test.ts` — 4 reducer tests pass
- [x] `JournalEntriesTable.test.tsx` — focusedIndex highlight test + existing tests pass
- [x] `JournalEntriesPage.test.tsx` — all existing tests pass with Redux Provider
- [x] `ChartOfAccountsPage.test.tsx` — all existing tests pass with Redux Provider
- [x] `accounting-auto-posting.integration.test.tsx` — passes
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)