### PR TITLE
fix: entity workspace selection reset on row click (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [1.90.0](https://github.com/blur88/erp2/compare/v1.89.0...v1.90.0) (2026-04-25)
+
+
+### Bug Fixes
+
+* **test:** correctly verify useLayoutScroll cleanup resets context on unmount ([e0f258e](https://github.com/blur88/erp2/commit/e0f258ec609d9bf3546c876771c6b4ad6f598281))
+
+
+### Features
+
+* add LayoutScrollContext for per-page scroll control ([ec2f224](https://github.com/blur88/erp2/commit/ec2f224aee8b3bc8b37801bba0ef7a4a3868185e))
+* enable scroll on DashboardPage (fixes [#432](https://github.com/blur88/erp2/issues/432)) ([7c40c8e](https://github.com/blur88/erp2/commit/7c40c8e76c02088a5c2e8ae89d7692721c8fd7b5))
+* wire LayoutScrollContext into MainLayout ([5500227](https://github.com/blur88/erp2/commit/5500227ef86c1396eca317006aa82cf82c0df2a5))
+
 # [1.89.0](https://github.com/blur88/erp2/compare/v1.88.1...v1.89.0) (2026-04-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.87.5](https://github.com/blur88/erp2/compare/v1.87.4...v1.87.5) (2026-04-23)
+
+
+### Bug Fixes
+
+* **db:** set migrationsTransactionMode to 'each' to allow CONCURRENTLY migrations ([3f65c9d](https://github.com/blur88/erp2/commit/3f65c9d4552f2e27a4cae3437d5885a375ed5905))
+* **deps:** force uuid>=14.0.0 to resolve GHSA-w5hq-g745-h8pq (issue [#422](https://github.com/blur88/erp2/issues/422)) ([64c79e9](https://github.com/blur88/erp2/commit/64c79e938f5d3c9283d862555bddf4adef4ab9d6))
+* **test:** add uuid shim and typeorm src transform to E2E jest config ([01d0c76](https://github.com/blur88/erp2/commit/01d0c765c314ee417ae998be2a003137e5723870))
+
 ## [1.87.4](https://github.com/blur88/erp2/compare/v1.87.3...v1.87.4) (2026-04-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# [1.88.0](https://github.com/blur88/erp2/compare/v1.87.6...v1.88.0) (2026-04-24)
+
+
+### Features
+
+* **accounting:** add accountingSlice with selectedJournalEntry and selectedAccount ([77213e2](https://github.com/blur88/erp2/commit/77213e2eb1047f900c73aa5219ad650eeac99fc0))
+* **accounting:** add focusedIndex prop to ChartOfAccountsTable ([68c8fc0](https://github.com/blur88/erp2/commit/68c8fc00ea96320434ea1c1dad535f1c971ba1e3))
+* **accounting:** add focusedIndex prop to JournalEntriesTable ([5466435](https://github.com/blur88/erp2/commit/54664354770d77ec9455be93d4b9d1f41dd68ad7))
+* **accounting:** refactor useChartOfAccountsWorkspace to wrap useEntityWorkspace with Redux ([c00eda4](https://github.com/blur88/erp2/commit/c00eda4d130738607ac6f05b979ecf7ff76f5aba))
+* **accounting:** refactor useJournalEntriesWorkspace to wrap useEntityWorkspace with Redux ([af32e00](https://github.com/blur88/erp2/commit/af32e00d18a41869c298589f30eba8855b1224d0))
+* **accounting:** wire ChartOfAccountsPage to Redux accountingSlice with keyboard nav ([ba70075](https://github.com/blur88/erp2/commit/ba70075a8e93ae474d5bcfcd5f56b3ba0aad9570))
+* **accounting:** wire JournalEntriesPage to Redux accountingSlice with keyboard nav ([fb3fba6](https://github.com/blur88/erp2/commit/fb3fba6746007af6f95e31d4193c9b9036d2f78f))
+
 ## [1.87.6](https://github.com/blur88/erp2/compare/v1.87.5...v1.87.6) (2026-04-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@
 * **frontend:** isolate RTK Query API chunk ([c6a4154](https://github.com/blur88/erp2/commit/c6a41547880a3de783e5ad26427bff773e31f832))
 * **notifications:** tolerate missing slice state ([4c372c2](https://github.com/blur88/erp2/commit/4c372c2a7f333b00c9a8126c85f1399b85cbc9eb))
 
+## [1.88.2](https://github.com/blur88/erp2/compare/v1.88.1...v1.88.2) (2026-04-25)
+
+
+### Bug Fixes
+
+* **dashboard:** guard against non-array stock responses ([f141c28](https://github.com/blur88/erp2/commit/f141c28c8b829702edde140fba9d1da105a7705f))
+* **frontend:** isolate axios chunk for auth API ([b79d030](https://github.com/blur88/erp2/commit/b79d0301dd4ab2ed3d2ba496416c9360e175781b))
+* **frontend:** isolate redux persistence chunk ([46fbdcb](https://github.com/blur88/erp2/commit/46fbdcbf265f7aa35b552a5c7cacc85551935ea8))
+* **frontend:** isolate RTK Query API chunk ([c6a4154](https://github.com/blur88/erp2/commit/c6a41547880a3de783e5ad26427bff773e31f832))
+* **notifications:** tolerate missing slice state ([4c372c2](https://github.com/blur88/erp2/commit/4c372c2a7f333b00c9a8126c85f1399b85cbc9eb))
+
 ## [1.88.1](https://github.com/blur88/erp2/compare/v1.88.0...v1.88.1) (2026-04-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.90.5](https://github.com/blur88/erp2/compare/v1.90.4...v1.90.5) (2026-04-25)
+
+
+### Bug Fixes
+
+* add optional chaining to accountingSlice selectors (closes [#441](https://github.com/blur88/erp2/issues/441)) ([f189530](https://github.com/blur88/erp2/commit/f189530ef9e4f655356cd1f3a4e9c48ebbd778a4))
+
 ## [1.90.4](https://github.com/blur88/erp2/compare/v1.90.3...v1.90.4) (2026-04-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.87.1](https://github.com/blur88/erp2/compare/v1.87.0...v1.87.1) (2026-04-22)
+
+
+### Bug Fixes
+
+* **accounting:** pass server total to EntityTable header count (issue [#416](https://github.com/blur88/erp2/issues/416)) ([ed5c41b](https://github.com/blur88/erp2/commit/ed5c41b49cdf120a10eb6660661ae726713d7d96))
+
 # [1.87.0](https://github.com/blur88/erp2/compare/v1.86.1...v1.87.0) (2026-04-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.90.2](https://github.com/blur88/erp2/compare/v1.90.1...v1.90.2) (2026-04-25)
+
+
+### Bug Fixes
+
+* add optional chaining to slice selectors to survive redux-persist hydration gap (closes [#435](https://github.com/blur88/erp2/issues/435)) ([9e1f229](https://github.com/blur88/erp2/commit/9e1f229564dd6ee600109501e3de68933f8f1675))
+
 ## [1.90.1](https://github.com/blur88/erp2/compare/v1.90.0...v1.90.1) (2026-04-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [1.88.2](https://github.com/blur88/erp2/compare/v1.88.1...v1.88.2) (2026-04-25)
+
+
+### Bug Fixes
+
+* **dashboard:** guard against non-array stock responses ([f141c28](https://github.com/blur88/erp2/commit/f141c28c8b829702edde140fba9d1da105a7705f))
+* **frontend:** isolate axios chunk for auth API ([b79d030](https://github.com/blur88/erp2/commit/b79d0301dd4ab2ed3d2ba496416c9360e175781b))
+* **frontend:** isolate redux persistence chunk ([46fbdcb](https://github.com/blur88/erp2/commit/46fbdcbf265f7aa35b552a5c7cacc85551935ea8))
+* **frontend:** isolate RTK Query API chunk ([c6a4154](https://github.com/blur88/erp2/commit/c6a41547880a3de783e5ad26427bff773e31f832))
+* **notifications:** tolerate missing slice state ([4c372c2](https://github.com/blur88/erp2/commit/4c372c2a7f333b00c9a8126c85f1399b85cbc9eb))
+
 ## [1.88.1](https://github.com/blur88/erp2/compare/v1.88.0...v1.88.1) (2026-04-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.87.6](https://github.com/blur88/erp2/compare/v1.87.5...v1.87.6) (2026-04-23)
+
+
+### Internal Changes
+
+* chore(deps): update package-lock dependencies and sync versions ([](https://github.com/blur88/erp2/commit/))
+
 ## [1.87.5](https://github.com/blur88/erp2/compare/v1.87.4...v1.87.5) (2026-04-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.87.3](https://github.com/blur88/erp2/compare/v1.87.2...v1.87.3) (2026-04-23)
+
+
+### Internal Changes
+
+* refactor(accounting): replace Chip components with plain text in JournalEntryContextHeader (issue #420) ([](https://github.com/blur88/erp2/commit/))
+* refactor(accounting): normalize JournalEntriesTable column style to match Sales module (issue #420) ([](https://github.com/blur88/erp2/commit/))
+* docs: add implementation plan for issue #420 JE UI normalization ([](https://github.com/blur88/erp2/commit/))
+* docs: add design spec for issue #420 JE UI normalization ([](https://github.com/blur88/erp2/commit/))
+
 ## [1.87.2](https://github.com/blur88/erp2/compare/v1.87.1...v1.87.2) (2026-04-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# [1.89.0](https://github.com/blur88/erp2/compare/v1.88.1...v1.89.0) (2026-04-25)
+
+
+### Bug Fixes
+
+* **dashboard:** guard against non-array stock responses ([f141c28](https://github.com/blur88/erp2/commit/f141c28c8b829702edde140fba9d1da105a7705f))
+* **frontend:** isolate axios chunk for auth API ([b79d030](https://github.com/blur88/erp2/commit/b79d0301dd4ab2ed3d2ba496416c9360e175781b))
+* **frontend:** isolate redux persistence chunk ([46fbdcb](https://github.com/blur88/erp2/commit/46fbdcbf265f7aa35b552a5c7cacc85551935ea8))
+* **frontend:** isolate RTK Query API chunk ([c6a4154](https://github.com/blur88/erp2/commit/c6a41547880a3de783e5ad26427bff773e31f832))
+* **nginx:** disable keepalive recycling on WebSocket proxy path ([d9f81f0](https://github.com/blur88/erp2/commit/d9f81f0d30d2e6a98c2bc01e6ea340057fe8db78))
+* **notifications:** tolerate missing slice state ([4c372c2](https://github.com/blur88/erp2/commit/4c372c2a7f333b00c9a8126c85f1399b85cbc9eb))
+* **websocket:** debounce reconnect toast only show if down over 5s ([93b09e7](https://github.com/blur88/erp2/commit/93b09e799be5b1f41812180522e5160bca0854d5))
+
+
+### Features
+
+* **websocket:** add root namespace gateway with heartbeat config ([41cff75](https://github.com/blur88/erp2/commit/41cff751c0eec7727577c4ebb6a6d0661afb9503))
+* **websocket:** register AppWebSocketGateway in DashboardModule ([d7c1aad](https://github.com/blur88/erp2/commit/d7c1aadcb98779df15ed03bba9bd046777bdd17d))
+
 ## [1.88.2](https://github.com/blur88/erp2/compare/v1.88.1...v1.88.2) (2026-04-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.90.3](https://github.com/blur88/erp2/compare/v1.90.2...v1.90.3) (2026-04-25)
+
+
+### Bug Fixes
+
+* enable scroll on Purchasing Overview page to prevent content clipping (closes [#438](https://github.com/blur88/erp2/issues/438)) ([7a39293](https://github.com/blur88/erp2/commit/7a392934400394fcf59de93279c22095b9c30111))
+
 ## [1.90.2](https://github.com/blur88/erp2/compare/v1.90.1...v1.90.2) (2026-04-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.87.2](https://github.com/blur88/erp2/compare/v1.87.1...v1.87.2) (2026-04-23)
+
+
+### Internal Changes
+
+* refactor(accounting): reduce JournalEntriesTable to single referenceNumber column (issue #418) ([](https://github.com/blur88/erp2/commit/))
+* docs: add implementation plan for issue #418 JournalEntriesTable minimalist refactor ([](https://github.com/blur88/erp2/commit/))
+
 ## [1.87.1](https://github.com/blur88/erp2/compare/v1.87.0...v1.87.1) (2026-04-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.88.1](https://github.com/blur88/erp2/compare/v1.88.0...v1.88.1) (2026-04-24)
+
+
+### Internal Changes
+
+* chore: update dependency lockfiles for backend and frontend projects ([](https://github.com/blur88/erp2/commit/))
+
 # [1.88.0](https://github.com/blur88/erp2/compare/v1.87.6...v1.88.0) (2026-04-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.87.4](https://github.com/blur88/erp2/compare/v1.87.3...v1.87.4) (2026-04-23)
+
+
+### Internal Changes
+
+* chore: update dependency lockfiles across frontend and backend projects ([](https://github.com/blur88/erp2/commit/))
+
 ## [1.87.3](https://github.com/blur88/erp2/compare/v1.87.2...v1.87.3) (2026-04-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.90.4](https://github.com/blur88/erp2/compare/v1.90.3...v1.90.4) (2026-04-25)
+
+
+### Bug Fixes
+
+* enable scroll on Accounting Dashboard page (closes [#439](https://github.com/blur88/erp2/issues/439)) ([b3078a5](https://github.com/blur88/erp2/commit/b3078a50f72bde5ecbd3c91364a54edff2d74e6c))
+* enable scroll on Inventory Overview page (closes [#439](https://github.com/blur88/erp2/issues/439) partially) ([3efc5a5](https://github.com/blur88/erp2/commit/3efc5a5b2431406c65cc93bd4ef83ea57670b8e5))
+
 ## [1.90.3](https://github.com/blur88/erp2/compare/v1.90.2...v1.90.3) (2026-04-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.90.1](https://github.com/blur88/erp2/compare/v1.90.0...v1.90.1) (2026-04-25)
+
+
+### Bug Fixes
+
+* enable scroll on SalesPage (closes [#434](https://github.com/blur88/erp2/issues/434) scroll) ([8322597](https://github.com/blur88/erp2/commit/832259747edf93bf2b21d8c49eec8280f1b23b7e))
+* normalize sortOrder to uppercase in BaseQueryDto ([d66c095](https://github.com/blur88/erp2/commit/d66c095481eb3b840cc65a781dea03aea045590b))
+* use uppercase DESC in fetchRecentOrders (closes [#434](https://github.com/blur88/erp2/issues/434) 500) ([4e1a147](https://github.com/blur88/erp2/commit/4e1a147a3f88000502f995ec44f7024604e9c212))
+
 # [1.90.0](https://github.com/blur88/erp2/compare/v1.89.0...v1.90.0) (2026-04-25)
 
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erp-backend",
-  "version": "1.86.0",
+  "version": "1.87.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-backend",
-      "version": "1.86.0",
+      "version": "1.87.3",
       "license": "MIT",
       "dependencies": {
         "@nestjs/bull": "^11.0.3",
@@ -4681,9 +4681,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.20",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
-      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
+      "version": "2.10.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
+      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5920,9 +5920,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.343",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.343.tgz",
-      "integrity": "sha512-YHnQ3MXI08icvL9ZKnEBy05F2EQ8ob01UaMOuMbM8l+4UcAq6MPPbBTJBbsBUg3H8JeZNt+O4fjsoWth3p6IFg==",
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "dev": true,
       "license": "ISC"
     },
@@ -8941,9 +8941,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.12.41",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.41.tgz",
-      "integrity": "sha512-lsmMmGXBxXIK/VMLEj0kL6MtUs1kBGj1nTCzi6zgQoG1DEwqwt2DQyHxcLykceIxAnfE3hya7NuIh6PpC6S3fA==",
+      "version": "1.12.42",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.42.tgz",
+      "integrity": "sha512-oKQFPTibqQwZZkChCDVMFVJXMZdyJNqDWZWYNn8BgyAaK/6yFJEowxCY0RVFirRyWP63hMRuKlkSEd9qlvbWXg==",
       "license": "MIT"
     },
     "node_modules/lie": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erp-backend",
-  "version": "1.87.3",
+  "version": "1.87.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-backend",
-      "version": "1.87.3",
+      "version": "1.87.4",
       "license": "MIT",
       "dependencies": {
         "@nestjs/bull": "^11.0.3",
@@ -42,7 +42,8 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "socket.io": "^4.8.1",
-        "typeorm": "^0.3.17"
+        "typeorm": "^0.3.17",
+        "uuid": "^14.0.0"
       },
       "devDependencies": {
         "@nestjs/cli": "^11.0.0",
@@ -12233,19 +12234,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/typeorm/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -12469,12 +12457,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erp-backend",
-  "version": "1.87.5",
+  "version": "1.88.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-backend",
-      "version": "1.87.5",
+      "version": "1.88.0",
       "license": "MIT",
       "dependencies": {
         "@nestjs/bull": "^11.0.3",
@@ -6038,14 +6038,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -6278,9 +6278,9 @@
       }
     },
     "node_modules/eslint/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10743,9 +10743,9 @@
       }
     },
     "node_modules/schema-utils/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11459,9 +11459,9 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
-      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.5.0.tgz",
+      "integrity": "sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erp-backend",
-  "version": "1.87.4",
+  "version": "1.87.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-backend",
-      "version": "1.87.4",
+      "version": "1.87.5",
       "license": "MIT",
       "dependencies": {
         "@nestjs/bull": "^11.0.3",
@@ -11440,9 +11440,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
-      "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
+      "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -12603,9 +12603,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
-      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.0.tgz",
+      "integrity": "sha512-gHwIe1cgBvvfLeu1Yz/dcFpmHfKDVxxyqI+kzqmuxZED81z2ChxpyqPaWcNqigPywhaEke7AjSGga+kxY55gjQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-backend",
-  "version": "1.88.2",
+  "version": "1.89.0",
   "description": "ERP System Backend API",
   "author": "ERP Development Team",
   "private": true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-backend",
-  "version": "1.87.2",
+  "version": "1.87.3",
   "description": "ERP System Backend API",
   "author": "ERP Development Team",
   "private": true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-backend",
-  "version": "1.87.4",
+  "version": "1.87.5",
   "description": "ERP System Backend API",
   "author": "ERP Development Team",
   "private": true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-backend",
-  "version": "1.90.4",
+  "version": "1.90.5",
   "description": "ERP System Backend API",
   "author": "ERP Development Team",
   "private": true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-backend",
-  "version": "1.89.0",
+  "version": "1.90.0",
   "description": "ERP System Backend API",
   "author": "ERP Development Team",
   "private": true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-backend",
-  "version": "1.88.0",
+  "version": "1.88.1",
   "description": "ERP System Backend API",
   "author": "ERP Development Team",
   "private": true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-backend",
-  "version": "1.87.5",
+  "version": "1.87.6",
   "description": "ERP System Backend API",
   "author": "ERP Development Team",
   "private": true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-backend",
-  "version": "1.90.0",
+  "version": "1.90.1",
   "description": "ERP System Backend API",
   "author": "ERP Development Team",
   "private": true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-backend",
-  "version": "1.87.0",
+  "version": "1.87.1",
   "description": "ERP System Backend API",
   "author": "ERP Development Team",
   "private": true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-backend",
-  "version": "1.87.1",
+  "version": "1.87.2",
   "description": "ERP System Backend API",
   "author": "ERP Development Team",
   "private": true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-backend",
-  "version": "1.88.1",
+  "version": "1.88.2",
   "description": "ERP System Backend API",
   "author": "ERP Development Team",
   "private": true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-backend",
-  "version": "1.87.3",
+  "version": "1.87.4",
   "description": "ERP System Backend API",
   "author": "ERP Development Team",
   "private": true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-backend",
-  "version": "1.87.6",
+  "version": "1.88.0",
   "description": "ERP System Backend API",
   "author": "ERP Development Team",
   "private": true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-backend",
-  "version": "1.90.3",
+  "version": "1.90.4",
   "description": "ERP System Backend API",
   "author": "ERP Development Team",
   "private": true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-backend",
-  "version": "1.90.1",
+  "version": "1.90.2",
   "description": "ERP System Backend API",
   "author": "ERP Development Team",
   "private": true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -59,7 +59,8 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "socket.io": "^4.8.1",
-    "typeorm": "^0.3.17"
+    "typeorm": "^0.3.17",
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.0",
@@ -89,6 +90,7 @@
     "typescript": "6.0.3"
   },
   "overrides": {
+    "uuid": "$uuid",
     "body-parser": "2.2.1",
     "tar": "7.5.4",
     "js-yaml": "4.1.1",
@@ -139,6 +141,7 @@
       ]
     ],
     "moduleNameMapper": {
+      "^uuid$": "<rootDir>/test/shims/uuid.ts",
       "^@/(.*)$": "<rootDir>/src/$1",
       "^@modules/(.*)$": "<rootDir>/src/modules/$1",
       "^@common/(.*)$": "<rootDir>/src/common/$1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-backend",
-  "version": "1.90.2",
+  "version": "1.90.3",
   "description": "ERP System Backend API",
   "author": "ERP Development Team",
   "private": true,

--- a/backend/src/common/dto/base-query.dto.spec.ts
+++ b/backend/src/common/dto/base-query.dto.spec.ts
@@ -1,0 +1,48 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { BaseQueryDto } from './base-query.dto';
+
+describe('BaseQueryDto', () => {
+  it('accepts uppercase ASC', async () => {
+    const dto = plainToInstance(BaseQueryDto, { sortOrder: 'ASC' });
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+    expect(dto.sortOrder).toBe('ASC');
+  });
+
+  it('accepts uppercase DESC', async () => {
+    const dto = plainToInstance(BaseQueryDto, { sortOrder: 'DESC' });
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+    expect(dto.sortOrder).toBe('DESC');
+  });
+
+  it('normalizes lowercase asc to ASC', async () => {
+    const dto = plainToInstance(BaseQueryDto, { sortOrder: 'asc' });
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+    expect(dto.sortOrder).toBe('ASC');
+  });
+
+  it('normalizes lowercase desc to DESC', async () => {
+    const dto = plainToInstance(BaseQueryDto, { sortOrder: 'desc' });
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+    expect(dto.sortOrder).toBe('DESC');
+  });
+
+  it('rejects invalid sortOrder values', async () => {
+    const dto = plainToInstance(BaseQueryDto, { sortOrder: 'INVALID' });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('accepts omitted sortOrder', async () => {
+    const dto = plainToInstance(BaseQueryDto, {});
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+  });
+});

--- a/backend/src/common/dto/base-query.dto.ts
+++ b/backend/src/common/dto/base-query.dto.ts
@@ -21,6 +21,7 @@ export class BaseQueryDto {
   sortBy?: string;
 
   @IsOptional()
+  @Transform(({ value }) => value?.toUpperCase())
   @IsIn(['ASC', 'DESC'])
   sortOrder?: 'ASC' | 'DESC';
 

--- a/backend/src/config/database-config.factory.ts
+++ b/backend/src/config/database-config.factory.ts
@@ -95,7 +95,8 @@ export function createDatabaseConfig(configService: ConfigService, allowDefaults
       StockAdjustment, StockAdjustmentItem, StockMovement, Supplier, User, VendorPayment,
     ],
     migrations: [__dirname + '/../database/migrations/*{.ts,.js}'],
-    
+    migrationsTransactionMode: 'each',
+
     // Security: Disable auto-synchronization in production
     synchronize: !isProduction && isDevelopment && configService.get<string>('DB_SYNCHRONIZE', 'false') === 'true',
     

--- a/backend/src/modules/dashboard/dashboard-module.ts
+++ b/backend/src/modules/dashboard/dashboard-module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { DashboardController } from './controllers/dashboard-controller';
 import { DashboardService } from './services/dashboard-service';
 import { DashboardWebSocketGateway } from './gateways/dashboard-websocket-gateway';
+import { AppWebSocketGateway } from './gateways/app-websocket-gateway';
 
 // Import necessary service dependencies
 // import { SalesModule } from '../sales/sales.module'; // Temporarily disabled for startup
@@ -16,7 +17,7 @@ import { InventoryModule } from '../inventory/inventory.module';
     // PurchasingModule  // Disabled - not enabled in app.module.ts
   ],
   controllers: [DashboardController],
-  providers: [DashboardService, DashboardWebSocketGateway],
+  providers: [DashboardService, DashboardWebSocketGateway, AppWebSocketGateway],
   exports: [DashboardService]
 })
 export class DashboardModule {}

--- a/backend/src/modules/dashboard/gateways/app-websocket-gateway.spec.ts
+++ b/backend/src/modules/dashboard/gateways/app-websocket-gateway.spec.ts
@@ -1,0 +1,13 @@
+import { AppWebSocketGateway } from './app-websocket-gateway';
+
+describe('AppWebSocketGateway', () => {
+  let gateway: AppWebSocketGateway;
+
+  beforeEach(() => {
+    gateway = new AppWebSocketGateway();
+  });
+
+  it('should be defined', () => {
+    expect(gateway).toBeDefined();
+  });
+});

--- a/backend/src/modules/dashboard/gateways/app-websocket-gateway.ts
+++ b/backend/src/modules/dashboard/gateways/app-websocket-gateway.ts
@@ -1,0 +1,15 @@
+import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+import { Server } from 'socket.io';
+
+@WebSocketGateway({
+  cors: {
+    origin: '*',
+    methods: ['GET', 'POST'],
+  },
+  pingInterval: 25000,
+  pingTimeout: 60000,
+})
+export class AppWebSocketGateway {
+  @WebSocketServer()
+  server: Server;
+}

--- a/backend/test/jest-e2e.json
+++ b/backend/test/jest-e2e.json
@@ -8,7 +8,11 @@
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },
+  "transformIgnorePatterns": [
+    "/node_modules/(?!typeorm/src)"
+  ],
   "moduleNameMapper": {
+    "^uuid$": "<rootDir>/shims/uuid.ts",
     "^@/(.*)$": "<rootDir>/../src/$1",
     "^@modules/(.*)$": "<rootDir>/../src/modules/$1",
     "^@common/(.*)$": "<rootDir>/../src/common/$1",

--- a/backend/test/shims/uuid.ts
+++ b/backend/test/shims/uuid.ts
@@ -1,0 +1,7 @@
+import { randomUUID } from 'node:crypto';
+
+export function v4(): string {
+  return randomUUID();
+}
+
+export default { v4 };

--- a/docs/superpowers/plans/2026-04-22-journal-entries-refactor.md
+++ b/docs/superpowers/plans/2026-04-22-journal-entries-refactor.md
@@ -1,0 +1,1118 @@
+# Journal Entries Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align the Journal Entries module's components and hook with the Sales/Purchasing module pattern — remove all bulk selection, replace the table with `EntityTable`, rewrite the context header to use the two-column Grid layout, and dedup `SOURCE_ROUTES`.
+
+**Architecture:** Six focused file changes, no new files created. The hook is simplified first, then components updated top-down so that type errors surface immediately. Tests are updated in the same task as the code they cover.
+
+**Tech Stack:** React 19, TypeScript, MUI v7, RTK Query, Vitest
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts` | Remove bulk state/handlers, dedup SOURCE_ROUTES |
+| `frontend/src/pages/accounting/components/JournalEntriesTable.tsx` | Rewrite using EntityTable, remove checkboxes/actions |
+| `frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx` | Rewrite to match new props |
+| `frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx` | Rewrite to Grid layout with detailTableSx |
+| `frontend/src/pages/accounting/components/JournalEntryWorkspaceCard.tsx` | Minor style alignment |
+| `frontend/src/pages/accounting/components/JournalEntriesDialogs.tsx` | Remove bulk dialogs |
+| `frontend/src/pages/accounting/JournalEntriesPage.tsx` | Remove bulk prop threading |
+| `frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx` | Remove bulk mock setup |
+
+---
+
+## Task 1: Simplify `useJournalEntriesWorkspace`
+
+Remove all bulk state and handlers. Dedup `SOURCE_ROUTES` (currently copy-pasted in both the hook and `JournalEntryContextHeader`).
+
+**Files:**
+- Modify: `frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts`
+
+- [ ] **Step 1: Replace the entire file with the simplified version**
+
+```typescript
+import { useCallback, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { useNotification } from '@/hooks/useNotification'
+import {
+  useDeleteJournalEntryMutation,
+  useLazyGetJournalEntryQuery,
+  usePostJournalEntryMutation,
+  useReverseJournalEntryMutation,
+} from '@/store/api/accountingApi'
+import { JournalEntry } from '@/types'
+import { getErrorMessage } from '@/utils/errorMessage'
+
+export const SOURCE_ROUTES: Record<string, (id: string) => string> = {
+  sales_order: (id) => `/sales/orders?highlight=${id}`,
+  payment: (id) => `/sales/payments?highlight=${id}`,
+  goods_received_note: (id) => `/purchasing/goods-received?grnId=${id}`,
+  vendor_payment: (id) => `/purchasing/vendor-payments?vpId=${id}`,
+  expense: () => `/accounting/expenses`,
+  owner_equity_transaction: () => `/accounting/owner-equity`,
+  fund_transfer: () => `/accounting/fund-transfers`,
+  stock_adjustment: (id) => `/inventory/stock-adjustments/${id}/edit`,
+}
+
+export function useJournalEntriesWorkspace(refetch: () => void) {
+  const navigate = useNavigate()
+  const { showSuccess, showError } = useNotification()
+
+  const [selectedEntry, setSelectedEntry] = useState<JournalEntry | null>(null)
+  const [postTarget, setPostTarget] = useState<JournalEntry | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<JournalEntry | null>(null)
+  const [reverseTarget, setReverseTarget] = useState<JournalEntry | null>(null)
+  const [actionLoading, setActionLoading] = useState(false)
+  const searchInputRef = useRef<HTMLInputElement | null>(null)
+  const listRef = useRef<HTMLDivElement | null>(null)
+
+  const [fetchEntry] = useLazyGetJournalEntryQuery()
+  const [postJournalEntry] = usePostJournalEntryMutation()
+  const [reverseJournalEntry] = useReverseJournalEntryMutation()
+  const [deleteJournalEntry] = useDeleteJournalEntryMutation()
+
+  const handleSelect = useCallback(async (entry: JournalEntry) => {
+    setSelectedEntry(entry)
+    try {
+      const fresh = await fetchEntry(entry.id).unwrap()
+      setSelectedEntry(fresh)
+    }
+    catch { /* keep list-row data */ }
+  }, [fetchEntry])
+
+  const handleConfirmPost = useCallback(async () => {
+    if (!postTarget) return
+    setActionLoading(true)
+    try {
+      await postJournalEntry(postTarget.id).unwrap()
+      showSuccess(`Journal entry ${postTarget.referenceNumber} posted`)
+      setPostTarget(null)
+      setSelectedEntry(null)
+      refetch()
+    }
+    catch (error: unknown) {
+      showError(getErrorMessage(error, 'Failed to post journal entry'))
+    }
+    finally {
+      setActionLoading(false)
+    }
+  }, [postTarget, postJournalEntry, showSuccess, showError, refetch])
+
+  const handleConfirmReverse = useCallback(async (reverseDate: string) => {
+    if (!reverseTarget) return
+    setActionLoading(true)
+    try {
+      const result = await reverseJournalEntry({ id: reverseTarget.id, reverseDate }).unwrap()
+      showSuccess(`Journal entry ${reverseTarget.referenceNumber} reversed`)
+      setReverseTarget(null)
+      setSelectedEntry(result)
+      refetch()
+    }
+    catch (error: unknown) {
+      showError(getErrorMessage(error, 'Failed to reverse journal entry'))
+    }
+    finally {
+      setActionLoading(false)
+    }
+  }, [reverseTarget, reverseJournalEntry, showSuccess, showError, refetch])
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!deleteTarget) return
+    setActionLoading(true)
+    try {
+      await deleteJournalEntry(deleteTarget.id).unwrap()
+      showSuccess(`Journal entry ${deleteTarget.referenceNumber} deleted`)
+      setDeleteTarget(null)
+      setSelectedEntry(null)
+      refetch()
+    }
+    catch (error: unknown) {
+      showError(getErrorMessage(error, 'Failed to delete journal entry'))
+    }
+    finally {
+      setActionLoading(false)
+    }
+  }, [deleteTarget, deleteJournalEntry, showSuccess, showError, refetch])
+
+  return {
+    selectedEntry,
+    postTarget,
+    setPostTarget,
+    deleteTarget,
+    setDeleteTarget,
+    reverseTarget,
+    setReverseTarget,
+    actionLoading,
+    searchInputRef,
+    listRef,
+    handleSelect,
+    handleConfirmPost,
+    handleConfirmReverse,
+    handleConfirmDelete,
+    navigateToEdit: (entry: JournalEntry) => navigate(`/accounting/journal-entries/${entry.id}/edit`),
+    navigateToCreate: () => navigate('/accounting/journal-entries/new'),
+    navigateToSource: (sourceType: string, sourceId: string) => {
+      const route = SOURCE_ROUTES[sourceType]
+      if (route) navigate(route(sourceId))
+    },
+  }
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd frontend && npm run type-check 2>&1 | head -40
+```
+
+Expected: errors only in files that still reference the removed props (`JournalEntriesTable`, `JournalEntriesPage`, `JournalEntriesDialogs`) — not in the hook itself.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
+git commit -m "refactor(accounting): simplify useJournalEntriesWorkspace, dedup SOURCE_ROUTES (issue #416)"
+```
+
+---
+
+## Task 2: Rewrite `JournalEntriesTable` using `EntityTable`
+
+Remove checkboxes, bulk selection, and per-row action buttons. Pure display list.
+
+**Files:**
+- Modify: `frontend/src/pages/accounting/components/JournalEntriesTable.tsx`
+- Modify: `frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx`
+
+- [ ] **Step 1: Rewrite the test file first**
+
+```typescript
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { JournalEntriesTable } from './JournalEntriesTable'
+import { JournalEntryStatus } from '@/types'
+
+vi.mock('@/utils/formatters', () => ({
+  formatCurrency: (value: number) => `$${value}`,
+  formatDate: (date: string) => date,
+}))
+
+vi.mock('@/components/common/EntityTable', () => ({
+  default: ({ rows, loading, label, onSelect }: any) => (
+    <div>
+      {loading && <div>Loading...</div>}
+      {rows.length === 0 && <div>No {label} found</div>}
+      {rows.map((row: any) => (
+        <div key={row.id} onClick={() => onSelect(row)} data-testid={`row-${row.id}`}>
+          {row.referenceNumber}
+        </div>
+      ))}
+    </div>
+  ),
+}))
+
+const makeEntry = (overrides = {}) => ({
+  id: '1',
+  referenceNumber: 'JE-001',
+  entryDate: '2026-01-01',
+  description: 'Test entry',
+  status: JournalEntryStatus.DRAFT,
+  totalDebits: 100,
+  totalCredits: 100,
+  sourceType: 'manual',
+  sourceId: null,
+  lines: [],
+  ...overrides,
+})
+
+describe('JournalEntriesTable', () => {
+  const defaultProps = {
+    entries: [],
+    loading: false,
+    selectedEntryId: null,
+    onSelect: vi.fn(),
+  }
+
+  it('shows empty state when no entries', () => {
+    render(<JournalEntriesTable {...defaultProps} />)
+    expect(screen.getByText('No Journal Entries found')).toBeInTheDocument()
+  })
+
+  it('renders entry rows', () => {
+    render(<JournalEntriesTable {...defaultProps} entries={[makeEntry()]} />)
+    expect(screen.getByText('JE-001')).toBeInTheDocument()
+  })
+
+  it('calls onSelect when row is clicked', () => {
+    const onSelect = vi.fn()
+    render(<JournalEntriesTable {...defaultProps} entries={[makeEntry()]} onSelect={onSelect} />)
+    fireEvent.click(screen.getByText('JE-001'))
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: '1' }))
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+cd frontend && npx vitest run src/pages/accounting/components/JournalEntriesTable.test.tsx 2>&1 | tail -20
+```
+
+Expected: FAIL — old component has wrong props.
+
+- [ ] **Step 3: Rewrite `JournalEntriesTable.tsx`**
+
+```typescript
+import { useRef, type RefObject } from 'react'
+import { Chip, Link, Typography } from '@mui/material'
+
+import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
+import { JournalEntry, JournalEntryStatus } from '@/types'
+import { formatCurrency, formatDate } from '@/utils/formatters'
+
+const ENTRY_TYPE_LABELS: Record<string, string> = {
+  manual: 'Manual Entry',
+  sales_order: 'Sales Order',
+  payment: 'Customer Payment',
+  settlement: 'Settlement',
+  goods_received_note: 'Goods Receipt',
+  vendor_payment: 'Vendor Payment',
+  stock_adjustment: 'Stock Adjustment',
+  owner_equity_transaction: 'Owner Equity',
+  expense: 'Expense',
+  opening_balance: 'Opening Balance',
+  fund_transfer: 'Fund Transfer',
+}
+
+function statusColor(status: JournalEntryStatus) {
+  if (status === JournalEntryStatus.POSTED) return 'success' as const
+  if (status === JournalEntryStatus.REVERSED) return 'error' as const
+  return 'default' as const
+}
+
+interface Props {
+  entries: JournalEntry[]
+  loading: boolean
+  selectedEntryId: string | null
+  onSelect: (entry: JournalEntry) => void
+  onViewSource?: (sourceType: string, sourceId: string) => void
+  listRef?: RefObject<HTMLDivElement | null>
+}
+
+export function JournalEntriesTable({ entries, loading, selectedEntryId, onSelect, onViewSource, listRef }: Props) {
+  const fallbackRef = useRef<HTMLDivElement | null>(null)
+
+  const columns: ColumnConfig<JournalEntry>[] = [
+    {
+      key: 'referenceNumber',
+      raw: true,
+      render: (entry) => (
+        <Typography variant="body2" sx={{ fontWeight: 500, color: 'primary.main', fontSize: '0.8rem' }}>
+          {entry.referenceNumber}
+        </Typography>
+      ),
+    },
+    {
+      key: 'entryDate',
+      render: (entry) => formatDate(entry.entryDate),
+    },
+    {
+      key: 'description',
+      render: (entry) => entry.description,
+    },
+    {
+      key: 'sourceType',
+      raw: true,
+      render: (entry) => (
+        <Chip label={ENTRY_TYPE_LABELS[entry.sourceType ?? ''] ?? 'Manual Entry'} size="small" />
+      ),
+    },
+    {
+      key: 'source',
+      raw: true,
+      render: (entry) =>
+        entry.sourceType && entry.sourceType !== 'manual' && entry.sourceId && onViewSource ? (
+          <Link
+            component="button"
+            variant="body2"
+            onClick={(e) => { e.stopPropagation(); onViewSource(entry.sourceType!, entry.sourceId!) }}
+          >
+            View Transaction
+          </Link>
+        ) : null,
+    },
+    {
+      key: 'totalDebits',
+      render: (entry) => formatCurrency(entry.totalDebits),
+    },
+    {
+      key: 'totalCredits',
+      render: (entry) => formatCurrency(entry.totalCredits),
+    },
+    {
+      key: 'status',
+      raw: true,
+      render: (entry) => (
+        <Chip label={entry.status} color={statusColor(entry.status)} size="small" />
+      ),
+    },
+  ]
+
+  return (
+    <EntityTable
+      rows={entries}
+      columns={columns}
+      loading={loading}
+      total={entries.length}
+      label="Journal Entries"
+      selectedId={selectedEntryId ?? undefined}
+      focusedIndex={-1}
+      onSelect={onSelect}
+      listRef={listRef ?? fallbackRef}
+      dataAttr="entry"
+    />
+  )
+}
+```
+
+- [ ] **Step 4: Run test to confirm it passes**
+
+```bash
+cd frontend && npx vitest run src/pages/accounting/components/JournalEntriesTable.test.tsx 2>&1 | tail -20
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/accounting/components/JournalEntriesTable.tsx \
+        frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx
+git commit -m "refactor(accounting): replace JournalEntriesTable with EntityTable, remove bulk selection (issue #416)"
+```
+
+---
+
+## Task 3: Rewrite `JournalEntryContextHeader` to Grid layout
+
+Match the `OrderContextHeader` / `ChartOfAccountContextHeader` pattern exactly.
+
+**Files:**
+- Modify: `frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx`
+
+- [ ] **Step 1: Replace the entire file**
+
+```typescript
+import { Box, Chip, Link, Paper, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material'
+import Grid from '@mui/material/Grid'
+import { default as DeleteIcon } from '@mui/icons-material/Delete'
+import { default as EditIcon } from '@mui/icons-material/Edit'
+import { default as PostIcon } from '@mui/icons-material/PostAdd'
+import { default as ReverseIcon } from '@mui/icons-material/Undo'
+
+import { AppButton } from '@/components/common/AppButton'
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import { JournalEntry, JournalEntryStatus } from '@/types'
+import { formatCurrency, formatDate } from '@/utils/formatters'
+
+import { SOURCE_ROUTES } from '../hooks/useJournalEntriesWorkspace'
+
+const ENTRY_TYPE_LABELS: Record<string, string> = {
+  manual: 'Manual Entry',
+  sales_order: 'Sales Order',
+  payment: 'Customer Payment',
+  settlement: 'Settlement',
+  goods_received_note: 'Goods Receipt',
+  vendor_payment: 'Vendor Payment',
+  stock_adjustment: 'Stock Adjustment',
+  owner_equity_transaction: 'Owner Equity',
+  expense: 'Expense',
+  opening_balance: 'Opening Balance',
+  fund_transfer: 'Fund Transfer',
+}
+
+const detailTableSx = {
+  tableLayout: 'fixed',
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const labelCellSx = {
+  fontWeight: 600,
+  color: 'text.secondary',
+  fontSize: '0.8rem',
+}
+
+const valueCellSx = {
+  fontSize: '0.8rem',
+}
+
+const sectionHeaderCellSx = {
+  pb: TABLE_STYLES.cell.padding.py * 0.67,
+  py: TABLE_STYLES.cell.padding.py * 0.67,
+  borderTop: TABLE_STYLES.cell.border,
+}
+
+function statusColor(status: JournalEntryStatus) {
+  if (status === JournalEntryStatus.POSTED) return 'success' as const
+  if (status === JournalEntryStatus.REVERSED) return 'error' as const
+  return 'default' as const
+}
+
+interface Props {
+  selectedEntry: JournalEntry | null
+  onEdit: () => void
+  onPost: () => void
+  onReverse: () => void
+  onDelete: () => void
+  onViewSource: (sourceType: string, sourceId: string) => void
+}
+
+export function JournalEntryContextHeader({ selectedEntry, onEdit, onPost, onReverse, onDelete, onViewSource }: Props) {
+  if (!selectedEntry) {
+    return (
+      <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
+        <Typography variant="h6" sx={{ color: 'text.secondary' }}>
+          Select a journal entry to view details
+        </Typography>
+      </Paper>
+    )
+  }
+
+  const isDraft = selectedEntry.status === JournalEntryStatus.DRAFT
+  const isPosted = selectedEntry.status === JournalEntryStatus.POSTED
+  const isBalanced = Math.abs(selectedEntry.totalDebits - selectedEntry.totalCredits) < 0.01
+  const hasSource = selectedEntry.sourceType && selectedEntry.sourceId && SOURCE_ROUTES[selectedEntry.sourceType]
+
+  return (
+    <Paper sx={{ overflow: 'hidden' }}>
+      <Box
+        sx={{
+          p: TABLE_STYLES.cell.padding.px,
+          borderBottom: TABLE_STYLES.cell.border,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Typography
+          variant="tableHeader"
+          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+        >
+          JE Details — {selectedEntry.referenceNumber}
+        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          {isDraft && (
+            <>
+              <AppButton size="small" variant="outlined" startIcon={<EditIcon />} onClick={onEdit}>Edit</AppButton>
+              <AppButton size="small" variant="success" startIcon={<PostIcon />} onClick={onPost} disabled={!isBalanced}>Post</AppButton>
+              <AppButton size="small" variant="danger" startIcon={<DeleteIcon />} onClick={onDelete}>Delete</AppButton>
+            </>
+          )}
+          {isPosted && (
+            <AppButton size="small" variant="warning" startIcon={<ReverseIcon />} onClick={onReverse}>Reverse</AppButton>
+          )}
+        </Box>
+      </Box>
+
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Entry Information
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Date</TableCell>
+                    <TableCell sx={valueCellSx}>{formatDate(selectedEntry.entryDate)}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Description</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedEntry.description}</TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Type</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      <Chip
+                        size="small"
+                        label={ENTRY_TYPE_LABELS[selectedEntry.sourceType ?? ''] ?? 'Manual Entry'}
+                      />
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Source</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {hasSource ? (
+                        <Link
+                          component="button"
+                          variant="body2"
+                          onClick={() => onViewSource(selectedEntry.sourceType!, selectedEntry.sourceId!)}
+                        >
+                          View {ENTRY_TYPE_LABELS[selectedEntry.sourceType!] ?? selectedEntry.sourceType}
+                        </Link>
+                      ) : '—'}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Financials
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Status</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      <Chip label={selectedEntry.status} color={statusColor(selectedEntry.status)} size="small" />
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Debits</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(selectedEntry.totalDebits)}</TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Credits</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(selectedEntry.totalCredits)}</TableCell>
+                  </TableRow>
+                  {!isBalanced && (
+                    <TableRow>
+                      <TableCell sx={labelCellSx}>Balance</TableCell>
+                      <TableCell sx={valueCellSx}>
+                        <Chip label="Unbalanced" color="warning" size="small" />
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+        </Grid>
+      </Box>
+    </Paper>
+  )
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd frontend && npm run type-check 2>&1 | head -40
+```
+
+Expected: errors only in `JournalEntriesPage.tsx` (still passes old `onNavigateToSource` prop).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx
+git commit -m "refactor(accounting): rewrite JournalEntryContextHeader to Grid layout (issue #416)"
+```
+
+---
+
+## Task 4: Align `JournalEntryWorkspaceCard` styling
+
+Minor: ensure `headerSx` exactly matches other workspace cards.
+
+**Files:**
+- Modify: `frontend/src/pages/accounting/components/JournalEntryWorkspaceCard.tsx`
+
+- [ ] **Step 1: Update `headerSx` to use `px` for both padding axes**
+
+Current code at line 19:
+```typescript
+<Box sx={{ px: 2, py: 1, borderBottom: TABLE_STYLES.cell.border }}>
+```
+
+Replace with:
+```typescript
+<Box sx={{ px: TABLE_STYLES.cell.padding.px, py: 1, borderBottom: TABLE_STYLES.cell.border }}>
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd frontend && npm run type-check 2>&1 | grep WorkspaceCard
+```
+
+Expected: no output (no errors in this file).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/accounting/components/JournalEntryWorkspaceCard.tsx
+git commit -m "refactor(accounting): align JournalEntryWorkspaceCard header padding (issue #416)"
+```
+
+---
+
+## Task 5: Remove bulk dialogs from `JournalEntriesDialogs`
+
+**Files:**
+- Modify: `frontend/src/pages/accounting/components/JournalEntriesDialogs.tsx`
+
+- [ ] **Step 1: Replace the entire file**
+
+```typescript
+import { useState } from 'react'
+import { getCurrentDate } from '@/utils/formatters'
+
+import ConfirmationDialog from '@/components/common/ConfirmationDialog'
+import { JournalEntry } from '@/types'
+
+interface Props {
+  postTarget: JournalEntry | null
+  deleteTarget: JournalEntry | null
+  reverseTarget: JournalEntry | null
+  actionLoading: boolean
+  onConfirmPost: () => void
+  onConfirmDelete: () => void
+  onConfirmReverse: (reverseDate: string) => void
+  onCancelPost: () => void
+  onCancelDelete: () => void
+  onCancelReverse: () => void
+}
+
+export function JournalEntriesDialogs({
+  postTarget,
+  deleteTarget,
+  reverseTarget,
+  actionLoading,
+  onConfirmPost,
+  onConfirmDelete,
+  onConfirmReverse,
+  onCancelPost,
+  onCancelDelete,
+  onCancelReverse,
+}: Props) {
+  const [reverseDate] = useState(getCurrentDate())
+
+  return (
+    <>
+      <ConfirmationDialog
+        open={!!postTarget}
+        title="Post Journal Entry"
+        message={`Post journal entry ${postTarget?.referenceNumber}? This cannot be undone.`}
+        confirmText="Post"
+        cancelText="Cancel"
+        onConfirm={onConfirmPost}
+        onCancel={onCancelPost}
+        loading={actionLoading}
+      />
+      <ConfirmationDialog
+        open={!!deleteTarget}
+        title="Delete Journal Entry"
+        message={`Delete journal entry ${deleteTarget?.referenceNumber}? This cannot be undone.`}
+        confirmText="Delete"
+        cancelText="Cancel"
+        onConfirm={onConfirmDelete}
+        onCancel={onCancelDelete}
+        loading={actionLoading}
+      />
+      <ConfirmationDialog
+        open={!!reverseTarget}
+        title="Reverse Journal Entry"
+        message={`Reverse journal entry ${reverseTarget?.referenceNumber}? A new reversing entry will be created.`}
+        confirmText="Reverse"
+        cancelText="Cancel"
+        onConfirm={() => onConfirmReverse(reverseDate)}
+        onCancel={onCancelReverse}
+        loading={actionLoading}
+      />
+    </>
+  )
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd frontend && npm run type-check 2>&1 | grep Dialogs
+```
+
+Expected: errors in `JournalEntriesPage.tsx` only (still passing removed props).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/accounting/components/JournalEntriesDialogs.tsx
+git commit -m "refactor(accounting): remove bulk dialogs from JournalEntriesDialogs (issue #416)"
+```
+
+---
+
+## Task 6: Update `JournalEntriesPage` — remove bulk prop threading
+
+**Files:**
+- Modify: `frontend/src/pages/accounting/JournalEntriesPage.tsx`
+- Modify: `frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx`
+
+- [ ] **Step 1: Replace the entire page file**
+
+```typescript
+import React, { useCallback, useMemo, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+import AccountMappingWarning from '@/components/accounting/AccountMappingWarning'
+import GenericListPage from '@/components/common/GenericListPage'
+import { useFilterBar } from '@/hooks/useFilterBar'
+import { useGetJournalEntriesQuery } from '@/store/api/accountingApi'
+import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
+import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
+
+import { JournalEntryContextHeader } from './components/JournalEntryContextHeader'
+import { JournalEntriesDialogs } from './components/JournalEntriesDialogs'
+import { JournalEntriesTable } from './components/JournalEntriesTable'
+import { JournalEntryWorkspaceCard } from './components/JournalEntryWorkspaceCard'
+import { useJournalEntriesWorkspace } from './hooks/useJournalEntriesWorkspace'
+
+interface JEFilters {
+  search: string
+  status: string | null
+  entryType: string | null
+  period: PeriodValue
+}
+
+export const JournalEntriesPage: React.FC = () => {
+  const [sortBy, setSortBy] = useState('createdAt')
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
+
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  const filterConfig = useMemo<FilterBarConfig<JEFilters>>(
+    () => ({
+      search: { placeholder: 'Search by reference or description...' },
+      fields: [
+        { field: 'period', label: 'Period', type: 'period' },
+        { field: 'status', label: 'Status', type: 'journal-entry-status' },
+        { field: 'entryType', label: 'Entry Type', type: 'journal-entry-type' },
+      ],
+      defaults: {
+        search: '',
+        status: null,
+        entryType: null,
+        period: { key: null, from: null, to: null },
+      },
+    }),
+    [],
+  )
+
+  const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
+
+  const weekStartsOn = getStartOfWeek()
+  const dateRange = useMemo(() => {
+    const period = appliedFilters.period
+    if (!period || period.key === null) return { fromDate: undefined, toDate: undefined }
+    if (period.key === 'custom') return { fromDate: period.from ?? undefined, toDate: period.to ?? undefined }
+    const resolved = getPeriodDateRange(period.key, weekStartsOn)
+    return { fromDate: resolved.from, toDate: resolved.to }
+  }, [appliedFilters.period, weekStartsOn])
+
+  const urlParams = useMemo(() => new URLSearchParams(location.search), [location.search])
+  const sourceTypeParam = urlParams.get('sourceType')
+  const sourceIdParam = urlParams.get('sourceId')
+
+  const queryArgs = useMemo(() => ({
+    search: appliedFilters.search || undefined,
+    status: appliedFilters.status ? appliedFilters.status.toUpperCase() : undefined,
+    sourceType: sourceIdParam ? sourceTypeParam ?? undefined : appliedFilters.entryType || undefined,
+    sourceId: sourceIdParam ?? undefined,
+    startDate: dateRange.fromDate,
+    endDate: dateRange.toDate,
+    sortBy,
+    sortOrder: sortOrder.toUpperCase() as 'ASC' | 'DESC',
+  }), [appliedFilters, dateRange, sortBy, sortOrder, sourceTypeParam, sourceIdParam])
+
+  const { data, isLoading, refetch } = useGetJournalEntriesQuery(queryArgs)
+  const entries = data?.data ?? []
+  const pagination = data?.meta
+  const workspace = useJournalEntriesWorkspace(() => { void refetch() })
+
+  const filterHandlers = useMemo(() => ({
+    ...handlers,
+    onSearchChange: (value: string) => {
+      handlers.onSearchChange(value)
+      window.setTimeout(() => { workspace.searchInputRef.current?.focus() }, 0)
+    },
+  }), [handlers, workspace])
+
+  const handleSort = useCallback((field: string) => {
+    setSortOrder((prev) => (sortBy === field && prev === 'desc' ? 'asc' : 'desc'))
+    setSortBy(field)
+  }, [sortBy])
+
+  return (
+    <>
+      <AccountMappingWarning context="system" />
+      <GenericListPage
+        title="Journal Entries"
+        subtitle="Manage and post accounting journal entries"
+        primaryAction={{ label: 'New Journal Entry', onClick: workspace.navigateToCreate }}
+        filterConfig={filterConfig}
+        draftFilters={draftFilters}
+        handlers={filterHandlers}
+        hasActiveFilters={hasActiveFilters}
+        searchInputRef={workspace.searchInputRef}
+        sort={{ field: 'createdAt', sortBy, sortOrder, onSort: handleSort }}
+        listSlot={(
+          <JournalEntriesTable
+            entries={entries}
+            loading={isLoading}
+            selectedEntryId={workspace.selectedEntry?.id ?? null}
+            onSelect={workspace.handleSelect}
+            onViewSource={workspace.navigateToSource}
+            listRef={workspace.listRef}
+          />
+        )}
+        headerSlot={(
+          <JournalEntryContextHeader
+            selectedEntry={workspace.selectedEntry}
+            onEdit={() => workspace.selectedEntry && workspace.navigateToEdit(workspace.selectedEntry)}
+            onPost={() => workspace.selectedEntry && workspace.setPostTarget(workspace.selectedEntry)}
+            onReverse={() => workspace.selectedEntry && workspace.setReverseTarget(workspace.selectedEntry)}
+            onDelete={() => workspace.selectedEntry && workspace.setDeleteTarget(workspace.selectedEntry)}
+            onViewSource={workspace.navigateToSource}
+          />
+        )}
+        workspaceSlot={<JournalEntryWorkspaceCard selectedEntry={workspace.selectedEntry} />}
+        dialogs={(
+          <JournalEntriesDialogs
+            postTarget={workspace.postTarget}
+            deleteTarget={workspace.deleteTarget}
+            reverseTarget={workspace.reverseTarget}
+            actionLoading={workspace.actionLoading}
+            onConfirmPost={workspace.handleConfirmPost}
+            onConfirmDelete={workspace.handleConfirmDelete}
+            onConfirmReverse={workspace.handleConfirmReverse}
+            onCancelPost={() => workspace.setPostTarget(null)}
+            onCancelDelete={() => workspace.setDeleteTarget(null)}
+            onCancelReverse={() => workspace.setReverseTarget(null)}
+          />
+        )}
+      />
+    </>
+  )
+}
+
+export default JournalEntriesPage
+```
+
+- [ ] **Step 2: Update the page test — remove bulk mock setup**
+
+Replace `frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx`:
+
+```typescript
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+
+import JournalEntriesPage from '../JournalEntriesPage'
+import { JournalEntryStatus } from '@/types'
+
+vi.mock('@/hooks/useNotification', () => ({
+  useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
+}))
+vi.mock('@/components/accounting/AccountMappingWarning', () => ({ default: () => null }))
+vi.mock('@/utils/formatters', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/formatters')>('@/utils/formatters')
+  return {
+    ...actual,
+    formatCurrency: (value: number) => `$${value}`,
+    formatDate: (date: string) => date,
+    getCurrentDate: () => '2026-04-22',
+  }
+})
+vi.mock('@/utils/dateRange', () => ({
+  getPeriodDateRange: () => ({ from: undefined, to: undefined }),
+  getStartOfWeek: () => 0,
+}))
+
+const mockedApi = vi.hoisted(() => ({
+  useGetJournalEntriesQuery: vi.fn(),
+  useLazyGetJournalEntryQuery: vi.fn(),
+  useDeleteJournalEntryMutation: vi.fn(),
+  usePostJournalEntryMutation: vi.fn(),
+  useReverseJournalEntryMutation: vi.fn(),
+}))
+
+const mockNavigate = vi.fn()
+const mockLocation = { search: '', pathname: '/accounting/journal-entries' }
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => mockLocation,
+  }
+})
+
+vi.mock('@/store/api/accountingApi', () => mockedApi)
+
+const mockEntry = {
+  id: '1',
+  referenceNumber: 'JE-001',
+  entryDate: '2026-01-01',
+  description: 'Test',
+  status: JournalEntryStatus.POSTED,
+  totalDebits: 100,
+  totalCredits: 100,
+  isBalanced: true,
+  isDraft: false,
+  isPosted: true,
+  isReversed: false,
+  fiscalPeriodId: 'fp1',
+  lines: [],
+  createdAt: '2026-01-01',
+  updatedAt: '2026-01-01',
+}
+
+describe('JournalEntriesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedApi.useGetJournalEntriesQuery.mockReturnValue({
+      data: { data: [mockEntry], meta: { total: 1 } },
+      isLoading: false,
+      refetch: vi.fn(),
+    })
+    mockedApi.useLazyGetJournalEntryQuery.mockReturnValue([vi.fn().mockResolvedValue({ id: '1' })])
+    mockedApi.useDeleteJournalEntryMutation.mockReturnValue([vi.fn()])
+    mockedApi.usePostJournalEntryMutation.mockReturnValue([vi.fn()])
+    mockedApi.useReverseJournalEntryMutation.mockReturnValue([vi.fn()])
+  })
+
+  it('renders the page title', () => {
+    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    expect(screen.getByText('Journal Entries')).toBeInTheDocument()
+  })
+
+  it('renders journal entry rows', () => {
+    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    expect(screen.getByText('JE-001')).toBeInTheDocument()
+  })
+
+  it('clicking a row selects it and shows details in the context header', async () => {
+    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+
+    fireEvent.click(screen.getByText('JE-001'))
+
+    await waitFor(() => {
+      expect(screen.getAllByText('JE-001').length).toBeGreaterThan(1)
+    })
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 3: Type-check — should be clean**
+
+```bash
+cd frontend && npm run type-check 2>&1 | head -20
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Run both test files**
+
+```bash
+cd frontend && npx vitest run \
+  src/pages/accounting/components/JournalEntriesTable.test.tsx \
+  src/pages/accounting/__tests__/JournalEntriesPage.test.tsx \
+  2>&1 | tail -20
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/accounting/JournalEntriesPage.tsx \
+        frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
+git commit -m "refactor(accounting): update JournalEntriesPage, remove bulk prop threading (issue #416)"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 1: Run full type-check**
+
+```bash
+cd frontend && npm run type-check 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 2: Run all changed test files**
+
+```bash
+cd frontend && npx vitest run \
+  src/pages/accounting/components/JournalEntriesTable.test.tsx \
+  src/pages/accounting/__tests__/JournalEntriesPage.test.tsx \
+  2>&1 | tail -30
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run lint**
+
+```bash
+cd frontend && npm run lint 2>&1 | grep -E "accounting/.*Journal" | head -20
+```
+
+Expected: no errors in Journal Entries files.
+
+- [ ] **Step 4: Open a PR**
+
+```bash
+gh pr create \
+  --title "refactor(accounting): align Journal Entries components with module pattern (issue #416)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Replaced `JournalEntriesTable` custom table with `EntityTable` — no checkboxes, no per-row actions
+- Removed all bulk post/delete state and handlers from hook, page, and dialogs
+- Rewrote `JournalEntryContextHeader` to use two-column Grid layout with `detailTableSx`/`labelCellSx`/`valueCellSx` matching Sales/COA pattern
+- Deduplicated `SOURCE_ROUTES` — defined once in the hook, exported for header use
+- Aligned `JournalEntryWorkspaceCard` header padding
+
+Closes #416
+
+## Test plan
+- [ ] All existing tests pass
+- [ ] Type-check clean
+- [ ] Journal Entries page loads and displays entries
+- [ ] Clicking a row shows details in context header
+- [ ] Post/Delete/Reverse actions work from context header
+- [ ] Navigate-to-source link works from context header and table
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-04-23-fix-uuid-vulnerability.md
+++ b/docs/superpowers/plans/2026-04-23-fix-uuid-vulnerability.md
@@ -1,0 +1,100 @@
+# Fix Backend uuid Vulnerability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve 5 moderate-severity vulnerabilities (GHSA-w5hq-g745-h8pq) in `backend/` by forcing all transitive `uuid` consumers to `>=14.0.0` via `overrides` and declaring `uuid` as an explicit direct dependency.
+
+**Architecture:** Add `uuid@^14.0.0` to `dependencies` and add a `"uuid": ">=14.0.0"` entry to the existing `overrides` block in `backend/package.json`. No source code changes required — `search.service.ts` already imports `v4` and will resolve to the new version automatically.
+
+**Tech Stack:** npm overrides, uuid@14, Node 24
+
+---
+
+### Task 1: Update `backend/package.json`
+
+**Files:**
+- Modify: `backend/package.json`
+
+- [ ] **Step 1: Add `uuid` to `dependencies`**
+
+Open `backend/package.json`. In the `"dependencies"` block, add after the `"typeorm"` line:
+
+```json
+"typeorm": "^0.3.17",
+"uuid": "^14.0.0"
+```
+
+- [ ] **Step 2: Add `uuid` to the `overrides` block**
+
+In the `"overrides"` block (around line 91), add `"uuid"` as the first entry:
+
+```json
+"overrides": {
+  "uuid": ">=14.0.0",
+  "body-parser": "2.2.1",
+  "tar": "7.5.4",
+  "js-yaml": "4.1.1",
+  "qs": "6.14.2",
+  "file-type": "21.3.2",
+  "path-to-regexp": "8.4.2",
+  "lodash": "^4.18.1",
+  "@angular-devkit/core": {
+    "ajv": "8.18.0"
+  },
+  "picomatch": ">=4.0.4",
+  "@nestjs/mapped-types": "2.1.1"
+}
+```
+
+- [ ] **Step 3: Install dependencies**
+
+```bash
+cd backend && npm install
+```
+
+Expected: installs complete with no errors. `uuid@14.x` appears in `node_modules/`.
+
+- [ ] **Step 4: Verify uuid version resolved correctly**
+
+```bash
+cd backend && npm list uuid
+```
+
+Expected output (all entries show `14.x.x`):
+```
+erp-backend@...
+├── uuid@14.0.0
+└─┬ bull@4.16.5
+  └── uuid@14.0.0 deduped
+... (all uuid entries should be 14.x)
+```
+
+The key check: no `uuid@8.x` or `uuid@11.x` entries anywhere in the tree.
+
+- [ ] **Step 5: Run `npm audit`**
+
+```bash
+cd backend && npm audit
+```
+
+Expected:
+```
+found 0 vulnerabilities
+```
+
+If any uuid-related vulnerabilities remain, the override did not apply correctly — re-check the `overrides` block for typos.
+
+- [ ] **Step 6: Run the backend test suite**
+
+```bash
+cd backend && npm run test
+```
+
+Expected: all tests pass. This confirms nothing broke from the uuid version change. The suite takes a few minutes — wait for it to complete.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd backend && git add package.json package-lock.json
+git commit -m "fix(deps): force uuid>=14.0.0 to resolve GHSA-w5hq-g745-h8pq (issue #422)"
+```

--- a/docs/superpowers/plans/2026-04-23-fix-uuid-vulnerability.md
+++ b/docs/superpowers/plans/2026-04-23-fix-uuid-vulnerability.md
@@ -4,9 +4,9 @@
 
 **Goal:** Resolve 5 moderate-severity vulnerabilities (GHSA-w5hq-g745-h8pq) in `backend/` by forcing all transitive `uuid` consumers to `>=14.0.0` via `overrides` and declaring `uuid` as an explicit direct dependency.
 
-**Architecture:** Add `uuid@^14.0.0` to `dependencies` and add a `"uuid": ">=14.0.0"` entry to the existing `overrides` block in `backend/package.json`. No source code changes required — `search.service.ts` already imports `v4` and will resolve to the new version automatically.
+**Architecture:** Add `uuid@^14.0.0` to `dependencies`, add `"uuid": "$uuid"` to the `overrides` block (npm 11 requires the `$` reference syntax when the package is also a direct dep), and add a Jest shim so the CJS test runner can resolve the ESM-only uuid@14 package. No application source changes required.
 
-**Tech Stack:** npm overrides, uuid@14, Node 24
+**Tech Stack:** npm overrides, uuid@14, Node 24, Jest/ts-jest shim
 
 ---
 
@@ -14,6 +14,7 @@
 
 **Files:**
 - Modify: `backend/package.json`
+- Create: `backend/test/shims/uuid.ts`
 
 - [ ] **Step 1: Add `uuid` to `dependencies`**
 
@@ -26,11 +27,11 @@ Open `backend/package.json`. In the `"dependencies"` block, add after the `"type
 
 - [ ] **Step 2: Add `uuid` to the `overrides` block**
 
-In the `"overrides"` block (around line 91), add `"uuid"` as the first entry:
+In the `"overrides"` block, add `"uuid"` as the first entry. Use `"$uuid"` (not `">=14.0.0"`) — npm 11 rejects a plain version spec when the package is also a direct dependency (EOVERRIDE). The `$uuid` reference tells npm to use the resolved direct dep version for all transitive consumers.
 
 ```json
 "overrides": {
-  "uuid": ">=14.0.0",
+  "uuid": "$uuid",
   "body-parser": "2.2.1",
   "tar": "7.5.4",
   "js-yaml": "4.1.1",
@@ -46,7 +47,29 @@ In the `"overrides"` block (around line 91), add `"uuid"` as the first entry:
 }
 ```
 
-- [ ] **Step 3: Install dependencies**
+- [ ] **Step 3: Add Jest shim for uuid@14 ESM compatibility**
+
+uuid@14 is ESM-only; Jest runs in CommonJS mode via `ts-jest`. Without a shim, Jest fails to parse the uuid package. Create `backend/test/shims/uuid.ts`:
+
+```ts
+import { randomUUID } from 'node:crypto';
+
+export function v4(): string {
+  return randomUUID();
+}
+
+export default { v4 };
+```
+
+Then add the mapper to `jest.moduleNameMapper` in `backend/package.json` (inside the existing `"moduleNameMapper"` block):
+
+```json
+"^uuid$": "<rootDir>/test/shims/uuid.ts"
+```
+
+This shim applies to Jest only — production runtime resolves uuid normally.
+
+- [ ] **Step 4: Install dependencies**
 
 ```bash
 cd backend && npm install
@@ -54,7 +77,7 @@ cd backend && npm install
 
 Expected: installs complete with no errors. `uuid@14.x` appears in `node_modules/`.
 
-- [ ] **Step 4: Verify uuid version resolved correctly**
+- [ ] **Step 5: Verify uuid version resolved correctly**
 
 ```bash
 cd backend && npm list uuid
@@ -71,7 +94,7 @@ erp-backend@...
 
 The key check: no `uuid@8.x` or `uuid@11.x` entries anywhere in the tree.
 
-- [ ] **Step 5: Run `npm audit`**
+- [ ] **Step 6: Run `npm audit`**
 
 ```bash
 cd backend && npm audit
@@ -84,17 +107,17 @@ found 0 vulnerabilities
 
 If any uuid-related vulnerabilities remain, the override did not apply correctly — re-check the `overrides` block for typos.
 
-- [ ] **Step 6: Run the backend test suite**
+- [ ] **Step 7: Run the backend test suite**
 
 ```bash
 cd backend && npm run test
 ```
 
-Expected: all tests pass. This confirms nothing broke from the uuid version change. The suite takes a few minutes — wait for it to complete.
+Expected: all tests pass. The suite takes a few minutes — wait for it to complete.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 8: Commit**
 
 ```bash
-cd backend && git add package.json package-lock.json
+git add backend/package.json backend/package-lock.json backend/test/shims/uuid.ts
 git commit -m "fix(deps): force uuid>=14.0.0 to resolve GHSA-w5hq-g745-h8pq (issue #422)"
 ```

--- a/docs/superpowers/plans/2026-04-23-issue-418-journal-entries-table-minimalist.md
+++ b/docs/superpowers/plans/2026-04-23-issue-418-journal-entries-table-minimalist.md
@@ -1,0 +1,184 @@
+# Issue #418 — JournalEntriesTable Ultra-Minimalist Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce `JournalEntriesTable` to a single `referenceNumber` column, removing all redundant columns and the `onViewSource` prop, mirroring the pattern used in `OrdersTable`.
+
+**Architecture:** Strip `JournalEntriesTable` down to one column and clean up its prop interface. Update `JournalEntriesPage` to remove the now-deleted prop. No other files change — all removed data is already displayed in `JournalEntryContextHeader`.
+
+**Tech Stack:** React 19, TypeScript, Material-UI v7, Vitest
+
+---
+
+### Task 1: Simplify JournalEntriesTable
+
+**Files:**
+- Modify: `frontend/src/pages/accounting/components/JournalEntriesTable.tsx`
+
+- [ ] **Step 1: Update the file to single-column, remove onViewSource**
+
+Replace the entire file with:
+
+```tsx
+import { useRef, type RefObject } from 'react'
+import { Typography } from '@mui/material'
+
+import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
+import { JournalEntry } from '@/types'
+
+const COLUMNS: ColumnConfig<JournalEntry>[] = [
+  {
+    key: 'referenceNumber',
+    raw: true,
+    render: (entry) => (
+      <Typography variant="body2" sx={{ fontWeight: 500, color: 'primary.main', fontSize: '0.8rem' }}>
+        {entry.referenceNumber}
+      </Typography>
+    ),
+  },
+]
+
+interface Props {
+  entries: JournalEntry[]
+  loading: boolean
+  total: number
+  selectedEntryId: string | null
+  onSelect: (entry: JournalEntry) => void
+  listRef?: RefObject<HTMLDivElement | null>
+}
+
+export function JournalEntriesTable({
+  entries,
+  loading,
+  total,
+  selectedEntryId,
+  onSelect,
+  listRef,
+}: Props) {
+  const fallbackRef = useRef<HTMLDivElement | null>(null)
+
+  return (
+    <EntityTable
+      rows={entries}
+      columns={COLUMNS}
+      loading={loading}
+      total={total}
+      label="Journal Entries"
+      selectedId={selectedEntryId ?? undefined}
+      focusedIndex={-1}
+      onSelect={onSelect}
+      listRef={listRef ?? fallbackRef}
+      dataAttr="entry"
+    />
+  )
+}
+```
+
+- [ ] **Step 2: Run TypeScript check**
+
+```bash
+cd frontend && npm run type-check 2>&1 | grep -A2 "JournalEntries"
+```
+
+Expected: errors referencing `onViewSource` on the call site in `JournalEntriesPage.tsx` (we fix that next), no errors inside `JournalEntriesTable.tsx` itself.
+
+- [ ] **Step 3: Run existing tests to verify they still pass**
+
+```bash
+cd frontend && npx vitest run src/pages/accounting/components/JournalEntriesTable.test.tsx
+```
+
+Expected: 3 tests pass. The test mock renders only `referenceNumber`, so no changes needed.
+
+---
+
+### Task 2: Remove onViewSource from JournalEntriesPage
+
+**Files:**
+- Modify: `frontend/src/pages/accounting/JournalEntriesPage.tsx`
+
+- [ ] **Step 1: Remove the onViewSource prop from the JournalEntriesTable call**
+
+In `JournalEntriesPage.tsx`, find the `<JournalEntriesTable>` JSX block (lines ~110–119) and remove the `onViewSource` line:
+
+```tsx
+        listSlot={(
+          <JournalEntriesTable
+            entries={entries}
+            loading={isLoading}
+            total={pagination?.total ?? entries.length}
+            selectedEntryId={workspace.selectedEntry?.id ?? null}
+            onSelect={workspace.handleSelect}
+            listRef={workspace.listRef}
+          />
+        )}
+```
+
+- [ ] **Step 2: Run TypeScript check — expect clean**
+
+```bash
+cd frontend && npm run type-check 2>&1 | grep -i "error" | head -20
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Run the page-level tests**
+
+```bash
+cd frontend && npx vitest run src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/accounting/components/JournalEntriesTable.tsx \
+        frontend/src/pages/accounting/JournalEntriesPage.tsx
+git commit -m "refactor(accounting): reduce JournalEntriesTable to single referenceNumber column (issue #418)"
+```
+
+---
+
+### Task 3: Verify and close
+
+- [ ] **Step 1: Run the full accounting-related test suite**
+
+```bash
+cd frontend && npx vitest run src/pages/accounting/
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Confirm no remaining references to removed props**
+
+```bash
+grep -rn "onViewSource" frontend/src/pages/accounting/
+```
+
+Expected: only output is inside `JournalEntryContextHeader.tsx` (which keeps its own `onViewSource` prop — that's correct and untouched).
+
+- [ ] **Step 3: Open a PR closing the issue**
+
+```bash
+gh pr create \
+  --title "refactor(accounting): JournalEntriesTable ultra-minimalist single column (issue #418)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Reduces `JournalEntriesTable` to a single `referenceNumber` column, matching the `OrdersTable` / `ProductsTable` pattern
+- Removes `onViewSource` prop from `JournalEntriesTable` (source link is already in `JournalEntryContextHeader`)
+- Removes all unused imports (Chip, Link, formatCurrency, formatDate, ENTRY_TYPE_LABELS, statusColor)
+
+All removed data (date, description, type, source, debits, credits, status) is confirmed available in `JournalEntryContextHeader` and `JournalEntryWorkspaceCard`.
+
+Closes #418
+
+## Test plan
+- [ ] `JournalEntriesTable` unit tests pass (3 tests)
+- [ ] `JournalEntriesPage` tests pass
+- [ ] TypeScript check clean
+- [ ] Visually verified: list shows only JE Number, detail panel shows full entry info
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-04-23-issue-420-normalize-je-ui.md
+++ b/docs/superpowers/plans/2026-04-23-issue-420-normalize-je-ui.md
@@ -1,0 +1,392 @@
+# Issue #420: Normalize JE UI with Sales Module — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove custom font/color styling from the JE list column and replace Chip components in the JE detail header with plain text, matching the Sales module's visual patterns.
+
+**Architecture:** Two isolated component edits — `JournalEntriesTable.tsx` drops its custom `Typography` render and `JournalEntryContextHeader.tsx` replaces three `Chip` usages with inline text. No backend changes, no new files.
+
+**Tech Stack:** React 19, MUI v7, TypeScript, Vitest
+
+---
+
+## Files
+
+| Action | File |
+|--------|------|
+| Modify | `frontend/src/pages/accounting/components/JournalEntriesTable.tsx` |
+| Modify | `frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx` |
+| Verify | `frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx` (no change expected) |
+
+---
+
+### Task 1: Simplify `JournalEntriesTable.tsx`
+
+**Files:**
+- Modify: `frontend/src/pages/accounting/components/JournalEntriesTable.tsx`
+- Verify: `frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx`
+
+- [ ] **Step 1: Verify existing test passes before touching anything**
+
+```bash
+cd frontend && npx vitest run src/pages/accounting/components/JournalEntriesTable.test.tsx
+```
+
+Expected: all 3 tests PASS.
+
+- [ ] **Step 2: Replace the component file content**
+
+Replace the entire file `frontend/src/pages/accounting/components/JournalEntriesTable.tsx` with:
+
+```tsx
+import { useRef, type RefObject } from 'react'
+
+import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
+import { JournalEntry } from '@/types'
+
+const COLUMNS: ColumnConfig<JournalEntry>[] = [
+  { key: 'referenceNumber', render: (entry) => entry.referenceNumber },
+]
+
+interface Props {
+  entries: JournalEntry[]
+  loading: boolean
+  total: number
+  selectedEntryId: string | null
+  onSelect: (entry: JournalEntry) => void
+  listRef?: RefObject<HTMLDivElement | null>
+}
+
+export function JournalEntriesTable({
+  entries,
+  loading,
+  total,
+  selectedEntryId,
+  onSelect,
+  listRef,
+}: Props) {
+  const fallbackRef = useRef<HTMLDivElement | null>(null)
+
+  return (
+    <EntityTable
+      rows={entries}
+      columns={COLUMNS}
+      loading={loading}
+      total={total}
+      label="Journal Entries"
+      selectedId={selectedEntryId ?? undefined}
+      focusedIndex={-1}
+      onSelect={onSelect}
+      listRef={listRef ?? fallbackRef}
+      dataAttr="entry"
+    />
+  )
+}
+```
+
+Changes from original: removed `Typography` import, removed `raw: true`, replaced custom `Typography` render with plain string render — matching `OrdersTable.tsx` exactly.
+
+- [ ] **Step 3: Run TypeScript check**
+
+```bash
+cd frontend && npm run type-check 2>&1 | grep -E "JournalEntriesTable|error TS" | head -20
+```
+
+Expected: no errors for this file.
+
+- [ ] **Step 4: Run the test**
+
+```bash
+cd frontend && npx vitest run src/pages/accounting/components/JournalEntriesTable.test.tsx
+```
+
+Expected: all 3 tests PASS (the mock bypasses column renders so no test change needed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/accounting/components/JournalEntriesTable.tsx
+git commit -m "refactor(accounting): normalize JournalEntriesTable column style to match Sales module (issue #420)"
+```
+
+---
+
+### Task 2: Replace Chips with plain text in `JournalEntryContextHeader.tsx`
+
+**Files:**
+- Modify: `frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx`
+
+- [ ] **Step 1: Replace the entire file content**
+
+Replace `frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx` with:
+
+```tsx
+import { Box, Link, Paper, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material'
+import Grid from '@mui/material/Grid'
+import { default as DeleteIcon } from '@mui/icons-material/Delete'
+import { default as EditIcon } from '@mui/icons-material/Edit'
+import { default as PostIcon } from '@mui/icons-material/PostAdd'
+import { default as ReverseIcon } from '@mui/icons-material/Undo'
+
+import { AppButton } from '@/components/common/AppButton'
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import { JournalEntry, JournalEntryStatus } from '@/types'
+import { formatCurrency, formatDate } from '@/utils/formatters'
+
+import { SOURCE_ROUTES } from '../hooks/useJournalEntriesWorkspace'
+
+const ENTRY_TYPE_LABELS: Record<string, string> = {
+  manual: 'Manual Entry',
+  sales_order: 'Sales Order',
+  payment: 'Customer Payment',
+  settlement: 'Settlement',
+  goods_received_note: 'Goods Receipt',
+  vendor_payment: 'Vendor Payment',
+  stock_adjustment: 'Stock Adjustment',
+  owner_equity_transaction: 'Owner Equity',
+  expense: 'Expense',
+  opening_balance: 'Opening Balance',
+  fund_transfer: 'Fund Transfer',
+}
+
+const detailTableSx = {
+  tableLayout: 'fixed',
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const labelCellSx = {
+  fontWeight: 600,
+  color: 'text.secondary',
+  fontSize: '0.8rem',
+}
+
+const valueCellSx = {
+  fontSize: '0.8rem',
+}
+
+const sectionHeaderCellSx = {
+  pb: TABLE_STYLES.cell.padding.py * 0.67,
+  py: TABLE_STYLES.cell.padding.py * 0.67,
+  borderTop: TABLE_STYLES.cell.border,
+}
+
+interface Props {
+  selectedEntry: JournalEntry | null
+  onEdit: () => void
+  onPost: () => void
+  onReverse: () => void
+  onDelete: () => void
+  onViewSource: (sourceType: string, sourceId: string) => void
+}
+
+export function JournalEntryContextHeader({
+  selectedEntry,
+  onEdit,
+  onPost,
+  onReverse,
+  onDelete,
+  onViewSource,
+}: Props) {
+  if (!selectedEntry) {
+    return (
+      <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
+        <Typography variant="h6" sx={{ color: 'text.secondary' }}>
+          Select a journal entry to view details
+        </Typography>
+      </Paper>
+    )
+  }
+
+  const isDraft = selectedEntry.status === JournalEntryStatus.DRAFT
+  const isPosted = selectedEntry.status === JournalEntryStatus.POSTED
+  const isBalanced = Math.abs(selectedEntry.totalDebits - selectedEntry.totalCredits) < 0.01
+  const hasSource = selectedEntry.sourceType && selectedEntry.sourceId && SOURCE_ROUTES[selectedEntry.sourceType]
+
+  return (
+    <Paper sx={{ overflow: 'hidden' }}>
+      <Box
+        sx={{
+          p: TABLE_STYLES.cell.padding.px,
+          borderBottom: TABLE_STYLES.cell.border,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Typography
+          variant="tableHeader"
+          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+        >
+          JE Details - {selectedEntry.referenceNumber}
+        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          {isDraft && (
+            <>
+              <AppButton size="small" variant="outlined" startIcon={<EditIcon />} onClick={onEdit}>
+                Edit
+              </AppButton>
+              <AppButton size="small" variant="success" startIcon={<PostIcon />} onClick={onPost} disabled={!isBalanced}>
+                Post
+              </AppButton>
+              <AppButton size="small" variant="danger" startIcon={<DeleteIcon />} onClick={onDelete}>
+                Delete
+              </AppButton>
+            </>
+          )}
+          {isPosted && (
+            <AppButton size="small" variant="warning" startIcon={<ReverseIcon />} onClick={onReverse}>
+              Reverse
+            </AppButton>
+          )}
+        </Box>
+      </Box>
+
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Entry Information
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Date</TableCell>
+                    <TableCell sx={valueCellSx}>{formatDate(selectedEntry.entryDate)}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Description</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedEntry.description}</TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Type</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {ENTRY_TYPE_LABELS[selectedEntry.sourceType ?? ''] ?? 'Manual Entry'}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Source</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {hasSource ? (
+                        <Link
+                          component="button"
+                          variant="body2"
+                          onClick={() => onViewSource(selectedEntry.sourceType!, selectedEntry.sourceId!)}
+                        >
+                          View {ENTRY_TYPE_LABELS[selectedEntry.sourceType!] ?? selectedEntry.sourceType}
+                        </Link>
+                      ) : '—'}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Financials
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Status</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedEntry.status}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Debits</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(selectedEntry.totalDebits)}</TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Credits</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(selectedEntry.totalCredits)}</TableCell>
+                  </TableRow>
+                  {!isBalanced && (
+                    <TableRow>
+                      <TableCell sx={labelCellSx}>Balance</TableCell>
+                      <TableCell sx={valueCellSx}>Unbalanced</TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+        </Grid>
+      </Box>
+    </Paper>
+  )
+}
+```
+
+Changes from original: removed `Chip` from MUI import, removed `statusColor` function, replaced all three `<Chip>` usages with plain text.
+
+- [ ] **Step 2: Run TypeScript check**
+
+```bash
+cd frontend && npm run type-check 2>&1 | grep -E "JournalEntryContextHeader|error TS" | head -20
+```
+
+Expected: no errors for this file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx
+git commit -m "refactor(accounting): replace Chip components with plain text in JournalEntryContextHeader (issue #420)"
+```
+
+---
+
+### Task 3: Final verification
+
+- [ ] **Step 1: Run full accounting component test suite**
+
+```bash
+cd frontend && npx vitest run src/pages/accounting
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 2: Run TypeScript check across frontend**
+
+```bash
+cd frontend && npm run type-check
+```
+
+Expected: exit 0, no errors.
+
+- [ ] **Step 3: Create PR**
+
+```bash
+gh pr create --title "refactor(accounting): normalize JE list and details UI with Sales module (issue #420)" --body "$(cat <<'EOF'
+## Summary
+
+- `JournalEntriesTable`: removed custom `Typography` render (fontWeight 500, primary color) from `referenceNumber` column — now uses `EntityTable` default formatting (fontWeight 400, standard text color), matching `OrdersTable`
+- `JournalEntryContextHeader`: replaced `Chip` components for Type, Status, and Balance (unbalanced) with plain text using existing `valueCellSx` — matching `OrderContextHeader` pattern
+
+Closes #420
+
+## Test plan
+
+- [ ] Run `cd frontend && npx vitest run src/pages/accounting` — all pass
+- [ ] Run `cd frontend && npm run type-check` — no errors
+- [ ] Visually confirm JE list reference numbers render in default text color/weight
+- [ ] Visually confirm JE detail header shows Type, Status, Balance as plain text (no Chip chrome)
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-04-24-accounting-workspace-refactor.md
+++ b/docs/superpowers/plans/2026-04-24-accounting-workspace-refactor.md
@@ -1,0 +1,1175 @@
+# Accounting Workspace Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor `useJournalEntriesWorkspace` and `useChartOfAccountsWorkspace` to wrap `useEntityWorkspace`, add a Redux `accountingSlice`, and enable full keyboard navigation + focusedIndex table highlighting on JE and COA pages.
+
+**Architecture:** A new `accountingSlice` holds `selectedJournalEntry` and `selectedAccount` in Redux (matching `salesSlice`). Both workspace hooks are refactored to internally wrap `useEntityWorkspace`, accept Redux dispatch/state as config, and wire lazy-fetch on selection for JE. Both page components add Redux wiring and pass `focusedIndex` to their tables.
+
+**Tech Stack:** React 19, Redux Toolkit, RTK Query, Vitest, `@testing-library/react`, `useEntityWorkspace` (`src/hooks/useEntityWorkspace.ts`), `useKeyboardShortcuts` (from `src/hooks/useSearchAndFilter.ts`)
+
+---
+
+## File Map
+
+| File | Action |
+|:---|:---|
+| `frontend/src/store/slices/accountingSlice.ts` | Create |
+| `frontend/src/store/slices/__tests__/accountingSlice.test.ts` | Create |
+| `frontend/src/store/index.ts` | Modify — register `accountingSlice` |
+| `frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts` | Modify — wrap `useEntityWorkspace` |
+| `frontend/src/pages/accounting/hooks/useChartOfAccountsWorkspace.ts` | Modify — wrap `useEntityWorkspace` |
+| `frontend/src/pages/accounting/JournalEntriesPage.tsx` | Modify — Redux wiring, pass `focusedIndex` |
+| `frontend/src/pages/accounting/ChartOfAccountsPage.tsx` | Modify — Redux wiring, pass `focusedIndex` |
+| `frontend/src/pages/accounting/components/JournalEntriesTable.tsx` | Modify — accept and use `focusedIndex` prop |
+| `frontend/src/pages/accounting/components/ChartOfAccountsTable.tsx` | Modify — add and use `focusedIndex` prop |
+| `frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx` | Modify — add Redux Provider |
+| `frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx` | Modify — add Redux Provider |
+| `frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx` | Modify — add `focusedIndex` test |
+
+---
+
+## Task 1: Create `accountingSlice`
+
+**Files:**
+- Create: `frontend/src/store/slices/accountingSlice.ts`
+- Create: `frontend/src/store/slices/__tests__/accountingSlice.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// frontend/src/store/slices/__tests__/accountingSlice.test.ts
+import { describe, expect, it } from 'vitest'
+
+import accountingReducer, {
+  setSelectedJournalEntry,
+  setSelectedAccount,
+} from '@/store/slices/accountingSlice'
+
+describe('accountingSlice', () => {
+  it('sets selectedJournalEntry', () => {
+    const entry = { id: 'je-1', referenceNumber: 'JE-001' } as any
+    const state = accountingReducer(undefined, setSelectedJournalEntry(entry))
+    expect(state.selectedJournalEntry).toEqual(entry)
+  })
+
+  it('clears selectedJournalEntry', () => {
+    const entry = { id: 'je-1', referenceNumber: 'JE-001' } as any
+    const withEntry = accountingReducer(undefined, setSelectedJournalEntry(entry))
+    const cleared = accountingReducer(withEntry, setSelectedJournalEntry(null))
+    expect(cleared.selectedJournalEntry).toBeNull()
+  })
+
+  it('sets selectedAccount', () => {
+    const account = { id: 'acc-1', code: '1000', name: 'Cash' } as any
+    const state = accountingReducer(undefined, setSelectedAccount(account))
+    expect(state.selectedAccount).toEqual(account)
+  })
+
+  it('clears selectedAccount', () => {
+    const account = { id: 'acc-1', code: '1000', name: 'Cash' } as any
+    const withAccount = accountingReducer(undefined, setSelectedAccount(account))
+    const cleared = accountingReducer(withAccount, setSelectedAccount(null))
+    expect(cleared.selectedAccount).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd frontend && npx vitest run src/store/slices/__tests__/accountingSlice.test.ts
+```
+
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Create the slice**
+
+```typescript
+// frontend/src/store/slices/accountingSlice.ts
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+
+import type { RootState } from '@/store'
+import type { ChartOfAccount, JournalEntry } from '@/types'
+
+interface AccountingState {
+  selectedJournalEntry: JournalEntry | null
+  selectedAccount: ChartOfAccount | null
+}
+
+const initialState: AccountingState = {
+  selectedJournalEntry: null,
+  selectedAccount: null,
+}
+
+const accountingSlice = createSlice({
+  name: 'accounting',
+  initialState,
+  reducers: {
+    setSelectedJournalEntry: (state, action: PayloadAction<JournalEntry | null>) => {
+      state.selectedJournalEntry = action.payload
+    },
+    setSelectedAccount: (state, action: PayloadAction<ChartOfAccount | null>) => {
+      state.selectedAccount = action.payload
+    },
+  },
+})
+
+export const { setSelectedJournalEntry, setSelectedAccount } = accountingSlice.actions
+
+export const selectSelectedJournalEntry = (state: RootState) => state.accounting.selectedJournalEntry
+export const selectSelectedAccount = (state: RootState) => state.accounting.selectedAccount
+
+export default accountingSlice.reducer
+```
+
+- [ ] **Step 4: Register the slice in the store**
+
+In `frontend/src/store/index.ts`, add the import after the existing slice imports:
+
+```typescript
+import accountingSlice from './slices/accountingSlice'
+```
+
+Then add it to `rootReducer`:
+
+```typescript
+const rootReducer = combineReducers({
+  auth: authSlice,
+  notifications: notificationSlice,
+  inventory: inventorySlice,
+  sales: salesSlice,
+  purchasing: purchasingSlice,
+  backup: backupSlice,
+  auditLogs: auditLogSlice,
+  priceLists: priceListSlice,
+  accounting: accountingSlice,   // ← add this line
+  [auditLogApiSlice.reducerPath]: auditLogApiSlice.reducer,
+  // ... rest unchanged
+})
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd frontend && npx vitest run src/store/slices/__tests__/accountingSlice.test.ts
+```
+
+Expected: 4 tests PASS
+
+- [ ] **Step 6: Type-check**
+
+```bash
+cd frontend && npm run type-check
+```
+
+Expected: no errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/store/slices/accountingSlice.ts \
+        frontend/src/store/slices/__tests__/accountingSlice.test.ts \
+        frontend/src/store/index.ts
+git commit -m "feat(accounting): add accountingSlice with selectedJournalEntry and selectedAccount"
+```
+
+---
+
+## Task 2: Update `JournalEntriesTable` to accept `focusedIndex`
+
+**Files:**
+- Modify: `frontend/src/pages/accounting/components/JournalEntriesTable.tsx`
+- Modify: `frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to the existing `describe('JournalEntriesTable')` block in `JournalEntriesTable.test.tsx`. The mock must expose `focusedIndex` so we can assert it:
+
+```typescript
+// Replace the existing EntityTable mock entirely:
+vi.mock('@/components/common/EntityTable', () => ({
+  default: ({ rows, loading, label, onSelect, focusedIndex }: any) => (
+    <div>
+      {loading && <div>Loading...</div>}
+      {rows.length === 0 && <div>No {label} found</div>}
+      {rows.map((row: any, index: number) => (
+        <div
+          key={row.id}
+          onClick={() => onSelect(row)}
+          data-testid={`row-${row.id}`}
+          data-focused={index === focusedIndex ? 'true' : 'false'}
+        >
+          {row.referenceNumber}
+        </div>
+      ))}
+    </div>
+  ),
+}))
+```
+
+Then add this test:
+
+```typescript
+it('passes focusedIndex to EntityTable', () => {
+  render(
+    <JournalEntriesTable
+      {...defaultProps}
+      entries={[makeEntry()]}
+      focusedIndex={0}
+    />,
+  )
+  expect(screen.getByTestId('row-1')).toHaveAttribute('data-focused', 'true')
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd frontend && npx vitest run src/pages/accounting/components/JournalEntriesTable.test.tsx
+```
+
+Expected: FAIL — `focusedIndex` prop not accepted by `JournalEntriesTable`
+
+- [ ] **Step 3: Update `JournalEntriesTable` to accept and forward `focusedIndex`**
+
+```typescript
+// frontend/src/pages/accounting/components/JournalEntriesTable.tsx
+import { useRef, type RefObject } from 'react'
+
+import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
+import { JournalEntry } from '@/types'
+
+const COLUMNS: ColumnConfig<JournalEntry>[] = [
+  { key: 'referenceNumber', render: (entry) => entry.referenceNumber },
+]
+
+interface Props {
+  entries: JournalEntry[]
+  loading: boolean
+  total: number
+  selectedEntryId: string | null
+  focusedIndex: number
+  onSelect: (entry: JournalEntry) => void
+  listRef?: RefObject<HTMLDivElement | null>
+}
+
+export function JournalEntriesTable({
+  entries,
+  loading,
+  total,
+  selectedEntryId,
+  focusedIndex,
+  onSelect,
+  listRef,
+}: Props) {
+  const fallbackRef = useRef<HTMLDivElement | null>(null)
+
+  return (
+    <EntityTable
+      rows={entries}
+      columns={COLUMNS}
+      loading={loading}
+      total={total}
+      label="Journal Entries"
+      selectedId={selectedEntryId ?? undefined}
+      focusedIndex={focusedIndex}
+      onSelect={onSelect}
+      listRef={listRef ?? fallbackRef}
+      dataAttr="entry"
+    />
+  )
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd frontend && npx vitest run src/pages/accounting/components/JournalEntriesTable.test.tsx
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/accounting/components/JournalEntriesTable.tsx \
+        frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx
+git commit -m "feat(accounting): add focusedIndex prop to JournalEntriesTable"
+```
+
+---
+
+## Task 3: Update `ChartOfAccountsTable` to accept `focusedIndex`
+
+**Files:**
+- Modify: `frontend/src/pages/accounting/components/ChartOfAccountsTable.tsx`
+
+- [ ] **Step 1: Update `ChartOfAccountsTable` to accept and forward `focusedIndex`**
+
+```typescript
+// frontend/src/pages/accounting/components/ChartOfAccountsTable.tsx
+import { useRef, type RefObject } from 'react'
+
+import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
+import type { ChartOfAccount } from '@/types'
+
+interface Props {
+  accounts: ChartOfAccount[]
+  loading: boolean
+  selectedId: string | null
+  focusedIndex: number
+  onSelect: (item: ChartOfAccount) => void
+  listRef?: RefObject<HTMLDivElement | null>
+}
+
+const COLUMNS: ColumnConfig<ChartOfAccount>[] = [
+  { key: 'code', render: (account) => account.code },
+  { key: 'name', render: (account) => account.name },
+]
+
+export function ChartOfAccountsTable({
+  accounts,
+  loading,
+  selectedId,
+  focusedIndex,
+  onSelect,
+  listRef,
+}: Props) {
+  const fallbackRef = useRef<HTMLDivElement | null>(null)
+  return (
+    <EntityTable
+      rows={accounts}
+      columns={COLUMNS}
+      loading={loading}
+      total={accounts.length}
+      label="Accounts"
+      selectedId={selectedId ?? undefined}
+      focusedIndex={focusedIndex}
+      onSelect={onSelect}
+      listRef={listRef ?? fallbackRef}
+      dataAttr="account"
+    />
+  )
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd frontend && npm run type-check
+```
+
+Expected: errors about `ChartOfAccountsPage` passing no `focusedIndex` — that's expected, will be fixed in Task 5.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/accounting/components/ChartOfAccountsTable.tsx
+git commit -m "feat(accounting): add focusedIndex prop to ChartOfAccountsTable"
+```
+
+---
+
+## Task 4: Refactor `useJournalEntriesWorkspace`
+
+**Files:**
+- Modify: `frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts`
+
+- [ ] **Step 1: Rewrite the hook**
+
+```typescript
+// frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
+import { useCallback, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
+import { useNotification } from '@/hooks/useNotification'
+import type { AppDispatch } from '@/store'
+import {
+  useDeleteJournalEntryMutation,
+  useLazyGetJournalEntryQuery,
+  usePostJournalEntryMutation,
+  useReverseJournalEntryMutation,
+} from '@/store/api/accountingApi'
+import { setSelectedJournalEntry } from '@/store/slices/accountingSlice'
+import type { JournalEntry } from '@/types'
+import { getErrorMessage } from '@/utils/errorMessage'
+
+export const SOURCE_ROUTES: Record<string, (id: string) => string> = {
+  sales_order: (id) => `/sales/orders?highlight=${id}`,
+  payment: (id) => `/sales/payments?highlight=${id}`,
+  goods_received_note: (id) => `/purchasing/goods-received?grnId=${id}`,
+  vendor_payment: (id) => `/purchasing/vendor-payments?vpId=${id}`,
+  expense: () => '/accounting/expenses',
+  owner_equity_transaction: () => '/accounting/owner-equity',
+  fund_transfer: () => '/accounting/fund-transfers',
+  stock_adjustment: (id) => `/inventory/stock-adjustments/${id}/edit`,
+}
+
+interface UseJournalEntriesWorkspaceConfig {
+  dispatch: AppDispatch
+  entries: JournalEntry[]
+  selectedEntry: JournalEntry | null
+  refetch: () => void
+}
+
+export function useJournalEntriesWorkspace({
+  dispatch,
+  entries,
+  selectedEntry,
+  refetch,
+}: UseJournalEntriesWorkspaceConfig) {
+  const navigate = useNavigate()
+  const { showSuccess, showError } = useNotification()
+
+  const [postTarget, setPostTarget] = useState<JournalEntry | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<JournalEntry | null>(null)
+  const [reverseTarget, setReverseTarget] = useState<JournalEntry | null>(null)
+  const [actionLoading, setActionLoading] = useState(false)
+
+  const [fetchEntry] = useLazyGetJournalEntryQuery()
+  const [postJournalEntry] = usePostJournalEntryMutation()
+  const [reverseJournalEntry] = useReverseJournalEntryMutation()
+  const [deleteJournalEntry] = useDeleteJournalEntryMutation()
+
+  const selectAndLoadEntry = useCallback(async (entry: JournalEntry) => {
+    dispatch(setSelectedJournalEntry(entry))
+    try {
+      const fresh = await fetchEntry(entry.id).unwrap()
+      dispatch(setSelectedJournalEntry(fresh))
+    } catch {
+      /* keep list-row data */
+    }
+  }, [dispatch, fetchEntry])
+
+  const workspace = useEntityWorkspace({
+    entities: entries,
+    selectedEntity: selectedEntry,
+    selectEntity: (entry) => {
+      if (entry) {
+        void selectAndLoadEntry(entry)
+      } else {
+        dispatch(setSelectedJournalEntry(null))
+      }
+    },
+    refetch,
+    navigate,
+    routes: {
+      create: '/accounting/journal-entries/new',
+      edit: (id) => `/accounting/journal-entries/${id}/edit`,
+    },
+    notifications: { showSuccess: () => {}, showError: () => {} },
+    deleteMutation: async () => {},
+    onEscape: () => {
+      workspace.setFocusedIndex(-1)
+      dispatch(setSelectedJournalEntry(null))
+      setPostTarget(null)
+      setDeleteTarget(null)
+      setReverseTarget(null)
+    },
+  })
+
+  const handleConfirmPost = useCallback(async () => {
+    if (!postTarget) return
+    setActionLoading(true)
+    try {
+      await postJournalEntry(postTarget.id).unwrap()
+      showSuccess(`Journal entry ${postTarget.referenceNumber} posted`)
+      setPostTarget(null)
+      dispatch(setSelectedJournalEntry(null))
+      refetch()
+    } catch (error: unknown) {
+      showError(getErrorMessage(error, 'Failed to post journal entry'))
+    } finally {
+      setActionLoading(false)
+    }
+  }, [dispatch, postTarget, postJournalEntry, refetch, showError, showSuccess])
+
+  const handleConfirmReverse = useCallback(async (reverseDate: string) => {
+    if (!reverseTarget) return
+    setActionLoading(true)
+    try {
+      const result = await reverseJournalEntry({ id: reverseTarget.id, reverseDate }).unwrap()
+      showSuccess(`Journal entry ${reverseTarget.referenceNumber} reversed`)
+      setReverseTarget(null)
+      dispatch(setSelectedJournalEntry(result))
+      refetch()
+    } catch (error: unknown) {
+      showError(getErrorMessage(error, 'Failed to reverse journal entry'))
+    } finally {
+      setActionLoading(false)
+    }
+  }, [dispatch, refetch, reverseJournalEntry, reverseTarget, showError, showSuccess])
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!deleteTarget) return
+    setActionLoading(true)
+    try {
+      await deleteJournalEntry(deleteTarget.id).unwrap()
+      showSuccess(`Journal entry ${deleteTarget.referenceNumber} deleted`)
+      setDeleteTarget(null)
+      dispatch(setSelectedJournalEntry(null))
+      refetch()
+    } catch (error: unknown) {
+      showError(getErrorMessage(error, 'Failed to delete journal entry'))
+    } finally {
+      setActionLoading(false)
+    }
+  }, [deleteJournalEntry, deleteTarget, dispatch, refetch, showError, showSuccess])
+
+  return {
+    ...workspace,
+    selectedEntry,
+    postTarget,
+    setPostTarget,
+    deleteTarget,
+    setDeleteTarget,
+    reverseTarget,
+    setReverseTarget,
+    actionLoading,
+    handleConfirmPost,
+    handleConfirmReverse,
+    handleConfirmDelete,
+    navigateToEdit: (entry: JournalEntry) => navigate(`/accounting/journal-entries/${entry.id}/edit`),
+    navigateToCreate: () => navigate('/accounting/journal-entries/new'),
+    navigateToSource: (sourceType: string, sourceId: string) => {
+      const route = SOURCE_ROUTES[sourceType]
+      if (route) navigate(route(sourceId))
+    },
+  }
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd frontend && npm run type-check
+```
+
+Expected: errors from `JournalEntriesPage` calling hook with old signature — expected, fixed in Task 5.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
+git commit -m "feat(accounting): refactor useJournalEntriesWorkspace to wrap useEntityWorkspace with Redux"
+```
+
+---
+
+## Task 5: Update `JournalEntriesPage` to wire Redux
+
+**Files:**
+- Modify: `frontend/src/pages/accounting/JournalEntriesPage.tsx`
+- Modify: `frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx`
+
+- [ ] **Step 1: Update `JournalEntriesPage`**
+
+```typescript
+// frontend/src/pages/accounting/JournalEntriesPage.tsx
+import React, { useCallback, useMemo, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+
+import AccountMappingWarning from '@/components/accounting/AccountMappingWarning'
+import GenericListPage from '@/components/common/GenericListPage'
+import { useFilterBar } from '@/hooks/useFilterBar'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
+import { useGetJournalEntriesQuery } from '@/store/api/accountingApi'
+import { selectSelectedJournalEntry } from '@/store/slices/accountingSlice'
+import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
+import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
+
+import { JournalEntryContextHeader } from './components/JournalEntryContextHeader'
+import { JournalEntriesDialogs } from './components/JournalEntriesDialogs'
+import { JournalEntriesTable } from './components/JournalEntriesTable'
+import { JournalEntryWorkspaceCard } from './components/JournalEntryWorkspaceCard'
+import { useJournalEntriesWorkspace } from './hooks/useJournalEntriesWorkspace'
+
+interface JEFilters {
+  search: string
+  status: string | null
+  entryType: string | null
+  period: PeriodValue
+}
+
+export const JournalEntriesPage: React.FC = () => {
+  const [sortBy, setSortBy] = useState('createdAt')
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
+
+  const dispatch = useAppDispatch()
+  const selectedEntry = useAppSelector(selectSelectedJournalEntry)
+  const location = useLocation()
+
+  const filterConfig = useMemo<FilterBarConfig<JEFilters>>(
+    () => ({
+      search: { placeholder: 'Search by reference or description...' },
+      fields: [
+        { field: 'period', label: 'Period', type: 'period' },
+        { field: 'status', label: 'Status', type: 'journal-entry-status' },
+        { field: 'entryType', label: 'Entry Type', type: 'journal-entry-type' },
+      ],
+      defaults: {
+        search: '',
+        status: null,
+        entryType: null,
+        period: { key: null, from: null, to: null },
+      },
+    }),
+    [],
+  )
+
+  const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
+
+  const weekStartsOn = getStartOfWeek()
+  const dateRange = useMemo(() => {
+    const period = appliedFilters.period
+    if (!period || period.key === null) return { fromDate: undefined, toDate: undefined }
+    if (period.key === 'custom') return { fromDate: period.from ?? undefined, toDate: period.to ?? undefined }
+    const resolved = getPeriodDateRange(period.key, weekStartsOn)
+    return { fromDate: resolved.from, toDate: resolved.to }
+  }, [appliedFilters.period, weekStartsOn])
+
+  const urlParams = useMemo(() => new URLSearchParams(location.search), [location.search])
+  const sourceTypeParam = urlParams.get('sourceType')
+  const sourceIdParam = urlParams.get('sourceId')
+
+  const queryArgs = useMemo(() => ({
+    search: appliedFilters.search || undefined,
+    status: appliedFilters.status ? appliedFilters.status.toUpperCase() : undefined,
+    sourceType: sourceIdParam ? sourceTypeParam ?? undefined : appliedFilters.entryType || undefined,
+    sourceId: sourceIdParam ?? undefined,
+    startDate: dateRange.fromDate,
+    endDate: dateRange.toDate,
+    sortBy,
+    sortOrder: sortOrder.toUpperCase() as 'ASC' | 'DESC',
+  }), [appliedFilters, dateRange, sortBy, sortOrder, sourceIdParam, sourceTypeParam])
+
+  const { data, isLoading, refetch } = useGetJournalEntriesQuery(queryArgs)
+  const entries = data?.data ?? []
+  const pagination = data?.meta
+
+  const workspace = useJournalEntriesWorkspace({
+    dispatch,
+    entries,
+    selectedEntry,
+    refetch: () => { void refetch() },
+  })
+
+  const filterHandlers = useMemo(() => ({
+    ...handlers,
+    onSearchChange: (value: string) => {
+      handlers.onSearchChange(value)
+      workspace.setShouldPreserveSearchFocus(true)
+    },
+  }), [handlers, workspace])
+
+  const handleSort = useCallback((field: string) => {
+    setSortOrder((prev) => (sortBy === field && prev === 'desc' ? 'asc' : 'desc'))
+    setSortBy(field)
+  }, [sortBy])
+
+  return (
+    <>
+      <AccountMappingWarning context="system" />
+      <GenericListPage
+        title="Journal Entries"
+        subtitle="Manage and post accounting journal entries"
+        primaryAction={{ label: 'New Journal Entry', onClick: workspace.navigateToCreate }}
+        filterConfig={filterConfig}
+        draftFilters={draftFilters}
+        handlers={filterHandlers}
+        hasActiveFilters={hasActiveFilters}
+        searchInputRef={workspace.searchInputRef}
+        sort={{ field: 'createdAt', sortBy, sortOrder, onSort: handleSort }}
+        listSlot={(
+          <JournalEntriesTable
+            entries={entries}
+            loading={isLoading}
+            total={pagination?.total ?? entries.length}
+            selectedEntryId={selectedEntry?.id ?? null}
+            focusedIndex={workspace.focusedIndex}
+            onSelect={workspace.handleSelect}
+            listRef={workspace.listRef}
+          />
+        )}
+        headerSlot={(
+          <JournalEntryContextHeader
+            selectedEntry={selectedEntry}
+            onEdit={() => selectedEntry && workspace.navigateToEdit(selectedEntry)}
+            onPost={() => selectedEntry && workspace.setPostTarget(selectedEntry)}
+            onReverse={() => selectedEntry && workspace.setReverseTarget(selectedEntry)}
+            onDelete={() => selectedEntry && workspace.setDeleteTarget(selectedEntry)}
+            onViewSource={workspace.navigateToSource}
+          />
+        )}
+        workspaceSlot={<JournalEntryWorkspaceCard selectedEntry={selectedEntry} />}
+        dialogs={(
+          <JournalEntriesDialogs
+            postTarget={workspace.postTarget}
+            deleteTarget={workspace.deleteTarget}
+            reverseTarget={workspace.reverseTarget}
+            actionLoading={workspace.actionLoading}
+            onConfirmPost={workspace.handleConfirmPost}
+            onConfirmDelete={workspace.handleConfirmDelete}
+            onConfirmReverse={workspace.handleConfirmReverse}
+            onCancelPost={() => workspace.setPostTarget(null)}
+            onCancelDelete={() => workspace.setDeleteTarget(null)}
+            onCancelReverse={() => workspace.setReverseTarget(null)}
+          />
+        )}
+      />
+    </>
+  )
+}
+
+export default JournalEntriesPage
+```
+
+- [ ] **Step 2: Update `JournalEntriesPage.test.tsx` to provide Redux store**
+
+The test needs a Redux `Provider` with `accountingSlice` so `useAppSelector` works. Replace the two `render(...)` wrappers that use `<BrowserRouter>` with a helper that also provides the store. Add these imports and the wrapper helper after the existing `beforeEach` mock setup:
+
+```typescript
+// Add these imports at the top of JournalEntriesPage.test.tsx:
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import accountingReducer from '@/store/slices/accountingSlice'
+
+// Add this helper before the describe block:
+function makeStore() {
+  return configureStore({ reducer: { accounting: accountingReducer } })
+}
+
+function renderPage() {
+  return render(
+    <Provider store={makeStore()}>
+      <BrowserRouter>
+        <JournalEntriesPage />
+      </BrowserRouter>
+    </Provider>,
+  )
+}
+```
+
+Then replace all four `render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)` calls with `renderPage()`.
+
+- [ ] **Step 3: Run existing JE page tests**
+
+```bash
+cd frontend && npx vitest run src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
+```
+
+Expected: all existing tests PASS
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd frontend && npm run type-check
+```
+
+Expected: no errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/accounting/JournalEntriesPage.tsx \
+        frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
+git commit -m "feat(accounting): wire JournalEntriesPage to Redux accountingSlice with keyboard nav"
+```
+
+---
+
+## Task 6: Refactor `useChartOfAccountsWorkspace`
+
+**Files:**
+- Modify: `frontend/src/pages/accounting/hooks/useChartOfAccountsWorkspace.ts`
+
+- [ ] **Step 1: Rewrite the hook**
+
+```typescript
+// frontend/src/pages/accounting/hooks/useChartOfAccountsWorkspace.ts
+import { useCallback, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
+import { useNotification } from '@/hooks/useNotification'
+import type { AppDispatch } from '@/store'
+import { useDeleteChartOfAccountMutation, useSeedDefaultChartOfAccountsMutation } from '@/store/api/accountingApi'
+import { setSelectedAccount } from '@/store/slices/accountingSlice'
+import type { ChartOfAccount } from '@/types'
+
+interface UseChartOfAccountsWorkspaceConfig {
+  dispatch: AppDispatch
+  accounts: ChartOfAccount[]
+  selectedAccount: ChartOfAccount | null
+  refetch: () => void
+}
+
+export function useChartOfAccountsWorkspace({
+  dispatch,
+  accounts,
+  selectedAccount,
+  refetch,
+}: UseChartOfAccountsWorkspaceConfig) {
+  const navigate = useNavigate()
+  const { showSuccess, showError } = useNotification()
+
+  const [formDialogOpen, setFormDialogOpen] = useState(false)
+  const [deleteTarget, setDeleteTarget] = useState<ChartOfAccount | null>(null)
+  const [seedConfirmOpen, setSeedConfirmOpen] = useState(false)
+  const [deletedDialogOpen, setDeletedDialogOpen] = useState(false)
+
+  const [deleteChartOfAccount] = useDeleteChartOfAccountMutation()
+  const [seedDefaultChartOfAccounts] = useSeedDefaultChartOfAccountsMutation()
+
+  const workspace = useEntityWorkspace({
+    entities: accounts,
+    selectedEntity: selectedAccount,
+    selectEntity: (account) => dispatch(setSelectedAccount(account)),
+    refetch,
+    navigate,
+    routes: {
+      create: '',
+      edit: () => '',
+    },
+    notifications: { showSuccess: () => {}, showError: () => {} },
+    deleteMutation: async () => {},
+    onEnter: () => {
+      if (selectedAccount) {
+        setFormDialogOpen(true)
+      }
+    },
+    onEscape: () => {
+      workspace.setFocusedIndex(-1)
+      dispatch(setSelectedAccount(null))
+      setFormDialogOpen(false)
+      setDeleteTarget(null)
+    },
+  })
+
+  const handleDelete = useCallback(async () => {
+    if (!deleteTarget) return
+    try {
+      await deleteChartOfAccount(deleteTarget.id).unwrap()
+      showSuccess(`Account "${deleteTarget.name}" deleted successfully`)
+      setDeleteTarget(null)
+      if (selectedAccount?.id === deleteTarget.id) dispatch(setSelectedAccount(null))
+      refetch()
+    } catch (error: any) {
+      showError(error || 'Failed to delete account')
+    }
+  }, [deleteChartOfAccount, deleteTarget, dispatch, refetch, selectedAccount?.id, showError, showSuccess])
+
+  const handleSeed = useCallback(async () => {
+    try {
+      const result = await seedDefaultChartOfAccounts().unwrap()
+      showSuccess(result.message || 'Default accounts seeded successfully')
+      setSeedConfirmOpen(false)
+      refetch()
+    } catch (error: any) {
+      showError(error || 'Failed to seed default accounts')
+      setSeedConfirmOpen(false)
+    }
+  }, [refetch, seedDefaultChartOfAccounts, showError, showSuccess])
+
+  return {
+    ...workspace,
+    selected: selectedAccount,
+    setSelected: (account: ChartOfAccount | null) => dispatch(setSelectedAccount(account)),
+    formDialogOpen,
+    setFormDialogOpen,
+    deleteTarget,
+    setDeleteTarget,
+    seedConfirmOpen,
+    setSeedConfirmOpen,
+    deletedDialogOpen,
+    setDeletedDialogOpen,
+    handleDelete,
+    handleSeed,
+  }
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd frontend && npm run type-check
+```
+
+Expected: errors from `ChartOfAccountsPage` calling hook with old signature — expected, fixed in Task 7.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/accounting/hooks/useChartOfAccountsWorkspace.ts
+git commit -m "feat(accounting): refactor useChartOfAccountsWorkspace to wrap useEntityWorkspace with Redux"
+```
+
+---
+
+## Task 7: Update `ChartOfAccountsPage` to wire Redux
+
+**Files:**
+- Modify: `frontend/src/pages/accounting/ChartOfAccountsPage.tsx`
+- Modify: `frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx`
+
+- [ ] **Step 1: Update `ChartOfAccountsPage`**
+
+```typescript
+// frontend/src/pages/accounting/ChartOfAccountsPage.tsx
+import React, { useMemo, useState } from 'react'
+
+import AccountMappingWarning from '@/components/accounting/AccountMappingWarning'
+import GenericListPage from '@/components/common/GenericListPage'
+import { useFilterBar } from '@/hooks/useFilterBar'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
+import { useGetChartOfAccountsHierarchyQuery } from '@/store/api/accountingApi'
+import { selectSelectedAccount } from '@/store/slices/accountingSlice'
+import type { ChartOfAccount } from '@/types'
+import type { FilterBarConfig } from '@/types/filterBar.types'
+
+import { ChartOfAccountContextHeader } from './components/ChartOfAccountContextHeader'
+import { ChartOfAccountsDialogs } from './components/ChartOfAccountsDialogs'
+import { ChartOfAccountsTable } from './components/ChartOfAccountsTable'
+import { ChartOfAccountWorkspaceCard } from './components/ChartOfAccountWorkspaceCard'
+import { useChartOfAccountsWorkspace } from './hooks/useChartOfAccountsWorkspace'
+
+interface CoaFilters {
+  search: string
+  accountType: string | null
+  isActive: string | null
+}
+
+const filterConfig: FilterBarConfig<CoaFilters> = {
+  search: { placeholder: 'Search by code or name...' },
+  fields: [
+    { field: 'accountType', label: 'Account Type', type: 'account-type' },
+    { field: 'isActive', label: 'Status', type: 'status' },
+  ],
+  defaults: { search: '', accountType: null, isActive: null },
+}
+
+const ChartOfAccountsPage: React.FC = () => {
+  const dispatch = useAppDispatch()
+  const selectedAccount = useAppSelector(selectSelectedAccount)
+  const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
+  const { data: hierarchyData, isLoading, error, refetch } = useGetChartOfAccountsHierarchyQuery()
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
+
+  const accounts = useMemo(() => {
+    const result: ChartOfAccount[] = []
+
+    const walk = (nodes: ChartOfAccount[]) => {
+      for (const node of nodes) {
+        result.push(node)
+
+        if (node.children?.length) {
+          walk(node.children)
+        }
+      }
+    }
+
+    walk(hierarchyData ?? [])
+    return result
+  }, [hierarchyData])
+
+  const filteredAccounts = useMemo(() => {
+    let result = accounts
+
+    if (appliedFilters.search) {
+      const searchTerm = appliedFilters.search.toLowerCase()
+      result = result.filter(
+        (account) =>
+          account.code.toLowerCase().includes(searchTerm) ||
+          account.name.toLowerCase().includes(searchTerm),
+      )
+    }
+
+    if (appliedFilters.accountType) {
+      result = result.filter((account) => account.type === appliedFilters.accountType)
+    }
+
+    if (appliedFilters.isActive) {
+      const isActive = appliedFilters.isActive === 'active'
+      result = result.filter((account) => account.isActive === isActive)
+    }
+
+    return [...result].sort((left, right) =>
+      sortOrder === 'asc'
+        ? left.code.localeCompare(right.code)
+        : right.code.localeCompare(left.code),
+    )
+  }, [accounts, appliedFilters, sortOrder])
+
+  const workspace = useChartOfAccountsWorkspace({
+    dispatch,
+    accounts: filteredAccounts,
+    selectedAccount,
+    refetch: () => { void refetch() },
+  })
+
+  return (
+    <>
+      <AccountMappingWarning context="system" />
+      <GenericListPage
+        title="Chart of Accounts"
+        subtitle={`Manage your accounting structure and account hierarchy (${hasActiveFilters ? `${filteredAccounts.length} of ${accounts.length}` : `${accounts.length} total`})`}
+        primaryAction={{
+          label: 'Add Account',
+          onClick: () => {
+            workspace.setSelected(null)
+            workspace.setFormDialogOpen(true)
+          },
+        }}
+        secondaryAction={{ label: 'View Deleted', onClick: () => workspace.setDeletedDialogOpen(true) }}
+        filterConfig={filterConfig}
+        draftFilters={draftFilters}
+        handlers={handlers}
+        hasActiveFilters={hasActiveFilters}
+        searchInputRef={workspace.searchInputRef}
+        sort={{
+          field: 'code',
+          sortBy: 'code',
+          sortOrder,
+          onSort: () => setSortOrder((prev) => (prev === 'asc' ? 'desc' : 'asc')),
+        }}
+        error={(error as any)?.data ?? null}
+        listSlot={
+          <ChartOfAccountsTable
+            accounts={filteredAccounts}
+            loading={isLoading}
+            selectedId={selectedAccount?.id ?? null}
+            focusedIndex={workspace.focusedIndex}
+            onSelect={workspace.handleSelect}
+            listRef={workspace.listRef}
+          />
+        }
+        headerSlot={
+          <ChartOfAccountContextHeader
+            selected={selectedAccount}
+            onEdit={() => workspace.setFormDialogOpen(true)}
+            onDelete={() => selectedAccount && workspace.setDeleteTarget(selectedAccount)}
+          />
+        }
+        workspaceSlot={<ChartOfAccountWorkspaceCard selected={selectedAccount} />}
+        dialogs={
+          <ChartOfAccountsDialogs
+            formDialogOpen={workspace.formDialogOpen}
+            selected={selectedAccount}
+            onCloseForm={() => workspace.setFormDialogOpen(false)}
+            onFormSuccess={() => {
+              workspace.setFormDialogOpen(false)
+              void refetch()
+            }}
+            deleteTarget={workspace.deleteTarget}
+            onConfirmDelete={() => void workspace.handleDelete()}
+            onCancelDelete={() => workspace.setDeleteTarget(null)}
+            seedConfirmOpen={workspace.seedConfirmOpen}
+            onConfirmSeed={() => void workspace.handleSeed()}
+            onCancelSeed={() => workspace.setSeedConfirmOpen(false)}
+            deletedDialogOpen={workspace.deletedDialogOpen}
+            onCloseDeletedDialog={() => workspace.setDeletedDialogOpen(false)}
+            onChanged={() => void refetch()}
+          />
+        }
+      />
+    </>
+  )
+}
+
+export default ChartOfAccountsPage
+```
+
+- [ ] **Step 2: Update `ChartOfAccountsPage.test.tsx` to provide Redux store**
+
+Add these imports at the top:
+
+```typescript
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import accountingReducer from '@/store/slices/accountingSlice'
+```
+
+Add this helper before the `describe` block, replacing the existing `renderPage`:
+
+```typescript
+function makeStore() {
+  return configureStore({ reducer: { accounting: accountingReducer } })
+}
+
+function renderPage() {
+  return render(
+    <Provider store={makeStore()}>
+      <BrowserRouter>
+        <ChartOfAccountsPage />
+      </BrowserRouter>
+    </Provider>,
+  )
+}
+```
+
+- [ ] **Step 3: Run COA page tests**
+
+```bash
+cd frontend && npx vitest run src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx
+```
+
+Expected: all existing tests PASS
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd frontend && npm run type-check
+```
+
+Expected: no errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/accounting/ChartOfAccountsPage.tsx \
+        frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx
+git commit -m "feat(accounting): wire ChartOfAccountsPage to Redux accountingSlice with keyboard nav"
+```
+
+---
+
+## Task 8: Final verification
+
+- [ ] **Step 1: Run all accounting-related tests**
+
+```bash
+cd frontend && npx vitest run \
+  src/store/slices/__tests__/accountingSlice.test.ts \
+  src/pages/accounting/__tests__/JournalEntriesPage.test.tsx \
+  src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx \
+  src/pages/accounting/components/JournalEntriesTable.test.tsx
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 2: Full type-check**
+
+```bash
+cd frontend && npm run type-check
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Lint**
+
+```bash
+cd frontend && npm run lint
+```
+
+Expected: no errors
+
+- [ ] **Step 4: Commit (if any lint fixes were needed)**
+
+```bash
+git add -p
+git commit -m "fix(accounting): lint fixes after workspace refactor"
+```
+
+Skip this step if lint was already clean.

--- a/docs/superpowers/plans/2026-04-24-keyboard-nav-standardization.md
+++ b/docs/superpowers/plans/2026-04-24-keyboard-nav-standardization.md
@@ -1,0 +1,600 @@
+# Keyboard Navigation Standardization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Standardize keyboard navigation across Sales Orders, Invoices, Payments, and Customers so that arrow/page key navigation triggers a full-detail API fetch on all four pages, and eliminate the duplicate keyboard event listener in `useOrdersWorkspace`.
+
+**Architecture:** Add an optional `onNavigate` callback to `useEntityWorkspace` that fires on every keyboard navigation move (inside `selectAtIndex`). Each feature hook/page passes its lazy RTK Query fetch as `onNavigate`. `useOrdersWorkspace` removes its duplicate `useKeyboardShortcuts` registration and redundant navigation override handlers, delegating to the base hook.
+
+**Tech Stack:** React 19, TypeScript, RTK Query (`useLazyGet*Query` hooks), Vitest
+
+---
+
+## File Map
+
+| File | Action |
+|------|--------|
+| `frontend/src/hooks/useEntityWorkspace.ts` | Modify — add `onNavigate` to config and `selectAtIndex` |
+| `frontend/src/hooks/useEntityWorkspace.test.ts` | Modify — add 3 tests for `onNavigate` |
+| `frontend/src/pages/sales/hooks/useOrdersWorkspace.ts` | Modify — remove duplicate listener + 6 nav overrides, add `onNavigate` |
+| `frontend/src/pages/sales/hooks/useInvoicesWorkspace.ts` | Modify — add `useLazyGetInvoiceQuery` + `onNavigate` |
+| `frontend/src/pages/sales/hooks/usePaymentsWorkspace.ts` | Modify — add `useLazyGetPaymentQuery` + `onNavigate` |
+| `frontend/src/pages/sales/CustomersPage.tsx` | Modify — add `useLazyGetCustomerQuery` + `onNavigate` |
+| `frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx` | Modify — remove stale nav handler mocks |
+| `frontend/src/pages/sales/__tests__/InvoicesPage.filterbar.test.tsx` | Modify — remove stale nav handler mocks |
+| `frontend/src/pages/sales/__tests__/PaymentsPage.filterbar.test.tsx` | Modify — remove stale nav handler mocks |
+
+---
+
+## Task 1: Add `onNavigate` to `useEntityWorkspace`
+
+**Files:**
+- Modify: `frontend/src/hooks/useEntityWorkspace.ts`
+
+- [ ] **Step 1: Add `onNavigate` to `UseEntityWorkspaceConfig`**
+
+In `frontend/src/hooks/useEntityWorkspace.ts`, add the optional field to the config interface (after `onEscape`):
+
+```ts
+export interface UseEntityWorkspaceConfig<T extends { id: string }> {
+  entities: T[]
+  selectedEntity: T | null
+  selectEntity: (entity: T | null) => void
+  refetch: () => void
+  navigate: NavigateFunction
+  routes: {
+    create: string
+    edit: (id: string) => string
+  }
+  notifications: {
+    showSuccess: (message: string) => void
+    showError: (message: string) => void
+  }
+  deleteMutation: (id: string) => Promise<void>
+  onEnter?: () => void
+  onEscape?: () => void
+  onNavigate?: (entity: T, index: number) => void
+}
+```
+
+- [ ] **Step 2: Destructure `onNavigate` from config**
+
+In the `useEntityWorkspace` function body, add `onNavigate` to the destructuring (after `onEscape`):
+
+```ts
+const {
+  entities,
+  selectedEntity,
+  selectEntity,
+  refetch,
+  navigate,
+  routes,
+  notifications,
+  deleteMutation,
+  onEnter,
+  onEscape,
+  onNavigate,
+} = config
+```
+
+- [ ] **Step 3: Call `onNavigate` inside `selectAtIndex`**
+
+Replace the existing `selectAtIndex` implementation (lines 118–127) with:
+
+```ts
+const selectAtIndex = useCallback((index: number) => {
+  const entity = entities[index]
+
+  if (!entity) {
+    return
+  }
+
+  setFocusedIndex(index)
+  selectEntity(entity)
+  onNavigate?.(entity, index)
+}, [entities, selectEntity, onNavigate])
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd frontend && npm run type-check 2>&1 | grep -E "error|useEntityWorkspace"
+```
+
+Expected: no errors related to `useEntityWorkspace`.
+
+---
+
+## Task 2: Test `onNavigate` in `useEntityWorkspace`
+
+**Files:**
+- Modify: `frontend/src/hooks/useEntityWorkspace.test.ts`
+
+- [ ] **Step 1: Write three failing tests**
+
+Add these three `it` blocks inside the existing `describe('useEntityWorkspace', ...)` block at the end of the file:
+
+```ts
+it('onNavigate is called when navigating down', () => {
+  const onNavigate = vi.fn()
+  const config = makeConfig({ onNavigate })
+  const { result } = renderHook(() => useEntityWorkspace(config))
+
+  act(() => {
+    result.current.setFocusedIndex(0)
+  })
+  act(() => {
+    result.current.handleNavigateDown()
+  })
+
+  expect(onNavigate).toHaveBeenCalledWith(config.entities[1], 1)
+})
+
+it('onNavigate is called when navigating up', () => {
+  const onNavigate = vi.fn()
+  const config = makeConfig({ onNavigate })
+  const { result } = renderHook(() => useEntityWorkspace(config))
+
+  act(() => {
+    result.current.setFocusedIndex(2)
+  })
+  act(() => {
+    result.current.handleNavigateUp()
+  })
+
+  expect(onNavigate).toHaveBeenCalledWith(config.entities[1], 1)
+})
+
+it('onNavigate is NOT called when selecting via handleSelect (click)', () => {
+  const onNavigate = vi.fn()
+  const config = makeConfig({ onNavigate })
+  const { result } = renderHook(() => useEntityWorkspace(config))
+
+  act(() => {
+    result.current.handleSelect(config.entities[1])
+  })
+
+  expect(onNavigate).not.toHaveBeenCalled()
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd frontend && npx vitest run src/hooks/useEntityWorkspace.test.ts
+```
+
+Expected: the three new tests FAIL (onNavigate not yet called / not yet in config).
+
+- [ ] **Step 3: Verify tests pass after Task 1 changes**
+
+```bash
+cd frontend && npx vitest run src/hooks/useEntityWorkspace.test.ts
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/hooks/useEntityWorkspace.ts frontend/src/hooks/useEntityWorkspace.test.ts
+git commit -m "feat(workspace): add onNavigate callback to useEntityWorkspace"
+```
+
+---
+
+## Task 3: Refactor `useOrdersWorkspace`
+
+**Files:**
+- Modify: `frontend/src/pages/sales/hooks/useOrdersWorkspace.ts`
+
+- [ ] **Step 1: Remove the duplicate `useKeyboardShortcuts` import usage**
+
+The import at line 6 (`import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter'`) is only used by the duplicate listener. Remove the entire second `useKeyboardShortcuts` call (currently lines 839–852):
+
+```ts
+// DELETE this entire block:
+useKeyboardShortcuts({
+  onSearch: () => {
+    workspace.searchInputRef.current?.focus()
+    workspace.searchInputRef.current?.select()
+  },
+  onArrowUp: handleNavigateUp,
+  onArrowDown: handleNavigateDown,
+  onEnter: workspace.handleEnterAction,
+  onPageUp: handlePageUpNavigation,
+  onPageDown: handlePageDownNavigation,
+  onHome: handleNavigateToFirst,
+  onEnd: handleNavigateToLast,
+  onEscape: workspace.handleEscapeAction,
+})
+```
+
+Also remove the `useKeyboardShortcuts` import line if it is no longer referenced anywhere else in the file.
+
+- [ ] **Step 2: Remove `selectAndLoadOrder` and the six navigation overrides**
+
+Delete the following functions entirely (they are replaced by `onNavigate`):
+
+- `selectAndLoadOrder` (lines ~306–311)
+- `handleNavigateUp` (lines ~313–317)
+- `handleNavigateDown` (lines ~319–323)
+- `handleNavigateToFirst` (lines ~325–329)
+- `handleNavigateToLast` (lines ~331–335)
+- `handlePageUpNavigation` (lines ~337–342)
+- `handlePageDownNavigation` (lines ~344–349)
+
+- [ ] **Step 3: Add `onNavigate` to the `useEntityWorkspace` config call**
+
+In the existing `useEntityWorkspace({...})` call (around line 92), add `onNavigate` alongside the other config options:
+
+```ts
+const workspace = useEntityWorkspace({
+  entities: orders,
+  selectedEntity: selectedOrder,
+  selectEntity: (order) => dispatch(setSelectedOrder(order)),
+  refetch: refetchOrders,
+  navigate,
+  routes: {
+    create: '/sales/orders/create',
+    edit: (id) => `/sales/orders/${id}/edit`,
+  },
+  notifications: { showSuccess: () => {}, showError: () => {} },
+  deleteMutation: async () => {},
+  onNavigate: (order) => {
+    void triggerGetSalesOrder(order.id).unwrap().then((fullOrder) => {
+      dispatch(setSelectedOrder(fullOrder))
+    })
+    userHasNavigatedRef.current = true
+  },
+  onEnter: () => {
+    if (workspaceRef.current?.focusedIndex != null && workspaceRef.current.focusedIndex >= 0) {
+      const order = orders[workspaceRef.current.focusedIndex]
+      if (order) {
+        navigate(`/sales/orders/${order.id}/edit`)
+      }
+    }
+  },
+  onEscape: () => {
+    workspaceRef.current?.setFocusedIndex(-1)
+    dispatch(setSelectedOrder(null))
+    setViewDialog(false)
+    setBlockedDialogOpen(false)
+    setDeletedOrdersDialogOpen(false)
+    setDeleteConfirmOpen(false)
+  },
+})
+```
+
+- [ ] **Step 4: Remove the six nav handlers from the return object**
+
+In the `return { ... }` at the bottom of `useOrdersWorkspace`, remove these six keys (they are now provided by the base workspace spread):
+
+```ts
+// REMOVE these from the return object:
+handleNavigateUp,
+handleNavigateDown,
+handleNavigateToFirst,
+handleNavigateToLast,
+handlePageUpNavigation,
+handlePageDownNavigation,
+```
+
+The `...workspace` spread already exposes the base hook's versions of these.
+
+- [ ] **Step 5: Type-check**
+
+```bash
+cd frontend && npm run type-check 2>&1 | grep -E "error|useOrdersWorkspace"
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Run orders workspace tests**
+
+```bash
+cd frontend && npx vitest run src/pages/sales/hooks/useOrdersWorkspace.test.tsx
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 7: Update `OrdersPage.filterbar.test.tsx` mock**
+
+Open `frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx` and remove the six stale nav handler mock entries. Find the mock object (around line 65) and delete these lines:
+
+```ts
+// DELETE these lines from the mock:
+handleNavigateUp: vi.fn(),
+handleNavigateDown: vi.fn(),
+handleNavigateToFirst: vi.fn(),
+handleNavigateToLast: vi.fn(),
+handlePageUpNavigation: vi.fn(),
+handlePageDownNavigation: vi.fn(),
+```
+
+- [ ] **Step 8: Run filterbar test**
+
+```bash
+cd frontend && npx vitest run src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/pages/sales/hooks/useOrdersWorkspace.ts \
+        frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
+git commit -m "feat(sales): remove duplicate keyboard listener from useOrdersWorkspace, add onNavigate"
+```
+
+---
+
+## Task 4: Add `onNavigate` to `useInvoicesWorkspace`
+
+**Files:**
+- Modify: `frontend/src/pages/sales/hooks/useInvoicesWorkspace.ts`
+
+- [ ] **Step 1: Import `useLazyGetInvoiceQuery`**
+
+Add to the existing import from `@/store/api/salesApi` (or add a new import line if not already importing from there):
+
+```ts
+import { useLazyGetInvoiceQuery } from '@/store/api/salesApi'
+```
+
+Verify the hook name exists:
+```bash
+grep "useLazyGetInvoiceQuery" frontend/src/store/api/salesApi.ts
+```
+Expected: one matching line.
+
+- [ ] **Step 2: Instantiate the lazy query**
+
+Inside `useInvoicesWorkspace`, after the existing `const [fetchJournalEntries] = useLazyGetJournalEntriesQuery()` line, add:
+
+```ts
+const [triggerGetInvoice] = useLazyGetInvoiceQuery()
+```
+
+- [ ] **Step 3: Add `onNavigate` to the `useEntityWorkspace` config call**
+
+In the existing `useEntityWorkspace({...})` call, add `onNavigate` alongside the other config options (after `deleteMutation`):
+
+```ts
+onNavigate: (invoice) => {
+  void triggerGetInvoice(invoice.id).unwrap().then((fullInvoice) => {
+    dispatch(setSelectedInvoice(fullInvoice as any))
+  })
+},
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd frontend && npm run type-check 2>&1 | grep -E "error|useInvoicesWorkspace"
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Update `InvoicesPage.filterbar.test.tsx` mock**
+
+Open `frontend/src/pages/sales/__tests__/InvoicesPage.filterbar.test.tsx` and remove the six stale nav handler mock entries (around line 52–58):
+
+```ts
+// DELETE these lines from the mock:
+handleNavigateUp: vi.fn(),
+handleNavigateDown: vi.fn(),
+handleNavigateToFirst: vi.fn(),
+handleNavigateToLast: vi.fn(),
+handlePageUpNavigation: vi.fn(),
+handlePageDownNavigation: vi.fn(),
+```
+
+- [ ] **Step 6: Run invoices tests**
+
+```bash
+cd frontend && npx vitest run src/pages/sales/hooks/useInvoicesWorkspace.test.tsx src/pages/sales/__tests__/InvoicesPage.filterbar.test.tsx
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/pages/sales/hooks/useInvoicesWorkspace.ts \
+        frontend/src/pages/sales/__tests__/InvoicesPage.filterbar.test.tsx
+git commit -m "feat(sales): add onNavigate lazy fetch to useInvoicesWorkspace"
+```
+
+---
+
+## Task 5: Add `onNavigate` to `usePaymentsWorkspace`
+
+**Files:**
+- Modify: `frontend/src/pages/sales/hooks/usePaymentsWorkspace.ts`
+
+- [ ] **Step 1: Import `useLazyGetPaymentQuery`**
+
+Add to the imports from `@/store/api/salesApi`:
+
+```ts
+import { useLazyGetPaymentQuery } from '@/store/api/salesApi'
+```
+
+Verify:
+```bash
+grep "useLazyGetPaymentQuery" frontend/src/store/api/salesApi.ts
+```
+Expected: one matching line.
+
+- [ ] **Step 2: Instantiate the lazy query**
+
+Inside `usePaymentsWorkspace`, after the existing `const [fetchJournalEntries] = useLazyGetJournalEntriesQuery()` line, add:
+
+```ts
+const [triggerGetPayment] = useLazyGetPaymentQuery()
+```
+
+- [ ] **Step 3: Add `onNavigate` to the `useEntityWorkspace` config call**
+
+In the existing `useEntityWorkspace({...})` call, add `onNavigate` (after `deleteMutation`):
+
+```ts
+onNavigate: (payment) => {
+  void triggerGetPayment(payment.id).unwrap().then((fullPayment) => {
+    dispatch(setSelectedPayment(fullPayment as any))
+  })
+},
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd frontend && npm run type-check 2>&1 | grep -E "error|usePaymentsWorkspace"
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Update `PaymentsPage.filterbar.test.tsx` mock**
+
+Open `frontend/src/pages/sales/__tests__/PaymentsPage.filterbar.test.tsx` and remove the six stale nav handler mock entries (around line 61–67):
+
+```ts
+// DELETE these lines from the mock:
+handleNavigateUp: vi.fn(),
+handleNavigateDown: vi.fn(),
+handleNavigateToFirst: vi.fn(),
+handleNavigateToLast: vi.fn(),
+handlePageUpNavigation: vi.fn(),
+handlePageDownNavigation: vi.fn(),
+```
+
+- [ ] **Step 6: Run payments tests**
+
+```bash
+cd frontend && npx vitest run src/pages/sales/hooks/usePaymentsWorkspace.test.tsx src/pages/sales/__tests__/PaymentsPage.filterbar.test.tsx
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/pages/sales/hooks/usePaymentsWorkspace.ts \
+        frontend/src/pages/sales/__tests__/PaymentsPage.filterbar.test.tsx
+git commit -m "feat(sales): add onNavigate lazy fetch to usePaymentsWorkspace"
+```
+
+---
+
+## Task 6: Add `onNavigate` to `CustomersPage`
+
+**Files:**
+- Modify: `frontend/src/pages/sales/CustomersPage.tsx`
+
+- [ ] **Step 1: Import `useLazyGetCustomerQuery`**
+
+`CustomersPage.tsx` already imports from `@/store/api/salesApi`. Add `useLazyGetCustomerQuery` to that import:
+
+```ts
+import {
+  useDeleteCustomerMutation,
+  useGetCustomersQuery,
+  useLazyGetCustomerQuery,
+} from '@/store/api/salesApi'
+```
+
+Verify:
+```bash
+grep "useLazyGetCustomerQuery" frontend/src/store/api/salesApi.ts
+```
+Expected: one matching line.
+
+- [ ] **Step 2: Instantiate the lazy query**
+
+Inside `CustomersPage`, after the existing `const [deleteCustomer] = useDeleteCustomerMutation()` line, add:
+
+```ts
+const [triggerGetCustomer] = useLazyGetCustomerQuery()
+```
+
+- [ ] **Step 3: Add `onNavigate` to the `useEntityWorkspace` config call**
+
+In the existing `useEntityWorkspace({...})` call (around line 75), add `onNavigate` after `deleteMutation`:
+
+```ts
+onNavigate: (customer) => {
+  void triggerGetCustomer(customer.id).unwrap().then((fullCustomer) => {
+    dispatch(setSelectedCustomer(fullCustomer))
+  })
+},
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd frontend && npm run type-check 2>&1 | grep -E "error|CustomersPage"
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run customers tests**
+
+```bash
+cd frontend && npx vitest run src/pages/sales/__tests__/CustomersPage.filter.test.tsx src/pages/sales/__tests__/CustomersPage.filterbar.test.tsx
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/sales/CustomersPage.tsx
+git commit -m "feat(sales): add onNavigate lazy fetch to CustomersPage"
+```
+
+---
+
+## Task 7: Final Verification
+
+- [ ] **Step 1: Run all affected test files**
+
+```bash
+cd frontend && npx vitest run \
+  src/hooks/useEntityWorkspace.test.ts \
+  src/pages/sales/hooks/useOrdersWorkspace.test.tsx \
+  src/pages/sales/hooks/useInvoicesWorkspace.test.tsx \
+  src/pages/sales/hooks/usePaymentsWorkspace.test.tsx \
+  src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx \
+  src/pages/sales/__tests__/InvoicesPage.filterbar.test.tsx \
+  src/pages/sales/__tests__/PaymentsPage.filterbar.test.tsx \
+  src/pages/sales/__tests__/CustomersPage.filter.test.tsx \
+  src/pages/sales/__tests__/CustomersPage.filterbar.test.tsx
+```
+
+Expected: all PASS.
+
+- [ ] **Step 2: Full type-check**
+
+```bash
+cd frontend && npm run type-check
+```
+
+Expected: zero errors.
+
+- [ ] **Step 3: Open a PR**
+
+```bash
+gh pr create \
+  --title "feat(workspace): standardize keyboard navigation with onNavigate callback" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds optional `onNavigate` callback to `useEntityWorkspace` — fires on keyboard navigation (arrow/pgUp/pgDn/home/end), not on click
+- Removes duplicate `useKeyboardShortcuts` registration from `useOrdersWorkspace` (was registering two listeners for the same keys)
+- Invoices, Payments, and Customers now trigger a lazy API fetch on keyboard navigation, matching Sales Orders behavior
+
+Closes #426
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-04-25-entity-workspace-selection-fix.md
+++ b/docs/superpowers/plans/2026-04-25-entity-workspace-selection-fix.md
@@ -1,0 +1,586 @@
+# Entity Workspace Selection Reset Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix selection resetting to "Select a …" placeholder when clicking rows in any entity list page (Customers, Suppliers, Products, Orders, etc.) — closes #444.
+
+**Architecture:** Two independent fixes applied together: (1) add an `isFetching` guard to `useEntityWorkspace` so a transient empty `entities` array during a background refetch never clears the selection; (2) wrap every inline `selectEntity` arrow passed to `useEntityWorkspace` in `useCallback` so its reference is stable across renders, preventing the auto-selection effect from re-running spuriously.
+
+**Tech Stack:** React 19, Redux Toolkit / RTK Query, Vitest, `@testing-library/react`
+
+---
+
+### Task 1: Add `isFetching` guard to `useEntityWorkspace` hook (with tests)
+
+**Files:**
+- Modify: `frontend/src/hooks/useEntityWorkspace.ts`
+- Modify: `frontend/src/hooks/useEntityWorkspace.test.ts`
+
+- [ ] **Step 1: Write two failing tests**
+
+Open `frontend/src/hooks/useEntityWorkspace.test.ts`. Add these two tests inside the existing `describe('useEntityWorkspace', ...)` block, after the last existing test:
+
+```ts
+it('does not clear selection when entities become empty during a fetch', () => {
+  const config = makeConfig({ isFetching: true, entities: [] })
+
+  renderHook(() => useEntityWorkspace(config))
+
+  // selectEntity should never be called — not to auto-select (empty list)
+  // and not to clear (isFetching guards it)
+  expect(config.selectEntity).not.toHaveBeenCalled()
+})
+
+it('clears selection when entities become empty and not fetching', () => {
+  const config = makeConfig({ isFetching: false, entities: [] })
+
+  renderHook(() => useEntityWorkspace(config))
+
+  expect(config.selectEntity).toHaveBeenCalledWith(null)
+})
+```
+
+- [ ] **Step 2: Run the new tests to confirm they fail**
+
+```bash
+cd frontend && npx vitest run src/hooks/useEntityWorkspace.test.ts
+```
+
+Expected: the two new tests fail (TypeScript error or runtime — `isFetching` not in config type yet).
+
+- [ ] **Step 3: Add `isFetching` to the config interface and guard the effect**
+
+In `frontend/src/hooks/useEntityWorkspace.ts`, make these changes:
+
+**In `UseEntityWorkspaceConfig` interface** — add the optional field after `deleteMutation`:
+
+```ts
+  deleteMutation: (id: string) => Promise<void>
+  isFetching?: boolean
+  onEnter?: () => void
+  onEscape?: () => void
+```
+
+**In the hook body** — destructure it alongside the other config fields:
+
+```ts
+  const {
+    entities,
+    selectedEntity,
+    selectEntity,
+    refetch,
+    navigate,
+    routes,
+    notifications,
+    deleteMutation,
+    isFetching = false,
+    onEnter,
+    onEscape,
+  } = config
+```
+
+**Replace the auto-selection effect** (currently lines 74–86) with:
+
+```ts
+  useEffect(() => {
+    if (entities.length === 0) {
+      if (!isFetching) {
+        hasAutoSelected.current = false
+        setFocusedIndex(-1)
+        selectEntity(null)
+      }
+      return
+    }
+
+    if (!selectedEntity && focusedIndex === -1 && !hasAutoSelected.current) {
+      hasAutoSelected.current = true
+      selectEntity(entities[0])
+    }
+  }, [entities, focusedIndex, isFetching, selectedEntity, selectEntity])
+```
+
+- [ ] **Step 4: Run the tests and confirm all pass**
+
+```bash
+cd frontend && npx vitest run src/hooks/useEntityWorkspace.test.ts
+```
+
+Expected: all tests pass including the 2 new ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/hooks/useEntityWorkspace.ts frontend/src/hooks/useEntityWorkspace.test.ts
+git commit -m "fix: guard useEntityWorkspace selection clear when isFetching (closes part of #444)"
+```
+
+---
+
+### Task 2: Memoize `selectEntity` and pass `isFetching` in `CustomersPage`
+
+**Files:**
+- Modify: `frontend/src/pages/sales/CustomersPage.tsx`
+
+- [ ] **Step 1: Memoize `selectEntity` and pass `isFetching`**
+
+In `CustomersPage.tsx`, `dispatch` is already available. Add a `useCallback`-wrapped `selectEntity` before the `useEntityWorkspace` call, then pass it and `isFetching` into the hook.
+
+Replace the current inline arrow at lines 78–80 and add `isFetching`:
+
+```ts
+  const selectCustomer = useCallback(
+    (customer: Customer | null) => { dispatch(setSelectedCustomer(customer)) },
+    [dispatch],
+  )
+
+  const workspace = useEntityWorkspace({
+    entities: customers,
+    selectedEntity: selectedCustomer,
+    selectEntity: selectCustomer,
+    isFetching,
+    refetch: () => { void refetch() },
+    // ... rest unchanged
+```
+
+The full `useEntityWorkspace` call should become:
+
+```ts
+  const workspace = useEntityWorkspace({
+    entities: customers,
+    selectedEntity: selectedCustomer,
+    selectEntity: selectCustomer,
+    isFetching,
+    refetch: () => {
+      void refetch()
+    },
+    navigate,
+    routes: {
+      create: '/sales/customers/create',
+      edit: (id) => `/sales/customers/${id}/edit`,
+    },
+    notifications: {
+      showSuccess,
+      showError: (message) => {
+        setPageError(message)
+        showError(message)
+      },
+    },
+    deleteMutation: (id) => deleteCustomer(id).unwrap(),
+  })
+```
+
+Also add `Customer` to the imports from `@/types` if it is not already imported. Check the top of the file — it is imported via the slice types indirectly; add it explicitly:
+
+```ts
+import type { Customer } from '@/types'
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd frontend && npm run type-check 2>&1 | grep CustomersPage
+```
+
+Expected: no errors for this file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/sales/CustomersPage.tsx
+git commit -m "fix: memoize selectEntity and pass isFetching in CustomersPage (#444)"
+```
+
+---
+
+### Task 3: Memoize `selectEntity` and pass `isFetching` in `SuppliersPage`
+
+**Files:**
+- Modify: `frontend/src/pages/purchasing/SuppliersPage.tsx`
+
+- [ ] **Step 1: Read the relevant section of SuppliersPage**
+
+The file already imports `useCallback` (line 1) and has `isFetching` from `useGetSuppliersQuery` (line 68). Find the `useEntityWorkspace` call (starts around line 72).
+
+- [ ] **Step 2: Add memoized `selectEntity` and pass `isFetching`**
+
+Add before the `useEntityWorkspace` call (after `const suppliers = suppliersResponse?.data ?? []`):
+
+```ts
+  const selectSupplier = useCallback(
+    (supplier: Supplier | null) => { dispatch(setSelectedSupplier(supplier)) },
+    [dispatch],
+  )
+```
+
+Then in the `useEntityWorkspace` call, replace the inline arrow with `selectSupplier` and add `isFetching`:
+
+```ts
+    entities: suppliers,
+    selectedEntity: selectedSupplier,
+    selectEntity: selectSupplier,
+    isFetching,
+```
+
+Check that `Supplier` type is imported from `@/types` at the top of the file. Add if missing.
+
+- [ ] **Step 3: Type-check**
+
+```bash
+cd frontend && npm run type-check 2>&1 | grep SuppliersPage
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/purchasing/SuppliersPage.tsx
+git commit -m "fix: memoize selectEntity and pass isFetching in SuppliersPage (#444)"
+```
+
+---
+
+### Task 4: Memoize `selectEntity` in `useVendorPaymentsWorkspace` and `useGRNWorkspace`
+
+**Files:**
+- Modify: `frontend/src/pages/purchasing/hooks/useVendorPaymentsWorkspace.ts`
+- Modify: `frontend/src/pages/purchasing/hooks/useGRNWorkspace.ts`
+
+Neither file has access to `isFetching` — only the `useCallback` fix applies.
+
+- [ ] **Step 1: Fix `useVendorPaymentsWorkspace`**
+
+The file imports `{ useEffect, useRef, useState }` from `'react'` (line 1). Add `useCallback` to that import:
+
+```ts
+import { useCallback, useEffect, useRef, useState } from 'react'
+```
+
+`dispatch` is already available (received as a prop). Add a memoized callback before `useEntityWorkspace`:
+
+```ts
+  const selectPayment = useCallback(
+    (payment: VendorPayment | null) => dispatch(setSelectedVendorPayment(payment)),
+    [dispatch],
+  )
+```
+
+Then in `useEntityWorkspace`, replace `selectEntity: (payment) => dispatch(setSelectedVendorPayment(payment))` with:
+
+```ts
+    selectEntity: selectPayment,
+```
+
+- [ ] **Step 2: Fix `useGRNWorkspace`**
+
+Same pattern. Add `useCallback` to the import:
+
+```ts
+import { useCallback, useEffect, useRef, useState } from 'react'
+```
+
+Add before `useEntityWorkspace`:
+
+```ts
+  const selectGRN = useCallback(
+    (grn: GoodsReceivedNote | null) => dispatch(setSelectedGRN(grn)),
+    [dispatch],
+  )
+```
+
+Replace in `useEntityWorkspace`:
+
+```ts
+    selectEntity: selectGRN,
+```
+
+- [ ] **Step 3: Type-check both files**
+
+```bash
+cd frontend && npm run type-check 2>&1 | grep -E "useVendorPayments|useGRN"
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/purchasing/hooks/useVendorPaymentsWorkspace.ts \
+        frontend/src/pages/purchasing/hooks/useGRNWorkspace.ts
+git commit -m "fix: memoize selectEntity in purchasing workspace hooks (#444)"
+```
+
+---
+
+### Task 5: Memoize `selectEntity` in inventory workspace hooks
+
+**Files:**
+- Modify: `frontend/src/pages/inventory/hooks/useProductsWorkspace.ts`
+- Modify: `frontend/src/pages/inventory/hooks/useStockAdjustmentsWorkspace.ts`
+- Modify: `frontend/src/pages/inventory/hooks/useCategoriesWorkspace.ts`
+
+All three already import `useCallback`. Only add the memoized variable and swap the inline arrow.
+
+- [ ] **Step 1: Fix `useProductsWorkspace`**
+
+Add before `useEntityWorkspace`:
+
+```ts
+  const selectProduct = useCallback(
+    (product: Product | null) => dispatch(setSelectedProduct(product)),
+    [dispatch],
+  )
+```
+
+Replace `selectEntity: (product) => dispatch(setSelectedProduct(product))` with:
+
+```ts
+    selectEntity: selectProduct,
+```
+
+- [ ] **Step 2: Fix `useStockAdjustmentsWorkspace`**
+
+Add before `useEntityWorkspace`:
+
+```ts
+  const selectAdjustment = useCallback(
+    (adjustment: StockAdjustment | null) => dispatch(setSelectedStockAdjustment(adjustment)),
+    [dispatch],
+  )
+```
+
+Replace `selectEntity: (adjustment) => dispatch(setSelectedStockAdjustment(adjustment))` with:
+
+```ts
+    selectEntity: selectAdjustment,
+```
+
+Check the entity type name by looking at the `entities:` line and existing imports — the type is whatever `adjustments` array items are.
+
+- [ ] **Step 3: Fix `useCategoriesWorkspace`**
+
+Add before `useEntityWorkspace`:
+
+```ts
+  const selectCategory = useCallback(
+    (category: Category | null) => dispatch(setSelectedCategory(category)),
+    [dispatch],
+  )
+```
+
+Replace `selectEntity: (category) => dispatch(setSelectedCategory(category))` with:
+
+```ts
+    selectEntity: selectCategory,
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd frontend && npm run type-check 2>&1 | grep -E "useProducts|useStockAdj|useCategories"
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/inventory/hooks/useProductsWorkspace.ts \
+        frontend/src/pages/inventory/hooks/useStockAdjustmentsWorkspace.ts \
+        frontend/src/pages/inventory/hooks/useCategoriesWorkspace.ts
+git commit -m "fix: memoize selectEntity in inventory workspace hooks (#444)"
+```
+
+---
+
+### Task 6: Memoize `selectEntity` in sales workspace hooks
+
+**Files:**
+- Modify: `frontend/src/pages/sales/hooks/useInvoicesWorkspace.ts`
+- Modify: `frontend/src/pages/sales/hooks/useOrdersWorkspace.ts`
+- Modify: `frontend/src/pages/sales/hooks/usePaymentsWorkspace.ts`
+
+`useOrdersWorkspace` and `usePaymentsWorkspace` already import `useCallback`. `useInvoicesWorkspace` does not — add it.
+
+- [ ] **Step 1: Fix `useInvoicesWorkspace`**
+
+Add `useCallback` to the React import (line 1):
+
+```ts
+import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react'
+```
+
+Add before `useEntityWorkspace`:
+
+```ts
+  const selectInvoice = useCallback(
+    (invoice: InvoiceItem | null) => dispatch(setSelectedInvoice(invoice as any)),
+    [dispatch],
+  )
+```
+
+Replace `selectEntity: (invoice) => dispatch(setSelectedInvoice(invoice as any))` with:
+
+```ts
+    selectEntity: selectInvoice,
+```
+
+- [ ] **Step 2: Fix `useOrdersWorkspace`**
+
+`useCallback` already imported. Add before `useEntityWorkspace`:
+
+```ts
+  const selectOrder = useCallback(
+    (order: SalesOrder | null) => dispatch(setSelectedOrder(order)),
+    [dispatch],
+  )
+```
+
+Replace `selectEntity: (order) => dispatch(setSelectedOrder(order))` with:
+
+```ts
+    selectEntity: selectOrder,
+```
+
+- [ ] **Step 3: Fix `usePaymentsWorkspace`**
+
+`useCallback` already imported. Add before `useEntityWorkspace`:
+
+```ts
+  const selectPayment = useCallback(
+    (payment: PaymentListItem | null) => dispatch(setSelectedPayment(payment as any)),
+    [dispatch],
+  )
+```
+
+Replace `selectEntity: (payment) => dispatch(setSelectedPayment(payment as any))` with:
+
+```ts
+    selectEntity: selectPayment,
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd frontend && npm run type-check 2>&1 | grep -E "useInvoices|useOrders|usePayments"
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/sales/hooks/useInvoicesWorkspace.ts \
+        frontend/src/pages/sales/hooks/useOrdersWorkspace.ts \
+        frontend/src/pages/sales/hooks/usePaymentsWorkspace.ts
+git commit -m "fix: memoize selectEntity in sales workspace hooks (#444)"
+```
+
+---
+
+### Task 7: Memoize `selectEntity` in accounting workspace hooks
+
+**Files:**
+- Modify: `frontend/src/pages/accounting/hooks/useChartOfAccountsWorkspace.ts`
+- Modify: `frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts`
+
+Both already import `useCallback`.
+
+- [ ] **Step 1: Fix `useChartOfAccountsWorkspace`**
+
+Add before `useEntityWorkspace`:
+
+```ts
+  const selectAccount = useCallback(
+    (account: ChartOfAccount | null) => dispatch(setSelectedAccount(account)),
+    [dispatch],
+  )
+```
+
+Replace `selectEntity: (account) => dispatch(setSelectedAccount(account))` with:
+
+```ts
+    selectEntity: selectAccount,
+```
+
+- [ ] **Step 2: Fix `useJournalEntriesWorkspace`**
+
+`useJournalEntriesWorkspace` uses a custom `selectAndLoadEntry` flow — the inline `selectEntity` passed to `useEntityWorkspace` is at line 68. Add before `useEntityWorkspace`:
+
+```ts
+  const selectEntry = useCallback(
+    (entry: JournalEntry | null) => {
+      dispatch(setSelectedJournalEntry(entry))
+    },
+    [dispatch],
+  )
+```
+
+Replace the inline arrow `selectEntity: (entry) => { dispatch(setSelectedJournalEntry(entry)) }` with:
+
+```ts
+    selectEntity: selectEntry,
+```
+
+- [ ] **Step 3: Type-check**
+
+```bash
+cd frontend && npm run type-check 2>&1 | grep -E "useChartOfAccounts|useJournalEntries"
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/accounting/hooks/useChartOfAccountsWorkspace.ts \
+        frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
+git commit -m "fix: memoize selectEntity in accounting workspace hooks (#444)"
+```
+
+---
+
+### Task 8: Full type-check and test run
+
+**Files:** none modified
+
+- [ ] **Step 1: Full TypeScript check**
+
+```bash
+cd frontend && npm run type-check
+```
+
+Expected: zero errors.
+
+- [ ] **Step 2: Run the hook test file**
+
+```bash
+cd frontend && npx vitest run src/hooks/useEntityWorkspace.test.ts
+```
+
+Expected: all tests pass (12 tests including the 2 new ones from Task 1).
+
+- [ ] **Step 3: Open a PR**
+
+```bash
+gh pr create \
+  --title "fix: entity workspace selection reset on row click (#444)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds `isFetching?: boolean` to `useEntityWorkspace` config — skips clearing selection when entities array is transiently empty during a background RTK Query refetch
+- Wraps every inline `selectEntity` arrow passed to `useEntityWorkspace` in `useCallback` across all 10 consumers, eliminating the spurious effect re-runs caused by unstable function references
+
+Closes #444
+
+## Test plan
+
+- [ ] New unit tests in `useEntityWorkspace.test.ts` cover both the `isFetching` guard and the stable-reference expectation
+- [ ] `npm run type-check` passes with zero errors
+- [ ] Manual: navigate to `/sales/customers`, click different customers — header and workspace card update reliably every time
+- [ ] Manual: same check on Suppliers, Products, Sales Orders pages
+
+🤖 Generated with [Claude Code](https://claude.ai/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-04-25-issue-434-sales-scroll-sortorder.md
+++ b/docs/superpowers/plans/2026-04-25-issue-434-sales-scroll-sortorder.md
@@ -1,0 +1,246 @@
+# Issue #434: Sales Page Scroll + sortOrder Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two bugs on the Sales overview page — missing scroll and a 500 error caused by lowercase `sortOrder` in the API call.
+
+**Architecture:** Three targeted changes across two files: add `useLayoutScroll(true)` to `SalesPage`, uppercase the `sortOrder` param in the `fetchRecentOrders` call, and add a `@Transform` to `BaseQueryDto.sortOrder` to normalize case before validation.
+
+**Tech Stack:** React 19, NestJS 11, class-validator, class-transformer, Vitest (frontend tests), Jest (backend tests)
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `frontend/src/pages/sales/SalesPage.tsx` | Add `useLayoutScroll(true)` hook call; fix `sortOrder: 'desc'` → `'DESC'` |
+| `backend/src/common/dto/base-query.dto.ts` | Add `@Transform` to normalize `sortOrder` to uppercase |
+
+---
+
+### Task 1: Fix scroll on SalesPage
+
+**Files:**
+- Modify: `frontend/src/pages/sales/SalesPage.tsx`
+
+- [ ] **Step 1: Add the import**
+
+In `frontend/src/pages/sales/SalesPage.tsx`, add `useLayoutScroll` to the imports. The existing import block ends at line 35. Add after line 35:
+
+```ts
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
+```
+
+- [ ] **Step 2: Call the hook**
+
+In `SalesPage.tsx`, the component function starts at line 37:
+
+```ts
+const SalesPage: React.FC = () => {
+  const navigate = useNavigate()
+```
+
+Add `useLayoutScroll(true)` as the first line of the component body:
+
+```ts
+const SalesPage: React.FC = () => {
+  useLayoutScroll(true)
+  const navigate = useNavigate()
+```
+
+- [ ] **Step 3: Verify type-check passes**
+
+```bash
+cd frontend && npm run type-check
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/sales/SalesPage.tsx
+git commit -m "fix: enable scroll on SalesPage (closes #434 scroll)"
+```
+
+---
+
+### Task 2: Fix sortOrder case in fetchRecentOrders
+
+**Files:**
+- Modify: `frontend/src/pages/sales/SalesPage.tsx`
+
+- [ ] **Step 1: Fix the typo**
+
+In `frontend/src/pages/sales/SalesPage.tsx` at line 114, change `sortOrder: 'desc'` to `sortOrder: 'DESC'`:
+
+Before:
+```ts
+params: { limit: 5, sortBy: 'orderDate', sortOrder: 'desc' },
+```
+
+After:
+```ts
+params: { limit: 5, sortBy: 'orderDate', sortOrder: 'DESC' },
+```
+
+- [ ] **Step 2: Verify type-check passes**
+
+```bash
+cd frontend && npm run type-check
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Run the existing SalesPage test**
+
+```bash
+cd frontend && npx vitest run src/pages/sales/__tests__/SalesPage.filters.test.tsx
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/sales/SalesPage.tsx
+git commit -m "fix: use uppercase DESC in fetchRecentOrders (closes #434 500)"
+```
+
+---
+
+### Task 3: Harden BaseQueryDto — normalize sortOrder to uppercase
+
+**Files:**
+- Modify: `backend/src/common/dto/base-query.dto.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/src/common/dto/base-query.dto.spec.ts` with this content:
+
+```ts
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { BaseQueryDto } from './base-query.dto';
+
+describe('BaseQueryDto', () => {
+  it('accepts uppercase ASC', async () => {
+    const dto = plainToInstance(BaseQueryDto, { sortOrder: 'ASC' });
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+    expect(dto.sortOrder).toBe('ASC');
+  });
+
+  it('accepts uppercase DESC', async () => {
+    const dto = plainToInstance(BaseQueryDto, { sortOrder: 'DESC' });
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+    expect(dto.sortOrder).toBe('DESC');
+  });
+
+  it('normalizes lowercase asc to ASC', async () => {
+    const dto = plainToInstance(BaseQueryDto, { sortOrder: 'asc' });
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+    expect(dto.sortOrder).toBe('ASC');
+  });
+
+  it('normalizes lowercase desc to DESC', async () => {
+    const dto = plainToInstance(BaseQueryDto, { sortOrder: 'desc' });
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+    expect(dto.sortOrder).toBe('DESC');
+  });
+
+  it('rejects invalid sortOrder values', async () => {
+    const dto = plainToInstance(BaseQueryDto, { sortOrder: 'INVALID' });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('accepts omitted sortOrder', async () => {
+    const dto = plainToInstance(BaseQueryDto, {});
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd backend && npx jest src/common/dto/base-query.dto.spec.ts --no-coverage
+```
+
+Expected: the `normalizes lowercase asc` and `normalizes lowercase desc` tests FAIL (sortOrder is not normalized yet).
+
+- [ ] **Step 3: Add the @Transform to BaseQueryDto**
+
+In `backend/src/common/dto/base-query.dto.ts`, update the `sortOrder` field (currently lines 19–25):
+
+Before:
+```ts
+  @IsOptional()
+  @IsIn(['ASC', 'DESC'])
+  sortOrder?: 'ASC' | 'DESC';
+```
+
+After:
+```ts
+  @IsOptional()
+  @Transform(({ value }) => value?.toUpperCase())
+  @IsIn(['ASC', 'DESC'])
+  sortOrder?: 'ASC' | 'DESC';
+```
+
+`Transform` is already imported from `class-transformer` at line 1.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd backend && npx jest src/common/dto/base-query.dto.spec.ts --no-coverage
+```
+
+Expected: all 6 tests pass.
+
+- [ ] **Step 5: Run broader backend tests to check for regressions**
+
+```bash
+cd backend && npm run test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/common/dto/base-query.dto.ts backend/src/common/dto/base-query.dto.spec.ts
+git commit -m "fix: normalize sortOrder to uppercase in BaseQueryDto"
+```
+
+---
+
+### Task 4: Open PR closing issue #434
+
+- [ ] **Step 1: Push and open PR**
+
+```bash
+gh pr create --title "fix: sales page scroll and sortOrder 500 (closes #434)" --body "$(cat <<'EOF'
+## Summary
+- Enables scroll on the Sales overview page via `useLayoutScroll(true)`
+- Fixes 500 error by correcting `sortOrder: 'desc'` → `'DESC'` in `fetchRecentOrders`
+- Hardens `BaseQueryDto` to normalize `sortOrder` to uppercase before validation, preventing recurrence
+
+## Test plan
+- [ ] Navigate to `/sales` — content below the fold should be scrollable
+- [ ] No 500 in browser console on page load
+- [ ] Backend tests pass: `cd backend && npm run test`
+- [ ] Frontend type-check passes: `cd frontend && npm run type-check`
+
+Closes #434
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-04-25-issue-439-inventory-accounting-scroll-fix.md
+++ b/docs/superpowers/plans/2026-04-25-issue-439-inventory-accounting-scroll-fix.md
@@ -1,0 +1,212 @@
+# Issue #439 — Inventory & Accounting Dashboard Scroll Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable page-level scrolling on `InventoryPage` and `AccountingDashboardPage` by opting them into the existing `LayoutScrollContext` mechanism.
+
+**Architecture:** `MainLayout` already reads `LayoutScrollContext` and sets `overflow: auto` when the value is `true`. Pages opt in by calling `useLayoutScroll(true)` inside the component. `DashboardPage`, `SalesPage`, and `PurchasingPage` already use this pattern — this plan applies the same two-line change to the two missing pages.
+
+**Tech Stack:** React 19, TypeScript, Vitest, `@testing-library/react`
+
+---
+
+## File Map
+
+| Action | File |
+|--------|------|
+| Modify | `frontend/src/pages/inventory/InventoryPage.tsx` |
+| Modify | `frontend/src/pages/inventory/__tests__/InventoryPage.filters.test.tsx` |
+| Modify | `frontend/src/pages/accounting/AccountingDashboardPage.tsx` |
+| Modify | `frontend/src/pages/accounting/__tests__/AccountingDashboardPage.test.tsx` |
+
+---
+
+### Task 1: Enable scroll on InventoryPage
+
+**Files:**
+- Modify: `frontend/src/pages/inventory/InventoryPage.tsx`
+- Modify: `frontend/src/pages/inventory/__tests__/InventoryPage.filters.test.tsx`
+
+- [ ] **Step 1: Add the failing scroll assertion to the test**
+
+Open `frontend/src/pages/inventory/__tests__/InventoryPage.filters.test.tsx`.
+
+After the existing imports block (line 6, after `import InventoryPage from '../InventoryPage'`), add:
+
+```ts
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
+```
+
+After the existing `vi.mock` blocks, add:
+
+```ts
+vi.mock('@/contexts/LayoutScrollContext', () => ({
+  useLayoutScroll: vi.fn(),
+}))
+```
+
+Then, inside the existing `describe('InventoryPage filters', ...)` block, add a new `it` block. Place it after the existing `beforeEach` and before (or after) other `it` blocks:
+
+```ts
+it('enables layout scroll', () => {
+  render(
+    <MemoryRouter initialEntries={['/']}>
+      <InventoryPage />
+    </MemoryRouter>,
+  )
+  expect(useLayoutScroll).toHaveBeenCalledWith(true)
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd frontend && npx vitest run src/pages/inventory/__tests__/InventoryPage.filters.test.tsx --reporter=verbose 2>&1 | tail -30
+```
+
+Expected: FAIL — `useLayoutScroll` was not called (it is not yet imported or called in `InventoryPage.tsx`).
+
+- [ ] **Step 3: Add the import to InventoryPage**
+
+Open `frontend/src/pages/inventory/InventoryPage.tsx`. After the last `import` line (line 49, `import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'`), add:
+
+```ts
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
+```
+
+- [ ] **Step 4: Call the hook inside the component**
+
+In `frontend/src/pages/inventory/InventoryPage.tsx`, find the `InventoryPage` component body (line 71: `const InventoryPage: React.FC = () => {`). Add the hook call as the first line inside the component, after the opening brace:
+
+```ts
+const InventoryPage: React.FC = () => {
+  useLayoutScroll(true)
+  const theme = useTheme()
+  // ... rest unchanged
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+cd frontend && npx vitest run src/pages/inventory/__tests__/InventoryPage.filters.test.tsx --reporter=verbose 2>&1 | tail -20
+```
+
+Expected: PASS — all tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/inventory/InventoryPage.tsx \
+        frontend/src/pages/inventory/__tests__/InventoryPage.filters.test.tsx
+git commit -m "fix: enable scroll on Inventory Overview page (closes #439 partially)"
+```
+
+---
+
+### Task 2: Enable scroll on AccountingDashboardPage
+
+**Files:**
+- Modify: `frontend/src/pages/accounting/AccountingDashboardPage.tsx`
+- Modify: `frontend/src/pages/accounting/__tests__/AccountingDashboardPage.test.tsx`
+
+- [ ] **Step 1: Add the failing scroll assertion to the test**
+
+Open `frontend/src/pages/accounting/__tests__/AccountingDashboardPage.test.tsx`.
+
+After the existing imports block (after all existing `import` lines near the top), add:
+
+```ts
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
+```
+
+After the existing `vi.mock` blocks, add:
+
+```ts
+vi.mock('@/contexts/LayoutScrollContext', () => ({
+  useLayoutScroll: vi.fn(),
+}))
+```
+
+Then add a new `describe` block at the bottom of the file (outside any existing `describe`):
+
+```ts
+describe('AccountingDashboardPage scroll', () => {
+  it('enables layout scroll', () => {
+    renderWithProviders()
+    expect(useLayoutScroll).toHaveBeenCalledWith(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd frontend && npx vitest run src/pages/accounting/__tests__/AccountingDashboardPage.test.tsx --reporter=verbose 2>&1 | tail -30
+```
+
+Expected: FAIL — `useLayoutScroll` was not called.
+
+- [ ] **Step 3: Add the import to AccountingDashboardPage**
+
+Open `frontend/src/pages/accounting/AccountingDashboardPage.tsx`. After the last `import` line (line 41, `import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter';`), add:
+
+```ts
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
+```
+
+- [ ] **Step 4: Call the hook inside the component**
+
+In `frontend/src/pages/accounting/AccountingDashboardPage.tsx`, find the `AccountingDashboardPage` component body (line 160: `const AccountingDashboardPage: React.FC = () => {`). Add the hook call as the first line inside the component:
+
+```ts
+const AccountingDashboardPage: React.FC = () => {
+  useLayoutScroll(true)
+  const navigate = useNavigate();
+  // ... rest unchanged
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+cd frontend && npx vitest run src/pages/accounting/__tests__/AccountingDashboardPage.test.tsx --reporter=verbose 2>&1 | tail -20
+```
+
+Expected: PASS — all tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/accounting/AccountingDashboardPage.tsx \
+        frontend/src/pages/accounting/__tests__/AccountingDashboardPage.test.tsx
+git commit -m "fix: enable scroll on Accounting Dashboard page (closes #439)"
+```
+
+---
+
+### Task 3: Open PR
+
+- [ ] **Step 1: Push branch and open PR**
+
+```bash
+git push origin main
+gh pr create \
+  --title "fix: enable scroll on Inventory and Accounting Dashboard pages" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds \`useLayoutScroll(true)\` to \`InventoryPage\` and \`AccountingDashboardPage\`
+- Follows the identical pattern already used by Dashboard, Sales, and Purchasing overview pages
+- Adds scroll assertion tests to both pages' test files
+
+Closes #439
+
+## Test plan
+- [ ] Run \`npx vitest run src/pages/inventory/__tests__/InventoryPage.filters.test.tsx\` — all pass
+- [ ] Run \`npx vitest run src/pages/accounting/__tests__/AccountingDashboardPage.test.tsx\` — all pass
+- [ ] Navigate to \`/inventory\` — content scrolls
+- [ ] Navigate to \`/accounting\` — content scrolls
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-04-25-per-page-scroll-control.md
+++ b/docs/superpowers/plans/2026-04-25-per-page-scroll-control.md
@@ -1,0 +1,312 @@
+# Per-Page Scroll Control Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix dashboard scrolling (issue #432) by introducing a `useLayoutScroll` hook that lets pages opt in to scrolling, with all pages defaulting to no-scroll.
+
+**Architecture:** A `LayoutScrollContext` holds a boolean `scrollEnabled` state. `MainLayout` wraps `<Outlet>` with the provider and reads the value to toggle `overflow` on the `<main>` box. Pages call `useLayoutScroll(true)` to opt in; the hook resets to `false` on unmount so scroll never leaks between routes.
+
+**Tech Stack:** React 19, MUI v7, React Router v6, Vitest
+
+---
+
+## File Map
+
+- Create: `frontend/src/contexts/LayoutScrollContext.tsx` — context, provider, two hooks
+- Modify: `frontend/src/components/common/MainLayout.tsx` — wrap Outlet, consume context
+- Modify: `frontend/src/pages/dashboard/DashboardPage.tsx` — call `useLayoutScroll(true)`
+
+---
+
+### Task 1: Create LayoutScrollContext
+
+**Files:**
+- Create: `frontend/src/contexts/LayoutScrollContext.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/contexts/LayoutScrollContext.test.tsx`:
+
+```tsx
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { LayoutScrollProvider, useLayoutScroll, useLayoutScrollContext } from './LayoutScrollContext'
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <LayoutScrollProvider>{children}</LayoutScrollProvider>
+)
+
+describe('LayoutScrollContext', () => {
+  it('defaults to scrollEnabled = false', () => {
+    const { result } = renderHook(() => useLayoutScrollContext(), { wrapper })
+    expect(result.current).toBe(false)
+  })
+
+  it('useLayoutScroll(true) enables scroll on mount', () => {
+    const { result } = renderHook(() => {
+      useLayoutScroll(true)
+      return useLayoutScrollContext()
+    }, { wrapper })
+    expect(result.current).toBe(true)
+  })
+
+  it('useLayoutScroll resets to false on unmount', () => {
+    const { result, unmount } = renderHook(() => {
+      useLayoutScroll(true)
+      return useLayoutScrollContext()
+    }, { wrapper })
+    expect(result.current).toBe(true)
+    unmount()
+    // After unmount, a new consumer sees the reset default
+    const { result: result2 } = renderHook(() => useLayoutScrollContext(), { wrapper })
+    expect(result2.current).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd frontend && npx vitest run src/contexts/LayoutScrollContext.test.tsx
+```
+
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement the context**
+
+Create `frontend/src/contexts/LayoutScrollContext.tsx`:
+
+```tsx
+import React, { createContext, useContext, useEffect, useState } from 'react'
+
+const LayoutScrollContext = createContext<boolean>(false)
+const LayoutScrollSetContext = createContext<React.Dispatch<React.SetStateAction<boolean>>>(() => {})
+
+export const LayoutScrollProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [scrollEnabled, setScrollEnabled] = useState(false)
+  return (
+    <LayoutScrollContext.Provider value={scrollEnabled}>
+      <LayoutScrollSetContext.Provider value={setScrollEnabled}>
+        {children}
+      </LayoutScrollSetContext.Provider>
+    </LayoutScrollContext.Provider>
+  )
+}
+
+export const useLayoutScrollContext = () => useContext(LayoutScrollContext)
+
+export const useLayoutScroll = (enabled: boolean) => {
+  const setScrollEnabled = useContext(LayoutScrollSetContext)
+  useEffect(() => {
+    setScrollEnabled(enabled)
+    return () => setScrollEnabled(false)
+  }, [enabled, setScrollEnabled])
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd frontend && npx vitest run src/contexts/LayoutScrollContext.test.tsx
+```
+
+Expected: 3 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/contexts/LayoutScrollContext.tsx frontend/src/contexts/LayoutScrollContext.test.tsx
+git commit -m "feat: add LayoutScrollContext for per-page scroll control"
+```
+
+---
+
+### Task 2: Wire context into MainLayout
+
+**Files:**
+- Modify: `frontend/src/components/common/MainLayout.tsx`
+
+- [ ] **Step 1: Update MainLayout**
+
+In `frontend/src/components/common/MainLayout.tsx`, add the import at the top with other imports:
+
+```tsx
+import { LayoutScrollProvider, useLayoutScrollContext } from '@/contexts/LayoutScrollContext'
+```
+
+Extract the inner content into a child component so the hook can consume the context that wraps it. Replace the entire file content with:
+
+```tsx
+import React, { useEffect, useState } from 'react'
+import { Outlet, useLocation } from 'react-router-dom'
+import { Box, Drawer } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+
+import { DRAWER_WIDTH_COLLAPSED, DRAWER_WIDTH_EXPANDED } from '@/constants/layout'
+import { LayoutScrollProvider, useLayoutScrollContext } from '@/contexts/LayoutScrollContext'
+
+import Sidebar from './Sidebar'
+import TopBar from './TopBar'
+
+const MainContent: React.FC = () => {
+  const scrollEnabled = useLayoutScrollContext()
+  return (
+    <Box
+      component="main"
+      sx={{
+        flexGrow: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        pt: 11,
+        px: { xs: 2, sm: 3 },
+        pb: 3,
+        bgcolor: 'background.default',
+        height: '100%',
+        overflow: scrollEnabled ? 'auto' : 'hidden',
+        maxWidth: '100%',
+      }}
+    >
+      <Outlet />
+    </Box>
+  )
+}
+
+const MainLayout: React.FC = () => {
+  const theme = useTheme()
+  const location = useLocation()
+  const [mobileOpen, setMobileOpen] = useState(false)
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false
+    return localStorage.getItem('sidebar-collapsed') === 'true'
+  })
+
+  useEffect(() => {
+    setMobileOpen(false)
+  }, [location.pathname])
+
+  const handleDrawerToggle = () => {
+    setMobileOpen(open => !open)
+  }
+
+  const handleToggleCollapse = () => {
+    setCollapsed(current => {
+      const next = !current
+      localStorage.setItem('sidebar-collapsed', String(next))
+      return next
+    })
+  }
+
+  return (
+    <Box sx={{ display: 'flex', minHeight: '100vh', height: '100vh' }}>
+      <TopBar collapsed={collapsed} onMobileMenuOpen={handleDrawerToggle} />
+
+      <Box
+        component="nav"
+        sx={{
+          width: { lg: collapsed ? DRAWER_WIDTH_COLLAPSED : DRAWER_WIDTH_EXPANDED },
+          flexShrink: { lg: 0 },
+        }}
+      >
+        <Drawer
+          key={location.pathname}
+          variant="temporary"
+          open={mobileOpen}
+          onClose={handleDrawerToggle}
+          ModalProps={{ keepMounted: false }}
+          sx={{
+            display: { xs: 'block', lg: 'none' },
+            '& .MuiDrawer-paper': {
+              boxSizing: 'border-box',
+              width: DRAWER_WIDTH_EXPANDED,
+            },
+          }}
+        >
+          <Sidebar collapsed={false} onItemClick={handleDrawerToggle} />
+        </Drawer>
+
+        <Drawer
+          variant="permanent"
+          sx={{
+            display: { xs: 'none', lg: 'block' },
+            '& .MuiDrawer-paper': {
+              bgcolor: theme.palette.background.default,
+              boxSizing: 'border-box',
+              width: collapsed ? DRAWER_WIDTH_COLLAPSED : DRAWER_WIDTH_EXPANDED,
+              transition: 'width 0.22s ease',
+              overflowX: 'hidden',
+            },
+          }}
+          open
+        >
+          <Sidebar collapsed={collapsed} onToggleCollapse={handleToggleCollapse} />
+        </Drawer>
+      </Box>
+
+      <LayoutScrollProvider>
+        <MainContent />
+      </LayoutScrollProvider>
+    </Box>
+  )
+}
+
+export default MainLayout
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd frontend && npm run type-check
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/common/MainLayout.tsx
+git commit -m "feat: wire LayoutScrollContext into MainLayout"
+```
+
+---
+
+### Task 3: Enable scroll on DashboardPage
+
+**Files:**
+- Modify: `frontend/src/pages/dashboard/DashboardPage.tsx`
+
+- [ ] **Step 1: Add the hook call**
+
+In `frontend/src/pages/dashboard/DashboardPage.tsx`, add the import after the existing imports:
+
+```tsx
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
+```
+
+Then at the top of the `DashboardPage` component body (before any other logic), add:
+
+```tsx
+useLayoutScroll(true)
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd frontend && npm run type-check
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Run existing Dashboard tests**
+
+```bash
+cd frontend && npx vitest run src/pages/dashboard/DashboardPage.test.tsx
+```
+
+Expected: all tests PASS (the hook is a side-effect-only call; tests mock context or won't break)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/dashboard/DashboardPage.tsx
+git commit -m "feat: enable scroll on DashboardPage (fixes #432)"
+```

--- a/docs/superpowers/plans/2026-04-25-websocket-stability-fix.md
+++ b/docs/superpowers/plans/2026-04-25-websocket-stability-fix.md
@@ -1,0 +1,432 @@
+# WebSocket Stability Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix intermittent "transport close" WebSocket disconnections and suppress noisy reconnect toasts for sub-5-second blips.
+
+**Architecture:** Add a root-namespace NestJS WebSocket gateway with explicit heartbeat config; patch the NGINX `/socket.io/` location to disable keepalive connection recycling; add a disconnect timestamp ref in `useWebSocket.tsx` to gate the reconnect toast.
+
+**Tech Stack:** NestJS 11 + `@nestjs/websockets` ^11 + `socket.io` ^4.8, React 19 + `socket.io-client` ^4.7, NGINX
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `backend/src/modules/dashboard/gateways/app-websocket-gateway.ts` | Create | Root namespace (`/`) gateway with heartbeat config |
+| `backend/src/modules/dashboard/dashboard-module.ts` | Modify | Register `AppWebSocketGateway` as provider |
+| `nginx/nginx.conf` | Modify | Add `keepalive_requests 0` to `/socket.io/` location |
+| `frontend/src/hooks/useWebSocket.tsx` | Modify | Add `disconnectTimeRef`, debounce reconnect toast |
+
+---
+
+## Task 1: Create root namespace gateway with heartbeat config
+
+The frontend `WebSocketProvider` connects to the root namespace (`/`) but no NestJS gateway is registered there — only on `dashboard`. This task adds the missing gateway with correct `pingTimeout`.
+
+**Files:**
+- Create: `backend/src/modules/dashboard/gateways/app-websocket-gateway.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/src/modules/dashboard/gateways/app-websocket-gateway.spec.ts`:
+
+```typescript
+import { AppWebSocketGateway } from './app-websocket-gateway';
+
+describe('AppWebSocketGateway', () => {
+  let gateway: AppWebSocketGateway;
+
+  beforeEach(() => {
+    gateway = new AppWebSocketGateway();
+  });
+
+  it('should be defined', () => {
+    expect(gateway).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd backend && npx jest src/modules/dashboard/gateways/app-websocket-gateway.spec.ts --no-coverage
+```
+
+Expected: FAIL — `Cannot find module './app-websocket-gateway'`
+
+- [ ] **Step 3: Create the gateway**
+
+Create `backend/src/modules/dashboard/gateways/app-websocket-gateway.ts`:
+
+```typescript
+import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+import { Server } from 'socket.io';
+
+@WebSocketGateway({
+  cors: {
+    origin: '*',
+    methods: ['GET', 'POST'],
+  },
+  pingInterval: 25000,
+  pingTimeout: 60000,
+})
+export class AppWebSocketGateway {
+  @WebSocketServer()
+  server: Server;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd backend && npx jest src/modules/dashboard/gateways/app-websocket-gateway.spec.ts --no-coverage
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd backend && git add src/modules/dashboard/gateways/app-websocket-gateway.ts src/modules/dashboard/gateways/app-websocket-gateway.spec.ts
+git commit -m "feat(websocket): add root namespace gateway with heartbeat config"
+```
+
+---
+
+## Task 2: Register the new gateway in DashboardModule
+
+**Files:**
+- Modify: `backend/src/modules/dashboard/dashboard-module.ts`
+
+- [ ] **Step 1: Add `AppWebSocketGateway` to providers**
+
+Edit `backend/src/modules/dashboard/dashboard-module.ts`. Change:
+
+```typescript
+import { DashboardWebSocketGateway } from './gateways/dashboard-websocket-gateway';
+```
+
+to:
+
+```typescript
+import { DashboardWebSocketGateway } from './gateways/dashboard-websocket-gateway';
+import { AppWebSocketGateway } from './gateways/app-websocket-gateway';
+```
+
+And change:
+
+```typescript
+  providers: [DashboardService, DashboardWebSocketGateway],
+```
+
+to:
+
+```typescript
+  providers: [DashboardService, DashboardWebSocketGateway, AppWebSocketGateway],
+```
+
+- [ ] **Step 2: Verify backend compiles**
+
+```bash
+cd backend && npm run build 2>&1 | tail -20
+```
+
+Expected: no TypeScript errors, build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/modules/dashboard/dashboard-module.ts
+git commit -m "feat(websocket): register AppWebSocketGateway in DashboardModule"
+```
+
+---
+
+## Task 3: Fix NGINX keepalive recycling for WebSocket path
+
+The `/socket.io/` location block in `nginx/nginx.conf` inherits upstream keepalive connection pooling, which can recycle the TCP tunnel mid-WebSocket session.
+
+**Files:**
+- Modify: `nginx/nginx.conf` — `/socket.io/` location block (lines 163–182)
+
+- [ ] **Step 1: Add `keepalive_requests 0` to the WebSocket location**
+
+Open `nginx/nginx.conf`. Find the `location /socket.io/` block (currently lines 163–182) and add `keepalive_requests 0;` after `proxy_buffering off;`:
+
+```nginx
+        # WebSocket support for Socket.IO
+        location /socket.io/ {
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+
+            # WebSocket headers
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # WebSocket timeouts
+            proxy_cache_bypass $http_upgrade;
+            proxy_read_timeout 86400s;
+            proxy_send_timeout 86400s;
+
+            # Buffer settings
+            proxy_buffering off;
+            keepalive_requests 0;
+        }
+```
+
+- [ ] **Step 2: Validate the NGINX config**
+
+```bash
+docker compose exec nginx nginx -t 2>&1 || echo "Container not running — validate after deploy"
+```
+
+If the container is running, expected: `nginx: configuration file /etc/nginx/nginx.conf test is successful`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add nginx/nginx.conf
+git commit -m "fix(nginx): disable keepalive recycling on WebSocket proxy path"
+```
+
+---
+
+## Task 4: Debounce reconnect toast in useWebSocket.tsx
+
+Only show "Real-time connection restored" if the connection was down for more than 5 seconds.
+
+**Files:**
+- Modify: `frontend/src/hooks/useWebSocket.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/hooks/__tests__/useWebSocket.reconnect.test.tsx`:
+
+```typescript
+import { renderHook, act } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+// Mock dependencies
+vi.mock('./useNotification', () => ({
+  useNotification: () => ({ showNotification: mockShowNotification }),
+}))
+vi.mock('./useRedux', () => ({
+  useAppDispatch: () => vi.fn(),
+  useAppSelector: (selector: any) => selector({ auth: { isAuthenticated: true, accessToken: 'token' } }),
+}))
+vi.mock('@/store/slices/notificationSlice', () => ({
+  addNotification: vi.fn(),
+}))
+
+const mockShowNotification = vi.fn()
+
+// Mock socket.io-client
+const mockSocket = {
+  on: vi.fn(),
+  onAny: vi.fn(),
+  disconnect: vi.fn(),
+  emit: vi.fn(),
+  connected: true,
+}
+vi.mock('socket.io-client', () => ({
+  io: () => mockSocket,
+}))
+
+import { WebSocketProvider } from '../useWebSocket'
+
+describe('useWebSocket reconnect toast debounce', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does NOT show toast when reconnect happens within 5 seconds of disconnect', () => {
+    // Simulate: disconnect then reconnect within 5s
+    // Find the 'disconnect' and 'reconnect' handlers registered on the mock socket
+    const handlers: Record<string, Function> = {}
+    mockSocket.on.mockImplementation((event: string, cb: Function) => {
+      handlers[event] = cb
+    })
+
+    const wrapper = ({ children }: any) => <WebSocketProvider>{children}</WebSocketProvider>
+    renderHook(() => {}, { wrapper })
+
+    act(() => {
+      handlers['disconnect']?.('transport close')
+      // Reconnect fires 2 seconds later (within 5s threshold)
+      vi.advanceTimersByTime(2000)
+      handlers['reconnect']?.(1)
+    })
+
+    expect(mockShowNotification).not.toHaveBeenCalledWith(
+      'Real-time connection restored',
+      'success',
+    )
+  })
+
+  it('DOES show toast when reconnect happens after more than 5 seconds', () => {
+    const handlers: Record<string, Function> = {}
+    mockSocket.on.mockImplementation((event: string, cb: Function) => {
+      handlers[event] = cb
+    })
+
+    const wrapper = ({ children }: any) => <WebSocketProvider>{children}</WebSocketProvider>
+    renderHook(() => {}, { wrapper })
+
+    act(() => {
+      handlers['disconnect']?.('transport close')
+      // Reconnect fires 6 seconds later (beyond 5s threshold)
+      vi.advanceTimersByTime(6000)
+      handlers['reconnect']?.(1)
+    })
+
+    expect(mockShowNotification).toHaveBeenCalledWith(
+      'Real-time connection restored',
+      'success',
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd frontend && npx vitest run src/hooks/__tests__/useWebSocket.reconnect.test.tsx
+```
+
+Expected: FAIL — toast fires unconditionally regardless of timing.
+
+- [ ] **Step 3: Add disconnect timestamp ref and debounce logic**
+
+Edit `frontend/src/hooks/useWebSocket.tsx`. After the existing refs (around line 35):
+
+```typescript
+  const socketRef = useRef<Socket | null>(null)
+  const listenersRef = useRef<Map<string, Set<Function>>>(new Map())
+  const disconnectTimeRef = useRef<number | null>(null)
+```
+
+Then update the `disconnect` handler (around line 71) to record the timestamp:
+
+```typescript
+      socket.on('disconnect', (reason) => {
+        console.log('WebSocket disconnected:', reason)
+        disconnectTimeRef.current = Date.now()
+        setIsConnected(false)
+        if (reason === 'io server disconnect') {
+          socket.connect()
+        }
+      })
+```
+
+Then update the `reconnect` handler (around line 88) to check elapsed time:
+
+```typescript
+      socket.on('reconnect', (attemptNumber) => {
+        console.log('WebSocket reconnected after', attemptNumber, 'attempts')
+        setIsConnected(true)
+        const downFor = disconnectTimeRef.current ? Date.now() - disconnectTimeRef.current : 0
+        if (downFor > 5000) {
+          showNotification('Real-time connection restored', 'success')
+        }
+        disconnectTimeRef.current = null
+      })
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd frontend && npx vitest run src/hooks/__tests__/useWebSocket.reconnect.test.tsx
+```
+
+Expected: PASS — both cases pass.
+
+- [ ] **Step 5: Run TypeScript check**
+
+```bash
+cd frontend && npm run type-check 2>&1 | tail -20
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/hooks/useWebSocket.tsx frontend/src/hooks/__tests__/useWebSocket.reconnect.test.tsx
+git commit -m "fix(websocket): debounce reconnect toast — only show if down >5s"
+```
+
+---
+
+## Task 5: End-to-end verification in Docker
+
+- [ ] **Step 1: Rebuild and restart affected containers**
+
+```bash
+docker compose build backend nginx && docker compose up -d backend nginx
+```
+
+Expected: both containers start healthy (`docker compose ps` shows `healthy`).
+
+- [ ] **Step 2: Open browser devtools and confirm WebSocket upgrade**
+
+Open the app at `http://localhost`. In devtools Network tab, filter to `WS`. Confirm:
+- A connection to `/socket.io/` appears
+- Status shows `101 Switching Protocols`
+- The connection stays open (no `transport close` in console for 2+ minutes)
+
+- [ ] **Step 3: Confirm no disconnect/reconnect cycle in console**
+
+Wait 2 minutes on the dashboard. Expected: no `WebSocket disconnected: transport close` log entries.
+
+- [ ] **Step 4: Simulate a backend restart and check toast behavior**
+
+```bash
+docker compose restart backend
+```
+
+Watch the browser. Expected:
+- Console shows `WebSocket disconnected: transport close` then `WebSocket reconnected after N attempts`
+- "Real-time connection restored" toast appears (backend takes >5s to restart and reconnect)
+
+- [ ] **Step 5: Create PR closing issue #430**
+
+```bash
+gh pr create --title "fix(websocket): resolve transport close disconnections and debounce reconnect toast" --body "$(cat <<'EOF'
+## Summary
+- Add root namespace (`/`) WebSocket gateway with `pingTimeout: 60000` to match what the frontend actually connects to
+- Disable NGINX keepalive connection recycling on the `/socket.io/` proxy path
+- Debounce the "Real-time connection restored" toast — only shown if connection was down >5 seconds
+
+## Test plan
+- [ ] Backend test: `AppWebSocketGateway` instantiates correctly
+- [ ] Frontend test: reconnect toast debounce — fires after >5s, silent for <5s
+- [ ] Docker: WebSocket stays connected for 2+ minutes with no `transport close` in console
+- [ ] Docker: backend restart triggers toast (down >5s); brief blip does not
+
+Closes #430
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** All three root causes addressed — heartbeat config (Task 1–2), NGINX keepalive (Task 3), toast debounce (Task 4). ✓
+- **Namespace mismatch:** The spec calls out that the frontend connects to `/` not `dashboard`. Task 1 creates `AppWebSocketGateway` on `/`. ✓
+- **No placeholders:** All code is complete. ✓
+- **Type consistency:** `disconnectTimeRef` typed as `useRef<number | null>(null)` and accessed consistently. ✓
+- **Out of scope preserved:** `DashboardWebSocketGateway` unchanged, dashboard stays REST-based. ✓

--- a/docs/superpowers/specs/2026-04-22-journal-entries-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-22-journal-entries-refactor-design.md
@@ -1,0 +1,123 @@
+# Journal Entries Module Refactor — Design Spec
+
+**Issue:** #416  
+**Date:** 2026-04-22  
+**Branch:** feat/journal-entries-refactor-416
+
+## Goal
+
+Align the Journal Entries module's sub-components and workspace hook with the patterns established across Sales and Purchasing modules (using `OrderContextHeader` / `EntityTable` as the reference). Remove bulk selection entirely.
+
+---
+
+## Changes
+
+### 1. `JournalEntriesTable`
+
+Replace the current custom raw-MUI table with `EntityTable`.
+
+- Remove: checkboxes, `selectedIds`, per-row Post/Delete action buttons, `onToggleCheck`, `onSelectAll`, `onPost`, `onDelete` props
+- Columns (all `raw: true` where non-plain-text):
+  - Reference — `primary.main` styled text
+  - Date
+  - Description (truncated)
+  - Type — `Chip`
+  - Source — clickable link (or `—` if none)
+  - Debits — right-aligned
+  - Credits — right-aligned
+  - Status — `Chip`
+- Props reduce to: `entries`, `loading`, `selectedEntryId`, `onSelect`, `listRef`
+
+### 2. `JournalEntryContextHeader`
+
+Rewrite to match the `OrderContextHeader` / `ChartOfAccountContextHeader` pattern exactly.
+
+**Header bar:**
+- Left: uppercase `"JE Details - {referenceNumber}"` (`variant="tableHeader"`, `0.8rem`, `letterSpacing: 0.5px`)
+- Right: action buttons — Edit (Draft only), Post (Draft + balanced only), Delete (Draft only), Reverse (Posted only)
+
+**Body:** two-column `Grid` with `detailTableSx` / `labelCellSx` / `valueCellSx`, zebra-stripe rows
+
+- Left column — **Entry Information** section:
+  - Date
+  - Description
+  - Type (`Chip`)
+  - Source (clickable link, or `—`)
+
+- Right column — **Financials** section:
+  - Status (`Chip`)
+  - Debits
+  - Credits
+  - Balance indicator: "Unbalanced" `Chip` (warning) when `|debits - credits| >= 0.01`
+
+**Empty state:** centered `"Select a journal entry to view details"` (matches other modules).
+
+**Prop changes:**
+- Remove `onNavigateToSource(path: string)` — replaced by `onViewSource(sourceType, sourceId)` resolved in the hook
+- Header receives the already-resolved path or the hook passes a navigation callback
+
+### 3. `JournalEntryWorkspaceCard`
+
+Minor alignment only — already close to the pattern.
+
+- Ensure `headerSx` matches the other workspace cards (`px`, `py`, `borderBottom`)
+- No logic changes
+
+### 4. `useJournalEntriesWorkspace`
+
+**Remove:**
+- `selectedIds`, `setSelectedIds`
+- `handleToggleCheck`, `handleSelectAll`
+- `bulkPostOpen`, `setBulkPostOpen`
+- `bulkDeleteOpen`, `setBulkDeleteOpen`
+- `handleBulkPost`, `handleBulkDelete`
+- `useBulkDeleteJournalEntriesMutation`, `useBulkPostJournalEntriesMutation` imports
+
+**Dedup `SOURCE_ROUTES`:**  
+Currently copy-pasted in both the hook and `JournalEntryContextHeader`. Define once in the hook; expose `navigateToSource(sourceType, sourceId)` (already exists in return value). Remove `SOURCE_ROUTES` from the header component — it calls `onViewSource(sourceType, sourceId)` and the hook handles navigation.
+
+**Result:** hook returns only — `selectedEntry`, `postTarget`, `setPostTarget`, `deleteTarget`, `setDeleteTarget`, `reverseTarget`, `setReverseTarget`, `actionLoading`, `searchInputRef`, `listRef`, `handleSelect`, `handleConfirmPost`, `handleConfirmReverse`, `handleConfirmDelete`, `navigateToEdit`, `navigateToCreate`, `navigateToSource`
+
+### 5. `JournalEntriesDialogs`
+
+Remove bulk dialogs and their props:
+- Remove: `bulkPostIds`, `bulkDeleteIds`, `onConfirmBulkPost`, `onConfirmBulkDelete`, `onCancelBulkPost`, `onCancelBulkDelete`
+
+Keep: post, delete, reverse confirmation dialogs (unchanged logic).
+
+### 6. `JournalEntriesPage`
+
+- Remove `contentSlot` (bulk action buttons)
+- Remove prop threading for `onToggleCheck`, `onSelectAll`, `selectedIds`
+- Remove bulk dialog props from `JournalEntriesDialogs`
+- No filter, sort, or query changes
+
+---
+
+## Acceptance Criteria
+
+- [ ] `JournalEntriesTable` uses `EntityTable`, no checkboxes or action columns
+- [ ] `JournalEntryContextHeader` uses two-column Grid layout with `detailTableSx`/`labelCellSx`/`valueCellSx`
+- [ ] `SOURCE_ROUTES` defined only once (in the hook)
+- [ ] All bulk state and handlers removed from hook, table, page, and dialogs
+- [ ] No regression in post, delete, reverse, edit, navigate-to-source functionality
+- [ ] Existing `JournalEntriesPage.test.tsx` passes
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `components/JournalEntriesTable.tsx` | Rewrite using `EntityTable` |
+| `components/JournalEntryContextHeader.tsx` | Rewrite to match SO/COA pattern |
+| `components/JournalEntryWorkspaceCard.tsx` | Minor style alignment |
+| `components/JournalEntriesDialogs.tsx` | Remove bulk dialogs |
+| `hooks/useJournalEntriesWorkspace.ts` | Remove bulk state, dedup SOURCE_ROUTES |
+| `JournalEntriesPage.tsx` | Remove bulk contentSlot, trim prop threading |
+
+## Out of Scope
+
+- `useEntityWorkspace` shared hook — not created (no meaningful shared abstraction)
+- Filter, sort, or query changes
+- Any other accounting module components

--- a/docs/superpowers/specs/2026-04-23-fix-uuid-vulnerability-design.md
+++ b/docs/superpowers/specs/2026-04-23-fix-uuid-vulnerability-design.md
@@ -1,0 +1,60 @@
+# Design: Fix Backend uuid Vulnerability (Issue #422)
+
+## Summary
+
+Fix 5 moderate-severity vulnerabilities in `backend/` caused by transitive dependencies on `uuid <14.0.0` (GHSA-w5hq-g745-h8pq). The fix uses an `overrides` entry to force all transitive consumers to `uuid@>=14.0.0`, plus adds `uuid` as an explicit direct dependency since the app already uses it in `search.service.ts`.
+
+## Vulnerability Details
+
+- **Advisory:** GHSA-w5hq-g745-h8pq
+- **Affected range:** `uuid < 14.0.0`
+- **Issue:** Missing bounds check in `v3()`, `v5()`, `v6()` when a caller-supplied `buf` with invalid `offset` is provided — allows out-of-bounds writes
+- **Fixed in:** `uuid@14.0.0` (throws `RangeError` on invalid offset)
+
+## Affected Packages
+
+| Package | Pulls in uuid via | Current uuid version |
+|---|---|---|
+| `bull@4.16.5` | `uuid@^8.3.0` | `8.3.2` |
+| `exceljs@4.4.0` | `uuid@^8.3.0` | `8.3.2` |
+| `typeorm@0.3.28` | `uuid@^11.1.0` | `11.1.0` |
+
+## Breaking Change Analysis
+
+`uuid@14.0.0` has these breaking changes — none affect this project:
+
+| Breaking Change | Status |
+|---|---|
+| Requires Node ≥ 20, global `crypto` | Safe — local and Docker both use Node 24 |
+| TS minimum 5.4.3 | Safe — project uses TS 5.x |
+| CJS removed (uuid@12) | Safe — NestJS/Node 24 handles ESM |
+| `v3/v5/v6` buf bounds now throws | Safe — app only calls `v4()` with no buf arg |
+
+`bull` and `exceljs` declare `uuid@^8` but only call `v4()` internally — the v8→v14 API is backwards-compatible for that usage.
+
+## Changes
+
+### `backend/package.json`
+
+1. Add `uuid` to `dependencies`:
+   ```json
+   "uuid": "^14.0.0"
+   ```
+
+2. Add to the existing `overrides` block:
+   ```json
+   "uuid": ">=14.0.0"
+   ```
+
+No version changes to `bull`, `exceljs`, or `typeorm`. npm audit suggests downgrading these to older majors — that is the wrong direction and must not be followed.
+
+### `backend/src/modules/search/search.service.ts`
+
+No changes. The existing `import { v4 as uuidv4 } from 'uuid'` resolves to `uuid@14` via the new direct dep.
+
+## Verification
+
+1. `cd backend && npm install`
+2. `npm audit` → 0 vulnerabilities
+3. `npm run test` → all tests pass
+4. App starts and search endpoint functions correctly

--- a/docs/superpowers/specs/2026-04-23-fix-uuid-vulnerability-design.md
+++ b/docs/superpowers/specs/2026-04-23-fix-uuid-vulnerability-design.md
@@ -43,14 +43,27 @@ Fix 5 moderate-severity vulnerabilities in `backend/` caused by transitive depen
 
 2. Add to the existing `overrides` block:
    ```json
-   "uuid": ">=14.0.0"
+   "uuid": "$uuid"
    ```
+   npm 11 rejects `"uuid": ">=14.0.0"` when `uuid` is also a direct dependency (EOVERRIDE). The `$uuid` reference syntax tells npm to use the resolved version of the direct dep, satisfying both the transitive override and the conflict rule.
 
 No version changes to `bull`, `exceljs`, or `typeorm`. npm audit suggests downgrading these to older majors — that is the wrong direction and must not be followed.
 
 ### `backend/src/modules/search/search.service.ts`
 
 No changes. The existing `import { v4 as uuidv4 } from 'uuid'` resolves to `uuid@14` via the new direct dep.
+
+### `backend/test/shims/uuid.ts` (new file)
+
+uuid@14 ships ESM-only. Jest runs in CommonJS mode (via `ts-jest`). Without a shim, Jest's module resolver fails to parse the ESM uuid package. The shim is mapped in `package.json`'s `jest.moduleNameMapper` (`"^uuid$": "<rootDir>/test/shims/uuid.ts"`) and provides only `v4` — the one function the codebase uses — implemented via Node's built-in `crypto.randomUUID()`:
+
+```ts
+import { randomUUID } from 'node:crypto';
+export function v4(): string { return randomUUID(); }
+export default { v4 };
+```
+
+This shim is Jest-only; production runtime resolves `uuid` normally via the direct dependency.
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-04-23-issue-420-normalize-je-ui.md
+++ b/docs/superpowers/specs/2026-04-23-issue-420-normalize-je-ui.md
@@ -1,0 +1,50 @@
+# Issue #420: Normalize Journal Entries UI with Sales Module
+
+## Overview
+
+Align the Journal Entries list and detail header with the visual patterns established in the Sales module, removing custom styling that creates inconsistency.
+
+## Changes
+
+### 1. `JournalEntriesTable.tsx`
+
+Remove `raw: true` and the custom `Typography` render for the `referenceNumber` column. Use the same plain render pattern as `OrdersTable.tsx`:
+
+```tsx
+const COLUMNS: ColumnConfig<JournalEntry>[] = [
+  { key: 'referenceNumber', render: (entry) => entry.referenceNumber },
+]
+```
+
+- Drop the `Typography` import (no longer used).
+- Result: `EntityTable` handles default formatting (fontWeight 400, standard text color).
+
+### 2. `JournalEntryContextHeader.tsx`
+
+Replace all three `Chip` components with plain text inside existing `valueCellSx` cells:
+
+| Field | Before | After |
+|-------|--------|-------|
+| Type | `<Chip label={ENTRY_TYPE_LABELS[...]} />` | Plain text: `ENTRY_TYPE_LABELS[sourceType] ?? 'Manual Entry'` |
+| Status | `<Chip label={status} color={statusColor(...)} />` | Plain text: `selectedEntry.status` |
+| Balance (unbalanced) | `<Chip label="Unbalanced" color="warning" />` | Plain text: `Unbalanced` |
+
+- Remove `statusColor` helper function (no longer used).
+- Remove `Chip` from the MUI import (no longer used).
+
+## Test Updates
+
+The existing frontend test for `JournalEntriesTable` checks column rendering and expects the styled `Typography` output. It must be updated to expect plain text string output instead.
+
+## Acceptance Criteria
+
+- Journal Entries list reference number uses fontWeight 400 and default text color (same as Sales Orders list).
+- JE detail header Type, Status, and Balance fields display as plain text, no Chip chrome.
+- UI feels consistent when navigating between Sales and Accounting modules.
+- No TypeScript errors. Existing tests pass after update.
+
+## Out of Scope
+
+- No backend changes.
+- No changes to other accounting components.
+- Status text capitalization left as-is (raw enum values: `DRAFT`, `POSTED`, `REVERSED`).

--- a/docs/superpowers/specs/2026-04-24-accounting-workspace-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-24-accounting-workspace-refactor-design.md
@@ -1,0 +1,142 @@
+# Accounting Workspace Refactor Design
+
+**Issue:** #424  
+**Date:** 2026-04-24  
+**Scope:** Journal Entries page and Chart of Accounts page only
+
+## Goal
+
+Refactor `useJournalEntriesWorkspace` and `useChartOfAccountsWorkspace` to match the interactivity and state management standards established by the Sales/Purchasing pages (`useOrdersWorkspace` is the reference implementation).
+
+## Gaps Being Closed
+
+| Feature | Sales/Purchasing | JE/COA (before) |
+|:---|:---|:---|
+| Workspace Hook | `useEntityWorkspace` (wrapped) | Custom hook, no wrapping |
+| Keyboard Nav | Full (Arrows/Enter/Home/End/PageUp/PageDown) | None |
+| State Storage | Redux slice | Local hook state |
+| Auto-Selection | First item on load | Manual only |
+| Search Focus | `setShouldPreserveSearchFocus` | Manual `setTimeout` (JE) / none (COA) |
+| Focused Index | Tracked in table | Hardcoded `-1` (JE) / absent (COA) |
+
+---
+
+## Section 1 — Redux Slice
+
+**New file:** `frontend/src/store/slices/accountingSlice.ts`
+
+```ts
+interface AccountingState {
+  selectedJournalEntry: JournalEntry | null
+  selectedAccount: ChartOfAccount | null
+}
+```
+
+- Actions: `setSelectedJournalEntry`, `setSelectedAccount`
+- Selectors: `selectSelectedJournalEntry`, `selectSelectedAccount`
+- Registered in the store root reducer under the key `accounting`
+
+**New test file:** `frontend/src/store/slices/__tests__/accountingSlice.test.ts`  
+Minimal reducer tests: set/clear each selection. Matches existing slice test patterns.
+
+---
+
+## Section 2 — `useJournalEntriesWorkspace` Refactor
+
+**Signature change:** Accepts a config object `{ dispatch, entries, selectedEntry, refetch }` instead of just `refetch`.
+
+**Internally wraps `useEntityWorkspace`:**
+- `entities`: JE list passed in
+- `selectedEntity`: `selectedEntry` from Redux (via selector in the page, passed in)
+- `selectEntity`: dispatches `setSelectedJournalEntry`
+- `routes.edit`: `/accounting/journal-entries/:id/edit`
+- `onEnter`: default behavior (navigate to edit route) — no override needed
+- `onEscape`: clears selection, resets focused index, closes open dialogs
+- `deleteMutation`: no-op (`async () => {}`) — JE deletion is handled by `handleConfirmDelete` via `deleteTarget` flow, not the generic `useEntityWorkspace` delete
+
+**On selection (click and keyboard nav):** triggers `useLazyGetJournalEntryQuery` to fetch the full entry detail, then dispatches `setSelectedJournalEntry` with the fresh data. Matches the `triggerGetSalesOrder` pattern in `useOrdersWorkspace`.
+
+**Retained JE-specific state (unchanged):**
+- `postTarget`, `reverseTarget`, `deleteTarget`, `actionLoading`
+- `handleConfirmPost`, `handleConfirmReverse`, `handleConfirmDelete`
+- `navigateToCreate`, `navigateToSource`
+
+**`JournalEntriesPage` changes:**
+- Adds `useAppDispatch` + `useAppSelector(selectSelectedJournalEntry)`
+- Passes `dispatch`, `entries`, `selectedEntry` into the hook
+- Passes `workspace.focusedIndex` to `JournalEntriesTable` (removes hardcoded `-1`)
+- Removes manual `setTimeout` search focus — replaced by `setShouldPreserveSearchFocus`
+
+---
+
+## Section 3 — `useChartOfAccountsWorkspace` Refactor
+
+**Signature change:** Accepts a config object `{ dispatch, accounts, selectedAccount, refetch }`.
+
+**Internally wraps `useEntityWorkspace`:**
+- `entities`: flattened accounts array (computed in the page, passed in)
+- `selectedEntity`: `selectedAccount` from Redux
+- `selectEntity`: dispatches `setSelectedAccount`
+- `routes`: `{ create: '', edit: () => '' }` — no-ops, COA has no navigation routes
+- `onEnter`: override that calls `setFormDialogOpen(true)` (Enter opens the edit dialog)
+- `onEscape`: clears selection, closes form/delete dialogs
+- `deleteMutation`: no-op (`async () => {}`) — COA deletion is handled by `handleDelete` via `deleteTarget` flow, not the generic `useEntityWorkspace` delete
+
+**Retained COA-specific state (unchanged):**
+- `formDialogOpen`, `deleteTarget`, `seedConfirmOpen`, `deletedDialogOpen`
+- `handleDelete`, `handleSeed`
+
+**`ChartOfAccountsPage` changes:**
+- Adds `useAppDispatch` + `useAppSelector(selectSelectedAccount)`
+- Passes `dispatch`, `filteredAccounts`, `selectedAccount` into the hook
+- Passes `workspace.focusedIndex` to `ChartOfAccountsTable`
+- Search focus standardized via `setShouldPreserveSearchFocus`
+
+---
+
+## Section 4 — Table Updates
+
+### `JournalEntriesTable`
+- `focusedIndex: number` prop already exists in the interface but is hardcoded to `-1` at the call site
+- Pass the real `focusedIndex` from the workspace
+- Render visual focus highlight on the row matching `focusedIndex` (consistent with Sales/Purchasing tables)
+
+### `ChartOfAccountsTable`
+- Add `focusedIndex: number` prop
+- Render visual focus highlight on the row matching `focusedIndex`
+- Keep existing `selectedId` prop for the selection highlight (focused = keyboard cursor, selected = active workspace item — two distinct visual states)
+
+Both tables already use `data-index={index}` on rows and `listRef` for scroll-into-view — no structural changes needed.
+
+---
+
+## Section 5 — Testing
+
+### Updated test files
+- `pages/accounting/__tests__/JournalEntriesPage.test.tsx` — provide Redux store with `accountingSlice`, mock `selectedJournalEntry` from store
+- `pages/accounting/__tests__/ChartOfAccountsPage.test.tsx` — provide Redux store with `accountingSlice`, mock `selectedAccount` from store
+- `pages/accounting/components/JournalEntriesTable.test.tsx` — add test for `focusedIndex` visual highlight
+
+### New test files
+- `store/slices/__tests__/accountingSlice.test.ts` — basic reducer tests (set/clear selected entry, set/clear selected account)
+
+No changes to `useEntityWorkspace.test.ts` — the hook itself is not modified.
+
+---
+
+## Files Changed Summary
+
+| File | Change |
+|:---|:---|
+| `store/slices/accountingSlice.ts` | **New** |
+| `store/slices/__tests__/accountingSlice.test.ts` | **New** |
+| `store/index.ts` | Register `accountingSlice` reducer |
+| `pages/accounting/hooks/useJournalEntriesWorkspace.ts` | Refactor — wrap `useEntityWorkspace` |
+| `pages/accounting/hooks/useChartOfAccountsWorkspace.ts` | Refactor — wrap `useEntityWorkspace` |
+| `pages/accounting/JournalEntriesPage.tsx` | Add Redux wiring, pass `focusedIndex` |
+| `pages/accounting/ChartOfAccountsPage.tsx` | Add Redux wiring, pass `focusedIndex` |
+| `pages/accounting/components/JournalEntriesTable.tsx` | Pass real `focusedIndex`, add highlight |
+| `pages/accounting/components/ChartOfAccountsTable.tsx` | Add `focusedIndex` prop, add highlight |
+| `pages/accounting/__tests__/JournalEntriesPage.test.tsx` | Update Redux store setup |
+| `pages/accounting/__tests__/ChartOfAccountsPage.test.tsx` | Update Redux store setup |
+| `pages/accounting/components/JournalEntriesTable.test.tsx` | Add focusedIndex test |

--- a/docs/superpowers/specs/2026-04-24-keyboard-nav-standardization-design.md
+++ b/docs/superpowers/specs/2026-04-24-keyboard-nav-standardization-design.md
@@ -105,6 +105,19 @@ onNavigate: (customer) => {
 
 No changes needed. All four tables already pass `focusedIndex` to the shared `EntityTable` component which handles highlight styling uniformly.
 
+## Test Updates Required
+
+The filterbar tests for Orders, Invoices, and Payments mock the six navigation handlers directly. After removing them from `useOrdersWorkspace` return and confirming they are no longer in `useInvoicesWorkspace`/`usePaymentsWorkspace` return either, these mocks must be removed:
+
+- `frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx` — remove `handleNavigateUp/Down/ToFirst/ToLast/PageUp/PageDown` from mock
+- `frontend/src/pages/sales/__tests__/InvoicesPage.filterbar.test.tsx` — same
+- `frontend/src/pages/sales/__tests__/PaymentsPage.filterbar.test.tsx` — same
+
+New unit tests should be added to `useEntityWorkspace.test.ts` covering:
+- `onNavigate` is called on keyboard navigation (arrow up/down, pgUp/pgDn, home/end)
+- `onNavigate` is NOT called on `handleSelect` (click)
+- `onNavigate` is optional (no crash when omitted)
+
 ## What Does NOT Change
 
 - Click (`handleSelect` / row `onClick`) behavior on any page.

--- a/docs/superpowers/specs/2026-04-24-keyboard-nav-standardization-design.md
+++ b/docs/superpowers/specs/2026-04-24-keyboard-nav-standardization-design.md
@@ -1,0 +1,121 @@
+# Design: Standardize Workspace Keyboard Navigation (Issue #426)
+
+## Problem
+
+Keyboard navigation is inconsistent across the four main Sales workspace pages:
+
+- **Sales Orders**: Navigation keystrokes trigger a lazy API fetch (`triggerGetSalesOrder`) to load full order details. However, `useOrdersWorkspace` achieves this by registering a second `useKeyboardShortcuts` listener on top of the one already inside `useEntityWorkspace`, causing duplicate event listeners and duplicated navigation logic.
+- **Invoices / Payments / Customers**: Navigation keystrokes only move the visual focus indicator. No API fetch is triggered, so the detail panel shows only list-level data.
+
+## Goal
+
+- All four pages trigger a lazy API fetch when the user navigates with keyboard.
+- Remove the duplicate `useKeyboardShortcuts` registration in `useOrdersWorkspace`.
+- Keyboard navigation behavior (Arrow keys, PgUp/PgDn, Home/End) is identical across all workspace pages.
+
+## Approach: `onNavigate` callback in `useEntityWorkspace`
+
+Add one optional callback to `UseEntityWorkspaceConfig`:
+
+```ts
+onNavigate?: (entity: T, index: number) => void
+```
+
+`selectAtIndex` — the internal function called by every keyboard navigation handler — calls `onNavigate` after updating focused index and selecting the entity:
+
+```ts
+const selectAtIndex = useCallback((index: number) => {
+  const entity = entities[index]
+  if (!entity) return
+  setFocusedIndex(index)
+  selectEntity(entity)
+  onNavigate?.(entity, index)
+}, [entities, selectEntity, onNavigate])
+```
+
+`handleSelect` (mouse click) does NOT call `onNavigate`. Click handlers in each page already load full details on click and remain unchanged.
+
+## File-by-File Changes
+
+### 1. `frontend/src/hooks/useEntityWorkspace.ts`
+
+- Add `onNavigate?: (entity: T, index: number) => void` to `UseEntityWorkspaceConfig`.
+- Destructure `onNavigate` from config.
+- Call `onNavigate?.(entity, index)` inside `selectAtIndex` after `selectEntity(entity)`.
+- Add `onNavigate` to the `useCallback` dependency array of `selectAtIndex`.
+
+### 2. `frontend/src/pages/sales/hooks/useOrdersWorkspace.ts`
+
+- Remove the second `useKeyboardShortcuts` call (currently lines 839–852).
+- Remove the six custom navigation handlers: `handleNavigateUp`, `handleNavigateDown`, `handleNavigateToFirst`, `handleNavigateToLast`, `handlePageUpNavigation`, `handlePageDownNavigation`.
+- Remove `selectAndLoadOrder` helper (its logic moves into `onNavigate`).
+- Add `onNavigate` to the `useEntityWorkspace` config:
+
+```ts
+onNavigate: (order) => {
+  void triggerGetSalesOrder(order.id).unwrap().then((fullOrder) => {
+    dispatch(setSelectedOrder(fullOrder))
+  })
+  userHasNavigatedRef.current = true
+},
+```
+
+- Stop re-exporting the six removed navigation handlers from the return object (consumers use the base workspace spread).
+
+### 3. `frontend/src/pages/sales/hooks/useInvoicesWorkspace.ts`
+
+- Import `useLazyGetInvoiceQuery` from `salesApi`.
+- Add `onNavigate` to `useEntityWorkspace` config:
+
+```ts
+onNavigate: (invoice) => {
+  void triggerGetInvoice(invoice.id).unwrap().then((fullInvoice) => {
+    dispatch(setSelectedInvoice(fullInvoice as any))
+  })
+},
+```
+
+### 4. `frontend/src/pages/sales/hooks/usePaymentsWorkspace.ts`
+
+- Import `useLazyGetPaymentQuery` from `salesApi`.
+- Add `onNavigate` to `useEntityWorkspace` config:
+
+```ts
+onNavigate: (payment) => {
+  void triggerGetPayment(payment.id).unwrap().then((fullPayment) => {
+    dispatch(setSelectedPayment(fullPayment))
+  })
+},
+```
+
+### 5. `frontend/src/pages/sales/CustomersPage.tsx`
+
+- Import `useLazyGetCustomerQuery` from `salesApi`.
+- Add `onNavigate` to `useEntityWorkspace` config:
+
+```ts
+onNavigate: (customer) => {
+  void triggerGetCustomer(customer.id).unwrap().then((fullCustomer) => {
+    dispatch(setSelectedCustomer(fullCustomer))
+  })
+},
+```
+
+## Visual Consistency
+
+No changes needed. All four tables already pass `focusedIndex` to the shared `EntityTable` component which handles highlight styling uniformly.
+
+## What Does NOT Change
+
+- Click (`handleSelect` / row `onClick`) behavior on any page.
+- `handleOrderSelect` in `useOrdersWorkspace` (explicit click handler, keeps its own fetch).
+- `userHasNavigatedRef` and all highlight/pending-order logic in `useOrdersWorkspace`.
+- Any other workspace hooks (accounting, inventory, purchasing) — they don't need `onNavigate`.
+
+## Success Criteria
+
+- [ ] `useEntityWorkspace` supports optional `onNavigate` callback.
+- [ ] `useOrdersWorkspace` has no duplicate `useKeyboardShortcuts` call.
+- [ ] Arrow/PgUp/PgDn/Home/End navigation triggers a full-detail API fetch on all four pages.
+- [ ] Click selection behavior is unchanged on all four pages.
+- [ ] Existing tests pass; new tests cover `onNavigate` in `useEntityWorkspace`.

--- a/docs/superpowers/specs/2026-04-25-entity-workspace-selection-fix-design.md
+++ b/docs/superpowers/specs/2026-04-25-entity-workspace-selection-fix-design.md
@@ -1,0 +1,79 @@
+# Design: Entity Workspace Selection Reset Fix (Issue #444)
+
+## Problem
+
+Clicking a row in any entity list page (Customers, Suppliers, Products, Orders, etc.) sometimes fails to update the workspace card and context header. They revert to the "Select a …" placeholder or stay empty.
+
+## Root Cause
+
+Two independent bugs combine to cause this:
+
+1. **Unstable `selectEntity` reference.** Every page/workspace-hook passes `selectEntity` as an inline arrow function directly to `useEntityWorkspace`. This creates a new function reference on every render, causing the auto-selection `useEffect` (which lists `selectEntity` as a dependency) to re-run after every render — resetting `hasAutoSelected` and potentially clearing the selection.
+
+2. **Unconditional clear on empty entities.** The effect at `useEntityWorkspace.ts:74–86` calls `selectEntity(null)` whenever `entities.length === 0`. During an RTK Query background refetch, if the response hasn't resolved yet and the calling component defaults to `[]` (`customersResponse?.data ?? []`), selection gets wiped even though data is on its way.
+
+## Solution (Option C — Fix Both)
+
+### Change 1 — `useEntityWorkspace.ts`: add `isFetching` guard
+
+Add an optional `isFetching?: boolean` field to `UseEntityWorkspaceConfig`. In the auto-selection effect, skip the `selectEntity(null)` call when `isFetching` is true:
+
+```ts
+if (entities.length === 0) {
+  if (!isFetching) {
+    hasAutoSelected.current = false
+    setFocusedIndex(-1)
+    selectEntity(null)
+  }
+  return
+}
+```
+
+This prevents selection from being wiped while data is in flight. When `isFetching` is omitted it defaults to `false`, so existing behaviour is preserved for hooks that don't have access to fetch state.
+
+### Change 2 — All 10 call sites: memoize `selectEntity`
+
+Every call site that passes `selectEntity` as an inline arrow must wrap it in `useCallback`. Since `dispatch` is stable (Redux guarantees this), the memoized callback never changes identity, ending the render-loop.
+
+**Direct page components** (2 files):
+- `CustomersPage.tsx` — also pass `isFetching` from `useGetCustomersQuery`
+- `SuppliersPage.tsx` — also pass `isFetching` from `useGetSuppliersQuery`
+
+**Intermediate workspace hooks** (8 files — no access to `isFetching`, fix `useCallback` only):
+- `useVendorPaymentsWorkspace.ts`
+- `useGRNWorkspace.ts`
+- `useProductsWorkspace.ts`
+- `useStockAdjustmentsWorkspace.ts`
+- `useCategoriesWorkspace.ts`
+- `useInvoicesWorkspace.ts`
+- `useOrdersWorkspace.ts`
+- `useChartOfAccountsWorkspace.ts`
+- `usePaymentsWorkspace.ts`
+- `useJournalEntriesWorkspace.ts`
+
+## Testing
+
+- Update `useEntityWorkspace.test.ts` with two new cases:
+  1. **`isFetching` guard:** when `entities` transitions to `[]` with `isFetching: true`, `selectEntity` should NOT be called with `null`.
+  2. **Stable `selectEntity`:** verify the auto-selection effect does not fire a second time when `selectEntity` reference is replaced (simulates the inline-arrow bug).
+- Run the full hook test file after changes.
+- Manual smoke test: navigate to `/sales/customers`, click several customers, confirm header and workspace card update reliably each time.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/hooks/useEntityWorkspace.ts` | Add `isFetching?: boolean` to config; guard effect |
+| `src/hooks/useEntityWorkspace.test.ts` | Add 2 regression tests |
+| `src/pages/sales/CustomersPage.tsx` | `useCallback` for `selectEntity`; pass `isFetching` |
+| `src/pages/purchasing/SuppliersPage.tsx` | `useCallback` for `selectEntity`; pass `isFetching` |
+| `src/pages/purchasing/hooks/useVendorPaymentsWorkspace.ts` | `useCallback` for `selectEntity` |
+| `src/pages/purchasing/hooks/useGRNWorkspace.ts` | `useCallback` for `selectEntity` |
+| `src/pages/inventory/hooks/useProductsWorkspace.ts` | `useCallback` for `selectEntity` |
+| `src/pages/inventory/hooks/useStockAdjustmentsWorkspace.ts` | `useCallback` for `selectEntity` |
+| `src/pages/inventory/hooks/useCategoriesWorkspace.ts` | `useCallback` for `selectEntity` |
+| `src/pages/sales/hooks/useInvoicesWorkspace.ts` | `useCallback` for `selectEntity` |
+| `src/pages/sales/hooks/useOrdersWorkspace.ts` | `useCallback` for `selectEntity` |
+| `src/pages/accounting/hooks/useChartOfAccountsWorkspace.ts` | `useCallback` for `selectEntity` |
+| `src/pages/sales/hooks/usePaymentsWorkspace.ts` | `useCallback` for `selectEntity` |
+| `src/pages/accounting/hooks/useJournalEntriesWorkspace.ts` | `useCallback` for `selectEntity` |

--- a/docs/superpowers/specs/2026-04-25-issue-434-sales-scroll-sortorder-design.md
+++ b/docs/superpowers/specs/2026-04-25-issue-434-sales-scroll-sortorder-design.md
@@ -1,0 +1,50 @@
+# Issue #434: Sales Page Scroll + sortOrder 500 Fix
+
+## Summary
+
+Two independent bugs on the Sales overview page (`/sales`):
+
+1. Content is clipped at viewport height — the page is not scrollable.
+2. `GET /api/sales-orders?sortOrder=desc` returns 500 because `BaseQueryDto` validates `sortOrder` case-sensitively against `['ASC', 'DESC']`.
+
+## Fix 1: Scroll — `SalesPage.tsx`
+
+Call `useLayoutScroll(true)` at the top of the `SalesPage` component body. This is the same pattern used by `DashboardPage`. The hook signals `MainLayout` (via `LayoutScrollContext`) to switch the main container from `overflow: hidden` to `overflow: auto`.
+
+No other changes to the component.
+
+## Fix 2: Frontend API call — `SalesPage.tsx:114`
+
+Change `sortOrder: 'desc'` to `sortOrder: 'DESC'` in the `fetchRecentOrders` params object. Fixes the immediate 500.
+
+## Fix 3: Backend robustness — `BaseQueryDto`
+
+Add a `@Transform` decorator before `@IsIn` on the `sortOrder` field to uppercase the incoming value:
+
+```ts
+@IsOptional()
+@Transform(({ value }) => value?.toUpperCase())
+@IsIn(['ASC', 'DESC'])
+sortOrder?: 'ASC' | 'DESC';
+```
+
+`@Transform` runs before `@IsIn`, so `'asc'`/`'desc'` are normalized before validation. This prevents any future caller from hitting a 500 due to case mismatch. Scope is limited to `sortOrder` only — no other fields touched.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `frontend/src/pages/sales/SalesPage.tsx` | Add `useLayoutScroll(true)`; change `sortOrder: 'desc'` → `'DESC'` |
+| `backend/src/common/dto/base-query.dto.ts` | Add `@Transform` to uppercase `sortOrder` |
+
+## Testing
+
+- Navigate to `/sales` and verify content below the fold is accessible.
+- Confirm no 500 in browser console on page load.
+- Backend unit: send `sortOrder=desc` (lowercase) to `GET /api/sales-orders` and verify 200.
+- Existing `BaseQueryDto` tests should continue to pass.
+
+## Out of Scope
+
+- `sortBy` whitespace normalization (no reported bug, YAGNI).
+- Other pages' scroll behavior.

--- a/docs/superpowers/specs/2026-04-25-issue-439-inventory-accounting-scroll-fix-design.md
+++ b/docs/superpowers/specs/2026-04-25-issue-439-inventory-accounting-scroll-fix-design.md
@@ -1,0 +1,48 @@
+---
+title: Issue #439 — Inventory & Accounting Dashboard Scroll Fix
+date: 2026-04-25
+issue: https://github.com/blur88/erp2/issues/439
+---
+
+## Problem
+
+`InventoryPage` (`/inventory`) and `AccountingDashboardPage` (`/accounting`) do not scroll when content exceeds the viewport height. Content below the fold is inaccessible.
+
+The root cause is not in `MainLayout.tsx` — the scroll infrastructure already exists via `LayoutScrollContext`. These two pages simply never called `useLayoutScroll(true)` to opt in.
+
+## Existing Pattern
+
+`DashboardPage`, `SalesPage`, and `PurchasingPage` all use the same fix:
+
+```ts
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
+// inside component:
+useLayoutScroll(true)
+```
+
+`MainLayout` reads the context value and sets `overflow: auto` vs `overflow: hidden` on the main content box accordingly.
+
+## Design
+
+Apply the identical pattern to the two affected pages:
+
+### 1. `frontend/src/pages/inventory/InventoryPage.tsx`
+- Add import: `import { useLayoutScroll } from '@/contexts/LayoutScrollContext'`
+- Add hook call inside `InventoryPage` component: `useLayoutScroll(true)`
+
+### 2. `frontend/src/pages/accounting/AccountingDashboardPage.tsx`
+- Add import: `import { useLayoutScroll } from '@/contexts/LayoutScrollContext'`
+- Add hook call inside the component: `useLayoutScroll(true)`
+
+No changes to `MainLayout.tsx`, `LayoutScrollContext.tsx`, or any other file.
+
+## Testing
+
+- Run the existing test files for both pages to confirm no regressions:
+  - `frontend/src/pages/inventory/__tests__/` (if present) or targeted vitest run on `InventoryPage`
+  - `frontend/src/pages/accounting/__tests__/AccountingDashboardPage.test.tsx`
+- Manual verification: navigate to `/inventory` and `/accounting`, confirm content scrolls.
+
+## Scope
+
+Two files, two lines each (one import + one hook call). No architectural changes.

--- a/docs/superpowers/specs/2026-04-25-per-page-scroll-control-design.md
+++ b/docs/superpowers/specs/2026-04-25-per-page-scroll-control-design.md
@@ -1,0 +1,47 @@
+---
+title: Per-Page Scroll Control
+issue: #432
+date: 2026-04-25
+---
+
+## Problem
+
+`MainLayout.tsx` sets `overflow: 'hidden'` on the `<main>` container, which clips content on long-form pages like the Dashboard. The fix must allow certain pages to scroll while keeping others locked (no scroll).
+
+## Decision
+
+- Default: **no scroll** (`overflow: 'hidden'`)
+- Pages opt in to scrolling by calling `useLayoutScroll(true)`
+- Only `DashboardPage` opts in for now; all other pages remain non-scrollable until explicitly enabled
+
+## New Files
+
+### `frontend/src/contexts/LayoutScrollContext.tsx`
+
+- Exports `LayoutScrollProvider` — wraps children, holds `scrollEnabled` boolean state
+- Exports `useLayoutScrollContext` — internal hook used by `MainLayout` to read the value
+- Exports `useLayoutScroll(enabled: boolean)` — public hook for pages; sets value on mount, resets to `false` on unmount
+
+## Modified Files
+
+### `frontend/src/components/common/MainLayout.tsx`
+
+- Wrap `<Outlet />` with `<LayoutScrollProvider>`
+- Read `scrollEnabled` from context
+- Apply `overflow: scrollEnabled ? 'auto' : 'hidden'` on the `<main>` Box
+
+### `frontend/src/pages/dashboard/DashboardPage.tsx`
+
+- Call `useLayoutScroll(true)` at the top of the component
+
+## Behavior
+
+- Navigating to Dashboard: scroll enabled, page scrolls normally
+- Navigating away from Dashboard: hook cleanup resets scroll to `false`
+- All other pages: `overflow: 'hidden'`, behavior unchanged
+- Adding scroll to a new page in future: one line — `useLayoutScroll(true)`
+
+## Out of Scope
+
+- No route-based logic
+- No changes to individual workflow pages (Inventory, Sales, Purchasing, etc.)

--- a/docs/superpowers/specs/2026-04-25-websocket-stability-fix-design.md
+++ b/docs/superpowers/specs/2026-04-25-websocket-stability-fix-design.md
@@ -1,0 +1,82 @@
+# WebSocket Stability Fix — Design Spec
+
+**Issue:** #430
+**Date:** 2026-04-25
+**Scope:** Fix intermittent "transport close" disconnections and suppress noisy reconnect toasts
+
+---
+
+## Problem
+
+The Socket.IO connection established by `WebSocketProvider` (root namespace `/`) disconnects intermittently with reason `"transport close"` and auto-reconnects. Three root causes:
+
+1. **No `pingTimeout`/`pingInterval` on the server.** Default `pingTimeout` is 20s — too short for Docker networking latency spikes. A missed ping closes the connection before recovery is possible.
+2. **NGINX `keepalive 32` upstream pooling.** HTTP keepalive connection recycling can interfere with long-lived WebSocket tunnels, causing NGINX to close the underlying TCP connection mid-session.
+3. **Noisy reconnect toast.** The `reconnect` event fires a "Real-time connection restored" notification on every auto-recovery, including sub-second blips the user never noticed.
+
+**Out of scope:** The `DashboardWebSocketGateway` uses a `dashboard` namespace that the frontend never connects to — this is a separate cleanup issue. The dashboard page is REST-based and stays that way.
+
+---
+
+## Solution: Option B — Stable + Silent
+
+### 1. Backend — Root namespace gateway with heartbeat config
+
+`frontend/src/hooks/useWebSocket.tsx` connects to the root namespace (`/`). There is no NestJS gateway registered on `/` — only on `dashboard`. Add a minimal root gateway with explicit heartbeat settings:
+
+- `pingInterval: 25000` (25s — matches Socket.IO default, explicit for clarity)
+- `pingTimeout: 60000` (60s — tripled from 20s default to tolerate Docker network latency)
+
+**File:** `backend/src/modules/dashboard/gateways/app-websocket-gateway.ts` (new file)
+**Module:** Register in `DashboardModule`
+
+The existing `DashboardWebSocketGateway` (`namespace: 'dashboard'`) is left unchanged.
+
+### 2. NGINX — Disable keepalive reuse on WebSocket path
+
+The `/socket.io/` location block already sets correct WebSocket upgrade headers. Add:
+
+```nginx
+proxy_http_version 1.1;
+keepalive_requests 0;
+```
+
+`keepalive_requests 0` disables connection reuse for the WebSocket proxy path, preventing NGINX from recycling the TCP tunnel mid-session.
+
+**File:** `nginx/nginx.conf`
+
+### 3. Frontend — Debounced reconnect toast
+
+In `useWebSocket.tsx`, track the timestamp when `disconnect` fires using a `useRef`. In the `reconnect` handler, only call `showNotification` if `Date.now() - disconnectTimeRef.current > 5000`. Sub-second blips produce no visible notification.
+
+**File:** `frontend/src/hooks/useWebSocket.tsx`
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `backend/src/modules/dashboard/gateways/app-websocket-gateway.ts` | New root namespace gateway with heartbeat config |
+| `backend/src/modules/dashboard/dashboard.module.ts` | Register new gateway |
+| `nginx/nginx.conf` | Add `keepalive_requests 0` to `/socket.io/` location |
+| `frontend/src/hooks/useWebSocket.tsx` | Add disconnect timestamp ref, debounce reconnect toast |
+
+---
+
+## What We're NOT Changing
+
+- Transport order stays `['websocket', 'polling']` — polling fallback is a safety net
+- Dashboard page stays REST-based
+- `DashboardWebSocketGateway` namespace mismatch — separate cleanup ticket
+- No Redis adapter — single backend instance, in-memory adapter is correct
+
+---
+
+## Testing
+
+1. Start Docker Compose, open browser devtools network tab
+2. Filter to WS connections — confirm `/socket.io/` upgrades to WebSocket
+3. Let the connection sit for 2+ minutes — confirm no `transport close` in console
+4. Simulate a brief disconnect (restart backend container) — confirm toast only appears if down >5s
+5. Confirm existing notification events (`realtime_update`, `system_notification`, `business_alert`) still fire correctly

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erp-frontend",
-  "version": "1.87.5",
+  "version": "1.88.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-frontend",
-      "version": "1.87.5",
+      "version": "1.88.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -1829,9 +1829,9 @@
       }
     },
     "node_modules/@tanstack/query-devtools": {
-      "version": "5.100.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.100.0.tgz",
-      "integrity": "sha512-6l1vHtvZSpqKVbbRokaX3HJ+MDRFaPHQ1odOVkIibWJafrLi9pMtZDtyQmno2h0J6dmLzH9PxsKKPpGf1Uh/pA==",
+      "version": "5.100.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.100.1.tgz",
+      "integrity": "sha512-jZLV2l7XjYxXCrXHj9pj15gZuY8Te+idoSPS2hIh3+SxOd20Gn0rfUoqEw9vc+us/b16hi0/DWqpzx9O1ZsyIQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1855,19 +1855,19 @@
       }
     },
     "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.100.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.100.0.tgz",
-      "integrity": "sha512-TdDAmg6cqqPdBSZQuH7OghJPV03v8wnlEvHT9utN38D2mmD+I/Jb0bM5v7I5avNAPDerSKwlB/6AI1dWHinvug==",
+      "version": "5.100.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.100.1.tgz",
+      "integrity": "sha512-JuLinBUl/BlZhm0WVX83fJgE2a3YSbuEdxf3fgP+THg92hX7YfwuH5DzT35a6sL/rifZsPr0yJ9itB6jDOcdRg==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-devtools": "5.100.0"
+        "@tanstack/query-devtools": "5.100.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "@tanstack/react-query": "^5.100.0",
+        "@tanstack/react-query": "^5.100.1",
         "react": "^18 || ^19"
       }
     },
@@ -2582,9 +2582,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erp-frontend",
-  "version": "1.87.3",
+  "version": "1.87.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-frontend",
-      "version": "1.87.3",
+      "version": "1.87.5",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -1819,9 +1819,9 @@
       "license": "MIT"
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.99.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.2.tgz",
-      "integrity": "sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==",
+      "version": "5.100.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.1.tgz",
+      "integrity": "sha512-awvQhOO/2TrSCHE5LKKsXcvvj6WSBncwEcMFCB/ez0Qs0b17iyyivoGArNV3HFfXryZwCpnb/olsaBBKrIbtSw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1829,9 +1829,9 @@
       }
     },
     "node_modules/@tanstack/query-devtools": {
-      "version": "5.99.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.99.2.tgz",
-      "integrity": "sha512-TEF1d+RYO9l8oeCwgzmOHIgKwAzXQmw2s/ny2bW8qeg2OMkkLjALfVEivgCMR3OL/jVdMmeTPX56WrV+uvYJFg==",
+      "version": "5.100.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.100.0.tgz",
+      "integrity": "sha512-6l1vHtvZSpqKVbbRokaX3HJ+MDRFaPHQ1odOVkIibWJafrLi9pMtZDtyQmno2h0J6dmLzH9PxsKKPpGf1Uh/pA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1839,12 +1839,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.99.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.2.tgz",
-      "integrity": "sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==",
+      "version": "5.100.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.1.tgz",
+      "integrity": "sha512-UgWRLhQKprC37SsO6y1zRabOqDmM2gsdTNPbqTT35yl7kOOhwXU4nyfOiGHXPwoEFJV1IpSk85hjIFjNFWVpzw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.99.2"
+        "@tanstack/query-core": "5.100.1"
       },
       "funding": {
         "type": "github",
@@ -1855,19 +1855,19 @@
       }
     },
     "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.99.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.99.2.tgz",
-      "integrity": "sha512-8txkK9A9XBNTB8RoxVgfp6W3qwBr25tNP10L4yu3KuyhAdEvccECfIRzesSwMVk/wpVVioAr+hbMtUkMMF+WVw==",
+      "version": "5.100.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.100.0.tgz",
+      "integrity": "sha512-TdDAmg6cqqPdBSZQuH7OghJPV03v8wnlEvHT9utN38D2mmD+I/Jb0bM5v7I5avNAPDerSKwlB/6AI1dWHinvug==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-devtools": "5.99.2"
+        "@tanstack/query-devtools": "5.100.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "@tanstack/react-query": "^5.99.2",
+        "@tanstack/react-query": "^5.100.0",
         "react": "^18 || ^19"
       }
     },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erp-frontend",
-  "version": "1.86.0",
+  "version": "1.87.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-frontend",
-      "version": "1.86.0",
+      "version": "1.87.3",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -533,9 +533,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1076,9 +1076,9 @@
       "license": "MIT"
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.41.4",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.4.tgz",
-      "integrity": "sha512-3B9EinUkrdOUGYzHRzRWSXunQ4YFGboJnyLNRwEJWEde+j8fNhPUHvrN1E3g1DU/iS/s8JQrMNVe+S7AHHVs0w==",
+      "version": "0.41.5",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.5.tgz",
+      "integrity": "sha512-Fa2HztoLlZxRN6wVC2KB7q0SvRTKjfP0328NVnSit03+0nzm62syxyT46KGbgq3Vr1A/mmLeQwu3GprB0lNTjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1466,9 +1466,9 @@
       "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.126.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
-      "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1519,9 +1519,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
       "cpu": [
         "arm64"
       ],
@@ -1536,9 +1536,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
       "cpu": [
         "arm64"
       ],
@@ -1553,9 +1553,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
       "cpu": [
         "x64"
       ],
@@ -1570,9 +1570,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
       "cpu": [
         "x64"
       ],
@@ -1587,9 +1587,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
-      "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
       "cpu": [
         "arm"
       ],
@@ -1604,9 +1604,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
       "cpu": [
         "arm64"
       ],
@@ -1624,9 +1624,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
-      "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
       "cpu": [
         "arm64"
       ],
@@ -1644,9 +1644,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
       "cpu": [
         "ppc64"
       ],
@@ -1664,9 +1664,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
       "cpu": [
         "s390x"
       ],
@@ -1684,9 +1684,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
       "cpu": [
         "x64"
       ],
@@ -1704,9 +1704,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
-      "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
       ],
@@ -1724,9 +1724,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
       "cpu": [
         "arm64"
       ],
@@ -1741,9 +1741,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
-      "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
       "cpu": [
         "wasm32"
       ],
@@ -1751,8 +1751,8 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
         "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
@@ -1760,9 +1760,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
-      "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
       "cpu": [
         "arm64"
       ],
@@ -1777,9 +1777,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
-      "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
       "cpu": [
         "x64"
       ],
@@ -2713,9 +2713,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.20",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
-      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
+      "version": "2.10.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
+      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3181,9 +3181,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.343",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.343.tgz",
-      "integrity": "sha512-YHnQ3MXI08icvL9ZKnEBy05F2EQ8ob01UaMOuMbM8l+4UcAq6MPPbBTJBbsBUg3H8JeZNt+O4fjsoWth3p6IFg==",
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "dev": true,
       "license": "ISC"
     },
@@ -4747,9 +4747,9 @@
       "license": "MIT"
     },
     "node_modules/msw": {
-      "version": "2.13.4",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.13.4.tgz",
-      "integrity": "sha512-fPlKBeFe+8rpcyR3umUmmHuNwu6gc6T3STvkgEa9WDX/HEgal9wDeflpCUAIRtmvaLZM2igfI5y1bZ9G5J26KA==",
+      "version": "2.13.5",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.13.5.tgz",
+      "integrity": "sha512-LuJem+CbqbywJtafv4zh5kcCQNmZnKwfJgJ/LcNYjeG3CU/xJLepJM1CNZcbp+oV8tXFGvUfswPGru34Mx7QGQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5403,14 +5403,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.126.0",
-        "@rolldown/pluginutils": "1.0.0-rc.16"
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -5419,27 +5419,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
-      "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6025,16 +6025,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
-      "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.16",
+        "rolldown": "1.0.0-rc.17",
         "tinyglobby": "^0.2.16"
       },
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-frontend",
-  "version": "1.87.3",
+  "version": "1.87.4",
   "description": "Comprehensive ERP System Frontend",
   "private": true,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-frontend",
-  "version": "1.90.4",
+  "version": "1.90.5",
   "description": "Comprehensive ERP System Frontend",
   "private": true,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-frontend",
-  "version": "1.87.2",
+  "version": "1.87.3",
   "description": "Comprehensive ERP System Frontend",
   "private": true,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-frontend",
-  "version": "1.90.3",
+  "version": "1.90.4",
   "description": "Comprehensive ERP System Frontend",
   "private": true,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-frontend",
-  "version": "1.90.1",
+  "version": "1.90.2",
   "description": "Comprehensive ERP System Frontend",
   "private": true,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-frontend",
-  "version": "1.90.2",
+  "version": "1.90.3",
   "description": "Comprehensive ERP System Frontend",
   "private": true,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-frontend",
-  "version": "1.88.2",
+  "version": "1.89.0",
   "description": "Comprehensive ERP System Frontend",
   "private": true,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-frontend",
-  "version": "1.88.1",
+  "version": "1.88.2",
   "description": "Comprehensive ERP System Frontend",
   "private": true,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-frontend",
-  "version": "1.88.0",
+  "version": "1.88.1",
   "description": "Comprehensive ERP System Frontend",
   "private": true,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-frontend",
-  "version": "1.87.4",
+  "version": "1.87.5",
   "description": "Comprehensive ERP System Frontend",
   "private": true,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-frontend",
-  "version": "1.90.0",
+  "version": "1.90.1",
   "description": "Comprehensive ERP System Frontend",
   "private": true,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-frontend",
-  "version": "1.87.5",
+  "version": "1.87.6",
   "description": "Comprehensive ERP System Frontend",
   "private": true,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-frontend",
-  "version": "1.87.1",
+  "version": "1.87.2",
   "description": "Comprehensive ERP System Frontend",
   "private": true,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-frontend",
-  "version": "1.89.0",
+  "version": "1.90.0",
   "description": "Comprehensive ERP System Frontend",
   "private": true,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-frontend",
-  "version": "1.87.0",
+  "version": "1.87.1",
   "description": "Comprehensive ERP System Frontend",
   "private": true,
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erp-frontend",
-  "version": "1.87.6",
+  "version": "1.88.0",
   "description": "Comprehensive ERP System Frontend",
   "private": true,
   "type": "module",

--- a/frontend/src/__tests__/integration/accounting-auto-posting.integration.test.tsx
+++ b/frontend/src/__tests__/integration/accounting-auto-posting.integration.test.tsx
@@ -301,7 +301,7 @@ describe('Accounting Auto-Posting Integration Tests', () => {
       })
     })
 
-    it('displays both manual and auto-posted entries with correct type labels', async () => {
+    it('displays all entries as reference numbers in the list', async () => {
       renderJournalEntriesPage()
 
       await waitFor(() => {
@@ -309,23 +309,9 @@ describe('Accounting Auto-Posting Integration Tests', () => {
         expect(screen.getByText('JE-2026-002')).toBeInTheDocument()
         expect(screen.getByText('JE-2026-003')).toBeInTheDocument()
       })
-
-      expect(screen.getByText('Manual Entry')).toBeInTheDocument()
-      expect(screen.getByText('Sales Order')).toBeInTheDocument()
-      expect(screen.getByText('Customer Payment')).toBeInTheDocument()
     })
 
-    it('shows "View Transaction" link only for auto-posted entries', async () => {
-      renderJournalEntriesPage()
-
-      await waitFor(() => {
-        expect(screen.getByText('JE-2026-002')).toBeInTheDocument()
-      })
-
-      expect(screen.getAllByText('View Transaction')).toHaveLength(2)
-    })
-
-    it('navigates to source transaction when clicking View Transaction', async () => {
+    it('shows source link in context header when an auto-posted entry is selected', async () => {
       const user = createUser()
 
       renderJournalEntriesPage()
@@ -334,7 +320,29 @@ describe('Accounting Auto-Posting Integration Tests', () => {
         expect(screen.getByText('JE-2026-002')).toBeInTheDocument()
       })
 
-      await user.click(screen.getAllByText('View Transaction')[0])
+      await user.click(screen.getByText('JE-2026-002'))
+
+      await waitFor(() => {
+        expect(screen.getByText('View Sales Order')).toBeInTheDocument()
+      })
+    })
+
+    it('navigates to source transaction when clicking source link in context header', async () => {
+      const user = createUser()
+
+      renderJournalEntriesPage()
+
+      await waitFor(() => {
+        expect(screen.getByText('JE-2026-002')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByText('JE-2026-002'))
+
+      await waitFor(() => {
+        expect(screen.getByText('View Sales Order')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByText('View Sales Order'))
 
       expect(mockNavigate).toHaveBeenCalledWith('/sales/orders?highlight=so-123')
     })

--- a/frontend/src/__tests__/integration/accounting-auto-posting.integration.test.tsx
+++ b/frontend/src/__tests__/integration/accounting-auto-posting.integration.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
 import { BrowserRouter, MemoryRouter, Route, Routes } from 'react-router-dom'
 import { JournalEntryStatus } from '@/types'
 
@@ -67,6 +69,7 @@ import AccountMappingWarning from '@/components/accounting/AccountMappingWarning
 import AccountingEntryLink from '@/components/accounting/AccountingEntryLink'
 import AccountMappingsPage from '@/pages/accounting/AccountMappingsPage'
 import JournalEntriesPage from '@/pages/accounting/JournalEntriesPage'
+import accountingReducer from '@/store/slices/accountingSlice'
 
 const createUser = () => {
   return (userEvent as any).setup ? (userEvent as any).setup() : userEvent
@@ -77,12 +80,20 @@ const renderWithRouter = (component: React.ReactElement) => {
 }
 
 const renderJournalEntriesPage = (initialEntryUrl = '/accounting/journal-entries') => {
+  const store = configureStore({
+    reducer: {
+      accounting: accountingReducer,
+    },
+  })
+
   return render(
-    <MemoryRouter initialEntries={[initialEntryUrl]}>
-      <Routes>
-        <Route path="*" element={<JournalEntriesPage />} />
-      </Routes>
-    </MemoryRouter>,
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[initialEntryUrl]}>
+        <Routes>
+          <Route path="*" element={<JournalEntriesPage />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
   )
 }
 

--- a/frontend/src/components/common/MainLayout.tsx
+++ b/frontend/src/components/common/MainLayout.tsx
@@ -4,9 +4,33 @@ import { Box, Drawer } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 
 import { DRAWER_WIDTH_COLLAPSED, DRAWER_WIDTH_EXPANDED } from '@/constants/layout'
+import { LayoutScrollProvider, useLayoutScrollContext } from '@/contexts/LayoutScrollContext'
 
 import Sidebar from './Sidebar'
 import TopBar from './TopBar'
+
+const MainContent: React.FC = () => {
+  const scrollEnabled = useLayoutScrollContext()
+  return (
+    <Box
+      component="main"
+      sx={{
+        flexGrow: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        pt: 11,
+        px: { xs: 2, sm: 3 },
+        pb: 3,
+        bgcolor: 'background.default',
+        height: '100%',
+        overflow: scrollEnabled ? 'auto' : 'hidden',
+        maxWidth: '100%',
+      }}
+    >
+      <Outlet />
+    </Box>
+  )
+}
 
 const MainLayout: React.FC = () => {
   const theme = useTheme()
@@ -79,23 +103,9 @@ const MainLayout: React.FC = () => {
         </Drawer>
       </Box>
 
-      <Box
-        component="main"
-        sx={{
-          flexGrow: 1,
-          display: 'flex',
-          flexDirection: 'column',
-          pt: 11,
-          px: { xs: 2, sm: 3 },
-          pb: 3,
-          bgcolor: 'background.default',
-          height: '100%',
-          overflow: 'hidden',
-          maxWidth: '100%',
-        }}
-      >
-        <Outlet />
-      </Box>
+      <LayoutScrollProvider>
+        <MainContent />
+      </LayoutScrollProvider>
     </Box>
   )
 }

--- a/frontend/src/components/common/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/common/__tests__/MainLayout.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import { describe, it, vi } from 'vitest'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
 
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
 import MainLayout from '../MainLayout'
 
 vi.mock('../Sidebar', () => ({ default: () => <div data-testid="sidebar" /> }))
@@ -15,6 +16,11 @@ function makeStore() {
       notifications: (state = { notifications: [], unreadCount: 0 }) => state,
     },
   })
+}
+
+const ScrollOptInPage = () => {
+  useLayoutScroll(true)
+  return <div>Scrollable route</div>
 }
 
 describe('MainLayout', () => {
@@ -50,5 +56,23 @@ describe('MainLayout', () => {
     )
 
     expect(screen.getByRole('main')).toHaveStyle({ height: '100%' })
+  })
+
+  it('allows routed pages to opt in to main content scrolling', async () => {
+    render(
+      <Provider store={makeStore()}>
+        <MemoryRouter>
+          <Routes>
+            <Route element={<MainLayout />}>
+              <Route index element={<ScrollOptInPage />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('main')).toHaveStyle({ overflow: 'auto' })
+    })
   })
 })

--- a/frontend/src/contexts/LayoutScrollContext.test.tsx
+++ b/frontend/src/contexts/LayoutScrollContext.test.tsx
@@ -1,4 +1,6 @@
-import { renderHook, act } from '@testing-library/react'
+import React, { useState } from 'react'
+import { render, act } from '@testing-library/react'
+import { renderHook } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import { LayoutScrollProvider, useLayoutScroll, useLayoutScrollContext } from './LayoutScrollContext'
 
@@ -21,14 +23,32 @@ describe('LayoutScrollContext', () => {
   })
 
   it('useLayoutScroll resets to false on unmount', () => {
-    const { result, unmount } = renderHook(() => {
+    // Render a parent that tracks the context value and conditionally mounts
+    // a child that calls useLayoutScroll(true). Unmounting the child must
+    // trigger cleanup and reset the context to false.
+    let observedValue: boolean | null = null
+
+    const Observer = () => {
+      observedValue = useLayoutScrollContext()
+      return null
+    }
+
+    const Controller = () => {
       useLayoutScroll(true)
-      return useLayoutScrollContext()
-    }, { wrapper })
-    expect(result.current).toBe(true)
-    unmount()
-    // After unmount, a new consumer sees the reset default
-    const { result: result2 } = renderHook(() => useLayoutScrollContext(), { wrapper })
-    expect(result2.current).toBe(false)
+      return null
+    }
+
+    const App = ({ showController }: { showController: boolean }) => (
+      <LayoutScrollProvider>
+        <Observer />
+        {showController && <Controller />}
+      </LayoutScrollProvider>
+    )
+
+    const { rerender } = render(<App showController={true} />)
+    expect(observedValue).toBe(true)
+
+    act(() => { rerender(<App showController={false} />) })
+    expect(observedValue).toBe(false)
   })
 })

--- a/frontend/src/contexts/LayoutScrollContext.test.tsx
+++ b/frontend/src/contexts/LayoutScrollContext.test.tsx
@@ -1,0 +1,34 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { LayoutScrollProvider, useLayoutScroll, useLayoutScrollContext } from './LayoutScrollContext'
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <LayoutScrollProvider>{children}</LayoutScrollProvider>
+)
+
+describe('LayoutScrollContext', () => {
+  it('defaults to scrollEnabled = false', () => {
+    const { result } = renderHook(() => useLayoutScrollContext(), { wrapper })
+    expect(result.current).toBe(false)
+  })
+
+  it('useLayoutScroll(true) enables scroll on mount', () => {
+    const { result } = renderHook(() => {
+      useLayoutScroll(true)
+      return useLayoutScrollContext()
+    }, { wrapper })
+    expect(result.current).toBe(true)
+  })
+
+  it('useLayoutScroll resets to false on unmount', () => {
+    const { result, unmount } = renderHook(() => {
+      useLayoutScroll(true)
+      return useLayoutScrollContext()
+    }, { wrapper })
+    expect(result.current).toBe(true)
+    unmount()
+    // After unmount, a new consumer sees the reset default
+    const { result: result2 } = renderHook(() => useLayoutScrollContext(), { wrapper })
+    expect(result2.current).toBe(false)
+  })
+})

--- a/frontend/src/contexts/LayoutScrollContext.tsx
+++ b/frontend/src/contexts/LayoutScrollContext.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+
+const LayoutScrollContext = createContext<boolean>(false)
+const LayoutScrollSetContext = createContext<React.Dispatch<React.SetStateAction<boolean>>>(() => {})
+
+export const LayoutScrollProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [scrollEnabled, setScrollEnabled] = useState(false)
+  return (
+    <LayoutScrollContext.Provider value={scrollEnabled}>
+      <LayoutScrollSetContext.Provider value={setScrollEnabled}>
+        {children}
+      </LayoutScrollSetContext.Provider>
+    </LayoutScrollContext.Provider>
+  )
+}
+
+export const useLayoutScrollContext = () => useContext(LayoutScrollContext)
+
+export const useLayoutScroll = (enabled: boolean) => {
+  const setScrollEnabled = useContext(LayoutScrollSetContext)
+  useEffect(() => {
+    setScrollEnabled(enabled)
+    return () => setScrollEnabled(false)
+  }, [enabled, setScrollEnabled])
+}

--- a/frontend/src/hooks/__tests__/useWebSocket.reconnect.test.tsx
+++ b/frontend/src/hooks/__tests__/useWebSocket.reconnect.test.tsx
@@ -1,0 +1,90 @@
+import { renderHook, act } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+
+const { mockShowNotification, mockSocket } = vi.hoisted(() => ({
+  mockShowNotification: vi.fn(),
+  mockSocket: {
+    on: vi.fn(),
+    onAny: vi.fn(),
+    disconnect: vi.fn(),
+    emit: vi.fn(),
+    connected: true,
+  },
+}))
+
+vi.mock('../useNotification', () => ({
+  useNotification: () => ({ showNotification: mockShowNotification }),
+}))
+
+vi.mock('../useRedux', () => ({
+  useAppDispatch: () => vi.fn(),
+  useAppSelector: (selector: any) =>
+    selector({ auth: { isAuthenticated: true, accessToken: 'token' } }),
+}))
+
+vi.mock('@/store/slices/notificationSlice', () => ({
+  addNotification: vi.fn(),
+}))
+
+vi.mock('socket.io-client', () => ({
+  io: () => mockSocket,
+}))
+
+import { WebSocketProvider } from '../useWebSocket'
+
+describe('useWebSocket reconnect toast debounce', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does NOT show toast when reconnect happens within 5 seconds of disconnect', () => {
+    const handlers: Record<string, Function> = {}
+    mockSocket.on.mockImplementation((event: string, cb: Function) => {
+      handlers[event] = cb
+    })
+
+    const wrapper = ({ children }: any) => (
+      <WebSocketProvider>{children}</WebSocketProvider>
+    )
+    renderHook(() => {}, { wrapper })
+
+    act(() => {
+      handlers['disconnect']?.('transport close')
+      vi.advanceTimersByTime(2000)
+      handlers['reconnect']?.(1)
+    })
+
+    expect(mockShowNotification).not.toHaveBeenCalledWith(
+      'Real-time connection restored',
+      'success',
+    )
+  })
+
+  it('DOES show toast when reconnect happens after more than 5 seconds', () => {
+    const handlers: Record<string, Function> = {}
+    mockSocket.on.mockImplementation((event: string, cb: Function) => {
+      handlers[event] = cb
+    })
+
+    const wrapper = ({ children }: any) => (
+      <WebSocketProvider>{children}</WebSocketProvider>
+    )
+    renderHook(() => {}, { wrapper })
+
+    act(() => {
+      handlers['disconnect']?.('transport close')
+      vi.advanceTimersByTime(6000)
+      handlers['reconnect']?.(1)
+    })
+
+    expect(mockShowNotification).toHaveBeenCalledWith(
+      'Real-time connection restored',
+      'success',
+    )
+  })
+})

--- a/frontend/src/hooks/useEntityWorkspace.test.ts
+++ b/frontend/src/hooks/useEntityWorkspace.test.ts
@@ -185,4 +185,20 @@ describe('useEntityWorkspace', () => {
     expect(onEscape).toHaveBeenCalledTimes(1)
     expect(config.selectEntity).not.toHaveBeenCalledWith(null)
   })
+
+  it('does not clear selection when entities become empty during a fetch', () => {
+    const config = makeConfig({ isFetching: true, entities: [] })
+
+    renderHook(() => useEntityWorkspace(config))
+
+    expect(config.selectEntity).not.toHaveBeenCalled()
+  })
+
+  it('clears selection when entities become empty and not fetching', () => {
+    const config = makeConfig({ isFetching: false, entities: [] })
+
+    renderHook(() => useEntityWorkspace(config))
+
+    expect(config.selectEntity).toHaveBeenCalledWith(null)
+  })
 })

--- a/frontend/src/hooks/useEntityWorkspace.ts
+++ b/frontend/src/hooks/useEntityWorkspace.ts
@@ -72,6 +72,8 @@ export function useEntityWorkspace<T extends { id: string }>(
   const listRef = useRef<HTMLDivElement>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
   const hasAutoSelected = useRef(false)
+  const focusedIndexRef = useRef(focusedIndex)
+  focusedIndexRef.current = focusedIndex
 
   useEffect(() => {
     if (entities.length === 0) {
@@ -83,11 +85,11 @@ export function useEntityWorkspace<T extends { id: string }>(
       return
     }
 
-    if (!selectedEntity && focusedIndex === -1 && !hasAutoSelected.current) {
+    if (!selectedEntity && focusedIndexRef.current === -1 && !hasAutoSelected.current) {
       hasAutoSelected.current = true
       selectEntity(entities[0])
     }
-  }, [entities, focusedIndex, isFetching, selectedEntity, selectEntity])
+  }, [entities, isFetching, selectedEntity, selectEntity])
 
   useEffect(() => {
     if (focusedIndex < 0 || !listRef.current) {

--- a/frontend/src/hooks/useEntityWorkspace.ts
+++ b/frontend/src/hooks/useEntityWorkspace.ts
@@ -19,6 +19,7 @@ export interface UseEntityWorkspaceConfig<T extends { id: string }> {
     showError: (message: string) => void
   }
   deleteMutation: (id: string) => Promise<void>
+  isFetching?: boolean
   onEnter?: () => void
   onEscape?: () => void
 }
@@ -58,6 +59,7 @@ export function useEntityWorkspace<T extends { id: string }>(
     routes,
     notifications,
     deleteMutation,
+    isFetching = false,
     onEnter,
     onEscape,
   } = config
@@ -73,9 +75,11 @@ export function useEntityWorkspace<T extends { id: string }>(
 
   useEffect(() => {
     if (entities.length === 0) {
-      hasAutoSelected.current = false
-      setFocusedIndex(-1)
-      selectEntity(null)
+      if (!isFetching) {
+        hasAutoSelected.current = false
+        setFocusedIndex(-1)
+        selectEntity(null)
+      }
       return
     }
 
@@ -83,7 +87,7 @@ export function useEntityWorkspace<T extends { id: string }>(
       hasAutoSelected.current = true
       selectEntity(entities[0])
     }
-  }, [entities, focusedIndex, selectedEntity, selectEntity])
+  }, [entities, focusedIndex, isFetching, selectedEntity, selectEntity])
 
   useEffect(() => {
     if (focusedIndex < 0 || !listRef.current) {

--- a/frontend/src/hooks/useWebSocket.tsx
+++ b/frontend/src/hooks/useWebSocket.tsx
@@ -33,6 +33,7 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   const [lastMessage, setLastMessage] = useState<WebSocketMessage | null>(null)
   const socketRef = useRef<Socket | null>(null)
   const listenersRef = useRef<Map<string, Set<Function>>>(new Map())
+  const disconnectTimeRef = useRef<number | null>(null)
 
   // Initialize WebSocket connection
   useEffect(() => {
@@ -70,6 +71,7 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({ chi
 
       socket.on('disconnect', (reason) => {
         console.log('WebSocket disconnected:', reason)
+        disconnectTimeRef.current = Date.now()
         setIsConnected(false)
         if (reason === 'io server disconnect') {
           // Server initiated disconnect, try to reconnect
@@ -88,7 +90,11 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       socket.on('reconnect', (attemptNumber) => {
         console.log('WebSocket reconnected after', attemptNumber, 'attempts')
         setIsConnected(true)
-        showNotification('Real-time connection restored', 'success')
+        const downFor = disconnectTimeRef.current ? Date.now() - disconnectTimeRef.current : 0
+        if (downFor > 5000) {
+          showNotification('Real-time connection restored', 'success')
+        }
+        disconnectTimeRef.current = null
       })
 
       socket.on('reconnect_failed', () => {

--- a/frontend/src/pages/accounting/AccountingDashboardPage.tsx
+++ b/frontend/src/pages/accounting/AccountingDashboardPage.tsx
@@ -39,6 +39,7 @@ import {
 import { formatCurrency, formatDate, getCurrentDate } from '@/utils/formatters';
 import type { JournalEntry } from '@/types';
 import { useKeyboardShortcuts } from '@/hooks/useSearchAndFilter';
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext';
 
 // Summary Card Component
 interface SummaryCardProps {
@@ -158,6 +159,7 @@ const getEntryTypeChip = (type: string) => {
 };
 
 const AccountingDashboardPage: React.FC = () => {
+  useLayoutScroll(true);
   const navigate = useNavigate();
 
   // Calculate YTD date range

--- a/frontend/src/pages/accounting/ChartOfAccountsPage.tsx
+++ b/frontend/src/pages/accounting/ChartOfAccountsPage.tsx
@@ -3,7 +3,9 @@ import React, { useMemo, useState } from 'react'
 import AccountMappingWarning from '@/components/accounting/AccountMappingWarning'
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import { useGetChartOfAccountsHierarchyQuery } from '@/store/api/accountingApi'
+import { selectSelectedAccount } from '@/store/slices/accountingSlice'
 import type { ChartOfAccount } from '@/types'
 import type { FilterBarConfig } from '@/types/filterBar.types'
 
@@ -29,11 +31,10 @@ const filterConfig: FilterBarConfig<CoaFilters> = {
 }
 
 const ChartOfAccountsPage: React.FC = () => {
+  const dispatch = useAppDispatch()
+  const selectedAccount = useAppSelector(selectSelectedAccount)
   const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
   const { data: hierarchyData, isLoading, error, refetch } = useGetChartOfAccountsHierarchyQuery()
-  const workspace = useChartOfAccountsWorkspace(() => {
-    void refetch()
-  })
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
 
   const accounts = useMemo(() => {
@@ -81,6 +82,15 @@ const ChartOfAccountsPage: React.FC = () => {
     )
   }, [accounts, appliedFilters, sortOrder])
 
+  const workspace = useChartOfAccountsWorkspace({
+    dispatch,
+    accounts: filteredAccounts,
+    selectedAccount,
+    refetch: () => {
+      void refetch()
+    },
+  })
+
   return (
     <>
       <AccountMappingWarning context="system" />
@@ -111,23 +121,24 @@ const ChartOfAccountsPage: React.FC = () => {
           <ChartOfAccountsTable
             accounts={filteredAccounts}
             loading={isLoading}
-            selectedId={workspace.selected?.id ?? null}
-            onSelect={workspace.setSelected}
+            selectedId={selectedAccount?.id ?? null}
+            focusedIndex={workspace.focusedIndex}
+            onSelect={workspace.handleSelect}
             listRef={workspace.listRef}
           />
         }
         headerSlot={
           <ChartOfAccountContextHeader
-            selected={workspace.selected}
+            selected={selectedAccount}
             onEdit={() => workspace.setFormDialogOpen(true)}
-            onDelete={() => workspace.selected && workspace.setDeleteTarget(workspace.selected)}
+            onDelete={() => selectedAccount && workspace.setDeleteTarget(selectedAccount)}
           />
         }
-        workspaceSlot={<ChartOfAccountWorkspaceCard selected={workspace.selected} />}
+        workspaceSlot={<ChartOfAccountWorkspaceCard selected={selectedAccount} />}
         dialogs={
           <ChartOfAccountsDialogs
             formDialogOpen={workspace.formDialogOpen}
-            selected={workspace.selected}
+            selected={selectedAccount}
             onCloseForm={() => workspace.setFormDialogOpen(false)}
             onFormSuccess={() => {
               workspace.setFormDialogOpen(false)

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -1,9 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
-import { Stack } from '@mui/material'
-import { AppButton } from '@/components/common/AppButton'
-import { default as DeleteIcon } from '@mui/icons-material/Delete'
-import { default as PostIcon } from '@mui/icons-material/PostAdd'
+import { useLocation } from 'react-router-dom'
 
 import AccountMappingWarning from '@/components/accounting/AccountMappingWarning'
 import GenericListPage from '@/components/common/GenericListPage'
@@ -30,7 +26,6 @@ export const JournalEntriesPage: React.FC = () => {
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
 
   const location = useLocation()
-  const navigate = useNavigate()
 
   const filterConfig = useMemo<FilterBarConfig<JEFilters>>(
     () => ({
@@ -74,11 +69,10 @@ export const JournalEntriesPage: React.FC = () => {
     endDate: dateRange.toDate,
     sortBy,
     sortOrder: sortOrder.toUpperCase() as 'ASC' | 'DESC',
-  }), [appliedFilters, dateRange, sortBy, sortOrder, sourceTypeParam, sourceIdParam])
+  }), [appliedFilters, dateRange, sortBy, sortOrder, sourceIdParam, sourceTypeParam])
 
   const { data, isLoading, refetch } = useGetJournalEntriesQuery(queryArgs)
   const entries = data?.data ?? []
-  const pagination = data?.meta
   const workspace = useJournalEntriesWorkspace(() => {
     void refetch()
   })
@@ -111,29 +105,13 @@ export const JournalEntriesPage: React.FC = () => {
         hasActiveFilters={hasActiveFilters}
         searchInputRef={workspace.searchInputRef}
         sort={{ field: 'createdAt', sortBy, sortOrder, onSort: handleSort }}
-        contentSlot={workspace.selectedIds.size > 0 ? (
-          <Stack direction="row" spacing={1} sx={{ mb: 1 }}>
-            <AppButton size="small" variant="primary" startIcon={<PostIcon />} onClick={() => workspace.setBulkPostOpen(true)}>
-              Post Selected ({workspace.selectedIds.size})
-            </AppButton>
-            <AppButton size="small" variant="danger" startIcon={<DeleteIcon />} onClick={() => workspace.setBulkDeleteOpen(true)}>
-              Delete Selected ({workspace.selectedIds.size})
-            </AppButton>
-          </Stack>
-        ) : null}
         listSlot={(
           <JournalEntriesTable
             entries={entries}
             loading={isLoading}
-            total={pagination?.total ?? 0}
             selectedEntryId={workspace.selectedEntry?.id ?? null}
-            selectedIds={workspace.selectedIds}
             onSelect={workspace.handleSelect}
-            onToggleCheck={workspace.handleToggleCheck}
-            onSelectAll={() => workspace.handleSelectAll(entries)}
-            onPost={(entry) => workspace.setPostTarget(entry)}
-            onDelete={(entry) => workspace.setDeleteTarget(entry)}
-            onViewSource={(sourceType, sourceId) => workspace.navigateToSource(sourceType, sourceId)}
+            onViewSource={workspace.navigateToSource}
             listRef={workspace.listRef}
           />
         )}
@@ -144,7 +122,7 @@ export const JournalEntriesPage: React.FC = () => {
             onPost={() => workspace.selectedEntry && workspace.setPostTarget(workspace.selectedEntry)}
             onReverse={() => workspace.selectedEntry && workspace.setReverseTarget(workspace.selectedEntry)}
             onDelete={() => workspace.selectedEntry && workspace.setDeleteTarget(workspace.selectedEntry)}
-            onNavigateToSource={(path) => navigate(path)}
+            onViewSource={workspace.navigateToSource}
           />
         )}
         workspaceSlot={<JournalEntryWorkspaceCard selectedEntry={workspace.selectedEntry} />}
@@ -153,19 +131,13 @@ export const JournalEntriesPage: React.FC = () => {
             postTarget={workspace.postTarget}
             deleteTarget={workspace.deleteTarget}
             reverseTarget={workspace.reverseTarget}
-            bulkPostIds={workspace.bulkPostOpen ? workspace.selectedIds : new Set<string>()}
-            bulkDeleteIds={workspace.bulkDeleteOpen ? workspace.selectedIds : new Set<string>()}
             actionLoading={workspace.actionLoading}
             onConfirmPost={workspace.handleConfirmPost}
             onConfirmDelete={workspace.handleConfirmDelete}
             onConfirmReverse={workspace.handleConfirmReverse}
-            onConfirmBulkPost={workspace.handleBulkPost}
-            onConfirmBulkDelete={workspace.handleBulkDelete}
             onCancelPost={() => workspace.setPostTarget(null)}
             onCancelDelete={() => workspace.setDeleteTarget(null)}
             onCancelReverse={() => workspace.setReverseTarget(null)}
-            onCancelBulkPost={() => workspace.setBulkPostOpen(false)}
-            onCancelBulkDelete={() => workspace.setBulkDeleteOpen(false)}
           />
         )}
       />

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -73,6 +73,7 @@ export const JournalEntriesPage: React.FC = () => {
 
   const { data, isLoading, refetch } = useGetJournalEntriesQuery(queryArgs)
   const entries = data?.data ?? []
+  const pagination = data?.meta
   const workspace = useJournalEntriesWorkspace(() => {
     void refetch()
   })
@@ -109,6 +110,7 @@ export const JournalEntriesPage: React.FC = () => {
           <JournalEntriesTable
             entries={entries}
             loading={isLoading}
+            total={pagination?.total ?? entries.length}
             selectedEntryId={workspace.selectedEntry?.id ?? null}
             onSelect={workspace.handleSelect}
             onViewSource={workspace.navigateToSource}

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -4,7 +4,9 @@ import { useLocation } from 'react-router-dom'
 import AccountMappingWarning from '@/components/accounting/AccountMappingWarning'
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import { useGetJournalEntriesQuery } from '@/store/api/accountingApi'
+import { selectSelectedJournalEntry } from '@/store/slices/accountingSlice'
 import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
 import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
 
@@ -25,6 +27,8 @@ export const JournalEntriesPage: React.FC = () => {
   const [sortBy, setSortBy] = useState('createdAt')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
 
+  const dispatch = useAppDispatch()
+  const selectedEntry = useAppSelector(selectSelectedJournalEntry)
   const location = useLocation()
 
   const filterConfig = useMemo<FilterBarConfig<JEFilters>>(
@@ -74,17 +78,20 @@ export const JournalEntriesPage: React.FC = () => {
   const { data, isLoading, refetch } = useGetJournalEntriesQuery(queryArgs)
   const entries = data?.data ?? []
   const pagination = data?.meta
-  const workspace = useJournalEntriesWorkspace(() => {
-    void refetch()
+  const workspace = useJournalEntriesWorkspace({
+    dispatch,
+    entries,
+    selectedEntry,
+    refetch: () => {
+      void refetch()
+    },
   })
 
   const filterHandlers = useMemo(() => ({
     ...handlers,
     onSearchChange: (value: string) => {
       handlers.onSearchChange(value)
-      window.setTimeout(() => {
-        workspace.searchInputRef.current?.focus()
-      }, 0)
+      workspace.setShouldPreserveSearchFocus(true)
     },
   }), [handlers, workspace])
 
@@ -111,22 +118,23 @@ export const JournalEntriesPage: React.FC = () => {
             entries={entries}
             loading={isLoading}
             total={pagination?.total ?? entries.length}
-            selectedEntryId={workspace.selectedEntry?.id ?? null}
+            selectedEntryId={selectedEntry?.id ?? null}
+            focusedIndex={workspace.focusedIndex}
             onSelect={workspace.handleSelect}
             listRef={workspace.listRef}
           />
         )}
         headerSlot={(
           <JournalEntryContextHeader
-            selectedEntry={workspace.selectedEntry}
-            onEdit={() => workspace.selectedEntry && workspace.navigateToEdit(workspace.selectedEntry)}
-            onPost={() => workspace.selectedEntry && workspace.setPostTarget(workspace.selectedEntry)}
-            onReverse={() => workspace.selectedEntry && workspace.setReverseTarget(workspace.selectedEntry)}
-            onDelete={() => workspace.selectedEntry && workspace.setDeleteTarget(workspace.selectedEntry)}
+            selectedEntry={selectedEntry}
+            onEdit={() => selectedEntry && workspace.navigateToEdit(selectedEntry)}
+            onPost={() => selectedEntry && workspace.setPostTarget(selectedEntry)}
+            onReverse={() => selectedEntry && workspace.setReverseTarget(selectedEntry)}
+            onDelete={() => selectedEntry && workspace.setDeleteTarget(selectedEntry)}
             onViewSource={workspace.navigateToSource}
           />
         )}
-        workspaceSlot={<JournalEntryWorkspaceCard selectedEntry={workspace.selectedEntry} />}
+        workspaceSlot={<JournalEntryWorkspaceCard selectedEntry={selectedEntry} />}
         dialogs={(
           <JournalEntriesDialogs
             postTarget={workspace.postTarget}

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -113,7 +113,6 @@ export const JournalEntriesPage: React.FC = () => {
             total={pagination?.total ?? entries.length}
             selectedEntryId={workspace.selectedEntry?.id ?? null}
             onSelect={workspace.handleSelect}
-            onViewSource={workspace.navigateToSource}
             listRef={workspace.listRef}
           />
         )}

--- a/frontend/src/pages/accounting/__tests__/AccountingDashboardPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/AccountingDashboardPage.test.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 
 import AccountingDashboardPage from '../AccountingDashboardPage';
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext';
 import { darkTheme } from '@/styles/theme';
 
 vi.mock('@/utils/formatters', () => ({
@@ -35,6 +36,10 @@ vi.mock('@/store/api/accountingApi', () => ({
   useGetJournalEntriesQuery: mockedApi.useGetJournalEntriesQuery,
   useGetCurrentFiscalPeriodQuery: mockedApi.useGetCurrentFiscalPeriodQuery,
   useGetPendingSettlementSummaryQuery: mockedApi.useGetPendingSettlementSummaryQuery,
+}));
+
+vi.mock('@/contexts/LayoutScrollContext', () => ({
+  useLayoutScroll: vi.fn(),
 }));
 
 const renderWithProviders = (useDarkTheme = false) => {
@@ -174,5 +179,12 @@ describe('AccountingDashboardPage', () => {
     expect(screen.getByText('$2222.22')).toBeInTheDocument();
     expect(screen.getByText('$3333.33')).toBeInTheDocument();
     expect(screen.getByText('$4444.44')).toBeInTheDocument();
+  });
+});
+
+describe('AccountingDashboardPage scroll', () => {
+  it('enables layout scroll', () => {
+    renderWithProviders();
+    expect(useLayoutScroll).toHaveBeenCalledWith(true);
   });
 });

--- a/frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
 import { BrowserRouter } from 'react-router-dom'
 
 import ChartOfAccountsPage from '../ChartOfAccountsPage'
+import accountingReducer from '@/store/slices/accountingSlice'
 
 const mockedApi = vi.hoisted(() => ({
   useGetChartOfAccountsHierarchyQuery: vi.fn(),
@@ -61,11 +64,17 @@ function setup(accounts = [mockAccount]) {
   })
 }
 
+function makeStore() {
+  return configureStore({ reducer: { accounting: accountingReducer } })
+}
+
 function renderPage() {
   return render(
-    <BrowserRouter>
-      <ChartOfAccountsPage />
-    </BrowserRouter>,
+    <Provider store={makeStore()}>
+      <BrowserRouter>
+        <ChartOfAccountsPage />
+      </BrowserRouter>
+    </Provider>,
   )
 }
 
@@ -98,7 +107,7 @@ describe('ChartOfAccountsPage', () => {
 
   it('renders account code from hierarchy data', () => {
     renderPage()
-    expect(screen.getByText('1000')).toBeInTheDocument()
+    expect(getRenderedAccountCodes()).toContain('1000')
   })
 
   it('flattens nested children into table', () => {
@@ -113,8 +122,7 @@ describe('ChartOfAccountsPage', () => {
 
     renderPage()
 
-    expect(screen.getByText('1000')).toBeInTheDocument()
-    expect(screen.getByText('1010')).toBeInTheDocument()
+    expect(getRenderedAccountCodes()).toEqual(expect.arrayContaining(['1000', '1010']))
   })
 
   it('filters by account type and hides non-matching accounts', async () => {
@@ -123,14 +131,13 @@ describe('ChartOfAccountsPage', () => {
 
     renderPage()
 
-    expect(screen.getByText('1000')).toBeInTheDocument()
-    expect(screen.getByText('2000')).toBeInTheDocument()
+    expect(getRenderedAccountCodes()).toEqual(expect.arrayContaining(['1000', '2000']))
 
     await user.click(screen.getByLabelText('Account Type'))
     await user.click(screen.getByRole('option', { name: 'Asset' }))
 
-    expect(screen.getByText('1000')).toBeInTheDocument()
-    expect(screen.queryByText('2000')).not.toBeInTheDocument()
+    expect(getRenderedAccountCodes()).toContain('1000')
+    expect(getRenderedAccountCodes()).not.toContain('2000')
   })
 
   it('filters by active status and hides inactive accounts', async () => {
@@ -139,14 +146,13 @@ describe('ChartOfAccountsPage', () => {
 
     renderPage()
 
-    expect(screen.getByText('1000')).toBeInTheDocument()
-    expect(screen.getByText('3000')).toBeInTheDocument()
+    expect(getRenderedAccountCodes()).toEqual(expect.arrayContaining(['1000', '3000']))
 
     await user.click(screen.getByLabelText('Status'))
     await user.click(screen.getByRole('option', { name: 'Active' }))
 
-    expect(screen.getByText('1000')).toBeInTheDocument()
-    expect(screen.queryByText('3000')).not.toBeInTheDocument()
+    expect(getRenderedAccountCodes()).toContain('1000')
+    expect(getRenderedAccountCodes()).not.toContain('3000')
   })
 
   it('combines account type and status filters', async () => {
@@ -164,9 +170,9 @@ describe('ChartOfAccountsPage', () => {
     await user.click(screen.getByLabelText('Status'))
     await user.click(screen.getByRole('option', { name: 'Active' }))
 
-    expect(screen.getByText('1000')).toBeInTheDocument()
-    expect(screen.queryByText('1100')).not.toBeInTheDocument()
-    expect(screen.queryByText('2000')).not.toBeInTheDocument()
+    expect(getRenderedAccountCodes()).toContain('1000')
+    expect(getRenderedAccountCodes()).not.toContain('1100')
+    expect(getRenderedAccountCodes()).not.toContain('2000')
   })
 
   it('toggles sort order for account codes', async () => {

--- a/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
@@ -97,4 +97,16 @@ describe('JournalEntriesPage', () => {
     })
     expect(mockNavigate).not.toHaveBeenCalled()
   })
+
+  it('renders journal entry details without chip styling', async () => {
+    const { container } = render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+
+    fireEvent.click(screen.getByText('JE-001'))
+
+    await waitFor(() => {
+      expect(screen.getByText('JE Details - JE-001')).toBeInTheDocument()
+    })
+
+    expect(container.querySelector('.MuiChip-root')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
@@ -71,7 +71,10 @@ describe('JournalEntriesPage', () => {
       isLoading: false,
       refetch: vi.fn(),
     })
-    mockedApi.useLazyGetJournalEntryQuery.mockReturnValue([vi.fn().mockResolvedValue({ id: '1' })])
+    mockedApi.useLazyGetJournalEntryQuery.mockReturnValue([
+      vi.fn().mockResolvedValue({ data: mockEntry }),
+      { data: mockEntry, isLoading: false, isFetching: false },
+    ])
     mockedApi.useDeleteJournalEntryMutation.mockReturnValue([vi.fn()])
     mockedApi.usePostJournalEntryMutation.mockReturnValue([vi.fn()])
     mockedApi.useReverseJournalEntryMutation.mockReturnValue([vi.fn()])

--- a/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
 import { BrowserRouter } from 'react-router-dom'
 
 import JournalEntriesPage from '../JournalEntriesPage'
+import accountingReducer from '@/store/slices/accountingSlice'
 import { JournalEntryStatus } from '@/types'
 
 vi.mock('@/hooks/useNotification', () => ({
@@ -63,6 +66,20 @@ const mockEntry = {
   updatedAt: '2026-01-01',
 }
 
+function makeStore() {
+  return configureStore({ reducer: { accounting: accountingReducer } })
+}
+
+function renderPage() {
+  return render(
+    <Provider store={makeStore()}>
+      <BrowserRouter>
+        <JournalEntriesPage />
+      </BrowserRouter>
+    </Provider>,
+  )
+}
+
 describe('JournalEntriesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -81,17 +98,17 @@ describe('JournalEntriesPage', () => {
   })
 
   it('renders the page title', () => {
-    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    renderPage()
     expect(screen.getByText('Journal Entries')).toBeInTheDocument()
   })
 
   it('renders journal entry rows', () => {
-    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    renderPage()
     expect(screen.getByText('JE-001')).toBeInTheDocument()
   })
 
   it('clicking a row selects it and shows details in the context header', async () => {
-    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    renderPage()
 
     fireEvent.click(screen.getByText('JE-001'))
 
@@ -102,7 +119,7 @@ describe('JournalEntriesPage', () => {
   })
 
   it('renders journal entry details without chip styling', async () => {
-    const { container } = render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    const { container } = renderPage()
 
     fireEvent.click(screen.getByText('JE-001'))
 

--- a/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
@@ -15,7 +15,7 @@ vi.mock('@/utils/formatters', async () => {
     ...actual,
     formatCurrency: (value: number) => `$${value}`,
     formatDate: (date: string) => date,
-    getCurrentDate: () => '2026-04-19',
+    getCurrentDate: () => '2026-04-22',
   }
 })
 vi.mock('@/utils/dateRange', () => ({
@@ -28,8 +28,6 @@ const mockedApi = vi.hoisted(() => ({
   useLazyGetJournalEntryQuery: vi.fn(),
   useDeleteJournalEntryMutation: vi.fn(),
   usePostJournalEntryMutation: vi.fn(),
-  useBulkPostJournalEntriesMutation: vi.fn(),
-  useBulkDeleteJournalEntriesMutation: vi.fn(),
   useReverseJournalEntryMutation: vi.fn(),
 }))
 
@@ -76,8 +74,6 @@ describe('JournalEntriesPage', () => {
     mockedApi.useLazyGetJournalEntryQuery.mockReturnValue([vi.fn().mockResolvedValue({ id: '1' })])
     mockedApi.useDeleteJournalEntryMutation.mockReturnValue([vi.fn()])
     mockedApi.usePostJournalEntryMutation.mockReturnValue([vi.fn()])
-    mockedApi.useBulkPostJournalEntriesMutation.mockReturnValue([vi.fn()])
-    mockedApi.useBulkDeleteJournalEntriesMutation.mockReturnValue([vi.fn()])
     mockedApi.useReverseJournalEntryMutation.mockReturnValue([vi.fn()])
   })
 
@@ -91,13 +87,13 @@ describe('JournalEntriesPage', () => {
     expect(screen.getByText('JE-001')).toBeInTheDocument()
   })
 
-  it('clicking a row selects it instead of navigating', async () => {
+  it('clicking a row selects it and shows details in the context header', async () => {
     render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
 
     fireEvent.click(screen.getByText('JE-001'))
 
     await waitFor(() => {
-      expect(screen.getAllByText('JE-001').length).toBeGreaterThan(1)
+      expect(screen.getByText('JE Details - JE-001')).toBeInTheDocument()
     })
     expect(mockNavigate).not.toHaveBeenCalled()
   })

--- a/frontend/src/pages/accounting/components/ChartOfAccountsTable.tsx
+++ b/frontend/src/pages/accounting/components/ChartOfAccountsTable.tsx
@@ -7,6 +7,7 @@ interface Props {
   accounts: ChartOfAccount[]
   loading: boolean
   selectedId: string | null
+  focusedIndex: number
   onSelect: (item: ChartOfAccount) => void
   listRef?: RefObject<HTMLDivElement | null>
 }
@@ -20,6 +21,7 @@ export function ChartOfAccountsTable({
   accounts,
   loading,
   selectedId,
+  focusedIndex,
   onSelect,
   listRef,
 }: Props) {
@@ -32,7 +34,7 @@ export function ChartOfAccountsTable({
       total={accounts.length}
       label="Accounts"
       selectedId={selectedId ?? undefined}
-      focusedIndex={-1}
+      focusedIndex={focusedIndex}
       onSelect={onSelect}
       listRef={listRef ?? fallbackRef}
       dataAttr="account"

--- a/frontend/src/pages/accounting/components/JournalEntriesDialogs.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesDialogs.tsx
@@ -8,38 +8,26 @@ interface Props {
   postTarget: JournalEntry | null
   deleteTarget: JournalEntry | null
   reverseTarget: JournalEntry | null
-  bulkPostIds: Set<string>
-  bulkDeleteIds: Set<string>
   actionLoading: boolean
   onConfirmPost: () => void
   onConfirmDelete: () => void
   onConfirmReverse: (reverseDate: string) => void
-  onConfirmBulkPost: () => void
-  onConfirmBulkDelete: () => void
   onCancelPost: () => void
   onCancelDelete: () => void
   onCancelReverse: () => void
-  onCancelBulkPost: () => void
-  onCancelBulkDelete: () => void
 }
 
 export function JournalEntriesDialogs({
   postTarget,
   deleteTarget,
   reverseTarget,
-  bulkPostIds,
-  bulkDeleteIds,
   actionLoading,
   onConfirmPost,
   onConfirmDelete,
   onConfirmReverse,
-  onConfirmBulkPost,
-  onConfirmBulkDelete,
   onCancelPost,
   onCancelDelete,
   onCancelReverse,
-  onCancelBulkPost,
-  onCancelBulkDelete,
 }: Props) {
   const [reverseDate] = useState(getCurrentDate())
 
@@ -73,27 +61,6 @@ export function JournalEntriesDialogs({
         cancelText="Cancel"
         onConfirm={() => onConfirmReverse(reverseDate)}
         onCancel={onCancelReverse}
-        loading={actionLoading}
-      >
-      </ConfirmationDialog>
-      <ConfirmationDialog
-        open={bulkPostIds.size > 0}
-        title="Bulk Post Entries"
-        message={`Post ${bulkPostIds.size} selected journal entries?`}
-        confirmText="Post"
-        cancelText="Cancel"
-        onConfirm={onConfirmBulkPost}
-        onCancel={onCancelBulkPost}
-        loading={actionLoading}
-      />
-      <ConfirmationDialog
-        open={bulkDeleteIds.size > 0}
-        title="Bulk Delete Entries"
-        message={`Delete ${bulkDeleteIds.size} selected journal entries?`}
-        confirmText="Delete"
-        cancelText="Cancel"
-        onConfirm={onConfirmBulkDelete}
-        onCancel={onCancelBulkDelete}
         loading={actionLoading}
       />
     </>

--- a/frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx
@@ -41,6 +41,7 @@ describe('JournalEntriesTable', () => {
   const defaultProps = {
     entries: [],
     loading: false,
+    total: 0,
     selectedEntryId: null,
     onSelect: vi.fn(),
   }

--- a/frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx
@@ -10,12 +10,17 @@ vi.mock('@/utils/formatters', () => ({
 }))
 
 vi.mock('@/components/common/EntityTable', () => ({
-  default: ({ rows, loading, label, onSelect }: any) => (
+  default: ({ rows, loading, label, onSelect, focusedIndex }: any) => (
     <div>
       {loading && <div>Loading...</div>}
       {rows.length === 0 && <div>No {label} found</div>}
-      {rows.map((row: any) => (
-        <div key={row.id} onClick={() => onSelect(row)} data-testid={`row-${row.id}`}>
+      {rows.map((row: any, index: number) => (
+        <div
+          key={row.id}
+          onClick={() => onSelect(row)}
+          data-testid={`row-${row.id}`}
+          data-focused={index === focusedIndex ? 'true' : 'false'}
+        >
           {row.referenceNumber}
         </div>
       ))}
@@ -61,5 +66,17 @@ describe('JournalEntriesTable', () => {
     render(<JournalEntriesTable {...defaultProps} entries={[makeEntry()]} onSelect={onSelect} />)
     fireEvent.click(screen.getByText('JE-001'))
     expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: '1' }))
+  })
+
+  it('passes focusedIndex to EntityTable', () => {
+    render(
+      <JournalEntriesTable
+        {...defaultProps}
+        entries={[makeEntry()]}
+        focusedIndex={0}
+      />,
+    )
+
+    expect(screen.getByTestId('row-1')).toHaveAttribute('data-focused', 'true')
   })
 })

--- a/frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx
@@ -9,8 +9,18 @@ vi.mock('@/utils/formatters', () => ({
   formatDate: (date: string) => date,
 }))
 
-vi.mock('@/components/common/AppButton', () => ({
-  AppButton: ({ onClick, children, startIcon }: any) => <button onClick={onClick}>{children}{startIcon}</button>,
+vi.mock('@/components/common/EntityTable', () => ({
+  default: ({ rows, loading, label, onSelect }: any) => (
+    <div>
+      {loading && <div>Loading...</div>}
+      {rows.length === 0 && <div>No {label} found</div>}
+      {rows.map((row: any) => (
+        <div key={row.id} onClick={() => onSelect(row)} data-testid={`row-${row.id}`}>
+          {row.referenceNumber}
+        </div>
+      ))}
+    </div>
+  ),
 }))
 
 const makeEntry = (overrides = {}) => ({
@@ -21,9 +31,9 @@ const makeEntry = (overrides = {}) => ({
   status: JournalEntryStatus.DRAFT,
   totalDebits: 100,
   totalCredits: 100,
-  isBalanced: true,
   sourceType: 'manual',
   sourceId: null,
+  lines: [],
   ...overrides,
 })
 
@@ -31,29 +41,23 @@ describe('JournalEntriesTable', () => {
   const defaultProps = {
     entries: [],
     loading: false,
-    total: 0,
     selectedEntryId: null,
-    selectedIds: new Set<string>(),
     onSelect: vi.fn(),
-    onToggleCheck: vi.fn(),
-    onSelectAll: vi.fn(),
-    onPost: vi.fn(),
-    onDelete: vi.fn(),
   }
 
   it('shows empty state when no entries', () => {
     render(<JournalEntriesTable {...defaultProps} />)
-    expect(screen.getByText('No journal entries found')).toBeInTheDocument()
+    expect(screen.getByText('No Journal Entries found')).toBeInTheDocument()
   })
 
   it('renders entry rows', () => {
-    render(<JournalEntriesTable {...defaultProps} entries={[makeEntry()]} total={1} />)
+    render(<JournalEntriesTable {...defaultProps} entries={[makeEntry()]} />)
     expect(screen.getByText('JE-001')).toBeInTheDocument()
   })
 
   it('calls onSelect when row is clicked', () => {
     const onSelect = vi.fn()
-    render(<JournalEntriesTable {...defaultProps} entries={[makeEntry()]} total={1} onSelect={onSelect} />)
+    render(<JournalEntriesTable {...defaultProps} entries={[makeEntry()]} onSelect={onSelect} />)
     fireEvent.click(screen.getByText('JE-001'))
     expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: '1' }))
   })

--- a/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
@@ -1,19 +1,10 @@
 import { useRef, type RefObject } from 'react'
-import { Typography } from '@mui/material'
 
 import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
 import { JournalEntry } from '@/types'
 
 const COLUMNS: ColumnConfig<JournalEntry>[] = [
-  {
-    key: 'referenceNumber',
-    raw: true,
-    render: (entry) => (
-      <Typography variant="body2" sx={{ fontWeight: 500, color: 'primary.main', fontSize: '0.8rem' }}>
-        {entry.referenceNumber}
-      </Typography>
-    ),
-  },
+  { key: 'referenceNumber', render: (entry) => entry.referenceNumber },
 ]
 
 interface Props {

--- a/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
@@ -12,6 +12,7 @@ interface Props {
   loading: boolean
   total: number
   selectedEntryId: string | null
+  focusedIndex: number
   onSelect: (entry: JournalEntry) => void
   listRef?: RefObject<HTMLDivElement | null>
 }
@@ -21,6 +22,7 @@ export function JournalEntriesTable({
   loading,
   total,
   selectedEntryId,
+  focusedIndex,
   onSelect,
   listRef,
 }: Props) {
@@ -34,7 +36,7 @@ export function JournalEntriesTable({
       total={total}
       label="Journal Entries"
       selectedId={selectedEntryId ?? undefined}
-      focusedIndex={-1}
+      focusedIndex={focusedIndex}
       onSelect={onSelect}
       listRef={listRef ?? fallbackRef}
       dataAttr="entry"

--- a/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
@@ -1,27 +1,9 @@
-import type { RefObject } from 'react'
-import { Checkbox, Chip, CircularProgress, Link, Paper, Stack, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tooltip, Typography } from '@mui/material'
-import { default as DeleteIcon } from '@mui/icons-material/Delete'
-import { default as PostIcon } from '@mui/icons-material/PostAdd'
+import { useRef, type RefObject } from 'react'
+import { Chip, Link, Typography } from '@mui/material'
 
-import { AppButton } from '@/components/common/AppButton'
-import { TABLE_STYLES } from '@/constants/tableStyles'
+import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
 import { JournalEntry, JournalEntryStatus } from '@/types'
 import { formatCurrency, formatDate } from '@/utils/formatters'
-
-interface Props {
-  entries: JournalEntry[]
-  loading: boolean
-  total: number
-  selectedEntryId: string | null
-  selectedIds: Set<string>
-  onSelect: (entry: JournalEntry) => void
-  onToggleCheck: (id: string) => void
-  onSelectAll: () => void
-  onPost: (entry: JournalEntry) => void
-  onDelete: (entry: JournalEntry) => void
-  onViewSource: (sourceType: string, sourceId: string) => void
-  listRef?: RefObject<HTMLDivElement | null>
-}
 
 const ENTRY_TYPE_LABELS: Record<string, string> = {
   manual: 'Manual Entry',
@@ -43,130 +25,99 @@ function statusColor(status: JournalEntryStatus) {
   return 'default' as const
 }
 
+interface Props {
+  entries: JournalEntry[]
+  loading: boolean
+  selectedEntryId: string | null
+  onSelect: (entry: JournalEntry) => void
+  onViewSource?: (sourceType: string, sourceId: string) => void
+  listRef?: RefObject<HTMLDivElement | null>
+}
+
 export function JournalEntriesTable({
   entries,
   loading,
   selectedEntryId,
-  selectedIds,
   onSelect,
-  onToggleCheck,
-  onSelectAll,
-  onPost,
-  onDelete,
   onViewSource,
   listRef,
 }: Props) {
-  const selectableEntries = entries.filter((entry) => entry.status === JournalEntryStatus.DRAFT)
-  const allSelected = selectableEntries.length > 0 && selectedIds.size === selectableEntries.length
-  const someSelected = selectedIds.size > 0 && selectedIds.size < selectableEntries.length
+  const fallbackRef = useRef<HTMLDivElement | null>(null)
+
+  const columns: ColumnConfig<JournalEntry>[] = [
+    {
+      key: 'referenceNumber',
+      raw: true,
+      render: (entry) => (
+        <Typography variant="body2" sx={{ fontWeight: 500, color: 'primary.main', fontSize: '0.8rem' }}>
+          {entry.referenceNumber}
+        </Typography>
+      ),
+    },
+    {
+      key: 'entryDate',
+      render: (entry) => formatDate(entry.entryDate),
+    },
+    {
+      key: 'description',
+      render: (entry) => entry.description,
+    },
+    {
+      key: 'sourceType',
+      raw: true,
+      render: (entry) => (
+        <Chip label={ENTRY_TYPE_LABELS[entry.sourceType ?? ''] ?? 'Manual Entry'} size="small" />
+      ),
+    },
+    {
+      key: 'source',
+      raw: true,
+      render: (entry) => (
+        entry.sourceType && entry.sourceType !== 'manual' && entry.sourceId && onViewSource
+          ? (
+              <Link
+                component="button"
+                variant="body2"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onViewSource(entry.sourceType!, entry.sourceId!)
+                }}
+              >
+                View Transaction
+              </Link>
+            )
+          : null
+      ),
+    },
+    {
+      key: 'totalDebits',
+      render: (entry) => formatCurrency(entry.totalDebits),
+    },
+    {
+      key: 'totalCredits',
+      render: (entry) => formatCurrency(entry.totalCredits),
+    },
+    {
+      key: 'status',
+      raw: true,
+      render: (entry) => (
+        <Chip label={entry.status} color={statusColor(entry.status)} size="small" />
+      ),
+    },
+  ]
 
   return (
-    <Paper ref={listRef} sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
-        <Table size={TABLE_STYLES.size} stickyHeader>
-          <TableHead>
-            <TableRow>
-              <TableCell padding="checkbox">
-                <Checkbox indeterminate={someSelected} checked={allSelected} onChange={onSelectAll} />
-              </TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Reference</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Date</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Description</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Type</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Source</TableCell>
-              <TableCell sx={{ fontWeight: 600 }} align="right">Debits</TableCell>
-              <TableCell sx={{ fontWeight: 600 }} align="right">Credits</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Status</TableCell>
-              <TableCell sx={{ fontWeight: 600 }} align="center">Actions</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {loading ? (
-              <TableRow>
-                <TableCell colSpan={10} align="center" sx={{ py: 4 }}>
-                  <CircularProgress />
-                </TableCell>
-              </TableRow>
-            ) : entries.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={10} align="center" sx={{ py: 4 }}>
-                  <Typography variant="body2" color="text.secondary">No journal entries found</Typography>
-                </TableCell>
-              </TableRow>
-            ) : entries.map((entry) => (
-              <TableRow
-                key={entry.id}
-                hover
-                selected={entry.id === selectedEntryId}
-                onClick={() => onSelect(entry)}
-                sx={{ cursor: 'pointer', height: TABLE_STYLES.row.height }}
-              >
-                <TableCell padding="checkbox" onClick={(event) => event.stopPropagation()}>
-                  <Checkbox
-                    disabled={entry.status !== JournalEntryStatus.DRAFT}
-                    checked={selectedIds.has(entry.id)}
-                    onChange={() => onToggleCheck(entry.id)}
-                  />
-                </TableCell>
-                <TableCell>
-                  <Typography variant="body2" sx={{ fontWeight: 500, color: 'primary.main' }}>
-                    {entry.referenceNumber}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="body2">{formatDate(entry.entryDate)}</Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="body2" sx={{ maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                    {entry.description}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Chip label={ENTRY_TYPE_LABELS[entry.sourceType ?? ''] ?? 'Manual Entry'} size="small" />
-                </TableCell>
-                <TableCell onClick={(event) => event.stopPropagation()}>
-                  {entry.sourceType && entry.sourceType !== 'manual' && entry.sourceId && (
-                    <Link
-                      component="button"
-                      variant="body2"
-                      onClick={() => onViewSource(entry.sourceType!, entry.sourceId!)}
-                    >
-                      View Transaction
-                    </Link>
-                  )}
-                </TableCell>
-                <TableCell align="right">
-                  <Typography variant="body2">{formatCurrency(entry.totalDebits)}</Typography>
-                </TableCell>
-                <TableCell align="right">
-                  <Typography variant="body2">{formatCurrency(entry.totalCredits)}</Typography>
-                </TableCell>
-                <TableCell>
-                  <Chip label={entry.status} color={statusColor(entry.status)} size="small" />
-                </TableCell>
-                <TableCell align="center" onClick={(event) => event.stopPropagation()}>
-                  <Stack direction="row" spacing={0.5} sx={{ justifyContent: 'center' }}>
-                    {entry.status === JournalEntryStatus.DRAFT && (
-                      <>
-                        <Tooltip title="Post">
-                          <span>
-                            <AppButton size="small" variant="success" onClick={() => onPost(entry)} startIcon={<PostIcon fontSize="small" />} />
-                          </span>
-                        </Tooltip>
-                        <Tooltip title="Delete">
-                          <span>
-                            <AppButton size="small" variant="danger" onClick={() => onDelete(entry)} startIcon={<DeleteIcon fontSize="small" />} />
-                          </span>
-                        </Tooltip>
-                      </>
-                    )}
-                  </Stack>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </Paper>
+    <EntityTable
+      rows={entries}
+      columns={columns}
+      loading={loading}
+      total={entries.length}
+      label="Journal Entries"
+      selectedId={selectedEntryId ?? undefined}
+      focusedIndex={-1}
+      onSelect={onSelect}
+      listRef={listRef ?? fallbackRef}
+      dataAttr="entry"
+    />
   )
 }

--- a/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
@@ -1,29 +1,20 @@
 import { useRef, type RefObject } from 'react'
-import { Chip, Link, Typography } from '@mui/material'
+import { Typography } from '@mui/material'
 
 import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
-import { JournalEntry, JournalEntryStatus } from '@/types'
-import { formatCurrency, formatDate } from '@/utils/formatters'
+import { JournalEntry } from '@/types'
 
-const ENTRY_TYPE_LABELS: Record<string, string> = {
-  manual: 'Manual Entry',
-  sales_order: 'Sales Order',
-  payment: 'Customer Payment',
-  settlement: 'Settlement',
-  goods_received_note: 'Goods Receipt',
-  vendor_payment: 'Vendor Payment',
-  stock_adjustment: 'Stock Adjustment',
-  owner_equity_transaction: 'Owner Equity',
-  expense: 'Expense',
-  opening_balance: 'Opening Balance',
-  fund_transfer: 'Fund Transfer',
-}
-
-function statusColor(status: JournalEntryStatus) {
-  if (status === JournalEntryStatus.POSTED) return 'success' as const
-  if (status === JournalEntryStatus.REVERSED) return 'error' as const
-  return 'default' as const
-}
+const COLUMNS: ColumnConfig<JournalEntry>[] = [
+  {
+    key: 'referenceNumber',
+    raw: true,
+    render: (entry) => (
+      <Typography variant="body2" sx={{ fontWeight: 500, color: 'primary.main', fontSize: '0.8rem' }}>
+        {entry.referenceNumber}
+      </Typography>
+    ),
+  },
+]
 
 interface Props {
   entries: JournalEntry[]
@@ -31,7 +22,6 @@ interface Props {
   total: number
   selectedEntryId: string | null
   onSelect: (entry: JournalEntry) => void
-  onViewSource?: (sourceType: string, sourceId: string) => void
   listRef?: RefObject<HTMLDivElement | null>
 }
 
@@ -41,77 +31,14 @@ export function JournalEntriesTable({
   total,
   selectedEntryId,
   onSelect,
-  onViewSource,
   listRef,
 }: Props) {
   const fallbackRef = useRef<HTMLDivElement | null>(null)
 
-  const columns: ColumnConfig<JournalEntry>[] = [
-    {
-      key: 'referenceNumber',
-      raw: true,
-      render: (entry) => (
-        <Typography variant="body2" sx={{ fontWeight: 500, color: 'primary.main', fontSize: '0.8rem' }}>
-          {entry.referenceNumber}
-        </Typography>
-      ),
-    },
-    {
-      key: 'entryDate',
-      render: (entry) => formatDate(entry.entryDate),
-    },
-    {
-      key: 'description',
-      render: (entry) => entry.description,
-    },
-    {
-      key: 'sourceType',
-      raw: true,
-      render: (entry) => (
-        <Chip label={ENTRY_TYPE_LABELS[entry.sourceType ?? ''] ?? 'Manual Entry'} size="small" />
-      ),
-    },
-    {
-      key: 'source',
-      raw: true,
-      render: (entry) => (
-        entry.sourceType && entry.sourceType !== 'manual' && entry.sourceId && onViewSource
-          ? (
-              <Link
-                component="button"
-                variant="body2"
-                onClick={(event) => {
-                  event.stopPropagation()
-                  onViewSource(entry.sourceType!, entry.sourceId!)
-                }}
-              >
-                View Transaction
-              </Link>
-            )
-          : null
-      ),
-    },
-    {
-      key: 'totalDebits',
-      render: (entry) => formatCurrency(entry.totalDebits),
-    },
-    {
-      key: 'totalCredits',
-      render: (entry) => formatCurrency(entry.totalCredits),
-    },
-    {
-      key: 'status',
-      raw: true,
-      render: (entry) => (
-        <Chip label={entry.status} color={statusColor(entry.status)} size="small" />
-      ),
-    },
-  ]
-
   return (
     <EntityTable
       rows={entries}
-      columns={columns}
+      columns={COLUMNS}
       loading={loading}
       total={total}
       label="Journal Entries"

--- a/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
@@ -28,6 +28,7 @@ function statusColor(status: JournalEntryStatus) {
 interface Props {
   entries: JournalEntry[]
   loading: boolean
+  total: number
   selectedEntryId: string | null
   onSelect: (entry: JournalEntry) => void
   onViewSource?: (sourceType: string, sourceId: string) => void
@@ -37,6 +38,7 @@ interface Props {
 export function JournalEntriesTable({
   entries,
   loading,
+  total,
   selectedEntryId,
   onSelect,
   onViewSource,
@@ -111,7 +113,7 @@ export function JournalEntriesTable({
       rows={entries}
       columns={columns}
       loading={loading}
-      total={entries.length}
+      total={total}
       label="Journal Entries"
       selectedId={selectedEntryId ?? undefined}
       focusedIndex={-1}

--- a/frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx
@@ -1,4 +1,4 @@
-import { Box, Chip, Link, Paper, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material'
+import { Box, Link, Paper, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material'
 import Grid from '@mui/material/Grid'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as EditIcon } from '@mui/icons-material/Edit'
@@ -51,12 +51,6 @@ const sectionHeaderCellSx = {
   pb: TABLE_STYLES.cell.padding.py * 0.67,
   py: TABLE_STYLES.cell.padding.py * 0.67,
   borderTop: TABLE_STYLES.cell.border,
-}
-
-function statusColor(status: JournalEntryStatus) {
-  if (status === JournalEntryStatus.POSTED) return 'success' as const
-  if (status === JournalEntryStatus.REVERSED) return 'error' as const
-  return 'default' as const
 }
 
 interface Props {
@@ -154,10 +148,7 @@ export function JournalEntryContextHeader({
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
                     <TableCell sx={labelCellSx}>Type</TableCell>
                     <TableCell sx={valueCellSx}>
-                      <Chip
-                        size="small"
-                        label={ENTRY_TYPE_LABELS[selectedEntry.sourceType ?? ''] ?? 'Manual Entry'}
-                      />
+                      {ENTRY_TYPE_LABELS[selectedEntry.sourceType ?? ''] ?? 'Manual Entry'}
                     </TableCell>
                   </TableRow>
                   <TableRow>
@@ -192,9 +183,7 @@ export function JournalEntryContextHeader({
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
                     <TableCell sx={labelCellSx}>Status</TableCell>
-                    <TableCell sx={valueCellSx}>
-                      <Chip label={selectedEntry.status} color={statusColor(selectedEntry.status)} size="small" />
-                    </TableCell>
+                    <TableCell sx={valueCellSx}>{selectedEntry.status}</TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell sx={labelCellSx}>Debits</TableCell>
@@ -207,9 +196,7 @@ export function JournalEntryContextHeader({
                   {!isBalanced && (
                     <TableRow>
                       <TableCell sx={labelCellSx}>Balance</TableCell>
-                      <TableCell sx={valueCellSx}>
-                        <Chip label="Unbalanced" color="warning" size="small" />
-                      </TableCell>
+                      <TableCell sx={valueCellSx}>Unbalanced</TableCell>
                     </TableRow>
                   )}
                 </TableBody>

--- a/frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx
@@ -1,4 +1,5 @@
-import { Box, Chip, Link, Paper, Stack, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
+import { Box, Chip, Link, Paper, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material'
+import Grid from '@mui/material/Grid'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as EditIcon } from '@mui/icons-material/Edit'
 import { default as PostIcon } from '@mui/icons-material/PostAdd'
@@ -8,6 +9,8 @@ import { AppButton } from '@/components/common/AppButton'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { JournalEntry, JournalEntryStatus } from '@/types'
 import { formatCurrency, formatDate } from '@/utils/formatters'
+
+import { SOURCE_ROUTES } from '../hooks/useJournalEntriesWorkspace'
 
 const ENTRY_TYPE_LABELS: Record<string, string> = {
   manual: 'Manual Entry',
@@ -23,15 +26,37 @@ const ENTRY_TYPE_LABELS: Record<string, string> = {
   fund_transfer: 'Fund Transfer',
 }
 
-const SOURCE_ROUTES: Record<string, (id: string) => string> = {
-  sales_order: (id) => `/sales/orders?highlight=${id}`,
-  payment: (id) => `/sales/payments?highlight=${id}`,
-  goods_received_note: (id) => `/purchasing/goods-received?grnId=${id}`,
-  vendor_payment: (id) => `/purchasing/vendor-payments?vpId=${id}`,
-  expense: () => `/accounting/expenses`,
-  owner_equity_transaction: () => `/accounting/owner-equity`,
-  fund_transfer: () => `/accounting/fund-transfers`,
-  stock_adjustment: (id) => `/inventory/stock-adjustments/${id}/edit`,
+const detailTableSx = {
+  tableLayout: 'fixed',
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const labelCellSx = {
+  fontWeight: 600,
+  color: 'text.secondary',
+  fontSize: '0.8rem',
+}
+
+const valueCellSx = {
+  fontSize: '0.8rem',
+}
+
+const sectionHeaderCellSx = {
+  pb: TABLE_STYLES.cell.padding.py * 0.67,
+  py: TABLE_STYLES.cell.padding.py * 0.67,
+  borderTop: TABLE_STYLES.cell.border,
+}
+
+function statusColor(status: JournalEntryStatus) {
+  if (status === JournalEntryStatus.POSTED) return 'success' as const
+  if (status === JournalEntryStatus.REVERSED) return 'error' as const
+  return 'default' as const
 }
 
 interface Props {
@@ -40,22 +65,23 @@ interface Props {
   onPost: () => void
   onReverse: () => void
   onDelete: () => void
-  onNavigateToSource: (path: string) => void
+  onViewSource: (sourceType: string, sourceId: string) => void
 }
 
-const cellSx = { border: 'none', py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px }
-
-function statusColor(status: JournalEntryStatus) {
-  if (status === JournalEntryStatus.POSTED) return 'success' as const
-  if (status === JournalEntryStatus.REVERSED) return 'error' as const
-  return 'default' as const
-}
-
-export function JournalEntryContextHeader({ selectedEntry, onEdit, onPost, onReverse, onDelete, onNavigateToSource }: Props) {
+export function JournalEntryContextHeader({
+  selectedEntry,
+  onEdit,
+  onPost,
+  onReverse,
+  onDelete,
+  onViewSource,
+}: Props) {
   if (!selectedEntry) {
     return (
-      <Paper sx={{ p: 2 }}>
-        <Typography variant="body2" color="text.secondary">Select a journal entry to view details</Typography>
+      <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
+        <Typography variant="h6" sx={{ color: 'text.secondary' }}>
+          Select a journal entry to view details
+        </Typography>
       </Paper>
     )
   }
@@ -63,63 +89,135 @@ export function JournalEntryContextHeader({ selectedEntry, onEdit, onPost, onRev
   const isDraft = selectedEntry.status === JournalEntryStatus.DRAFT
   const isPosted = selectedEntry.status === JournalEntryStatus.POSTED
   const isBalanced = Math.abs(selectedEntry.totalDebits - selectedEntry.totalCredits) < 0.01
+  const hasSource = selectedEntry.sourceType && selectedEntry.sourceId && SOURCE_ROUTES[selectedEntry.sourceType]
 
   return (
-    <Paper sx={{ p: 0 }}>
-      <Box sx={{ px: 2, pt: 1.5, pb: 1, borderBottom: TABLE_STYLES.cell.border }}>
-        <Stack direction="row" sx={{ justifyContent: 'space-between', alignItems: 'center' }}>
-          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{selectedEntry.referenceNumber}</Typography>
-            <Chip label={selectedEntry.status} color={statusColor(selectedEntry.status)} size="small" />
-            {selectedEntry.sourceType && (
-              <Chip label={ENTRY_TYPE_LABELS[selectedEntry.sourceType] ?? selectedEntry.sourceType} size="small" variant="outlined" />
-            )}
-            {!isBalanced && <Chip label="Unbalanced" color="warning" size="small" />}
-          </Stack>
-          <Stack direction="row" spacing={0.5}>
-            {isDraft && (
-              <>
-                <AppButton size="small" variant="outlined" startIcon={<EditIcon />} onClick={onEdit}>Edit</AppButton>
-                <AppButton size="small" variant="success" startIcon={<PostIcon />} onClick={onPost} disabled={!isBalanced}>Post</AppButton>
-                <AppButton size="small" variant="danger" startIcon={<DeleteIcon />} onClick={onDelete}>Delete</AppButton>
-              </>
-            )}
-            {isPosted && (
-              <AppButton size="small" variant="warning" startIcon={<ReverseIcon />} onClick={onReverse}>Reverse</AppButton>
-            )}
-          </Stack>
-        </Stack>
-      </Box>
-      <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': cellSx }}>
-        <TableBody>
-          <TableRow>
-            <TableCell sx={{ ...cellSx, color: 'text.secondary', width: 120 }}>Date</TableCell>
-            <TableCell>{formatDate(selectedEntry.entryDate)}</TableCell>
-            <TableCell sx={{ ...cellSx, color: 'text.secondary', width: 120 }}>Debits</TableCell>
-            <TableCell align="right">{formatCurrency(selectedEntry.totalDebits)}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell sx={{ ...cellSx, color: 'text.secondary' }}>Description</TableCell>
-            <TableCell>{selectedEntry.description}</TableCell>
-            <TableCell sx={{ ...cellSx, color: 'text.secondary' }}>Credits</TableCell>
-            <TableCell align="right">{formatCurrency(selectedEntry.totalCredits)}</TableCell>
-          </TableRow>
-          {selectedEntry.sourceType && selectedEntry.sourceId && SOURCE_ROUTES[selectedEntry.sourceType] && (
-            <TableRow>
-              <TableCell sx={{ ...cellSx, color: 'text.secondary' }}>Source</TableCell>
-              <TableCell colSpan={3}>
-                <Link
-                  component="button"
-                  variant="body2"
-                  onClick={() => onNavigateToSource(SOURCE_ROUTES[selectedEntry.sourceType!]!(selectedEntry.sourceId!))}
-                >
-                  View {ENTRY_TYPE_LABELS[selectedEntry.sourceType] ?? selectedEntry.sourceType}
-                </Link>
-              </TableCell>
-            </TableRow>
+    <Paper sx={{ overflow: 'hidden' }}>
+      <Box
+        sx={{
+          p: TABLE_STYLES.cell.padding.px,
+          borderBottom: TABLE_STYLES.cell.border,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Typography
+          variant="tableHeader"
+          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+        >
+          JE Details - {selectedEntry.referenceNumber}
+        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          {isDraft && (
+            <>
+              <AppButton size="small" variant="outlined" startIcon={<EditIcon />} onClick={onEdit}>
+                Edit
+              </AppButton>
+              <AppButton size="small" variant="success" startIcon={<PostIcon />} onClick={onPost} disabled={!isBalanced}>
+                Post
+              </AppButton>
+              <AppButton size="small" variant="danger" startIcon={<DeleteIcon />} onClick={onDelete}>
+                Delete
+              </AppButton>
+            </>
           )}
-        </TableBody>
-      </Table>
+          {isPosted && (
+            <AppButton size="small" variant="warning" startIcon={<ReverseIcon />} onClick={onReverse}>
+              Reverse
+            </AppButton>
+          )}
+        </Box>
+      </Box>
+
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Entry Information
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Date</TableCell>
+                    <TableCell sx={valueCellSx}>{formatDate(selectedEntry.entryDate)}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Description</TableCell>
+                    <TableCell sx={valueCellSx}>{selectedEntry.description}</TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Type</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      <Chip
+                        size="small"
+                        label={ENTRY_TYPE_LABELS[selectedEntry.sourceType ?? ''] ?? 'Manual Entry'}
+                      />
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Source</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {hasSource ? (
+                        <Link
+                          component="button"
+                          variant="body2"
+                          onClick={() => onViewSource(selectedEntry.sourceType!, selectedEntry.sourceId!)}
+                        >
+                          View {ENTRY_TYPE_LABELS[selectedEntry.sourceType!] ?? selectedEntry.sourceType}
+                        </Link>
+                      ) : '—'}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <TableContainer>
+              <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+                      <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                        Financials
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Status</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      <Chip label={selectedEntry.status} color={statusColor(selectedEntry.status)} size="small" />
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={labelCellSx}>Debits</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(selectedEntry.totalDebits)}</TableCell>
+                  </TableRow>
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Credits</TableCell>
+                    <TableCell sx={valueCellSx}>{formatCurrency(selectedEntry.totalCredits)}</TableCell>
+                  </TableRow>
+                  {!isBalanced && (
+                    <TableRow>
+                      <TableCell sx={labelCellSx}>Balance</TableCell>
+                      <TableCell sx={valueCellSx}>
+                        <Chip label="Unbalanced" color="warning" size="small" />
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Grid>
+        </Grid>
+      </Box>
     </Paper>
   )
 }

--- a/frontend/src/pages/accounting/components/JournalEntryWorkspaceCard.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntryWorkspaceCard.tsx
@@ -16,7 +16,7 @@ export function JournalEntryWorkspaceCard({ selectedEntry }: Props) {
 
   return (
     <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <Box sx={{ px: 2, py: 1, borderBottom: TABLE_STYLES.cell.border }}>
+      <Box sx={{ px: TABLE_STYLES.cell.padding.px, py: 1, borderBottom: TABLE_STYLES.cell.border }}>
         <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
           Ledger Lines
         </Typography>

--- a/frontend/src/pages/accounting/hooks/useChartOfAccountsWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useChartOfAccountsWorkspace.ts
@@ -30,10 +30,15 @@ export function useChartOfAccountsWorkspace({
   const [deleteChartOfAccount] = useDeleteChartOfAccountMutation()
   const [seedDefaultChartOfAccounts] = useSeedDefaultChartOfAccountsMutation()
 
+  const selectAccount = useCallback(
+    (account: ChartOfAccount | null) => dispatch(setSelectedAccount(account)),
+    [dispatch],
+  )
+
   const workspace = useEntityWorkspace({
     entities: accounts,
     selectedEntity: selectedAccount,
-    selectEntity: (account) => dispatch(setSelectedAccount(account)),
+    selectEntity: selectAccount,
     refetch,
     navigate,
     routes: {

--- a/frontend/src/pages/accounting/hooks/useChartOfAccountsWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useChartOfAccountsWorkspace.ts
@@ -1,20 +1,59 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
+import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import { useNotification } from '@/hooks/useNotification'
+import type { AppDispatch } from '@/store'
 import { useDeleteChartOfAccountMutation, useSeedDefaultChartOfAccountsMutation } from '@/store/api/accountingApi'
+import { setSelectedAccount } from '@/store/slices/accountingSlice'
 import type { ChartOfAccount } from '@/types'
 
-export function useChartOfAccountsWorkspace(refetch: () => void) {
+interface UseChartOfAccountsWorkspaceConfig {
+  dispatch: AppDispatch
+  accounts: ChartOfAccount[]
+  selectedAccount: ChartOfAccount | null
+  refetch: () => void
+}
+
+export function useChartOfAccountsWorkspace({
+  dispatch,
+  accounts,
+  selectedAccount,
+  refetch,
+}: UseChartOfAccountsWorkspaceConfig) {
+  const navigate = useNavigate()
   const { showSuccess, showError } = useNotification()
-  const [selected, setSelected] = useState<ChartOfAccount | null>(null)
   const [formDialogOpen, setFormDialogOpen] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<ChartOfAccount | null>(null)
   const [seedConfirmOpen, setSeedConfirmOpen] = useState(false)
   const [deletedDialogOpen, setDeletedDialogOpen] = useState(false)
-  const searchInputRef = useRef<HTMLInputElement | null>(null)
-  const listRef = useRef<HTMLDivElement | null>(null)
   const [deleteChartOfAccount] = useDeleteChartOfAccountMutation()
   const [seedDefaultChartOfAccounts] = useSeedDefaultChartOfAccountsMutation()
+
+  const workspace = useEntityWorkspace({
+    entities: accounts,
+    selectedEntity: selectedAccount,
+    selectEntity: (account) => dispatch(setSelectedAccount(account)),
+    refetch,
+    navigate,
+    routes: {
+      create: '',
+      edit: () => '',
+    },
+    notifications: { showSuccess: () => {}, showError: () => {} },
+    deleteMutation: async () => {},
+    onEnter: () => {
+      if (selectedAccount) {
+        setFormDialogOpen(true)
+      }
+    },
+    onEscape: () => {
+      workspace.setFocusedIndex(-1)
+      dispatch(setSelectedAccount(null))
+      setFormDialogOpen(false)
+      setDeleteTarget(null)
+    },
+  })
 
   const handleDelete = useCallback(async () => {
     if (!deleteTarget) return
@@ -22,12 +61,14 @@ export function useChartOfAccountsWorkspace(refetch: () => void) {
       await deleteChartOfAccount(deleteTarget.id).unwrap()
       showSuccess(`Account "${deleteTarget.name}" deleted successfully`)
       setDeleteTarget(null)
-      if (selected?.id === deleteTarget.id) setSelected(null)
+      if (selectedAccount?.id === deleteTarget.id) {
+        dispatch(setSelectedAccount(null))
+      }
       refetch()
     } catch (error: any) {
       showError(error || 'Failed to delete account')
     }
-  }, [deleteChartOfAccount, deleteTarget, refetch, selected?.id, showError, showSuccess])
+  }, [deleteChartOfAccount, deleteTarget, dispatch, refetch, selectedAccount?.id, showError, showSuccess])
 
   const handleSeed = useCallback(async () => {
     try {
@@ -41,5 +82,19 @@ export function useChartOfAccountsWorkspace(refetch: () => void) {
     }
   }, [refetch, seedDefaultChartOfAccounts, showError, showSuccess])
 
-  return { selected, setSelected, formDialogOpen, setFormDialogOpen, deleteTarget, setDeleteTarget, seedConfirmOpen, setSeedConfirmOpen, deletedDialogOpen, setDeletedDialogOpen, searchInputRef, listRef, handleDelete, handleSeed }
+  return {
+    ...workspace,
+    selected: selectedAccount,
+    setSelected: (account: ChartOfAccount | null) => dispatch(setSelectedAccount(account)),
+    formDialogOpen,
+    setFormDialogOpen,
+    deleteTarget,
+    setDeleteTarget,
+    seedConfirmOpen,
+    setSeedConfirmOpen,
+    deletedDialogOpen,
+    setDeletedDialogOpen,
+    handleDelete,
+    handleSeed,
+  }
 }

--- a/frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
@@ -3,27 +3,33 @@ import { useNavigate } from 'react-router-dom'
 
 import { useNotification } from '@/hooks/useNotification'
 import {
-  useBulkDeleteJournalEntriesMutation,
-  useBulkPostJournalEntriesMutation,
   useDeleteJournalEntryMutation,
   useLazyGetJournalEntryQuery,
   usePostJournalEntryMutation,
   useReverseJournalEntryMutation,
 } from '@/store/api/accountingApi'
-import { JournalEntry, JournalEntryStatus } from '@/types'
+import { JournalEntry } from '@/types'
 import { getErrorMessage } from '@/utils/errorMessage'
+
+export const SOURCE_ROUTES: Record<string, (id: string) => string> = {
+  sales_order: (id) => `/sales/orders?highlight=${id}`,
+  payment: (id) => `/sales/payments?highlight=${id}`,
+  goods_received_note: (id) => `/purchasing/goods-received?grnId=${id}`,
+  vendor_payment: (id) => `/purchasing/vendor-payments?vpId=${id}`,
+  expense: () => '/accounting/expenses',
+  owner_equity_transaction: () => '/accounting/owner-equity',
+  fund_transfer: () => '/accounting/fund-transfers',
+  stock_adjustment: (id) => `/inventory/stock-adjustments/${id}/edit`,
+}
 
 export function useJournalEntriesWorkspace(refetch: () => void) {
   const navigate = useNavigate()
   const { showSuccess, showError } = useNotification()
 
   const [selectedEntry, setSelectedEntry] = useState<JournalEntry | null>(null)
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [postTarget, setPostTarget] = useState<JournalEntry | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<JournalEntry | null>(null)
   const [reverseTarget, setReverseTarget] = useState<JournalEntry | null>(null)
-  const [bulkPostOpen, setBulkPostOpen] = useState(false)
-  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false)
   const [actionLoading, setActionLoading] = useState(false)
   const searchInputRef = useRef<HTMLInputElement | null>(null)
   const listRef = useRef<HTMLDivElement | null>(null)
@@ -32,8 +38,6 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
   const [postJournalEntry] = usePostJournalEntryMutation()
   const [reverseJournalEntry] = useReverseJournalEntryMutation()
   const [deleteJournalEntry] = useDeleteJournalEntryMutation()
-  const [bulkPostJournalEntries] = useBulkPostJournalEntriesMutation()
-  const [bulkDeleteJournalEntries] = useBulkDeleteJournalEntriesMutation()
 
   const handleSelect = useCallback(async (entry: JournalEntry) => {
     setSelectedEntry(entry)
@@ -41,24 +45,10 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
       const fresh = await fetchEntry(entry.id).unwrap()
       setSelectedEntry(fresh)
     }
-    catch { /* keep list-row data */ }
+    catch {
+      /* keep list-row data */
+    }
   }, [fetchEntry])
-
-  const handleToggleCheck = useCallback((id: string) => {
-    setSelectedIds((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }, [])
-
-  const handleSelectAll = useCallback((entries: JournalEntry[]) => {
-    const drafts = entries
-      .filter((entry) => entry.status === JournalEntryStatus.DRAFT)
-      .map((entry) => entry.id)
-    setSelectedIds((prev) => (prev.size === drafts.length ? new Set() : new Set(drafts)))
-  }, [])
 
   const handleConfirmPost = useCallback(async () => {
     if (!postTarget) return
@@ -76,7 +66,7 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
     finally {
       setActionLoading(false)
     }
-  }, [postTarget, postJournalEntry, showSuccess, showError, refetch])
+  }, [postTarget, postJournalEntry, refetch, showError, showSuccess])
 
   const handleConfirmReverse = useCallback(async (reverseDate: string) => {
     if (!reverseTarget) return
@@ -94,7 +84,7 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
     finally {
       setActionLoading(false)
     }
-  }, [reverseTarget, reverseJournalEntry, showSuccess, showError, refetch])
+  }, [refetch, reverseJournalEntry, reverseTarget, showError, showSuccess])
 
   const handleConfirmDelete = useCallback(async () => {
     if (!deleteTarget) return
@@ -112,82 +102,27 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
     finally {
       setActionLoading(false)
     }
-  }, [deleteTarget, deleteJournalEntry, showSuccess, showError, refetch])
-
-  const handleBulkPost = useCallback(async () => {
-    setActionLoading(true)
-    try {
-      const result = await bulkPostJournalEntries(Array.from(selectedIds)).unwrap()
-      showSuccess(`Posted ${result.succeeded.length} entries`)
-      if (result.failed.length > 0) showError(`${result.failed.length} entries failed`)
-      setSelectedIds(new Set())
-      setBulkPostOpen(false)
-      refetch()
-    }
-    catch (error: unknown) {
-      showError(getErrorMessage(error, 'Bulk post failed'))
-    }
-    finally {
-      setActionLoading(false)
-    }
-  }, [selectedIds, bulkPostJournalEntries, showSuccess, showError, refetch])
-
-  const handleBulkDelete = useCallback(async () => {
-    setActionLoading(true)
-    try {
-      const result = await bulkDeleteJournalEntries(Array.from(selectedIds)).unwrap()
-      showSuccess(`Deleted ${result.succeeded.length} entries`)
-      if (result.failed.length > 0) showError(`${result.failed.length} entries failed`)
-      setSelectedIds(new Set())
-      setBulkDeleteOpen(false)
-      refetch()
-    }
-    catch (error: unknown) {
-      showError(getErrorMessage(error, 'Bulk delete failed'))
-    }
-    finally {
-      setActionLoading(false)
-    }
-  }, [selectedIds, bulkDeleteJournalEntries, showSuccess, showError, refetch])
+  }, [deleteJournalEntry, deleteTarget, refetch, showError, showSuccess])
 
   return {
     selectedEntry,
-    selectedIds,
     postTarget,
     setPostTarget,
     deleteTarget,
     setDeleteTarget,
     reverseTarget,
     setReverseTarget,
-    bulkPostOpen,
-    setBulkPostOpen,
-    bulkDeleteOpen,
-    setBulkDeleteOpen,
     actionLoading,
     searchInputRef,
     listRef,
     handleSelect,
-    handleToggleCheck,
-    handleSelectAll,
     handleConfirmPost,
     handleConfirmReverse,
     handleConfirmDelete,
-    handleBulkPost,
-    handleBulkDelete,
     navigateToEdit: (entry: JournalEntry) => navigate(`/accounting/journal-entries/${entry.id}/edit`),
     navigateToCreate: () => navigate('/accounting/journal-entries/new'),
     navigateToSource: (sourceType: string, sourceId: string) => {
-      const routes: Record<string, (id: string) => string> = {
-        sales_order: (id) => `/sales/orders?highlight=${id}`,
-        payment: (id) => `/sales/payments?highlight=${id}`,
-        goods_received_note: (id) => `/purchasing/goods-received?grnId=${id}`,
-        vendor_payment: (id) => `/purchasing/vendor-payments?vpId=${id}`,
-        expense: () => `/accounting/expenses`,
-        owner_equity_transaction: () => `/accounting/owner-equity`,
-        fund_transfer: () => `/accounting/fund-transfers`,
-        stock_adjustment: (id) => `/inventory/stock-adjustments/${id}/edit`,
-      }
-      const route = routes[sourceType]
+      const route = SOURCE_ROUTES[sourceType]
       if (route) navigate(route(sourceId))
     },
   }

--- a/frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
@@ -1,14 +1,17 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import { useNotification } from '@/hooks/useNotification'
+import type { AppDispatch } from '@/store'
 import {
   useDeleteJournalEntryMutation,
   useLazyGetJournalEntryQuery,
   usePostJournalEntryMutation,
   useReverseJournalEntryMutation,
 } from '@/store/api/accountingApi'
-import { JournalEntry } from '@/types'
+import { setSelectedJournalEntry } from '@/store/slices/accountingSlice'
+import type { JournalEntry } from '@/types'
 import { getErrorMessage } from '@/utils/errorMessage'
 
 export const SOURCE_ROUTES: Record<string, (id: string) => string> = {
@@ -22,33 +25,70 @@ export const SOURCE_ROUTES: Record<string, (id: string) => string> = {
   stock_adjustment: (id) => `/inventory/stock-adjustments/${id}/edit`,
 }
 
-export function useJournalEntriesWorkspace(refetch: () => void) {
+interface UseJournalEntriesWorkspaceConfig {
+  dispatch: AppDispatch
+  entries: JournalEntry[]
+  selectedEntry: JournalEntry | null
+  refetch: () => void
+}
+
+export function useJournalEntriesWorkspace({
+  dispatch,
+  entries,
+  selectedEntry,
+  refetch,
+}: UseJournalEntriesWorkspaceConfig) {
   const navigate = useNavigate()
   const { showSuccess, showError } = useNotification()
 
-  const [selectedEntry, setSelectedEntry] = useState<JournalEntry | null>(null)
   const [postTarget, setPostTarget] = useState<JournalEntry | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<JournalEntry | null>(null)
   const [reverseTarget, setReverseTarget] = useState<JournalEntry | null>(null)
   const [actionLoading, setActionLoading] = useState(false)
-  const searchInputRef = useRef<HTMLInputElement | null>(null)
-  const listRef = useRef<HTMLDivElement | null>(null)
 
   const [fetchEntry] = useLazyGetJournalEntryQuery()
   const [postJournalEntry] = usePostJournalEntryMutation()
   const [reverseJournalEntry] = useReverseJournalEntryMutation()
   const [deleteJournalEntry] = useDeleteJournalEntryMutation()
 
-  const handleSelect = useCallback(async (entry: JournalEntry) => {
-    setSelectedEntry(entry)
+  const selectAndLoadEntry = useCallback(async (entry: JournalEntry) => {
+    dispatch(setSelectedJournalEntry(entry))
     try {
       const fresh = await fetchEntry(entry.id).unwrap()
-      setSelectedEntry(fresh)
+      dispatch(setSelectedJournalEntry(fresh))
     }
     catch {
       /* keep list-row data */
     }
-  }, [fetchEntry])
+  }, [dispatch, fetchEntry])
+
+  const workspace = useEntityWorkspace({
+    entities: entries,
+    selectedEntity: selectedEntry,
+    selectEntity: (entry) => {
+      if (entry) {
+        void selectAndLoadEntry(entry)
+        return
+      }
+
+      dispatch(setSelectedJournalEntry(null))
+    },
+    refetch,
+    navigate,
+    routes: {
+      create: '/accounting/journal-entries/new',
+      edit: (id) => `/accounting/journal-entries/${id}/edit`,
+    },
+    notifications: { showSuccess: () => {}, showError: () => {} },
+    deleteMutation: async () => {},
+    onEscape: () => {
+      workspace.setFocusedIndex(-1)
+      dispatch(setSelectedJournalEntry(null))
+      setPostTarget(null)
+      setDeleteTarget(null)
+      setReverseTarget(null)
+    },
+  })
 
   const handleConfirmPost = useCallback(async () => {
     if (!postTarget) return
@@ -57,7 +97,7 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
       await postJournalEntry(postTarget.id).unwrap()
       showSuccess(`Journal entry ${postTarget.referenceNumber} posted`)
       setPostTarget(null)
-      setSelectedEntry(null)
+      dispatch(setSelectedJournalEntry(null))
       refetch()
     }
     catch (error: unknown) {
@@ -66,7 +106,7 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
     finally {
       setActionLoading(false)
     }
-  }, [postTarget, postJournalEntry, refetch, showError, showSuccess])
+  }, [dispatch, postTarget, postJournalEntry, refetch, showError, showSuccess])
 
   const handleConfirmReverse = useCallback(async (reverseDate: string) => {
     if (!reverseTarget) return
@@ -75,7 +115,7 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
       const result = await reverseJournalEntry({ id: reverseTarget.id, reverseDate }).unwrap()
       showSuccess(`Journal entry ${reverseTarget.referenceNumber} reversed`)
       setReverseTarget(null)
-      setSelectedEntry(result)
+      dispatch(setSelectedJournalEntry(result))
       refetch()
     }
     catch (error: unknown) {
@@ -84,7 +124,7 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
     finally {
       setActionLoading(false)
     }
-  }, [refetch, reverseJournalEntry, reverseTarget, showError, showSuccess])
+  }, [dispatch, refetch, reverseJournalEntry, reverseTarget, showError, showSuccess])
 
   const handleConfirmDelete = useCallback(async () => {
     if (!deleteTarget) return
@@ -93,7 +133,7 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
       await deleteJournalEntry(deleteTarget.id).unwrap()
       showSuccess(`Journal entry ${deleteTarget.referenceNumber} deleted`)
       setDeleteTarget(null)
-      setSelectedEntry(null)
+      dispatch(setSelectedJournalEntry(null))
       refetch()
     }
     catch (error: unknown) {
@@ -102,9 +142,10 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
     finally {
       setActionLoading(false)
     }
-  }, [deleteJournalEntry, deleteTarget, refetch, showError, showSuccess])
+  }, [deleteJournalEntry, deleteTarget, dispatch, refetch, showError, showSuccess])
 
   return {
+    ...workspace,
     selectedEntry,
     postTarget,
     setPostTarget,
@@ -113,9 +154,6 @@ export function useJournalEntriesWorkspace(refetch: () => void) {
     reverseTarget,
     setReverseTarget,
     actionLoading,
-    searchInputRef,
-    listRef,
-    handleSelect,
     handleConfirmPost,
     handleConfirmReverse,
     handleConfirmDelete,

--- a/frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
@@ -62,10 +62,8 @@ export function useJournalEntriesWorkspace({
     }
   }, [dispatch, fetchEntry])
 
-  const workspace = useEntityWorkspace({
-    entities: entries,
-    selectedEntity: selectedEntry,
-    selectEntity: (entry) => {
+  const selectEntry = useCallback(
+    (entry: JournalEntry | null) => {
       if (entry) {
         void selectAndLoadEntry(entry)
         return
@@ -73,6 +71,13 @@ export function useJournalEntriesWorkspace({
 
       dispatch(setSelectedJournalEntry(null))
     },
+    [dispatch, selectAndLoadEntry],
+  )
+
+  const workspace = useEntityWorkspace({
+    entities: entries,
+    selectedEntity: selectedEntry,
+    selectEntity: selectEntry,
     refetch,
     navigate,
     routes: {

--- a/frontend/src/pages/dashboard/DashboardPage.test.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.test.tsx
@@ -2,10 +2,15 @@ import { describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import ThemeWrapper from '@/components/common/ThemeWrapper'
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
 import DashboardPage from './DashboardPage'
 
 vi.mock('@/hooks/useCurrency', () => ({
   useCurrency: () => ({ currency: 'USD' }),
+}))
+
+vi.mock('@/contexts/LayoutScrollContext', () => ({
+  useLayoutScroll: vi.fn(),
 }))
 
 vi.mock('@/store/api/salesApi', () => ({
@@ -78,5 +83,17 @@ describe('DashboardPage', () => {
 
     expect(screen.getByText('Dashboard')).toBeInTheDocument()
     expect(screen.getByText('Inventory overview')).toBeInTheDocument()
+  })
+
+  it('opts in to layout scrolling', () => {
+    render(
+      <ThemeWrapper>
+        <MemoryRouter>
+          <DashboardPage />
+        </MemoryRouter>
+      </ThemeWrapper>,
+    )
+
+    expect(useLayoutScroll).toHaveBeenCalledWith(true)
   })
 })

--- a/frontend/src/pages/dashboard/DashboardPage.test.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import ThemeWrapper from '@/components/common/ThemeWrapper'
+import DashboardPage from './DashboardPage'
+
+vi.mock('@/hooks/useCurrency', () => ({
+  useCurrency: () => ({ currency: 'USD' }),
+}))
+
+vi.mock('@/store/api/salesApi', () => ({
+  useGetSalesOrdersQuery: () => ({
+    data: { data: [] },
+    isLoading: false,
+    error: undefined,
+  }),
+  useGetPaymentsQuery: () => ({
+    data: { data: [] },
+    isLoading: false,
+    error: undefined,
+  }),
+}))
+
+vi.mock('@/store/api/purchasingApi', () => ({
+  useGetPurchaseOrdersQuery: () => ({
+    data: { data: [] },
+    isLoading: false,
+    error: undefined,
+  }),
+  useGetSuppliersQuery: () => ({
+    data: { data: [] },
+    isLoading: false,
+    error: undefined,
+  }),
+}))
+
+vi.mock('@/store/api/inventoryApi', () => ({
+  useGetDashboardStatsQuery: () => ({
+    data: {
+      totalProducts: 0,
+      totalCategories: 0,
+      inventoryValue: 0,
+      outOfStockCount: 0,
+      stockHealthMetrics: {
+        inStockPercentage: 100,
+        outOfStockPercentage: 0,
+      },
+    },
+    isLoading: false,
+    error: undefined,
+  }),
+  useGetOutOfStockProductsQuery: () => ({
+    data: { data: { items: [] } },
+    isLoading: false,
+    error: undefined,
+  }),
+}))
+
+vi.mock('./components', () => ({
+  DashboardStats: () => <div>Dashboard stats</div>,
+  QuickActions: () => <div>Quick actions</div>,
+  BusinessPerformanceChart: () => <div>Business performance</div>,
+  RecentSalesTable: () => <div>Recent sales</div>,
+  RecentPurchasesTable: () => <div>Recent purchases</div>,
+  TopPerformers: () => <div>Top performers</div>,
+  InventoryOverview: () => <div>Inventory overview</div>,
+}))
+
+describe('DashboardPage', () => {
+  it('renders when out-of-stock response data is not an array', () => {
+    render(
+      <ThemeWrapper>
+        <MemoryRouter>
+          <DashboardPage />
+        </MemoryRouter>
+      </ThemeWrapper>,
+    )
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    expect(screen.getByText('Inventory overview')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -70,6 +70,8 @@ interface DashboardData {
   }
 }
 
+const asArray = <T,>(value: unknown): T[] => (Array.isArray(value) ? value : [])
+
 const DashboardPage: React.FC = () => {
   const navigate = useNavigate()
   const { currency } = useCurrency()
@@ -88,10 +90,11 @@ const DashboardPage: React.FC = () => {
   const { data: inventoryStats, isLoading: inventoryLoading, error: inventoryError } = useGetDashboardStatsQuery()
   const { data: outOfStock = [], isLoading: outOfStockLoading, error: outOfStockError } = useGetOutOfStockProductsQuery()
   const { data: paymentsResponse, isLoading: paymentsLoading, error: paymentsError } = useGetPaymentsQuery({})
-  const salesOrders = salesOrdersResponse?.data ?? []
-  const purchaseOrders = purchaseOrdersResponse?.data ?? []
-  const suppliers = suppliersResponse?.data ?? []
-  const payments = paymentsResponse?.data ?? []
+  const salesOrders = asArray<any>(salesOrdersResponse?.data)
+  const purchaseOrders = asArray<any>(purchaseOrdersResponse?.data)
+  const suppliers = asArray<any>(suppliersResponse?.data)
+  const payments = asArray<any>(paymentsResponse?.data)
+  const outOfStockProducts = asArray<any>(outOfStock)
 
   const loading =
     salesLoading ||
@@ -300,8 +303,8 @@ const DashboardPage: React.FC = () => {
         totalProducts: inventoryStats?.totalProducts || 0,
         totalCategories: inventoryStats?.totalCategories || 0,
         inventoryValue: inventoryStats?.inventoryValue || 0,
-        outOfStockCount: inventoryStats?.outOfStockCount || outOfStock.length,
-        lowStockItems: outOfStock.slice(0, 5),
+        outOfStockCount: inventoryStats?.outOfStockCount || outOfStockProducts.length,
+        lowStockItems: outOfStockProducts.slice(0, 5),
         stockHealthMetrics: inventoryStats?.stockHealthMetrics || {
           inStockPercentage: 100,
           outOfStockPercentage: 0,
@@ -314,7 +317,7 @@ const DashboardPage: React.FC = () => {
         inventoryValue: inventoryStats?.inventoryValue || 0,
       },
     }
-  }, [inventoryStats, outOfStock, payments, purchaseOrders, salesOrders, suppliers])
+  }, [inventoryStats, outOfStockProducts, payments, purchaseOrders, salesOrders, suppliers])
 
   const stats = [
     {

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -11,6 +11,7 @@ import { default as SalesIcon } from '@mui/icons-material/PointOfSale'
 import { default as PurchasingIcon } from '@mui/icons-material/Assignment'
 import { default as CustomersIcon } from '@mui/icons-material/People'
 import PageHeader from '@/components/common/PageHeader'
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
 import { formatCurrency } from '@/utils/formatters'
 import { useNavigate } from 'react-router-dom'
 import { useCurrency } from '@/hooks/useCurrency'
@@ -73,6 +74,8 @@ interface DashboardData {
 const asArray = <T,>(value: unknown): T[] => (Array.isArray(value) ? value : [])
 
 const DashboardPage: React.FC = () => {
+  useLayoutScroll(true)
+
   const navigate = useNavigate()
   const { currency } = useCurrency()
 

--- a/frontend/src/pages/inventory/InventoryPage.tsx
+++ b/frontend/src/pages/inventory/InventoryPage.tsx
@@ -44,6 +44,7 @@ import { useFilterBar } from '@/hooks/useFilterBar'
 import { useInventoryAnalytics } from './hooks/useInventoryAnalytics'
 import { formatCurrency } from '@/utils/formatters'
 import { TABLE_STYLES } from '@/constants/tableStyles'
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
 import { resolveApiParams } from '@/utils/dashboardApiParams'
 import type { DashboardCompare } from '@/utils/dashboardApiParams'
 import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
@@ -69,6 +70,7 @@ function deltaPercent(current: number | undefined, previous: number | undefined)
 }
 
 const InventoryPage: React.FC = () => {
+  useLayoutScroll(true)
   const theme = useTheme()
   const navigate = useNavigate()
 

--- a/frontend/src/pages/inventory/__tests__/InventoryPage.filters.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/InventoryPage.filters.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
 import InventoryPage from '../InventoryPage'
 
 const mockUseGetSuppliersQuery = vi.fn()
@@ -32,6 +33,10 @@ vi.mock('@/components/filters/FilterBar', () => ({
 vi.mock('react-chartjs-2', () => ({
   Line: () => <div data-testid="inventory-line-chart" />,
   Doughnut: () => <div data-testid="inventory-doughnut-chart" />,
+}))
+
+vi.mock('@/contexts/LayoutScrollContext', () => ({
+  useLayoutScroll: vi.fn(),
 }))
 
 describe('InventoryPage filters', () => {
@@ -75,6 +80,15 @@ describe('InventoryPage filters', () => {
       isFetching: false,
       error: null,
     })
+  })
+
+  it('enables layout scroll', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <InventoryPage />
+      </MemoryRouter>,
+    )
+    expect(useLayoutScroll).toHaveBeenCalledWith(true)
   })
 
   it('passes inventory filter state into analytics', () => {

--- a/frontend/src/pages/inventory/hooks/useCategoriesWorkspace.ts
+++ b/frontend/src/pages/inventory/hooks/useCategoriesWorkspace.ts
@@ -49,10 +49,15 @@ export function useCategoriesWorkspace({
   const [deleteError, setDeleteError] = useState<any>(null)
   const [submitting, setSubmitting] = useState(false)
 
+  const selectCategory = useCallback(
+    (category: Category | null) => dispatch(setSelectedCategory(category)),
+    [dispatch],
+  )
+
   const workspace = useEntityWorkspace({
     entities: categories,
     selectedEntity: selectedCategory,
-    selectEntity: (category) => dispatch(setSelectedCategory(category)),
+    selectEntity: selectCategory,
     refetch: refetchCategories,
     navigate: (() => undefined) as any,
     routes: {

--- a/frontend/src/pages/inventory/hooks/useProductsWorkspace.ts
+++ b/frontend/src/pages/inventory/hooks/useProductsWorkspace.ts
@@ -48,10 +48,15 @@ export function useProductsWorkspace({
     return { id: navigationSelectionId } as Product
   }, [navigationSelectionId, selectedProduct])
 
+  const selectProduct = useCallback(
+    (product: Product | null) => dispatch(setSelectedProduct(product)),
+    [dispatch],
+  )
+
   const workspace = useEntityWorkspace({
     entities: products,
     selectedEntity: pendingSelectedProduct,
-    selectEntity: (product) => dispatch(setSelectedProduct(product)),
+    selectEntity: selectProduct,
     refetch: refetchProducts,
     navigate,
     routes: {

--- a/frontend/src/pages/inventory/hooks/useStockAdjustmentsWorkspace.ts
+++ b/frontend/src/pages/inventory/hooks/useStockAdjustmentsWorkspace.ts
@@ -65,10 +65,15 @@ export function useStockAdjustmentsWorkspace({
   const [completeStockAdjustment] = useCompleteStockAdjustmentMutation()
   const [uncompleteStockAdjustment] = useUncompleteStockAdjustmentMutation()
 
+  const selectAdjustment = useCallback(
+    (adjustment: StockAdjustment | null) => dispatch(setSelectedStockAdjustment(adjustment)),
+    [dispatch],
+  )
+
   const workspace = useEntityWorkspace({
     entities: adjustments,
     selectedEntity: selectedAdjustment,
-    selectEntity: (adjustment) => dispatch(setSelectedStockAdjustment(adjustment)),
+    selectEntity: selectAdjustment,
     refetch: refetchAdjustments,
     navigate,
     routes: {

--- a/frontend/src/pages/purchasing/PurchasingPage.tsx
+++ b/frontend/src/pages/purchasing/PurchasingPage.tsx
@@ -42,6 +42,7 @@ import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { FilterBar } from '@/components/filters/FilterBar'
 import { useFilterBar } from '@/hooks/useFilterBar'
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
 import { usePurchasingAnalytics } from './hooks/usePurchasingAnalytics'
 import { resolveApiParams } from '@/utils/dashboardApiParams'
 import type { DashboardCompare } from '@/utils/dashboardApiParams'
@@ -111,6 +112,8 @@ const PurchasingPage: React.FC = () => {
       paymentStatus: null,
     },
   }
+
+  useLayoutScroll(true)
 
   const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(purchasingConfig)
   const resolvedApiParams = resolveApiParams(appliedFilters)

--- a/frontend/src/pages/purchasing/SuppliersPage.tsx
+++ b/frontend/src/pages/purchasing/SuppliersPage.tsx
@@ -14,6 +14,7 @@ import {
   selectSelectedSupplier,
   setSelectedSupplier,
 } from '@/store/slices/purchasingSlice'
+import type { Supplier } from '@/types'
 import type { FilterBarConfig } from '@/types/filterBar.types'
 
 import SupplierContextHeader from './components/SupplierContextHeader'
@@ -69,12 +70,18 @@ const SuppliersPage: React.FC = () => {
   const [deleteSupplier] = useDeleteSupplierMutation()
   const suppliers = suppliersResponse?.data ?? []
 
+  const selectSupplier = useCallback(
+    (supplier: Supplier | null) => {
+      dispatch(setSelectedSupplier(supplier))
+    },
+    [dispatch],
+  )
+
   const workspace = useEntityWorkspace({
     entities: suppliers,
     selectedEntity: selectedSupplier,
-    selectEntity: (supplier) => {
-      dispatch(setSelectedSupplier(supplier))
-    },
+    selectEntity: selectSupplier,
+    isFetching,
     refetch: () => {
       void refetch()
     },

--- a/frontend/src/pages/purchasing/__tests__/PurchasingPage.filters.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/PurchasingPage.filters.test.tsx
@@ -3,11 +3,16 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
 import PurchasingPage from '../PurchasingPage'
 
 const mockUseGetSuppliersQuery = vi.fn()
 const mockUsePurchasingAnalytics = vi.fn()
 const filterBarSpy = vi.fn()
+
+vi.mock('@/contexts/LayoutScrollContext', () => ({
+  useLayoutScroll: vi.fn(),
+}))
 
 vi.mock('@/store/api/purchasingApi', () => ({
   useGetSuppliersQuery: (...args: unknown[]) => mockUseGetSuppliersQuery(...args),
@@ -119,5 +124,14 @@ describe('PurchasingPage filters', () => {
         }),
       ]),
     )
+  })
+
+  it('enables layout scroll so page content is not clipped', () => {
+    render(
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <PurchasingPage />
+      </MemoryRouter>,
+    )
+    expect(useLayoutScroll).toHaveBeenCalledWith(true)
   })
 })

--- a/frontend/src/pages/purchasing/hooks/useGRNWorkspace.ts
+++ b/frontend/src/pages/purchasing/hooks/useGRNWorkspace.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate, type SetURLSearchParams } from 'react-router-dom'
 
 import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
@@ -42,10 +42,15 @@ export function useGRNWorkspace({
   const [fetchJournalEntries] = useLazyGetJournalEntriesQuery()
   const [fetchGRN] = useLazyGetGoodsReceivedNoteQuery()
 
+  const selectGRN = useCallback(
+    (grn: GoodsReceivedNote | null) => dispatch(setSelectedGRN(grn)),
+    [dispatch],
+  )
+
   const workspace = useEntityWorkspace({
     entities: grns,
     selectedEntity: selectedGRN,
-    selectEntity: (grn) => dispatch(setSelectedGRN(grn)),
+    selectEntity: selectGRN,
     refetch,
     navigate,
     routes: {

--- a/frontend/src/pages/purchasing/hooks/useVendorPaymentsWorkspace.ts
+++ b/frontend/src/pages/purchasing/hooks/useVendorPaymentsWorkspace.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate, type SetURLSearchParams } from 'react-router-dom'
 
 import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
@@ -40,10 +40,15 @@ export function useVendorPaymentsWorkspace({
   const [fetchPayment] = useLazyGetVendorPaymentQuery()
   const [fetchJournalEntries] = useLazyGetJournalEntriesQuery()
 
+  const selectPayment = useCallback(
+    (payment: VendorPayment | null) => dispatch(setSelectedVendorPayment(payment)),
+    [dispatch],
+  )
+
   const workspace = useEntityWorkspace({
     entities: payments,
     selectedEntity: selectedPayment,
-    selectEntity: (payment) => dispatch(setSelectedVendorPayment(payment)),
+    selectEntity: selectPayment,
     refetch,
     navigate,
     routes: {

--- a/frontend/src/pages/sales/CustomersPage.tsx
+++ b/frontend/src/pages/sales/CustomersPage.tsx
@@ -14,6 +14,7 @@ import {
   selectSelectedCustomer,
   setSelectedCustomer,
 } from '@/store/slices/salesSlice'
+import type { Customer } from '@/types'
 import type { FilterBarConfig } from '@/types/filterBar.types'
 
 import CustomerContextHeader from './components/CustomerContextHeader'
@@ -72,12 +73,18 @@ const CustomersPage: React.FC = () => {
   const [deleteCustomer] = useDeleteCustomerMutation()
   const customers = customersResponse?.data ?? []
 
+  const selectCustomer = useCallback(
+    (customer: Customer | null) => {
+      dispatch(setSelectedCustomer(customer))
+    },
+    [dispatch],
+  )
+
   const workspace = useEntityWorkspace({
     entities: customers,
     selectedEntity: selectedCustomer,
-    selectEntity: (customer) => {
-      dispatch(setSelectedCustomer(customer))
-    },
+    selectEntity: selectCustomer,
+    isFetching,
     refetch: () => {
       void refetch()
     },

--- a/frontend/src/pages/sales/SalesPage.tsx
+++ b/frontend/src/pages/sales/SalesPage.tsx
@@ -33,8 +33,10 @@ import { useDashboardAnalytics } from './hooks/useDashboardAnalytics'
 import { resolveApiParams } from '@/utils/dashboardApiParams'
 import type { DashboardCompare } from '@/utils/dashboardApiParams'
 import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
+import { useLayoutScroll } from '@/contexts/LayoutScrollContext'
 
 const SalesPage: React.FC = () => {
+  useLayoutScroll(true)
   const navigate = useNavigate()
   const [recentOrders, setRecentOrders] = useState<any[]>([])
   const [recentOrdersLoading, setRecentOrdersLoading] = useState(true)

--- a/frontend/src/pages/sales/SalesPage.tsx
+++ b/frontend/src/pages/sales/SalesPage.tsx
@@ -113,7 +113,7 @@ const SalesPage: React.FC = () => {
       try {
         setRecentOrdersLoading(true)
         const response = await api.get('/sales-orders', {
-          params: { limit: 5, sortBy: 'orderDate', sortOrder: 'desc' },
+          params: { limit: 5, sortBy: 'orderDate', sortOrder: 'DESC' },
         })
 
         if (active) {

--- a/frontend/src/pages/sales/hooks/useInvoicesWorkspace.ts
+++ b/frontend/src/pages/sales/hooks/useInvoicesWorkspace.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type MouseEvent } from 'react'
+import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
@@ -67,10 +67,15 @@ export function useInvoicesWorkspace({
   const workspaceRef = useRef<EntityWorkspaceReturn<InvoiceListItem> | null>(null)
   const [fetchJournalEntries] = useLazyGetJournalEntriesQuery()
 
+  const selectInvoice = useCallback(
+    (invoice: InvoiceListItem | null) => dispatch(setSelectedInvoice(invoice as any)),
+    [dispatch],
+  )
+
   const workspace = useEntityWorkspace({
     entities: invoices,
     selectedEntity: selectedInvoice,
-    selectEntity: (invoice) => dispatch(setSelectedInvoice(invoice as any)),
+    selectEntity: selectInvoice,
     refetch,
     navigate,
     routes: {

--- a/frontend/src/pages/sales/hooks/useOrdersWorkspace.ts
+++ b/frontend/src/pages/sales/hooks/useOrdersWorkspace.ts
@@ -89,10 +89,15 @@ export function useOrdersWorkspace({
   const [unfulfillSalesOrder] = useUnfulfillSalesOrderMutation()
   const [fetchJournalEntries] = useLazyGetJournalEntriesQuery()
 
+  const selectOrder = useCallback(
+    (order: SalesOrder | null) => dispatch(setSelectedOrder(order)),
+    [dispatch],
+  )
+
   const workspace = useEntityWorkspace({
     entities: orders,
     selectedEntity: selectedOrder,
-    selectEntity: (order) => dispatch(setSelectedOrder(order)),
+    selectEntity: selectOrder,
     refetch: refetchOrders,
     navigate,
     routes: {

--- a/frontend/src/pages/sales/hooks/usePaymentsWorkspace.ts
+++ b/frontend/src/pages/sales/hooks/usePaymentsWorkspace.ts
@@ -83,10 +83,15 @@ export function usePaymentsWorkspace({
   const hasRestoredSelection = useRef(false)
   const [fetchJournalEntries] = useLazyGetJournalEntriesQuery()
 
+  const selectPayment = useCallback(
+    (payment: PaymentListItem | null) => dispatch(setSelectedPayment(payment as any)),
+    [dispatch],
+  )
+
   const workspace = useEntityWorkspace({
     entities: payments,
     selectedEntity: selectedPayment,
-    selectEntity: (payment) => dispatch(setSelectedPayment(payment as any)),
+    selectEntity: selectPayment,
     refetch,
     navigate,
     routes: {

--- a/frontend/src/services/__tests__/viteConfig.test.ts
+++ b/frontend/src/services/__tests__/viteConfig.test.ts
@@ -1,0 +1,30 @@
+import configFactory from '../../../vite.config'
+
+describe('vite chunk configuration', () => {
+  it('keeps axios out of app chunks so auth services do not evaluate through a circular entry chunk', () => {
+    const config =
+      typeof configFactory === 'function'
+        ? configFactory({
+            command: 'build',
+            mode: 'production',
+            isSsrBuild: false,
+            isPreview: false,
+          })
+        : configFactory
+
+    const groups =
+      config.build?.rolldownOptions?.output?.codeSplitting?.groups ?? []
+
+    expect(groups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'axios',
+          test: expect.any(RegExp),
+        }),
+      ])
+    )
+
+    const axiosGroup = groups.find((group) => group.name === 'axios')
+    expect(axiosGroup?.test.test('node_modules/axios/index.js')).toBe(true)
+  })
+})

--- a/frontend/src/services/__tests__/viteConfig.test.ts
+++ b/frontend/src/services/__tests__/viteConfig.test.ts
@@ -27,4 +27,32 @@ describe('vite chunk configuration', () => {
     const axiosGroup = groups.find((group) => group.name === 'axios')
     expect(axiosGroup?.test.test('node_modules/axios/index.js')).toBe(true)
   })
+
+  it('keeps RTK Query API slices out of the app entry chunk so baseQuery is initialized before use', () => {
+    const config =
+      typeof configFactory === 'function'
+        ? configFactory({
+            command: 'build',
+            mode: 'production',
+            isSsrBuild: false,
+            isPreview: false,
+          })
+        : configFactory
+
+    const groups =
+      config.build?.rolldownOptions?.output?.codeSplitting?.groups ?? []
+
+    expect(groups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'rtk-api',
+          test: expect.any(RegExp),
+        }),
+      ])
+    )
+
+    const rtkApiGroup = groups.find((group) => group.name === 'rtk-api')
+    expect(rtkApiGroup?.test.test('/home/blur/erp2/frontend/src/store/api/searchApi.ts')).toBe(true)
+    expect(rtkApiGroup?.test.test('/home/blur/erp2/frontend/src/store/api/baseQuery.ts')).toBe(true)
+  })
 })

--- a/frontend/src/services/__tests__/viteConfig.test.ts
+++ b/frontend/src/services/__tests__/viteConfig.test.ts
@@ -55,4 +55,23 @@ describe('vite chunk configuration', () => {
     expect(rtkApiGroup?.test.test('/home/blur/erp2/frontend/src/store/api/searchApi.ts')).toBe(true)
     expect(rtkApiGroup?.test.test('/home/blur/erp2/frontend/src/store/api/baseQuery.ts')).toBe(true)
   })
+
+  it('keeps redux persistence dependencies out of the app entry chunk so persist actions have a type', () => {
+    const config =
+      typeof configFactory === 'function'
+        ? configFactory({
+            command: 'build',
+            mode: 'production',
+            isSsrBuild: false,
+            isPreview: false,
+          })
+        : configFactory
+
+    const groups =
+      config.build?.rolldownOptions?.output?.codeSplitting?.groups ?? []
+
+    const reduxGroup = groups.find((group) => group.name === 'redux')
+    expect(reduxGroup?.test.test('node_modules/redux-persist/es/persistStore.js')).toBe(true)
+    expect(reduxGroup?.test.test('node_modules/redux/src/createStore.ts')).toBe(true)
+  })
 })

--- a/frontend/src/store/api/inventoryApi.ts
+++ b/frontend/src/store/api/inventoryApi.ts
@@ -161,7 +161,10 @@ export const inventoryApiSlice = createApi({
     }),
     getOutOfStockProducts: builder.query<Product[], void>({
       query: () => ({ url: '/inventory/products/out-of-stock' }),
-      transformResponse: (response: any) => (Array.isArray(response) ? response : response?.data ?? []),
+      transformResponse: (response: any) => {
+        const data = response?.data
+        return Array.isArray(response) ? response : Array.isArray(data) ? data : []
+      },
       providesTags: ['Product'],
     }),
 

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -16,6 +16,7 @@ import purchasingSlice from './slices/purchasingSlice'
 import backupSlice from './slices/backupSlice'
 import auditLogSlice from './slices/auditLogSlice'
 import priceListSlice from './slices/priceListSlice'
+import accountingSlice from './slices/accountingSlice'
 import { auditLogApiSlice } from './api/auditLogApi'
 import { backupApiSlice } from './api/backupApi'
 import { priceListApiSlice } from './api/priceListApi'
@@ -39,6 +40,7 @@ const rootReducer = combineReducers({
   backup: backupSlice,
   auditLogs: auditLogSlice,
   priceLists: priceListSlice,
+  accounting: accountingSlice,
   [auditLogApiSlice.reducerPath]: auditLogApiSlice.reducer,
   [backupApiSlice.reducerPath]: backupApiSlice.reducer,
   [priceListApiSlice.reducerPath]: priceListApiSlice.reducer,

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,11 +1,5 @@
-import { configureStore } from '@reduxjs/toolkit'
+import { configureStore, combineReducers } from '@reduxjs/toolkit'
 import { persistStore, persistReducer } from 'redux-persist'
-const storage = {
-  getItem: (key: string) => Promise.resolve(localStorage.getItem(key)),
-  setItem: (key: string, value: string) => Promise.resolve(localStorage.setItem(key, value)),
-  removeItem: (key: string) => Promise.resolve(localStorage.removeItem(key)),
-}
-import { combineReducers } from '@reduxjs/toolkit'
 
 // Import slices
 import authSlice from './slices/authSlice'
@@ -30,6 +24,12 @@ import { paymentMethodsApiSlice } from './api/paymentMethodsApi'
 import { printSettingsApiSlice } from './api/printSettingsApi'
 import { searchApiSlice } from './api/searchApi'
 import { PERSIST_KEY } from './persistKey'
+
+const storage = {
+  getItem: (key: string) => Promise.resolve(localStorage.getItem(key)),
+  setItem: (key: string, value: string) => Promise.resolve(localStorage.setItem(key, value)),
+  removeItem: (key: string) => Promise.resolve(localStorage.removeItem(key)),
+}
 
 const rootReducer = combineReducers({
   auth: authSlice,

--- a/frontend/src/store/slices/__tests__/accountingSlice.test.ts
+++ b/frontend/src/store/slices/__tests__/accountingSlice.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
 import accountingReducer, {
+  selectSelectedAccount,
+  selectSelectedJournalEntry,
   setSelectedAccount,
   setSelectedJournalEntry,
 } from '@/store/slices/accountingSlice'
@@ -34,5 +36,19 @@ describe('accountingSlice', () => {
     const cleared = accountingReducer(withAccount, setSelectedAccount(null))
 
     expect(cleared.selectedAccount).toBeNull()
+  })
+})
+
+describe('accountingSlice selectors - undefined state resilience', () => {
+  const stateWithoutAccounting = {} as any
+
+  it('selectSelectedJournalEntry returns undefined when accounting slice is absent', () => {
+    expect(() => selectSelectedJournalEntry(stateWithoutAccounting)).not.toThrow()
+    expect(selectSelectedJournalEntry(stateWithoutAccounting)).toBeUndefined()
+  })
+
+  it('selectSelectedAccount returns undefined when accounting slice is absent', () => {
+    expect(() => selectSelectedAccount(stateWithoutAccounting)).not.toThrow()
+    expect(selectSelectedAccount(stateWithoutAccounting)).toBeUndefined()
   })
 })

--- a/frontend/src/store/slices/__tests__/accountingSlice.test.ts
+++ b/frontend/src/store/slices/__tests__/accountingSlice.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import accountingReducer, {
+  setSelectedAccount,
+  setSelectedJournalEntry,
+} from '@/store/slices/accountingSlice'
+
+describe('accountingSlice', () => {
+  it('sets selectedJournalEntry', () => {
+    const entry = { id: 'je-1', referenceNumber: 'JE-001' } as any
+    const state = accountingReducer(undefined, setSelectedJournalEntry(entry))
+
+    expect(state.selectedJournalEntry).toEqual(entry)
+  })
+
+  it('clears selectedJournalEntry', () => {
+    const entry = { id: 'je-1', referenceNumber: 'JE-001' } as any
+    const withEntry = accountingReducer(undefined, setSelectedJournalEntry(entry))
+    const cleared = accountingReducer(withEntry, setSelectedJournalEntry(null))
+
+    expect(cleared.selectedJournalEntry).toBeNull()
+  })
+
+  it('sets selectedAccount', () => {
+    const account = { id: 'acc-1', code: '1000', name: 'Cash' } as any
+    const state = accountingReducer(undefined, setSelectedAccount(account))
+
+    expect(state.selectedAccount).toEqual(account)
+  })
+
+  it('clears selectedAccount', () => {
+    const account = { id: 'acc-1', code: '1000', name: 'Cash' } as any
+    const withAccount = accountingReducer(undefined, setSelectedAccount(account))
+    const cleared = accountingReducer(withAccount, setSelectedAccount(null))
+
+    expect(cleared.selectedAccount).toBeNull()
+  })
+})

--- a/frontend/src/store/slices/__tests__/inventorySlice.resilience.test.ts
+++ b/frontend/src/store/slices/__tests__/inventorySlice.resilience.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  selectSelectedProduct,
+  selectSelectedCategory,
+  selectSelectedStockAdjustment,
+  selectCategoryFilters,
+} from '../inventorySlice'
+
+describe('inventorySlice selectors - undefined state resilience', () => {
+  const stateWithoutInventory = {} as any
+
+  it('selectSelectedProduct returns undefined when inventory slice is absent', () => {
+    expect(() => selectSelectedProduct(stateWithoutInventory)).not.toThrow()
+    expect(selectSelectedProduct(stateWithoutInventory)).toBeUndefined()
+  })
+
+  it('selectSelectedCategory returns undefined when inventory slice is absent', () => {
+    expect(() => selectSelectedCategory(stateWithoutInventory)).not.toThrow()
+    expect(selectSelectedCategory(stateWithoutInventory)).toBeUndefined()
+  })
+
+  it('selectSelectedStockAdjustment returns undefined when inventory slice is absent', () => {
+    expect(() => selectSelectedStockAdjustment(stateWithoutInventory)).not.toThrow()
+    expect(selectSelectedStockAdjustment(stateWithoutInventory)).toBeUndefined()
+  })
+
+  it('selectCategoryFilters returns undefined when inventory slice is absent', () => {
+    expect(() => selectCategoryFilters(stateWithoutInventory)).not.toThrow()
+    expect(selectCategoryFilters(stateWithoutInventory)).toBeUndefined()
+  })
+})

--- a/frontend/src/store/slices/__tests__/notificationSlice.test.ts
+++ b/frontend/src/store/slices/__tests__/notificationSlice.test.ts
@@ -57,6 +57,13 @@ describe('notificationSlice', () => {
     expect(typeof notifications[0].timestamp).toBe('string')
   })
 
+  it('selectors return defaults when notifications state is missing', () => {
+    const state = {} as ReturnType<typeof store.getState>
+
+    expect(selectNotifications(state)).toEqual([])
+    expect(selectUnreadCount(state)).toBe(0)
+  })
+
   it('should clear all notifications on logout.fulfilled', () => {
     // Add some notifications
     store.dispatch(addNotification({ type: 'success', title: 'A', message: 'msg' }))

--- a/frontend/src/store/slices/__tests__/purchasingSlice.test.ts
+++ b/frontend/src/store/slices/__tests__/purchasingSlice.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  selectSelectedPurchaseOrder,
+  selectSelectedGRN,
+  selectSelectedVendorPayment,
+  selectSelectedSupplier,
+  selectSupplierFilters,
+} from '../purchasingSlice'
+
+describe('purchasingSlice selectors - undefined state resilience', () => {
+  const stateWithoutPurchasing = {} as any
+
+  it('selectSelectedPurchaseOrder returns undefined when purchasing slice is absent', () => {
+    expect(() => selectSelectedPurchaseOrder(stateWithoutPurchasing)).not.toThrow()
+    expect(selectSelectedPurchaseOrder(stateWithoutPurchasing)).toBeUndefined()
+  })
+
+  it('selectSelectedGRN returns undefined when purchasing slice is absent', () => {
+    expect(() => selectSelectedGRN(stateWithoutPurchasing)).not.toThrow()
+    expect(selectSelectedGRN(stateWithoutPurchasing)).toBeUndefined()
+  })
+
+  it('selectSelectedVendorPayment returns undefined when purchasing slice is absent', () => {
+    expect(() => selectSelectedVendorPayment(stateWithoutPurchasing)).not.toThrow()
+    expect(selectSelectedVendorPayment(stateWithoutPurchasing)).toBeUndefined()
+  })
+
+  it('selectSelectedSupplier returns undefined when purchasing slice is absent', () => {
+    expect(() => selectSelectedSupplier(stateWithoutPurchasing)).not.toThrow()
+    expect(selectSelectedSupplier(stateWithoutPurchasing)).toBeUndefined()
+  })
+
+  it('selectSupplierFilters returns undefined when purchasing slice is absent', () => {
+    expect(() => selectSupplierFilters(stateWithoutPurchasing)).not.toThrow()
+    expect(selectSupplierFilters(stateWithoutPurchasing)).toBeUndefined()
+  })
+})

--- a/frontend/src/store/slices/__tests__/salesSlice.test.ts
+++ b/frontend/src/store/slices/__tests__/salesSlice.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  selectSelectedCustomer,
+  selectSelectedOrder,
+  selectSelectedInvoice,
+  selectSelectedPayment,
+  selectSalesError,
+} from '../salesSlice'
+
+describe('salesSlice selectors - undefined state resilience', () => {
+  const stateWithoutSales = {} as any
+
+  it('selectSelectedCustomer returns undefined when sales slice is absent', () => {
+    expect(() => selectSelectedCustomer(stateWithoutSales)).not.toThrow()
+    expect(selectSelectedCustomer(stateWithoutSales)).toBeUndefined()
+  })
+
+  it('selectSelectedOrder returns undefined when sales slice is absent', () => {
+    expect(() => selectSelectedOrder(stateWithoutSales)).not.toThrow()
+    expect(selectSelectedOrder(stateWithoutSales)).toBeUndefined()
+  })
+
+  it('selectSelectedInvoice returns undefined when sales slice is absent', () => {
+    expect(() => selectSelectedInvoice(stateWithoutSales)).not.toThrow()
+    expect(selectSelectedInvoice(stateWithoutSales)).toBeUndefined()
+  })
+
+  it('selectSelectedPayment returns undefined when sales slice is absent', () => {
+    expect(() => selectSelectedPayment(stateWithoutSales)).not.toThrow()
+    expect(selectSelectedPayment(stateWithoutSales)).toBeUndefined()
+  })
+
+  it('selectSalesError returns undefined when sales slice is absent', () => {
+    expect(() => selectSalesError(stateWithoutSales)).not.toThrow()
+    expect(selectSalesError(stateWithoutSales)).toBeUndefined()
+  })
+})

--- a/frontend/src/store/slices/accountingSlice.ts
+++ b/frontend/src/store/slices/accountingSlice.ts
@@ -1,0 +1,34 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+
+import type { RootState } from '@/store'
+import type { ChartOfAccount, JournalEntry } from '@/types'
+
+interface AccountingState {
+  selectedJournalEntry: JournalEntry | null
+  selectedAccount: ChartOfAccount | null
+}
+
+const initialState: AccountingState = {
+  selectedJournalEntry: null,
+  selectedAccount: null,
+}
+
+const accountingSlice = createSlice({
+  name: 'accounting',
+  initialState,
+  reducers: {
+    setSelectedJournalEntry: (state, action: PayloadAction<JournalEntry | null>) => {
+      state.selectedJournalEntry = action.payload
+    },
+    setSelectedAccount: (state, action: PayloadAction<ChartOfAccount | null>) => {
+      state.selectedAccount = action.payload
+    },
+  },
+})
+
+export const { setSelectedJournalEntry, setSelectedAccount } = accountingSlice.actions
+
+export const selectSelectedJournalEntry = (state: RootState) => state.accounting.selectedJournalEntry
+export const selectSelectedAccount = (state: RootState) => state.accounting.selectedAccount
+
+export default accountingSlice.reducer

--- a/frontend/src/store/slices/accountingSlice.ts
+++ b/frontend/src/store/slices/accountingSlice.ts
@@ -28,7 +28,7 @@ const accountingSlice = createSlice({
 
 export const { setSelectedJournalEntry, setSelectedAccount } = accountingSlice.actions
 
-export const selectSelectedJournalEntry = (state: RootState) => state.accounting.selectedJournalEntry
-export const selectSelectedAccount = (state: RootState) => state.accounting.selectedAccount
+export const selectSelectedJournalEntry = (state: RootState) => state.accounting?.selectedJournalEntry
+export const selectSelectedAccount = (state: RootState) => state.accounting?.selectedAccount
 
 export default accountingSlice.reducer

--- a/frontend/src/store/slices/inventorySlice.ts
+++ b/frontend/src/store/slices/inventorySlice.ts
@@ -51,9 +51,9 @@ export const {
   setCategoryFilters,
 } = inventorySlice.actions
 
-export const selectSelectedProduct = (state: RootState) => state.inventory.selectedProduct
-export const selectSelectedCategory = (state: RootState) => state.inventory.selectedCategory
-export const selectSelectedStockAdjustment = (state: RootState) => state.inventory.selectedStockAdjustment
-export const selectCategoryFilters = (state: RootState) => state.inventory.filters.categories
+export const selectSelectedProduct = (state: RootState) => state.inventory?.selectedProduct
+export const selectSelectedCategory = (state: RootState) => state.inventory?.selectedCategory
+export const selectSelectedStockAdjustment = (state: RootState) => state.inventory?.selectedStockAdjustment
+export const selectCategoryFilters = (state: RootState) => state.inventory?.filters?.categories
 
 export default inventorySlice.reducer

--- a/frontend/src/store/slices/notificationSlice.ts
+++ b/frontend/src/store/slices/notificationSlice.ts
@@ -91,8 +91,8 @@ export const {
 
 // Selectors
 export const selectNotifications = (state: RootState) =>
-  state.notifications.notifications
+  state.notifications?.notifications ?? []
 export const selectUnreadCount = (state: RootState) =>
-  state.notifications.unreadCount
+  state.notifications?.unreadCount ?? 0
 
 export default notificationSlice.reducer

--- a/frontend/src/store/slices/purchasingSlice.ts
+++ b/frontend/src/store/slices/purchasingSlice.ts
@@ -65,10 +65,10 @@ export const {
   setSupplierFilters,
 } = purchasingSlice.actions
 
-export const selectSelectedPurchaseOrder = (state: RootState) => state.purchasing.selectedPurchaseOrder
-export const selectSelectedGRN = (state: RootState) => state.purchasing.selectedGRN
-export const selectSelectedVendorPayment = (state: RootState) => state.purchasing.selectedVendorPayment
-export const selectSelectedSupplier = (state: RootState) => state.purchasing.selectedSupplier
-export const selectSupplierFilters = (state: RootState) => state.purchasing.supplierFilters
+export const selectSelectedPurchaseOrder = (state: RootState) => state.purchasing?.selectedPurchaseOrder
+export const selectSelectedGRN = (state: RootState) => state.purchasing?.selectedGRN
+export const selectSelectedVendorPayment = (state: RootState) => state.purchasing?.selectedVendorPayment
+export const selectSelectedSupplier = (state: RootState) => state.purchasing?.selectedSupplier
+export const selectSupplierFilters = (state: RootState) => state.purchasing?.supplierFilters
 
 export default purchasingSlice.reducer

--- a/frontend/src/store/slices/salesSlice.ts
+++ b/frontend/src/store/slices/salesSlice.ts
@@ -49,10 +49,10 @@ export const {
   clearError,
 } = salesSlice.actions
 
-export const selectSelectedOrder = (state: RootState) => state.sales.selectedOrder
-export const selectSelectedInvoice = (state: RootState) => state.sales.selectedInvoice
-export const selectSelectedPayment = (state: RootState) => state.sales.selectedPayment
-export const selectSelectedCustomer = (state: RootState) => state.sales.selectedCustomer
-export const selectSalesError = (state: RootState) => state.sales.error
+export const selectSelectedOrder = (state: RootState) => state.sales?.selectedOrder
+export const selectSelectedInvoice = (state: RootState) => state.sales?.selectedInvoice
+export const selectSelectedPayment = (state: RootState) => state.sales?.selectedPayment
+export const selectSelectedCustomer = (state: RootState) => state.sales?.selectedCustomer
+export const selectSalesError = (state: RootState) => state.sales?.error
 
 export default salesSlice.reducer

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -108,7 +108,7 @@ export default defineConfig(({ mode }) => {
               },
               {
                 name: 'redux',
-                test: /node_modules[\\/](@reduxjs[\\/]toolkit|react-redux)[\\/]/,
+                test: /node_modules[\\/](@reduxjs[\\/]toolkit|react-redux|redux|redux-persist)[\\/]/,
                 priority: 10,
               },
             ],

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -97,6 +97,11 @@ export default defineConfig(({ mode }) => {
                 priority: 25,
               },
               {
+                name: 'rtk-api',
+                test: /src[\\/]store[\\/]api[\\/]/,
+                priority: 22,
+              },
+              {
                 name: 'router',
                 test: /node_modules[\\/](react-router|react-router-dom)[\\/]/,
                 priority: 20,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -92,6 +92,11 @@ export default defineConfig(({ mode }) => {
                 priority: 30,
               },
               {
+                name: 'axios',
+                test: /node_modules[\\/]axios[\\/]/,
+                priority: 25,
+              },
+              {
                 name: 'router',
                 test: /node_modules[\\/](react-router|react-router-dom)[\\/]/,
                 priority: 20,

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -179,6 +179,7 @@ http {
 
             # Buffer settings
             proxy_buffering off;
+            keepalive_requests 0;
         }
 
         # Frontend - SPA routing

--- a/package-lock.json
+++ b/package-lock.json
@@ -2538,9 +2538,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.12.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.12.1.tgz",
-      "integrity": "sha512-zcoUuF1kezGSAo0CqtvoLXX3mkRqzuqYdL6Y5tdo8g69NVV3CkjQ6ZBhBgB4d7vGkPcV6TcvLi3GRKPDFX+xTA==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.13.0.tgz",
+      "integrity": "sha512-cRmhaghDWA1lFgl3Ug4/VxDJdPBK/U+tNtnrl9kXunFqhWw1x4xL5txkNn7qzPuVfvXOmXyjHpMwsuk2uisbkg==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -2619,7 +2619,7 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.4.3",
         "@npmcli/config": "^10.8.1",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
@@ -2641,24 +2641,24 @@
         "hosted-git-info": "^9.0.2",
         "ini": "^6.0.0",
         "init-package-json": "^8.2.5",
-        "is-cidr": "^6.0.3",
+        "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.5",
-        "libnpmexec": "^10.2.5",
-        "libnpmfund": "^7.0.19",
+        "libnpmdiff": "^8.1.6",
+        "libnpmexec": "^10.2.6",
+        "libnpmfund": "^7.0.20",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.5",
+        "libnpmpack": "^9.1.6",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
         "libnpmversion": "^8.0.3",
         "make-fetch-happen": "^15.0.5",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.2.0",
+        "node-gyp": "^12.3.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
@@ -2677,7 +2677,7 @@
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.11",
+        "tar": "^7.5.13",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -2749,7 +2749,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.4.2",
+      "version": "9.4.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3000,7 +3000,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -3142,7 +3142,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3211,7 +3211,7 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.3",
+      "version": "5.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -3267,7 +3267,7 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -3443,12 +3443,12 @@
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "^5.0.1"
+        "cidr-regex": "^5.0.4"
       },
       "engines": {
         "node": ">=20"
@@ -3516,12 +3516,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.5",
+      "version": "8.1.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.4.3",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -3535,13 +3535,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.5",
+      "version": "10.2.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.4.3",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -3558,12 +3558,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.19",
+      "version": "7.0.20",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2"
+        "@npmcli/arborist": "^9.4.3"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -3583,12 +3583,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.5",
+      "version": "9.1.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.4.3",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -3658,7 +3658,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.7",
+      "version": "11.3.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -3690,12 +3690,12 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3743,34 +3743,16 @@
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.1.3"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
@@ -3851,7 +3833,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.2.0",
+      "version": "12.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3859,12 +3841,12 @@
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^15.0.0",
         "nopt": "^9.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
         "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
         "which": "^6.0.0"
       },
       "bin": {
@@ -4311,7 +4293,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.11",
+      "version": "7.5.13",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -4339,13 +4321,13 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -4372,7 +4354,7 @@
       }
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4404,6 +4386,15 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/undici": {
+      "version": "6.25.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {


### PR DESCRIPTION
## Summary

- Adds `isFetching?: boolean` to `useEntityWorkspace` config — skips clearing selection when `entities` is transiently empty during a background RTK Query refetch
- Wraps every inline `selectEntity` arrow passed to `useEntityWorkspace` in `useCallback` across all 10 consumers (CustomersPage, SuppliersPage, and 8 workspace hooks), eliminating spurious effect re-runs caused by unstable function references

Closes #444

## Test plan

- [x] 14/14 unit tests pass in `useEntityWorkspace.test.ts` (includes 2 new regression tests)
- [x] `npm run type-check` passes with zero errors
- [x] `npm run lint` passes
- [ ] Manual: navigate to `/sales/customers`, click different customers — header and workspace card update reliably each time
- [ ] Manual: same check on Suppliers, Products, Sales Orders, Invoices pages

🤖 Generated with [Claude Code](https://claude.ai/claude-code)