### PR TITLE
feat: per-page scroll control via useLayoutScroll hook

### DIFF
--- a/frontend/src/components/common/MainLayout.tsx
+++ b/frontend/src/components/common/MainLayout.tsx
@@ -4,9 +4,33 @@ import { Box, Drawer } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 
 import { DRAWER_WIDTH_COLLAPSED, DRAWER_WIDTH_EXPANDED } from '@/constants/layout'
+import { LayoutScrollProvider, useLayoutScrollContext } from '@/contexts/LayoutScrollContext'
 
 import Sidebar from './Sidebar'
 import TopBar from './TopBar'
+
+const MainContent: React.FC = () => {
+  const scrollEnabled = useLayoutScrollContext()
+  return (
+    <Box
+      component="main"
+      sx={{
+        flexGrow: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        pt: 11,
+        px: { xs: 2, sm: 3 },
+        pb: 3,
+        bgcolor: 'background.default',
+        height: '100%',
+        overflow: scrollEnabled ? 'auto' : 'hidden',
+        maxWidth: '100%',
+      }}
+    >
+      <Outlet />
+    </Box>
+  )
+}
 
 const MainLayout: React.FC = () => {
   const theme = useTheme()
@@ -79,23 +103,9 @@ const MainLayout: React.FC = () => {
         </Drawer>
       </Box>
 
-      <Box
-        component="main"
-        sx={{
-          flexGrow: 1,
-          display: 'flex',
-          flexDirection: 'column',
-          pt: 11,
-          px: { xs: 2, sm: 3 },
-          pb: 3,
-          bgcolor: 'background.default',
-          height: '100%',
-          overflow: 'hidden',
-          maxWidth: '100%',
-        }}
-      >
-        <Outlet />
-      </Box>
+      <LayoutScrollProvider>
+        <MainContent />
+      </LayoutScrollProvider>
     </Box>
   )
 }

--- a/frontend/src/components/common/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/common/__tests__/MainLayout.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import { describe, it, vi } from 'vitest'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
 
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
 import MainLayout from '../MainLayout'
 
 vi.mock('../Sidebar', () => ({ default: () => <div data-testid="sidebar" /> }))
@@ -15,6 +16,11 @@ function makeStore() {
       notifications: (state = { notifications: [], unreadCount: 0 }) => state,
     },
   })
+}
+
+const ScrollOptInPage = () => {
+  useLayoutScroll(true)
+  return <div>Scrollable route</div>
 }
 
 describe('MainLayout', () => {
@@ -50,5 +56,23 @@ describe('MainLayout', () => {
     )
 
     expect(screen.getByRole('main')).toHaveStyle({ height: '100%' })
+  })
+
+  it('allows routed pages to opt in to main content scrolling', async () => {
+    render(
+      <Provider store={makeStore()}>
+        <MemoryRouter>
+          <Routes>
+            <Route element={<MainLayout />}>
+              <Route index element={<ScrollOptInPage />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('main')).toHaveStyle({ overflow: 'auto' })
+    })
   })
 })

--- a/frontend/src/contexts/LayoutScrollContext.test.tsx
+++ b/frontend/src/contexts/LayoutScrollContext.test.tsx
@@ -1,4 +1,6 @@
-import { renderHook, act } from '@testing-library/react'
+import React, { useState } from 'react'
+import { render, act } from '@testing-library/react'
+import { renderHook } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import { LayoutScrollProvider, useLayoutScroll, useLayoutScrollContext } from './LayoutScrollContext'
 
@@ -21,14 +23,32 @@ describe('LayoutScrollContext', () => {
   })
 
   it('useLayoutScroll resets to false on unmount', () => {
-    const { result, unmount } = renderHook(() => {
+    // Render a parent that tracks the context value and conditionally mounts
+    // a child that calls useLayoutScroll(true). Unmounting the child must
+    // trigger cleanup and reset the context to false.
+    let observedValue: boolean | null = null
+
+    const Observer = () => {
+      observedValue = useLayoutScrollContext()
+      return null
+    }
+
+    const Controller = () => {
       useLayoutScroll(true)
-      return useLayoutScrollContext()
-    }, { wrapper })
-    expect(result.current).toBe(true)
-    unmount()
-    // After unmount, a new consumer sees the reset default
-    const { result: result2 } = renderHook(() => useLayoutScrollContext(), { wrapper })
-    expect(result2.current).toBe(false)
+      return null
+    }
+
+    const App = ({ showController }: { showController: boolean }) => (
+      <LayoutScrollProvider>
+        <Observer />
+        {showController && <Controller />}
+      </LayoutScrollProvider>
+    )
+
+    const { rerender } = render(<App showController={true} />)
+    expect(observedValue).toBe(true)
+
+    act(() => { rerender(<App showController={false} />) })
+    expect(observedValue).toBe(false)
   })
 })

