### PR TITLE
fix: add optional chaining to accountingSlice selectors

### DIFF
--- a/frontend/src/store/slices/__tests__/accountingSlice.test.ts
+++ b/frontend/src/store/slices/__tests__/accountingSlice.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
 import accountingReducer, {
+  selectSelectedAccount,
+  selectSelectedJournalEntry,
   setSelectedAccount,
   setSelectedJournalEntry,
 } from '@/store/slices/accountingSlice'
@@ -34,5 +36,19 @@ describe('accountingSlice', () => {
     const cleared = accountingReducer(withAccount, setSelectedAccount(null))
 
     expect(cleared.selectedAccount).toBeNull()
+  })
+})
+
+describe('accountingSlice selectors - undefined state resilience', () => {
+  const stateWithoutAccounting = {} as any
+
+  it('selectSelectedJournalEntry returns undefined when accounting slice is absent', () => {
+    expect(() => selectSelectedJournalEntry(stateWithoutAccounting)).not.toThrow()
+    expect(selectSelectedJournalEntry(stateWithoutAccounting)).toBeUndefined()
+  })
+
+  it('selectSelectedAccount returns undefined when accounting slice is absent', () => {
+    expect(() => selectSelectedAccount(stateWithoutAccounting)).not.toThrow()
+    expect(selectSelectedAccount(stateWithoutAccounting)).toBeUndefined()
   })
 })

--- a/frontend/src/store/slices/accountingSlice.ts
+++ b/frontend/src/store/slices/accountingSlice.ts
@@ -28,7 +28,7 @@ const accountingSlice = createSlice({
 
 export const { setSelectedJournalEntry, setSelectedAccount } = accountingSlice.actions
 
-export const selectSelectedJournalEntry = (state: RootState) => state.accounting.selectedJournalEntry
-export const selectSelectedAccount = (state: RootState) => state.accounting.selectedAccount
+export const selectSelectedJournalEntry = (state: RootState) => state.accounting?.selectedJournalEntry
+export const selectSelectedAccount = (state: RootState) => state.accounting?.selectedAccount
 
 export default accountingSlice.reducer


### PR DESCRIPTION
## Summary

- Adds `?.` optional chaining to both selectors in `accountingSlice.ts` (`selectSelectedJournalEntry`, `selectSelectedAccount`)
- Prevents `TypeError: can't access property "selectedAccount", e.accounting is undefined` during redux-persist rehydration
- Mirrors the identical fix already applied to `salesSlice.ts`
- Adds undefined-state resilience tests to `accountingSlice.test.ts` following the `salesSlice.test.ts` pattern

Closes #441

## Test plan

- [x] New resilience tests pass: `selectSelectedJournalEntry` and `selectSelectedAccount` return `undefined` without throwing when accounting slice is absent
- [x] Existing accountingSlice reducer tests still pass (6/6)
- [x] TypeScript check clean (`npm run type-check`)