### PR TITLE
feat: add independent scroll to overview/dashboard pages

### DIFF
--- a/frontend/src/components/common/GenericOverviewPage.test.tsx
+++ b/frontend/src/components/common/GenericOverviewPage.test.tsx
@@ -1,0 +1,25 @@
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import GenericOverviewPage from './GenericOverviewPage'
+
+describe('GenericOverviewPage', () => {
+  it('renders children inside an independently scrollable flex container', () => {
+    render(
+      <GenericOverviewPage>
+        <div>Overview content</div>
+      </GenericOverviewPage>
+    )
+
+    const container = screen.getByText('Overview content').parentElement
+
+    expect(container).toHaveStyle({
+      display: 'flex',
+      flexDirection: 'column',
+      flex: '1',
+      minHeight: '0',
+      overflow: 'auto',
+    })
+  })
+})

--- a/frontend/src/components/common/GenericOverviewPage.tsx
+++ b/frontend/src/components/common/GenericOverviewPage.tsx
@@ -7,7 +7,7 @@ interface GenericOverviewPageProps {
 
 export default function GenericOverviewPage({ children }: GenericOverviewPageProps) {
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, overflow: 'auto' }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, overflow: 'auto', mr: { xs: -2, sm: -3 }, pr: { xs: 2, sm: 3 } }}>
       {children}
     </Box>
   )

--- a/frontend/src/components/common/GenericOverviewPage.tsx
+++ b/frontend/src/components/common/GenericOverviewPage.tsx
@@ -1,0 +1,14 @@
+import { Box } from '@mui/material'
+import type { ReactNode } from 'react'
+
+interface GenericOverviewPageProps {
+  children: ReactNode
+}
+
+export default function GenericOverviewPage({ children }: GenericOverviewPageProps) {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, overflow: 'auto' }}>
+      {children}
+    </Box>
+  )
+}

--- a/frontend/src/pages/accounting/AccountingDashboardPage.tsx
+++ b/frontend/src/pages/accounting/AccountingDashboardPage.tsx
@@ -28,6 +28,7 @@ import { default as TrendingDownIcon } from '@mui/icons-material/TrendingDown'
 import { default as AddIcon } from '@mui/icons-material/Add'
 import { default as AccountBalanceWalletIcon } from '@mui/icons-material/AccountBalanceWallet';
 import PageHeader from '@/components/common/PageHeader';
+import GenericOverviewPage from '@/components/common/GenericOverviewPage';
 import { useNavigate } from 'react-router-dom';
 import {
   useGetBalanceSheetQuery,
@@ -232,7 +233,7 @@ const AccountingDashboardPage: React.FC = () => {
   });
 
   return (
-    <>
+    <GenericOverviewPage>
       <PageHeader
         variant="overview"
         title="Accounting Dashboard"
@@ -602,7 +603,7 @@ const AccountingDashboardPage: React.FC = () => {
           </Paper>
         </Grid>
       </Grid>
-    </>
+    </GenericOverviewPage>
   );
 };
 

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -11,6 +11,7 @@ import { default as SalesIcon } from '@mui/icons-material/PointOfSale'
 import { default as PurchasingIcon } from '@mui/icons-material/Assignment'
 import { default as CustomersIcon } from '@mui/icons-material/People'
 import PageHeader from '@/components/common/PageHeader'
+import GenericOverviewPage from '@/components/common/GenericOverviewPage'
 import { formatCurrency } from '@/utils/formatters'
 import { useNavigate } from 'react-router-dom'
 import { useCurrency } from '@/hooks/useCurrency'
@@ -363,14 +364,16 @@ const DashboardPage: React.FC = () => {
 
   if (loading) {
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: 400 }}>
-        <CircularProgress size={60} />
-      </Box>
+      <GenericOverviewPage>
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: 400 }}>
+          <CircularProgress size={60} />
+        </Box>
+      </GenericOverviewPage>
     )
   }
 
   return (
-    <>
+    <GenericOverviewPage>
       <PageHeader
         variant="overview"
         title="Dashboard"
@@ -414,7 +417,7 @@ const DashboardPage: React.FC = () => {
         totalCategories={dashboardData?.inventory.totalCategories || 0}
         outOfStockCount={dashboardData?.inventory.outOfStockCount || 0}
       />
-    </>
+    </GenericOverviewPage>
   )
 }
 

--- a/frontend/src/pages/inventory/InventoryPage.tsx
+++ b/frontend/src/pages/inventory/InventoryPage.tsx
@@ -39,6 +39,7 @@ import { format } from 'date-fns'
 import { useNavigate } from 'react-router-dom'
 import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
