### PR TITLE
fix: optional chaining on slice selectors to survive redux-persist hydration gap

### DIFF
--- a/frontend/src/store/slices/__tests__/inventorySlice.resilience.test.ts
+++ b/frontend/src/store/slices/__tests__/inventorySlice.resilience.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  selectSelectedProduct,
+  selectSelectedCategory,
+  selectSelectedStockAdjustment,
+  selectCategoryFilters,
+} from '../inventorySlice'
+
+describe('inventorySlice selectors - undefined state resilience', () => {
+  const stateWithoutInventory = {} as any
+
+  it('selectSelectedProduct returns undefined when inventory slice is absent', () => {
+    expect(() => selectSelectedProduct(stateWithoutInventory)).not.toThrow()
+    expect(selectSelectedProduct(stateWithoutInventory)).toBeUndefined()
+  })
+
+  it('selectSelectedCategory returns undefined when inventory slice is absent', () => {
+    expect(() => selectSelectedCategory(stateWithoutInventory)).not.toThrow()
+    expect(selectSelectedCategory(stateWithoutInventory)).toBeUndefined()
+  })
+
+  it('selectSelectedStockAdjustment returns undefined when inventory slice is absent', () => {
+    expect(() => selectSelectedStockAdjustment(stateWithoutInventory)).not.toThrow()
+    expect(selectSelectedStockAdjustment(stateWithoutInventory)).toBeUndefined()
+  })
+
+  it('selectCategoryFilters returns undefined when inventory slice is absent', () => {
+    expect(() => selectCategoryFilters(stateWithoutInventory)).not.toThrow()
+    expect(selectCategoryFilters(stateWithoutInventory)).toBeUndefined()
+  })
+})

--- a/frontend/src/store/slices/__tests__/purchasingSlice.test.ts
+++ b/frontend/src/store/slices/__tests__/purchasingSlice.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  selectSelectedPurchaseOrder,
+  selectSelectedGRN,
+  selectSelectedVendorPayment,
+  selectSelectedSupplier,
+  selectSupplierFilters,
+} from '../purchasingSlice'
+
+describe('purchasingSlice selectors - undefined state resilience', () => {
+  const stateWithoutPurchasing = {} as any
+
+  it('selectSelectedPurchaseOrder returns undefined when purchasing slice is absent', () => {
+    expect(() => selectSelectedPurchaseOrder(stateWithoutPurchasing)).not.toThrow()
+    expect(selectSelectedPurchaseOrder(stateWithoutPurchasing)).toBeUndefined()
+  })
+
+  it('selectSelectedGRN returns undefined when purchasing slice is absent', () => {
+    expect(() => selectSelectedGRN(stateWithoutPurchasing)).not.toThrow()
+    expect(selectSelectedGRN(stateWithoutPurchasing)).toBeUndefined()
+  })
+
+  it('selectSelectedVendorPayment returns undefined when purchasing slice is absent', () => {
+    expect(() => selectSelectedVendorPayment(stateWithoutPurchasing)).not.toThrow()
+    expect(selectSelectedVendorPayment(stateWithoutPurchasing)).toBeUndefined()
+  })
+
+  it('selectSelectedSupplier returns undefined when purchasing slice is absent', () => {
+    expect(() => selectSelectedSupplier(stateWithoutPurchasing)).not.toThrow()
+    expect(selectSelectedSupplier(stateWithoutPurchasing)).toBeUndefined()
+  })
+
+  it('selectSupplierFilters returns undefined when purchasing slice is absent', () => {
+    expect(() => selectSupplierFilters(stateWithoutPurchasing)).not.toThrow()
+    expect(selectSupplierFilters(stateWithoutPurchasing)).toBeUndefined()
+  })
+})

--- a/frontend/src/store/slices/__tests__/salesSlice.test.ts
+++ b/frontend/src/store/slices/__tests__/salesSlice.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  selectSelectedCustomer,
+  selectSelectedOrder,
+  selectSelectedInvoice,
+  selectSelectedPayment,
+  selectSalesError,
+} from '../salesSlice'
+
+describe('salesSlice selectors - undefined state resilience', () => {
+  const stateWithoutSales = {} as any
+
+  it('selectSelectedCustomer returns undefined when sales slice is absent', () => {
+    expect(() => selectSelectedCustomer(stateWithoutSales)).not.toThrow()
+    expect(selectSelectedCustomer(stateWithoutSales)).toBeUndefined()
+  })
+
+  it('selectSelectedOrder returns undefined when sales slice is absent', () => {
+    expect(() => selectSelectedOrder(stateWithoutSales)).not.toThrow()
+    expect(selectSelectedOrder(stateWithoutSales)).toBeUndefined()
+  })
+
+  it('selectSelectedInvoice returns undefined when sales slice is absent', () => {
+    expect(() => selectSelectedInvoice(stateWithoutSales)).not.toThrow()
+    expect(selectSelectedInvoice(stateWithoutSales)).toBeUndefined()
+  })
+
+  it('selectSelectedPayment returns undefined when sales slice is absent', () => {
+    expect(() => selectSelectedPayment(stateWithoutSales)).not.toThrow()
+    expect(selectSelectedPayment(stateWithoutSales)).toBeUndefined()
+  })
+
+  it('selectSalesError returns undefined when sales slice is absent', () => {
+    expect(() => selectSalesError(stateWithoutSales)).not.toThrow()
+    expect(selectSalesError(stateWithoutSales)).toBeUndefined()
+  })
+})

