### PR TITLE
fix(frontend): runtime stability fixes for chunks, dashboard, and notifications

### DIFF
--- a/frontend/src/pages/dashboard/DashboardPage.test.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import ThemeWrapper from '@/components/common/ThemeWrapper'
+import DashboardPage from './DashboardPage'
+
+vi.mock('@/hooks/useCurrency', () => ({
+  useCurrency: () => ({ currency: 'USD' }),
+}))
+
+vi.mock('@/store/api/salesApi', () => ({
+  useGetSalesOrdersQuery: () => ({
+    data: { data: [] },
+    isLoading: false,
+    error: undefined,
+  }),
+  useGetPaymentsQuery: () => ({
+    data: { data: [] },
+    isLoading: false,
+    error: undefined,
+  }),
+}))
+
+vi.mock('@/store/api/purchasingApi', () => ({
+  useGetPurchaseOrdersQuery: () => ({
+    data: { data: [] },
+    isLoading: false,
+    error: undefined,
+  }),
+  useGetSuppliersQuery: () => ({
+    data: { data: [] },
+    isLoading: false,
+    error: undefined,
+  }),
+}))
+
+vi.mock('@/store/api/inventoryApi', () => ({
+  useGetDashboardStatsQuery: () => ({
+    data: {
+      totalProducts: 0,
+      totalCategories: 0,
+      inventoryValue: 0,
+      outOfStockCount: 0,
+      stockHealthMetrics: {
+        inStockPercentage: 100,
+        outOfStockPercentage: 0,
+      },
+    },
+    isLoading: false,
+    error: undefined,
+  }),
+  useGetOutOfStockProductsQuery: () => ({
+    data: { data: { items: [] } },
+    isLoading: false,
+    error: undefined,
+  }),
+}))
+
+vi.mock('./components', () => ({
+  DashboardStats: () => <div>Dashboard stats</div>,
+  QuickActions: () => <div>Quick actions</div>,
+  BusinessPerformanceChart: () => <div>Business performance</div>,
+  RecentSalesTable: () => <div>Recent sales</div>,
+  RecentPurchasesTable: () => <div>Recent purchases</div>,
+  TopPerformers: () => <div>Top performers</div>,
+  InventoryOverview: () => <div>Inventory overview</div>,
+}))
+
+describe('DashboardPage', () => {
+  it('renders when out-of-stock response data is not an array', () => {
+    render(
+      <ThemeWrapper>
+        <MemoryRouter>
+          <DashboardPage />
+        </MemoryRouter>
+      </ThemeWrapper>,
+    )
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    expect(screen.getByText('Inventory overview')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -70,6 +70,8 @@ interface DashboardData {
   }
 }
 
+const asArray = <T,>(value: unknown): T[] => (Array.isArray(value) ? value : [])
+
 const DashboardPage: React.FC = () => {
   const navigate = useNavigate()
   const { currency } = useCurrency()
@@ -88,10 +90,11 @@ const DashboardPage: React.FC = () => {
   const { data: inventoryStats, isLoading: inventoryLoading, error: inventoryError } = useGetDashboardStatsQuery()
   const { data: outOfStock = [], isLoading: outOfStockLoading, error: outOfStockError } = useGetOutOfStockProductsQuery()
   const { data: paymentsResponse, isLoading: paymentsLoading, error: paymentsError } = useGetPaymentsQuery({})
-  const salesOrders = salesOrdersResponse?.data ?? []
-  const purchaseOrders = purchaseOrdersResponse?.data ?? []
-  const suppliers = suppliersResponse?.data ?? []
-  const payments = paymentsResponse?.data ?? []
+  const salesOrders = asArray<any>(salesOrdersResponse?.data)
+  const purchaseOrders = asArray<any>(purchaseOrdersResponse?.data)
+  const suppliers = asArray<any>(suppliersResponse?.data)
+  const payments = asArray<any>(paymentsResponse?.data)
+  const outOfStockProducts = asArray<any>(outOfStock)
 
   const loading =
     salesLoading ||
@@ -300,8 +303,8 @@ const DashboardPage: React.FC = () => {
         totalProducts: inventoryStats?.totalProducts || 0,
         totalCategories: inventoryStats?.totalCategories || 0,
         inventoryValue: inventoryStats?.inventoryValue || 0,
-        outOfStockCount: inventoryStats?.outOfStockCount || outOfStock.length,
-        lowStockItems: outOfStock.slice(0, 5),
+        outOfStockCount: inventoryStats?.outOfStockCount || outOfStockProducts.length,
+        lowStockItems: outOfStockProducts.slice(0, 5),
         stockHealthMetrics: inventoryStats?.stockHealthMetrics || {
           inStockPercentage: 100,
           outOfStockPercentage: 0,
@@ -314,7 +317,7 @@ const DashboardPage: React.FC = () => {
         inventoryValue: inventoryStats?.inventoryValue || 0,
       },
     }
-  }, [inventoryStats, outOfStock, payments, purchaseOrders, salesOrders, suppliers])
+  }, [inventoryStats, outOfStockProducts, payments, purchaseOrders, salesOrders, suppliers])
 
   const stats = [
     {

--- a/frontend/src/services/__tests__/viteConfig.test.ts
+++ b/frontend/src/services/__tests__/viteConfig.test.ts
@@ -1,0 +1,30 @@
+import configFactory from '../../../vite.config'
+
+describe('vite chunk configuration', () => {
+  it('keeps axios out of app chunks so auth services do not evaluate through a circular entry chunk', () => {
+    const config =
+      typeof configFactory === 'function'
+        ? configFactory({
+            command: 'build',
+            mode: 'production',
+            isSsrBuild: false,
+            isPreview: false,
+          })
+        : configFactory
+
+    const groups =
+      config.build?.rolldownOptions?.output?.codeSplitting?.groups ?? []
+
+    expect(groups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'axios',
+          test: expect.any(RegExp),
+        }),
+      ])
+    )
+
+    const axiosGroup = groups.find((group) => group.name === 'axios')
+    expect(axiosGroup?.test.test('node_modules/axios/index.js')).toBe(true)
+  })
+})

--- a/frontend/src/services/__tests__/viteConfig.test.ts
+++ b/frontend/src/services/__tests__/viteConfig.test.ts
@@ -27,4 +27,32 @@ describe('vite chunk configuration', () => {
     const axiosGroup = groups.find((group) => group.name === 'axios')
     expect(axiosGroup?.test.test('node_modules/axios/index.js')).toBe(true)
   })
+
+  it('keeps RTK Query API slices out of the app entry chunk so baseQuery is initialized before use', () => {
+    const config =
+      typeof configFactory === 'function'
+        ? configFactory({
+            command: 'build',
+            mode: 'production',
+            isSsrBuild: false,
+            isPreview: false,
+          })
+        : configFactory
+
+    const groups =
+      config.build?.rolldownOptions?.output?.codeSplitting?.groups ?? []
+
+    expect(groups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'rtk-api',
+          test: expect.any(RegExp),
+        }),
+      ])
+    )
+
+    const rtkApiGroup = groups.find((group) => group.name === 'rtk-api')
+    expect(rtkApiGroup?.test.test('/home/blur/erp2/frontend/src/store/api/searchApi.ts')).toBe(true)
+    expect(rtkApiGroup?.test.test('/home/blur/erp2/frontend/src/store/api/baseQuery.ts')).toBe(true)
+  })
 })