--- a/frontend/src/contexts/LayoutScrollContext.test.tsx
+++ b/frontend/src/contexts/LayoutScrollContext.test.tsx
@@ -1,0 +1,34 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { LayoutScrollProvider, useLayoutScroll, useLayoutScrollContext } from './LayoutScrollContext'
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <LayoutScrollProvider>{children}</LayoutScrollProvider>
+)
+
+describe('LayoutScrollContext', () => {
+  it('defaults to scrollEnabled = false', () => {
+    const { result } = renderHook(() => useLayoutScrollContext(), { wrapper })
+    expect(result.current).toBe(false)
+  })
+
+  it('useLayoutScroll(true) enables scroll on mount', () => {
+    const { result } = renderHook(() => {
+      useLayoutScroll(true)
+      return useLayoutScrollContext()
+    }, { wrapper })
+    expect(result.current).toBe(true)
+  })
+
+  it('useLayoutScroll resets to false on unmount', () => {
+    const { result, unmount } = renderHook(() => {
+      useLayoutScroll(true)
+      return useLayoutScrollContext()
+    }, { wrapper })
+    expect(result.current).toBe(true)
+    unmount()
+    // After unmount, a new consumer sees the reset default
+    const { result: result2 } = renderHook(() => useLayoutScrollContext(), { wrapper })
+    expect(result2.current).toBe(false)
+  })
+})

--- a/frontend/src/contexts/LayoutScrollContext.tsx
+++ b/frontend/src/contexts/LayoutScrollContext.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+
+const LayoutScrollContext = createContext<boolean>(false)
+const LayoutScrollSetContext = createContext<React.Dispatch<React.SetStateAction<boolean>>>(() => {})
+
+export const LayoutScrollProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [scrollEnabled, setScrollEnabled] = useState(false)
+  return (
+    <LayoutScrollContext.Provider value={scrollEnabled}>
+      <LayoutScrollSetContext.Provider value={setScrollEnabled}>
+        {children}
+      </LayoutScrollSetContext.Provider>
+    </LayoutScrollContext.Provider>
+  )
+}
+
+export const useLayoutScrollContext = () => useContext(LayoutScrollContext)
+
+export const useLayoutScroll = (enabled: boolean) => {
+  const setScrollEnabled = useContext(LayoutScrollSetContext)
+  useEffect(() => {
+    setScrollEnabled(enabled)
+    return () => setScrollEnabled(false)
+  }, [enabled, setScrollEnabled])
+}

--- a/frontend/src/pages/dashboard/DashboardPage.test.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.test.tsx
@@ -2,10 +2,15 @@ import { describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import ThemeWrapper from '@/components/common/ThemeWrapper'
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
 import DashboardPage from './DashboardPage'
 
 vi.mock('@/hooks/useCurrency', () => ({
   useCurrency: () => ({ currency: 'USD' }),
+}))
+
+vi.mock('@/contexts/LayoutScrollContext', () => ({
+  useLayoutScroll: vi.fn(),
 }))
 
 vi.mock('@/store/api/salesApi', () => ({
@@ -78,5 +83,17 @@ describe('DashboardPage', () => {
 
     expect(screen.getByText('Dashboard')).toBeInTheDocument()
     expect(screen.getByText('Inventory overview')).toBeInTheDocument()
+  })
+
+  it('opts in to layout scrolling', () => {
+    render(
+      <ThemeWrapper>
+        <MemoryRouter>
+          <DashboardPage />
+        </MemoryRouter>
+      </ThemeWrapper>,
+    )
+
+    expect(useLayoutScroll).toHaveBeenCalledWith(true)
   })
 })

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -11,6 +11,7 @@ import { default as SalesIcon } from '@mui/icons-material/PointOfSale'
 import { default as PurchasingIcon } from '@mui/icons-material/Assignment'
 import { default as CustomersIcon } from '@mui/icons-material/People'
 import PageHeader from '@/components/common/PageHeader'
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
 import { formatCurrency } from '@/utils/formatters'
 import { useNavigate } from 'react-router-dom'
 import { useCurrency } from '@/hooks/useCurrency'
@@ -73,6 +74,8 @@ interface DashboardData {
 const asArray = <T,>(value: unknown): T[] => (Array.isArray(value) ? value : [])
 
 const DashboardPage: React.FC = () => {
+  useLayoutScroll(true)
+
   const navigate = useNavigate()
   const { currency } = useCurrency()
 


### PR DESCRIPTION
## Summary

- Fixes #432 — dashboard content was cut off due to `overflow: hidden` on the main layout container
- Introduces `LayoutScrollContext` with a `useLayoutScroll(true)` opt-in hook; all pages default to no-scroll
- Only `DashboardPage` enables scroll for now; future pages opt in with a single hook call
- Cleanup on unmount resets scroll state so it never leaks between routes

## Changes

- `frontend/src/contexts/LayoutScrollContext.tsx` — new context, provider, and hook
- `frontend/src/components/common/MainLayout.tsx` — wraps `<Outlet>` with provider; `MainContent` sub-component reads context to toggle `overflow`
- `frontend/src/pages/dashboard/DashboardPage.tsx` — calls `useLayoutScroll(true)`

## Test plan

- [ ] Navigate to `/dashboard` — page scrolls normally
- [ ] Navigate away from `/dashboard` to any other page — no scroll, layout unchanged
- [ ] `npx vitest run src/contexts/LayoutScrollContext.test.tsx` — 3 tests pass
- [ ] `npm run type-check` — no errors
- [ ] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)