### PR TITLE
fix: enable scroll on Inventory and Accounting Dashboard pages

### DIFF
--- a/frontend/src/pages/accounting/AccountingDashboardPage.tsx
+++ b/frontend/src/pages/accounting/AccountingDashboardPage.tsx
@@ -39,6 +39,7 @@ import {
 import { formatCurrency, formatDate, getCurrentDate } from '@/utils/formatters';
 import type { JournalEntry } from '@/types';
 import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter';
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext';
 
 // Summary Card Component
 interface SummaryCardProps {
@@ -158,6 +159,7 @@ const getEntryTypeChip = (type: string) => {
 };
 
 const AccountingDashboardPage: React.FC = () => {
+  useLayoutScroll(true);
   const navigate = useNavigate();
 
   // Calculate YTD date range

--- a/frontend/src/pages/accounting/__tests__/AccountingDashboardPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/AccountingDashboardPage.test.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 
 import AccountingDashboardPage from '../AccountingDashboardPage';
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext';
 import { darkTheme } from '@/styles/theme';
 
 vi.mock('@/utils/formatters', () => ({
@@ -35,6 +36,10 @@ vi.mock('@/store/api/accountingApi', () => ({
   useGetJournalEntriesQuery: mockedApi.useGetJournalEntriesQuery,
   useGetCurrentFiscalPeriodQuery: mockedApi.useGetCurrentFiscalPeriodQuery,
   useGetPendingSettlementSummaryQuery: mockedApi.useGetPendingSettlementSummaryQuery,
+}));
+
+vi.mock('@/contexts/LayoutScrollContext', () => ({
+  useLayoutScroll: vi.fn(),
 }));
 
 const renderWithProviders = (useDarkTheme = false) => {
@@ -174,5 +179,12 @@ describe('AccountingDashboardPage', () => {
     expect(screen.getByText('$2222.22')).toBeInTheDocument();
     expect(screen.getByText('$3333.33')).toBeInTheDocument();
     expect(screen.getByText('$4444.44')).toBeInTheDocument();
+  });
+});
+
+describe('AccountingDashboardPage scroll', () => {
+  it('enables layout scroll', () => {
+    renderWithProviders();
+    expect(useLayoutScroll).toHaveBeenCalledWith(true);
   });
 });

--- a/frontend/src/pages/inventory/InventoryPage.tsx
+++ b/frontend/src/pages/inventory/InventoryPage.tsx
@@ -44,6 +44,7 @@ import { useFilterBar } from '@/hooks/useFilterBar'
 import { useInventoryAnalytics } from './hooks/useInventoryAnalytics'
 import { formatCurrency } from '@/utils/formatters'
 import { TABLE_STYLES } from '@/constants/tableStyles'
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
 import { resolveApiParams } from '@/utils/dashboardApiParams'
 import type { DashboardCompare } from '@/utils/dashboardApiParams'
 import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
@@ -69,6 +70,7 @@ function deltaPercent(current: number | undefined, previous: number | undefined)
 }
 
 const InventoryPage: React.FC = () => {
+  useLayoutScroll(true)
   const theme = useTheme()
   const navigate = useNavigate()
 

--- a/frontend/src/pages/inventory/__tests__/InventoryPage.filters.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/InventoryPage.filters.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
 import InventoryPage from '../InventoryPage'
 
 const mockUseGetSuppliersQuery = vi.fn()
@@ -32,6 +33,10 @@ vi.mock('@/components/filters/FilterBar', () => ({
 vi.mock('react-chartjs-2', () => ({
   Line: () => <div data-testid="inventory-line-chart" />,
   Doughnut: () => <div data-testid="inventory-doughnut-chart" />,
+}))
+
+vi.mock('@/contexts/LayoutScrollContext', () => ({
+  useLayoutScroll: vi.fn(),
 }))
 
 describe('InventoryPage filters', () => {
@@ -75,6 +80,15 @@ describe('InventoryPage filters', () => {
       isFetching: false,
       error: null,
     })
+  })
+
+  it('enables layout scroll', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <InventoryPage />
+      </MemoryRouter>,
+    )
+    expect(useLayoutScroll).toHaveBeenCalledWith(true)
   })
 
   it('passes inventory filter state into analytics', () => {


### PR DESCRIPTION
## Summary

- Adds `useLayoutScroll(true)` to `InventoryPage` and `AccountingDashboardPage`
- Follows the identical pattern already used by Dashboard, Sales, and Purchasing overview pages
- Adds scroll assertion tests to both pages' test files

Closes #439

## Test plan
- [x] `npx vitest run src/pages/inventory/__tests__/InventoryPage.filters.test.tsx src/pages/accounting/__tests__/AccountingDashboardPage.test.tsx` — 17 tests, all pass
- [x] `npm run lint` — passed
- [x] `npm run type-check` — passed
- [x] Navigate to `/inventory` — content scrolls
- [x] Navigate to `/accounting` — content scrolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)