+import GenericOverviewPage from '@/components/common/GenericOverviewPage'
 import { FilterBar } from '@/components/filters/FilterBar'
 import { useFilterBar } from '@/hooks/useFilterBar'
 import { useInventoryAnalytics } from './hooks/useInventoryAnalytics'
@@ -240,7 +241,7 @@ const InventoryPage: React.FC = () => {
   }
 
   return (
-    <>
+    <GenericOverviewPage>
       <PageHeader
         variant="overview"
         title="Inventory Overview"
@@ -600,7 +601,7 @@ const InventoryPage: React.FC = () => {
           </Grid>
         </Grid>
       </Box>
-    </>
+    </GenericOverviewPage>
   );
 }
 

--- a/frontend/src/pages/inventory/InventoryPage.tsx
+++ b/frontend/src/pages/inventory/InventoryPage.tsx
@@ -234,9 +234,11 @@ const InventoryPage: React.FC = () => {
 
   if (isLoading) {
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: 400 }}>
-        <CircularProgress size={60} />
-      </Box>
+      <GenericOverviewPage>
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: 400 }}>
+          <CircularProgress size={60} />
+        </Box>
+      </GenericOverviewPage>
     )
   }
 

--- a/frontend/src/pages/purchasing/PurchasingPage.tsx
+++ b/frontend/src/pages/purchasing/PurchasingPage.tsx
@@ -40,6 +40,7 @@ import { TABLE_STYLES } from '@/constants/tableStyles'
 import { useNavigate } from 'react-router-dom'
 import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
+import GenericOverviewPage from '@/components/common/GenericOverviewPage'
 import { FilterBar } from '@/components/filters/FilterBar'
 import { useFilterBar } from '@/hooks/useFilterBar'
 import { usePurchasingAnalytics } from './hooks/usePurchasingAnalytics'
@@ -206,7 +207,7 @@ const PurchasingPage: React.FC = () => {
   }
 
   return (
-    <>
+    <GenericOverviewPage>
       <PageHeader
         variant="overview"
         title="Purchasing Overview"
@@ -505,7 +506,7 @@ const PurchasingPage: React.FC = () => {
           </Grid>
         </Grid>
       </Box>
-    </>
+    </GenericOverviewPage>
   );
 }
 

--- a/frontend/src/pages/sales/SalesPage.tsx
+++ b/frontend/src/pages/sales/SalesPage.tsx
@@ -23,6 +23,7 @@ import { formatCurrency, formatDate, formatNumber } from '@/utils/formatters'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
+import GenericOverviewPage from '@/components/common/GenericOverviewPage'
 import { FilterBar } from '@/components/filters/FilterBar'
 import { useFilterBar } from '@/hooks/useFilterBar'
 import { useNavigate } from 'react-router-dom'
@@ -173,7 +174,7 @@ const SalesPage: React.FC = () => {
   ]
 
   return (
-    <>
+    <GenericOverviewPage>
       <PageHeader
         title="Sales Overview"
         subtitle="Monitor sales performance and manage customer relationships"
@@ -415,7 +416,7 @@ const SalesPage: React.FC = () => {
           <TopCustomersList customers={topCustomers as any[]} loading={isLoading} />
         </Grid>
       </Grid>
-    </>
+    </GenericOverviewPage>
   );
 }
 


### PR DESCRIPTION
## Summary

- Adds `GenericOverviewPage` thin scroll-container component with focused coverage
- Wraps all 5 overview/dashboard pages so content scrolls independently within the fixed layout
- No changes to `MainLayout` or page logic

Closes #446

## Test plan
- `cd frontend && npx vitest run src/components/common/GenericOverviewPage.test.tsx`
- `cd frontend && npm run type-check`
- `cd frontend && npx vitest run src/pages/dashboard` (no test files found under this folder)
- `cd frontend && npx vitest run src/pages/sales`
- `cd frontend && npx vitest run src/pages/purchasing`
- `cd frontend && npx vitest run src/pages/inventory`
- `cd frontend && npx vitest run src/pages/accounting/__tests__/AccountingDashboardPage`
- `cd frontend && npm run lint`
- `cd frontend && npm run test`

Manual checks for reviewers:
- [x] Verify each affected page scrolls on a small viewport (< 768px height)
- [x] Verify `TopBar` and sidebar remain fixed while page content scrolls
- [x] Verify no double scrollbars appear