--- a/frontend/src/services/__tests__/viteConfig.test.ts
+++ b/frontend/src/services/__tests__/viteConfig.test.ts
@@ -55,4 +55,23 @@ describe('vite chunk configuration', () => {
     expect(rtkApiGroup?.test.test('/home/blur/erp2/frontend/src/store/api/searchApi.ts')).toBe(true)
     expect(rtkApiGroup?.test.test('/home/blur/erp2/frontend/src/store/api/baseQuery.ts')).toBe(true)
   })
+
+  it('keeps redux persistence dependencies out of the app entry chunk so persist actions have a type', () => {
+    const config =
+      typeof configFactory === 'function'
+        ? configFactory({
+            command: 'build',
+            mode: 'production',
+            isSsrBuild: false,
+            isPreview: false,
+          })
+        : configFactory
+
+    const groups =
+      config.build?.rolldownOptions?.output?.codeSplitting?.groups ?? []
+
+    const reduxGroup = groups.find((group) => group.name === 'redux')
+    expect(reduxGroup?.test.test('node_modules/redux-persist/es/persistStore.js')).toBe(true)
+    expect(reduxGroup?.test.test('node_modules/redux/src/createStore.ts')).toBe(true)
+  })
 })

--- a/frontend/src/store/api/inventoryApi.ts
+++ b/frontend/src/store/api/inventoryApi.ts
@@ -161,7 +161,10 @@ export const inventoryApiSlice = createApi({
     }),
     getOutOfStockProducts: builder.query<Product[], void>({
       query: () => ({ url: '/inventory/products/out-of-stock' }),
-      transformResponse: (response: any) => (Array.isArray(response) ? response : response?.data ?? []),
+      transformResponse: (response: any) => {
+        const data = response?.data
+        return Array.isArray(response) ? response : Array.isArray(data) ? data : []
+      },
       providesTags: ['Product'],
     }),
 