--- a/frontend/src/store/slices/inventorySlice.ts
+++ b/frontend/src/store/slices/inventorySlice.ts
@@ -51,9 +51,9 @@ export const {
   setCategoryFilters,
 } = inventorySlice.actions
 
-export const selectSelectedProduct = (state: RootState) => state.inventory.selectedProduct
-export const selectSelectedCategory = (state: RootState) => state.inventory.selectedCategory
-export const selectSelectedStockAdjustment = (state: RootState) => state.inventory.selectedStockAdjustment
-export const selectCategoryFilters = (state: RootState) => state.inventory.filters.categories
+export const selectSelectedProduct = (state: RootState) => state.inventory?.selectedProduct
+export const selectSelectedCategory = (state: RootState) => state.inventory?.selectedCategory
+export const selectSelectedStockAdjustment = (state: RootState) => state.inventory?.selectedStockAdjustment
+export const selectCategoryFilters = (state: RootState) => state.inventory?.filters?.categories
 
 export default inventorySlice.reducer

--- a/frontend/src/store/slices/purchasingSlice.ts
+++ b/frontend/src/store/slices/purchasingSlice.ts
@@ -65,10 +65,10 @@ export const {
   setSupplierFilters,
 } = purchasingSlice.actions
 
-export const selectSelectedPurchaseOrder = (state: RootState) => state.purchasing.selectedPurchaseOrder
-export const selectSelectedGRN = (state: RootState) => state.purchasing.selectedGRN
-export const selectSelectedVendorPayment = (state: RootState) => state.purchasing.selectedVendorPayment
-export const selectSelectedSupplier = (state: RootState) => state.purchasing.selectedSupplier
-export const selectSupplierFilters = (state: RootState) => state.purchasing.supplierFilters
+export const selectSelectedPurchaseOrder = (state: RootState) => state.purchasing?.selectedPurchaseOrder
+export const selectSelectedGRN = (state: RootState) => state.purchasing?.selectedGRN
+export const selectSelectedVendorPayment = (state: RootState) => state.purchasing?.selectedVendorPayment
+export const selectSelectedSupplier = (state: RootState) => state.purchasing?.selectedSupplier
+export const selectSupplierFilters = (state: RootState) => state.purchasing?.supplierFilters
 
 export default purchasingSlice.reducer

--- a/frontend/src/store/slices/salesSlice.ts
+++ b/frontend/src/store/slices/salesSlice.ts
@@ -49,10 +49,10 @@ export const {
   clearError,
 } = salesSlice.actions
 
-export const selectSelectedOrder = (state: RootState) => state.sales.selectedOrder
-export const selectSelectedInvoice = (state: RootState) => state.sales.selectedInvoice
-export const selectSelectedPayment = (state: RootState) => state.sales.selectedPayment
-export const selectSelectedCustomer = (state: RootState) => state.sales.selectedCustomer
-export const selectSalesError = (state: RootState) => state.sales.error
+export const selectSelectedOrder = (state: RootState) => state.sales?.selectedOrder
+export const selectSelectedInvoice = (state: RootState) => state.sales?.selectedInvoice
+export const selectSelectedPayment = (state: RootState) => state.sales?.selectedPayment
+export const selectSelectedCustomer = (state: RootState) => state.sales?.selectedCustomer
+export const selectSalesError = (state: RootState) => state.sales?.error
 
 export default salesSlice.reducer


### PR DESCRIPTION
## Summary

- Adds `?.` optional chaining to all selectors in `salesSlice`, `inventorySlice`, and `purchasingSlice`
- Prevents `TypeError: Cannot read properties of undefined` during the brief window between app start and `redux-persist` REHYDRATE completing
- Adds 14 new tests covering the undefined-state scenario across all three slices

Closes #435

## Test plan

- [x] `npx vitest run src/store/slices/__tests__/salesSlice.test.ts` — 5 tests pass
- [x] `npx vitest run src/store/slices/__tests__/inventorySlice.resilience.test.ts` — 4 tests pass
- [x] `npx vitest run src/store/slices/__tests__/purchasingSlice.test.ts` — 5 tests pass
- [x] `npx vitest run src/store/slices/__tests__/inventorySlice.test.ts` — existing 2 tests still pass
- [x] `npm run type-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)