### PR TITLE
fix(websocket): resolve transport close disconnections and debounce reconnect toast

### DIFF
--- a/backend/src/modules/dashboard/dashboard-module.ts
+++ b/backend/src/modules/dashboard/dashboard-module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { DashboardController } from './controllers/dashboard-controller';
 import { DashboardService } from './services/dashboard-service';
 import { DashboardWebSocketGateway } from './gateways/dashboard-websocket-gateway';
+import { AppWebSocketGateway } from './gateways/app-websocket-gateway';
 
 // Import necessary service dependencies
 // import { SalesModule } from '../sales/sales.module'; // Temporarily disabled for startup
@@ -16,7 +17,7 @@ import { InventoryModule } from '../inventory/inventory.module';
     // PurchasingModule  // Disabled - not enabled in app.module.ts
   ],
   controllers: [DashboardController],
-  providers: [DashboardService, DashboardWebSocketGateway],
+  providers: [DashboardService, DashboardWebSocketGateway, AppWebSocketGateway],
   exports: [DashboardService]
 })
 export class DashboardModule {}

--- a/backend/src/modules/dashboard/gateways/app-websocket-gateway.spec.ts
+++ b/backend/src/modules/dashboard/gateways/app-websocket-gateway.spec.ts
@@ -1,0 +1,13 @@
+import { AppWebSocketGateway } from './app-websocket-gateway';
+
+describe('AppWebSocketGateway', () => {
+  let gateway: AppWebSocketGateway;
+
+  beforeEach(() => {
+    gateway = new AppWebSocketGateway();
+  });
+
+  it('should be defined', () => {
+    expect(gateway).toBeDefined();
+  });
+});

--- a/backend/src/modules/dashboard/gateways/app-websocket-gateway.ts
+++ b/backend/src/modules/dashboard/gateways/app-websocket-gateway.ts
@@ -1,0 +1,15 @@
+import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+import { Server } from 'socket.io';
+
+@WebSocketGateway({
+  cors: {
+    origin: '*',
+    methods: ['GET', 'POST'],
+  },
+  pingInterval: 25000,
+  pingTimeout: 60000,
+})
+export class AppWebSocketGateway {
+  @WebSocketServer()
+  server: Server;
+}

--- a/frontend/src/hooks/__tests__/useWebSocket.reconnect.test.tsx
+++ b/frontend/src/hooks/__tests__/useWebSocket.reconnect.test.tsx
@@ -1,0 +1,90 @@
+import { renderHook, act } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+
+const { mockShowNotification, mockSocket } = vi.hoisted(() => ({
+  mockShowNotification: vi.fn(),
+  mockSocket: {
+    on: vi.fn(),
+    onAny: vi.fn(),
+    disconnect: vi.fn(),
+    emit: vi.fn(),
+    connected: true,
+  },
+}))
+
+vi.mock('../useNotification', () => ({
+  useNotification: () => ({ showNotification: mockShowNotification }),
+}))
+
+vi.mock('../useRedux', () => ({
+  useAppDispatch: () => vi.fn(),
+  useAppSelector: (selector: any) =>
+    selector({ auth: { isAuthenticated: true, accessToken: 'token' } }),
+}))
+
+vi.mock('@/store/slices/notificationSlice', () => ({
+  addNotification: vi.fn(),
+}))
+
+vi.mock('socket.io-client', () => ({
+  io: () => mockSocket,
+}))
+
+import { WebSocketProvider } from '../useWebSocket'
+
+describe('useWebSocket reconnect toast debounce', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does NOT show toast when reconnect happens within 5 seconds of disconnect', () => {
+    const handlers: Record<string, Function> = {}
+    mockSocket.on.mockImplementation((event: string, cb: Function) => {
+      handlers[event] = cb
+    })
+
+    const wrapper = ({ children }: any) => (
+      <WebSocketProvider>{children}</WebSocketProvider>
+    )
+    renderHook(() => {}, { wrapper })
+
+    act(() => {
+      handlers['disconnect']?.('transport close')
+      vi.advanceTimersByTime(2000)
+      handlers['reconnect']?.(1)
+    })
+
+    expect(mockShowNotification).not.toHaveBeenCalledWith(
+      'Real-time connection restored',
+      'success',
+    )
+  })
+
+  it('DOES show toast when reconnect happens after more than 5 seconds', () => {
+    const handlers: Record<string, Function> = {}
+    mockSocket.on.mockImplementation((event: string, cb: Function) => {
+      handlers[event] = cb
+    })
+
+    const wrapper = ({ children }: any) => (
+      <WebSocketProvider>{children}</WebSocketProvider>
+    )
+    renderHook(() => {}, { wrapper })
+
+    act(() => {
+      handlers['disconnect']?.('transport close')
+      vi.advanceTimersByTime(6000)
+      handlers['reconnect']?.(1)
+    })
+
+    expect(mockShowNotification).toHaveBeenCalledWith(
+      'Real-time connection restored',
+      'success',
+    )
+  })
+})

--- a/frontend/src/hooks/useWebSocket.tsx
+++ b/frontend/src/hooks/useWebSocket.tsx
@@ -33,6 +33,7 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   const [lastMessage, setLastMessage] = useState<WebSocketMessage | null>(null)
   const socketRef = useRef<Socket | null>(null)
   const listenersRef = useRef<Map<string, Set<Function>>>(new Map())
+  const disconnectTimeRef = useRef<number | null>(null)
 
   // Initialize WebSocket connection
   useEffect(() => {
@@ -70,6 +71,7 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({ chi
 
       socket.on('disconnect', (reason) => {
         console.log('WebSocket disconnected:', reason)
+        disconnectTimeRef.current = Date.now()
         setIsConnected(false)
         if (reason === 'io server disconnect') {
           // Server initiated disconnect, try to reconnect
@@ -88,7 +90,11 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       socket.on('reconnect', (attemptNumber) => {
         console.log('WebSocket reconnected after', attemptNumber, 'attempts')
         setIsConnected(true)
-        showNotification('Real-time connection restored', 'success')
+        const downFor = disconnectTimeRef.current ? Date.now() - disconnectTimeRef.current : 0
+        if (downFor > 5000) {
+          showNotification('Real-time connection restored', 'success')
+        }
+        disconnectTimeRef.current = null
       })
 
       socket.on('reconnect_failed', () => {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -179,6 +179,7 @@ http {
 
             # Buffer settings
             proxy_buffering off;
+            keepalive_requests 0;
         }
 
         # Frontend - SPA routing


### PR DESCRIPTION
## Summary
- Add root namespace (`/`) WebSocket gateway with `pingTimeout: 60000` — frontend connects to `/` but only a `dashboard` namespace gateway existed
- Disable NGINX keepalive connection recycling on the `/socket.io/` proxy path (`keepalive_requests 0`)
- Debounce the "Real-time connection restored" toast — only shown if connection was down >5 seconds, silent for sub-second blips

## Test plan
- [x] Backend unit test: `AppWebSocketGateway` instantiates correctly (RED/GREEN)
- [x] Frontend unit test: reconnect toast debounce — fires after >5s, silent for <5s
- [x] `cd backend && npm run build` — passes
- [x] `docker compose exec nginx nginx -t` — passes
- [x] `cd frontend && npm run type-check` — passes
- [x] `cd backend && npm run lint && npm run test` — 62 suites, 832 tests passing
- [x] Docker: Socket.IO client stayed connected through NGINX for 120s with no `transport close`
- [x] Docker: backend restart triggered toast after ~16.3s reconnect (correctly above 5s threshold)

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)