--- a/frontend/src/store/slices/__tests__/notificationSlice.test.ts
+++ b/frontend/src/store/slices/__tests__/notificationSlice.test.ts
@@ -57,6 +57,13 @@ describe('notificationSlice', () => {
     expect(typeof notifications[0].timestamp).toBe('string')
   })
 
+  it('selectors return defaults when notifications state is missing', () => {
+    const state = {} as ReturnType<typeof store.getState>
+
+    expect(selectNotifications(state)).toEqual([])
+    expect(selectUnreadCount(state)).toBe(0)
+  })
+
   it('should clear all notifications on logout.fulfilled', () => {
     // Add some notifications
     store.dispatch(addNotification({ type: 'success', title: 'A', message: 'msg' }))

--- a/frontend/src/store/slices/notificationSlice.ts
+++ b/frontend/src/store/slices/notificationSlice.ts
@@ -91,8 +91,8 @@ export const {
 
 // Selectors
 export const selectNotifications = (state: RootState) =>
-  state.notifications.notifications
+  state.notifications?.notifications ?? []
 export const selectUnreadCount = (state: RootState) =>
-  state.notifications.unreadCount
+  state.notifications?.unreadCount ?? 0
 
 export default notificationSlice.reducer

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -108,7 +108,7 @@ export default defineConfig(({ mode }) => {
               },
               {
                 name: 'redux',
-                test: /node_modules[\\/](@reduxjs[\\/]toolkit|react-redux)[\\/]/,
+                test: /node_modules[\\/](@reduxjs[\\/]toolkit|react-redux|redux|redux-persist)[\\/]/,
                 priority: 10,
               },
             ],

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -97,6 +97,11 @@ export default defineConfig(({ mode }) => {
                 priority: 25,
               },
               {
+                name: 'rtk-api',
+                test: /src[\\/]store[\\/]api[\\/]/,
+                priority: 22,
+              },
+              {
                 name: 'router',
                 test: /node_modules[\\/](react-router|react-router-dom)[\\/]/,
                 priority: 20,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -92,6 +92,11 @@ export default defineConfig(({ mode }) => {
                 priority: 30,
               },
               {
+                name: 'axios',
+                test: /node_modules[\\/]axios[\\/]/,
+                priority: 25,
+              },
+              {
                 name: 'router',
                 test: /node_modules[\\/](react-router|react-router-dom)[\\/]/,
                 priority: 20,


### PR DESCRIPTION
## Summary
- Isolate axios, RTK Query API, and redux persistence into separate Vite chunks to prevent bundle conflicts
- Guard `DashboardPage` against non-array stock responses from the inventory API
- Make notification slice tolerant of missing/undefined slice state during rehydration

## Test Plan
- [x] Verify dashboard loads without console errors
- [x] Verify notifications do not throw on page load/refresh
- [x] Run `npx vitest run src/pages/dashboard/DashboardPage.test.tsx src/store/slices/__tests__/notificationSlice.test.ts src/services/__tests__/viteConfig.test.ts` — all 17 tests pass