### PR TITLE
fix: sales page scroll and sortOrder 500 (closes #434)

### DIFF
--- a/backend/src/common/dto/base-query.dto.spec.ts
+++ b/backend/src/common/dto/base-query.dto.spec.ts
@@ -1,0 +1,48 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { BaseQueryDto } from './base-query.dto';
+
+describe('BaseQueryDto', () => {
+  it('accepts uppercase ASC', async () => {
+    const dto = plainToInstance(BaseQueryDto, { sortOrder: 'ASC' });
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+    expect(dto.sortOrder).toBe('ASC');
+  });
+
+  it('accepts uppercase DESC', async () => {
+    const dto = plainToInstance(BaseQueryDto, { sortOrder: 'DESC' });
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+    expect(dto.sortOrder).toBe('DESC');
+  });
+
+  it('normalizes lowercase asc to ASC', async () => {
+    const dto = plainToInstance(BaseQueryDto, { sortOrder: 'asc' });
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+    expect(dto.sortOrder).toBe('ASC');
+  });
+
+  it('normalizes lowercase desc to DESC', async () => {
+    const dto = plainToInstance(BaseQueryDto, { sortOrder: 'desc' });
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+    expect(dto.sortOrder).toBe('DESC');
+  });
+
+  it('rejects invalid sortOrder values', async () => {
+    const dto = plainToInstance(BaseQueryDto, { sortOrder: 'INVALID' });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('accepts omitted sortOrder', async () => {
+    const dto = plainToInstance(BaseQueryDto, {});
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+  });
+});

--- a/backend/src/common/dto/base-query.dto.ts
+++ b/backend/src/common/dto/base-query.dto.ts
@@ -21,6 +21,7 @@ export class BaseQueryDto {
   sortBy?: string;
 
   @IsOptional()
+  @Transform(({ value }) => value?.toUpperCase())
   @IsIn(['ASC', 'DESC'])
   sortOrder?: 'ASC' | 'DESC';
 

--- a/frontend/src/pages/sales/SalesPage.tsx
+++ b/frontend/src/pages/sales/SalesPage.tsx
@@ -33,8 +33,10 @@ import { useDashboardAnalytics } from './hooks/useDashboardAnalytics'
 import { resolveApiParams } from '@/utils/dashboardApiParams'
 import type { DashboardCompare } from '@/utils/dashboardApiParams'
 import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
 
 const SalesPage: React.FC = () => {
+  useLayoutScroll(true)
   const navigate = useNavigate()
   const [recentOrders, setRecentOrders] = useState<any[]>([])
   const [recentOrdersLoading, setRecentOrdersLoading] = useState(true)

--- a/frontend/src/pages/sales/SalesPage.tsx
+++ b/frontend/src/pages/sales/SalesPage.tsx
@@ -113,7 +113,7 @@ const SalesPage: React.FC = () => {
       try {
         setRecentOrdersLoading(true)
         const response = await api.get('/sales-orders', {
-          params: { limit: 5, sortBy: 'orderDate', sortOrder: 'desc' },
+          params: { limit: 5, sortBy: 'orderDate', sortOrder: 'DESC' },
         })
 
         if (active) {


### PR DESCRIPTION
## Summary
- Enables scroll on the Sales overview page via `useLayoutScroll(true)`
- Fixes 500 error by correcting `sortOrder: 'desc'` to `sortOrder: 'DESC'` in `fetchRecentOrders`
- Hardens `BaseQueryDto` to normalize `sortOrder` to uppercase before validation, preventing recurrence

## Test plan
- [x] `cd frontend && npm run type-check`
- [x] `cd frontend && npx vitest run src/pages/sales/__tests__/SalesPage.filters.test.tsx`
- [x] `cd backend && npx jest src/common/dto/base-query.dto.spec.ts --no-coverage` (red before DTO change, green after)
- [x] `cd backend && npm run test`

Closes #434