### PR TITLE
feat(topbar): add keyboard shortcuts guide and standardize overlay state (issue #452)

### DIFF
--- a/frontend/src/components/common/KeyboardShortcutsModal.tsx
+++ b/frontend/src/components/common/KeyboardShortcutsModal.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect } from 'react'
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+  Typography,
+} from '@mui/material'
+import { default as CloseIcon } from '@mui/icons-material/Close'
+import { useTheme } from '@mui/material/styles'
+
+interface KeyboardShortcutsModalProps {
+  open: boolean
+  onClose: () => void
+}
+
+const LIST_NAVIGATION_SHORTCUTS = [
+  { key: '↑ / ↓', action: 'Navigate between items' },
+  { key: 'Page Up / Page Down', action: 'Jump 20 items' },
+  { key: 'Home / End', action: 'First / last item' },
+  { key: 'Enter', action: 'Edit selected item' },
+  { key: 'Escape', action: 'Clear selection or close dialog' },
+]
+
+const GLOBAL_SHORTCUTS = [
+  { key: 'Ctrl+K', action: 'Open global search' },
+  { key: '?', action: 'Show keyboard shortcuts' },
+]
+
+function ShortcutGroup({ label, shortcuts }: { label: string; shortcuts: { key: string; action: string }[] }) {
+  const theme = useTheme()
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Typography
+        variant="overline"
+        sx={{ color: theme.palette.text.secondary, fontWeight: 600, letterSpacing: '0.08em', display: 'block', mb: 1 }}
+      >
+        {label}
+      </Typography>
+      <Table size="small">
+        <TableBody>
+          {shortcuts.map(({ key, action }) => (
+            <TableRow key={key} sx={{ '&:last-child td': { border: 0 } }}>
+              <TableCell sx={{ pl: 0, width: 160, border: 0, py: 0.75 }}>
+                <Box
+                  component="kbd"
+                  sx={{
+                    bgcolor: theme.palette.action.hover,
+                    border: `1px solid ${theme.palette.divider}`,
+                    borderRadius: '4px',
+                    px: 0.75,
+                    py: 0.25,
+                    fontSize: '12px',
+                    fontFamily: 'monospace',
+                    color: theme.palette.text.primary,
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {key}
+                </Box>
+              </TableCell>
+              <TableCell sx={{ pr: 0, border: 0, py: 0.75 }}>
+                <Typography variant="body2" sx={{ color: theme.palette.text.secondary }}>
+                  {action}
+                </Typography>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  )
+}
+
+const KeyboardShortcutsModal: React.FC<KeyboardShortcutsModalProps> = ({ open, onClose }) => {
+  const theme = useTheme()
+
+  useEffect(() => {
+    if (!open) return undefined
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open, onClose])
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', pb: 1 }}>
+        <Typography variant="h6" sx={{ fontWeight: 600 }}>Keyboard Shortcuts</Typography>
+        <IconButton aria-label="close" onClick={onClose} size="small">
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent sx={{ pt: 1 }}>
+        <ShortcutGroup label="List Navigation" shortcuts={LIST_NAVIGATION_SHORTCUTS} />
+        <Divider sx={{ my: 2 }} />
+        <ShortcutGroup label="Global" shortcuts={GLOBAL_SHORTCUTS} />
+
+        <Box sx={{ mt: 2, pt: 2, borderTop: `1px solid ${theme.palette.divider}` }}>
+          <Typography variant="caption" sx={{ color: theme.palette.text.disabled }}>
+            List navigation shortcuts apply on list and table pages only.
+          </Typography>
+        </Box>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default KeyboardShortcutsModal

--- a/frontend/src/components/common/KeyboardShortcutsModal.tsx
+++ b/frontend/src/components/common/KeyboardShortcutsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import {
   Box,
   Dialog,
@@ -81,21 +81,6 @@ function ShortcutGroup({ label, shortcuts }: { label: string; shortcuts: { key: 
 
 const KeyboardShortcutsModal: React.FC<KeyboardShortcutsModalProps> = ({ open, onClose }) => {
   const theme = useTheme()
-
-  useEffect(() => {
-    if (!open) return undefined
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        onClose()
-      }
-    }
-
-    document.addEventListener('keydown', handleKeyDown)
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [open, onClose])
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>

--- a/frontend/src/components/common/SystemStatus.tsx
+++ b/frontend/src/components/common/SystemStatus.tsx
@@ -41,14 +41,20 @@ interface HealthResponse {
   }
 }
 
+interface SystemStatusProps {
+  anchorEl: HTMLElement | null
+  open: boolean
+  onOpen: (event: React.MouseEvent<HTMLElement>) => void
+  onClose: () => void
+}
+
 const statusPulse = keyframes`
   0%, 100% { opacity: 1; transform: scale(1); }
   50% { opacity: 0.4; transform: scale(1.3); }
 `
 
-const SystemStatus: React.FC = () => {
+const SystemStatus: React.FC<SystemStatusProps> = ({ anchorEl, open, onOpen, onClose }) => {
   const theme = useTheme()
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const [health, setHealth] = useState<HealthResponse | null>(null)
   const [loading, setLoading] = useState(false)
   const [frontendStatus, setFrontendStatus] = useState<'healthy' | 'unknown'>('healthy')
@@ -69,33 +75,21 @@ const SystemStatus: React.FC = () => {
 
   useEffect(() => {
     checkHealth()
-
     const interval = setInterval(checkHealth, 30000)
-
     return () => clearInterval(interval)
   }, [])
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget)
+    onOpen(event)
     void checkHealth()
   }
 
-  const handleClose = () => {
-    setAnchorEl(null)
-  }
-
-  const open = Boolean(anchorEl)
-
   const getStatusColor = (status: string): 'success' | 'error' | 'warning' | 'default' => {
     switch (status) {
-      case 'healthy':
-        return 'success'
-      case 'unhealthy':
-        return 'error'
-      case 'degraded':
-        return 'warning'
-      default:
-        return 'default'
+      case 'healthy': return 'success'
+      case 'unhealthy': return 'error'
+      case 'degraded': return 'warning'
+      default: return 'default'
     }
   }
 
@@ -107,27 +101,19 @@ const SystemStatus: React.FC = () => {
 
   const getDotColor = (status: 'healthy' | 'degraded' | 'unhealthy' | 'unknown'): string => {
     switch (status) {
-      case 'healthy':
-        return theme.palette.success.main
-      case 'degraded':
-        return theme.palette.warning.main
-      case 'unhealthy':
-        return theme.palette.error.main
-      default:
-        return theme.palette.text.secondary
+      case 'healthy': return theme.palette.success.main
+      case 'degraded': return theme.palette.warning.main
+      case 'unhealthy': return theme.palette.error.main
+      default: return theme.palette.text.secondary
     }
   }
 
   const getTooltipText = (status: 'healthy' | 'degraded' | 'unhealthy' | 'unknown'): string => {
     switch (status) {
-      case 'healthy':
-        return 'System: Healthy - All services operational'
-      case 'degraded':
-        return 'System: Degraded - One or more services affected'
-      case 'unhealthy':
-        return 'System: Unhealthy - Backend may be offline'
-      default:
-        return 'System: Unknown - Checking status...'
+      case 'healthy': return 'System: Healthy - All services operational'
+      case 'degraded': return 'System: Degraded - One or more services affected'
+      case 'unhealthy': return 'System: Unhealthy - Backend may be offline'
+      default: return 'System: Unknown - Checking status...'
     }
   }
 
@@ -172,53 +158,24 @@ const SystemStatus: React.FC = () => {
       <Popover
         open={open}
         anchorEl={anchorEl}
-        onClose={handleClose}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'right',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'right',
-        }}
-        slotProps={{
-          paper: {
-            sx: {
-              width: 350,
-              mt: 1,
-            },
-          },
-        }}
+        onClose={onClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{ paper: { sx: { width: 350, mt: 1 } } }}
       >
         <Box sx={{ p: 2 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
-            <Typography variant="h6" sx={{ fontWeight: 600 }}>
-              System Status
-            </Typography>
+            <Typography variant="h6" sx={{ fontWeight: 600 }}>System Status</Typography>
             {loading && <CircularProgress size={20} />}
           </Box>
 
           {health && (
             <>
               <Box sx={{ mb: 2 }}>
-                <Typography variant="caption" sx={{
-                  color: "text.secondary"
-                }}>
-                  Overall Status
-                </Typography>
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>Overall Status</Typography>
                 <Box sx={{ mt: 0.5 }}>
-                  <Chip
-                    label={health.status.toUpperCase()}
-                    color={getStatusColor(health.status)}
-                    size="small"
-                    sx={{ fontWeight: 600 }}
-                  />
-                  <Typography
-                    variant="caption"
-                    sx={{
-                      color: "text.secondary",
-                      ml: 1
-                    }}>
+                  <Chip label={health.status.toUpperCase()} color={getStatusColor(health.status)} size="small" sx={{ fontWeight: 600 }} />
+                  <Typography variant="caption" sx={{ color: 'text.secondary', ml: 1 }}>
                     Uptime: {formatUptime(health.uptime)}
                   </Typography>
                 </Box>
@@ -226,114 +183,28 @@ const SystemStatus: React.FC = () => {
 
               <Divider sx={{ my: 2 }} />
 
-              <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
-                Services
-              </Typography>
+              <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>Services</Typography>
 
               <List sx={{ p: 0 }}>
-                <ListItem sx={{ px: 0, py: 0.5 }}>
-                  <ListItemIcon sx={{ minWidth: 40 }}>
-                    <NginxIcon fontSize="small" color="action" />
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={
-                      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                        <Typography variant="body2">Frontend</Typography>
-                        <Chip
-                          label={frontendStatus.toUpperCase()}
-                          color={getStatusColor(frontendStatus)}
-                          size="small"
-                          sx={{ height: 20, fontSize: '0.65rem' }}
-                        />
-                      </Box>
-                    }
-                    secondary={
-                      <Typography variant="caption" sx={{
-                        color: "text.secondary"
-                      }}>
-                        Web server running
-                      </Typography>
-                    }
-                  />
-                </ListItem>
-
-                <ListItem sx={{ px: 0, py: 0.5 }}>
-                  <ListItemIcon sx={{ minWidth: 40 }}>
-                    <BackendIcon fontSize="small" color="action" />
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={
-                      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                        <Typography variant="body2">Backend API</Typography>
-                        <Chip
-                          label={health.services.backend.status.toUpperCase()}
-                          color={getStatusColor(health.services.backend.status)}
-                          size="small"
-                          sx={{ height: 20, fontSize: '0.65rem' }}
-                        />
-                      </Box>
-                    }
-                    secondary={
-                      <Typography variant="caption" sx={{
-                        color: "text.secondary"
-                      }}>
-                        {health.services.backend.message}
-                      </Typography>
-                    }
-                  />
-                </ListItem>
-
-                <ListItem sx={{ px: 0, py: 0.5 }}>
-                  <ListItemIcon sx={{ minWidth: 40 }}>
-                    <DatabaseIcon fontSize="small" color="action" />
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={
-                      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                        <Typography variant="body2">PostgreSQL</Typography>
-                        <Chip
-                          label={health.services.database.status.toUpperCase()}
-                          color={getStatusColor(health.services.database.status)}
-                          size="small"
-                          sx={{ height: 20, fontSize: '0.65rem' }}
-                        />
-                      </Box>
-                    }
-                    secondary={
-                      <Typography variant="caption" sx={{
-                        color: "text.secondary"
-                      }}>
-                        {health.services.database.message}
-                      </Typography>
-                    }
-                  />
-                </ListItem>
-
-                <ListItem sx={{ px: 0, py: 0.5 }}>
-                  <ListItemIcon sx={{ minWidth: 40 }}>
-                    <RedisIcon fontSize="small" color="action" />
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={
-                      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                        <Typography variant="body2">Redis</Typography>
-                        <Chip
-                          label={health.services.redis.status.toUpperCase()}
-                          color={getStatusColor(health.services.redis.status)}
-                          size="small"
-                          sx={{ height: 20, fontSize: '0.65rem' }}
-                        />
-                      </Box>
-                    }
-                    secondary={
-                      <Typography variant="caption" sx={{
-                        color: "text.secondary"
-                      }}>
-                        {health.services.redis.message}
-                      </Typography>
-                    }
-                  />
-                </ListItem>
+                {[
+                  { icon: <NginxIcon fontSize="small" color="action" />, label: 'Frontend', status: frontendStatus, message: 'Web server running' },
+                  { icon: <BackendIcon fontSize="small" color="action" />, label: 'Backend API', status: health.services.backend.status, message: health.services.backend.message },
+                  { icon: <DatabaseIcon fontSize="small" color="action" />, label: 'PostgreSQL', status: health.services.database.status, message: health.services.database.message },
+                  { icon: <RedisIcon fontSize="small" color="action" />, label: 'Redis', status: health.services.redis.status, message: health.services.redis.message },
+                ].map(({ icon, label, status, message }) => (
+                  <ListItem key={label} sx={{ px: 0, py: 0.5 }}>
+                    <ListItemIcon sx={{ minWidth: 40 }}>{icon}</ListItemIcon>
+                    <ListItemText
+                      primary={
+                        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                          <Typography variant="body2">{label}</Typography>
+                          <Chip label={status.toUpperCase()} color={getStatusColor(status)} size="small" sx={{ height: 20, fontSize: '0.65rem' }} />
+                        </Box>
+                      }
+                      secondary={<Typography variant="caption" sx={{ color: 'text.secondary' }}>{message}</Typography>}
+                    />
+                  </ListItem>
+                ))}
               </List>
             </>
           )}
@@ -341,9 +212,7 @@ const SystemStatus: React.FC = () => {
           {!health && !loading && (
             <Box sx={{ py: 3, textAlign: 'center' }}>
               <InfoIcon color="disabled" sx={{ fontSize: 32, mb: 1 }} />
-              <Typography variant="body2" sx={{
-                color: "text.secondary"
-              }}>
+              <Typography variant="body2" sx={{ color: 'text.secondary' }}>
                 Unable to fetch system health information
               </Typography>
             </Box>
@@ -351,7 +220,7 @@ const SystemStatus: React.FC = () => {
         </Box>
       </Popover>
     </>
-  );
+  )
 }
 
 export default SystemStatus

--- a/frontend/src/components/common/SystemStatus.tsx
+++ b/frontend/src/components/common/SystemStatus.tsx
@@ -57,20 +57,19 @@ const SystemStatus: React.FC<SystemStatusProps> = ({ anchorEl, open, onOpen, onC
   const theme = useTheme()
   const [health, setHealth] = useState<HealthResponse | null>(null)
   const [loading, setLoading] = useState(false)
-  const [frontendStatus, setFrontendStatus] = useState<'healthy' | 'unknown'>('healthy')
+  const frontendStatus = 'healthy' as const
 
   const checkHealth = async () => {
     setLoading(true)
     try {
       const response = await ApiService.get<HealthResponse>('/health')
-      const healthData = response as HealthResponse
-      setHealth(healthData)
-      setFrontendStatus('healthy')
+      setHealth(response as HealthResponse)
     } catch (error) {
       setHealth(null)
       console.error('Health check failed:', error)
+    } finally {
+      setLoading(false)
     }
-    setLoading(false)
   }
 
   useEffect(() => {

--- a/frontend/src/components/common/TopBar.tsx
+++ b/frontend/src/components/common/TopBar.tsx
@@ -13,6 +13,7 @@ import {
   useMediaQuery,
   useTheme,
 } from '@mui/material'
+import { default as KeyboardIcon } from '@mui/icons-material/Keyboard'
 import { default as MenuIcon } from '@mui/icons-material/Menu'
 import { default as NavigateNextIcon } from '@mui/icons-material/NavigateNext'
 import { default as NotificationsIcon } from '@mui/icons-material/Notifications'
@@ -22,6 +23,7 @@ import { DRAWER_WIDTH_COLLAPSED, DRAWER_WIDTH_EXPANDED, TOPBAR_HEIGHT } from '@/
 import { useAppSelector } from '@/hooks/useRedux'
 import { selectUnreadCount } from '@/store/slices/notificationSlice'
 
+import KeyboardShortcutsModal from './KeyboardShortcutsModal'
 import NotificationPanel from './NotificationPanel'
 import SearchModal from './SearchModal'
 import SystemStatus from './SystemStatus'
@@ -144,10 +146,7 @@ const NAVIGABLE_PATHS = new Set([
 ])
 
 type RouteHandle = { title?: string }
-
-type MatchShape = {
-  handle?: RouteHandle | null
-}
+type MatchShape = { handle?: RouteHandle | null }
 
 interface BreadcrumbSegment {
   label: string
@@ -156,9 +155,7 @@ interface BreadcrumbSegment {
 }
 
 function buildBreadcrumbs(pathname: string, matches: MatchShape[]): BreadcrumbSegment[] {
-  const leafMatch = [...matches]
-    .reverse()
-    .find(match => (match.handle as RouteHandle | undefined)?.title)
+  const leafMatch = [...matches].reverse().find(match => (match.handle as RouteHandle | undefined)?.title)
   const leafHandleTitle = (leafMatch?.handle as RouteHandle | undefined)?.title
   const parts = pathname.split('/').filter(Boolean)
   const prefixes = parts.map((_, index) => `/${parts.slice(0, index + 1).join('/')}`)
@@ -166,17 +163,8 @@ function buildBreadcrumbs(pathname: string, matches: MatchShape[]): BreadcrumbSe
   return prefixes.reduce<BreadcrumbSegment[]>((segments, prefix, index) => {
     const isLast = index === prefixes.length - 1
     const label = isLast && leafHandleTitle ? leafHandleTitle : BREADCRUMB_MAP[prefix]
-
-    if (!label) {
-      return segments
-    }
-
-    segments.push({
-      label,
-      path: prefix,
-      isNavigable: NAVIGABLE_PATHS.has(prefix) && !isLast,
-    })
-
+    if (!label) return segments
+    segments.push({ label, path: prefix, isNavigable: NAVIGABLE_PATHS.has(prefix) && !isLast })
     return segments
   }, [])
 }
@@ -194,7 +182,9 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
   const unreadCount = useAppSelector(selectUnreadCount)
 
   const [notificationAnchorEl, setNotificationAnchorEl] = useState<HTMLElement | null>(null)
+  const [systemStatusAnchorEl, setSystemStatusAnchorEl] = useState<HTMLElement | null>(null)
   const [searchOpen, setSearchOpen] = useState(false)
+  const [shortcutsOpen, setShortcutsOpen] = useState(false)
 
   const sidebarWidth = collapsed ? DRAWER_WIDTH_COLLAPSED : DRAWER_WIDTH_EXPANDED
   const breadcrumbs = buildBreadcrumbs(location.pathname, matches)
@@ -202,17 +192,21 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null
+      const tag = target?.tagName?.toLowerCase()
+      const editable = target?.isContentEditable
+
+      if (tag === 'input' || tag === 'textarea' || editable) return
+
       if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') {
-        const target = event.target as HTMLElement | null
-        const tag = target?.tagName?.toLowerCase()
-        const editable = target?.isContentEditable
-
-        if (tag === 'input' || tag === 'textarea' || editable) {
-          return
-        }
-
         event.preventDefault()
         setSearchOpen(true)
+        return
+      }
+
+      if (event.key === '?') {
+        event.preventDefault()
+        setShortcutsOpen(true)
       }
     }
 
@@ -268,46 +262,22 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
               >
                 {breadcrumbs.map((segment, index) => {
                   const isLast = index === breadcrumbs.length - 1
-
                   if (isLast) {
                     return (
-                      <Typography
-                        key={segment.path}
-                        sx={{ fontSize: '13px', color: theme.palette.text.primary, fontWeight: 500, display: 'flex', alignItems: 'center', lineHeight: 1.4 }}
-                      >
+                      <Typography key={segment.path} sx={{ fontSize: '13px', color: theme.palette.text.primary, fontWeight: 500, display: 'flex', alignItems: 'center', lineHeight: 1.4 }}>
                         {segment.label}
                       </Typography>
                     )
                   }
-
                   if (segment.isNavigable) {
                     return (
-                      <Link
-                        key={segment.path}
-                        component={RouterLink}
-                        to={segment.path}
-                        underline="hover"
-                        sx={{
-                          fontSize: '13px',
-                          fontWeight: 400,
-                          color: theme.palette.text.secondary,
-                          display: 'flex',
-                          alignItems: 'center',
-                          lineHeight: 1.4,
-                          transition: 'color 0.15s ease',
-                          '&:hover': { color: theme.palette.text.primary },
-                        }}
-                      >
+                      <Link key={segment.path} component={RouterLink} to={segment.path} underline="hover" sx={{ fontSize: '13px', fontWeight: 400, color: theme.palette.text.secondary, display: 'flex', alignItems: 'center', lineHeight: 1.4, transition: 'color 0.15s ease', '&:hover': { color: theme.palette.text.primary } }}>
                         {segment.label}
                       </Link>
                     )
                   }
-
                   return (
-                    <Typography
-                      key={segment.path}
-                      sx={{ fontSize: '13px', fontWeight: 400, color: theme.palette.text.secondary, display: 'flex', alignItems: 'center', lineHeight: 1.4 }}
-                    >
+                    <Typography key={segment.path} sx={{ fontSize: '13px', fontWeight: 400, color: theme.palette.text.secondary, display: 'flex', alignItems: 'center', lineHeight: 1.4 }}>
                       {segment.label}
                     </Typography>
                   )
@@ -339,24 +309,28 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
               <Typography sx={{ fontSize: '0.8125rem', color: theme.palette.text.secondary, flexGrow: 1 }}>
                 Search...
               </Typography>
-              <Box
-                component="kbd"
-                sx={{
-                  bgcolor: theme.palette.background.default,
-                  border: `1px solid ${theme.palette.grey[700]}`,
-                  borderRadius: '4px',
-                  px: 0.75,
-                  py: 0.25,
-                  fontSize: '11px',
-                  color: theme.palette.text.secondary,
-                  flexShrink: 0,
-                }}
-              >
+              <Box component="kbd" sx={{ bgcolor: theme.palette.background.default, border: `1px solid ${theme.palette.grey[700]}`, borderRadius: '4px', px: 0.75, py: 0.25, fontSize: '11px', color: theme.palette.text.secondary, flexShrink: 0 }}>
                 Ctrl+K
               </Box>
             </Box>
 
-            <SystemStatus />
+            <SystemStatus
+              anchorEl={systemStatusAnchorEl}
+              open={Boolean(systemStatusAnchorEl)}
+              onOpen={(e) => setSystemStatusAnchorEl(e.currentTarget)}
+              onClose={() => setSystemStatusAnchorEl(null)}
+            />
+
+            <Tooltip title="Keyboard Shortcuts">
+              <IconButton
+                aria-label="Keyboard Shortcuts"
+                onClick={() => setShortcutsOpen(true)}
+                color="inherit"
+                sx={{ '&:hover': { bgcolor: theme.palette.action.hover, borderRadius: '8px' } }}
+              >
+                <KeyboardIcon />
+              </IconButton>
+            </Tooltip>
 
             <Tooltip title="Notifications">
               <IconButton
@@ -378,8 +352,8 @@ const TopBar: React.FC<TopBarProps> = ({ collapsed, onMobileMenuOpen }) => {
         open={Boolean(notificationAnchorEl)}
         onClose={() => setNotificationAnchorEl(null)}
       />
-
       <SearchModal open={searchOpen} onClose={() => setSearchOpen(false)} />
+      <KeyboardShortcutsModal open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
     </>
   )
 }

--- a/frontend/src/components/common/__tests__/KeyboardShortcutsModal.test.tsx
+++ b/frontend/src/components/common/__tests__/KeyboardShortcutsModal.test.tsx
@@ -53,7 +53,8 @@ describe('KeyboardShortcutsModal', () => {
 
   it('calls onClose when Escape is pressed', () => {
     const { onClose } = renderModal()
-    fireEvent.keyDown(document, { key: 'Escape' })
+    const dialog = screen.getByRole('dialog')
+    fireEvent.keyDown(dialog, { key: 'Escape' })
     expect(onClose).toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/common/__tests__/KeyboardShortcutsModal.test.tsx
+++ b/frontend/src/components/common/__tests__/KeyboardShortcutsModal.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import KeyboardShortcutsModal from '../KeyboardShortcutsModal'
+
+function renderModal(open = true) {
+  const onClose = vi.fn()
+  render(<KeyboardShortcutsModal open={open} onClose={onClose} />)
+  return { onClose }
+}
+
+describe('KeyboardShortcutsModal', () => {
+  it('renders the List Navigation group heading', () => {
+    renderModal()
+    expect(screen.getByText('List Navigation')).toBeInTheDocument()
+  })
+
+  it('renders the Global group heading', () => {
+    renderModal()
+    expect(screen.getByText('Global')).toBeInTheDocument()
+  })
+
+  it('renders all list navigation shortcut rows', () => {
+    renderModal()
+    expect(screen.getByText('Navigate between items')).toBeInTheDocument()
+    expect(screen.getByText('Jump 20 items')).toBeInTheDocument()
+    expect(screen.getByText('First / last item')).toBeInTheDocument()
+    expect(screen.getByText('Edit selected item')).toBeInTheDocument()
+    expect(screen.getByText('Clear selection or close dialog')).toBeInTheDocument()
+  })
+
+  it('renders all global shortcut rows', () => {
+    renderModal()
+    expect(screen.getByText('Open global search')).toBeInTheDocument()
+    expect(screen.getByText('Show keyboard shortcuts')).toBeInTheDocument()
+  })
+
+  it('renders the footer note', () => {
+    renderModal()
+    expect(screen.getByText(/list navigation shortcuts apply on list and table pages only/i)).toBeInTheDocument()
+  })
+
+  it('does not render when open is false', () => {
+    renderModal(false)
+    expect(screen.queryByText('List Navigation')).not.toBeInTheDocument()
+  })
+
+  it('calls onClose when the close button is clicked', () => {
+    const { onClose } = renderModal()
+    fireEvent.click(screen.getByRole('button', { name: /close/i }))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('calls onClose when Escape is pressed', () => {
+    const { onClose } = renderModal()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/common/__tests__/SystemStatus.test.tsx
+++ b/frontend/src/components/common/__tests__/SystemStatus.test.tsx
@@ -71,4 +71,18 @@ describe('SystemStatus', () => {
 
     expect(onOpen).toHaveBeenCalled()
   })
+
+  it('shows the unable to fetch message when health check fails', async () => {
+    mockGet.mockRejectedValue(new Error('Network error'))
+
+    const anchorEl = document.createElement('button')
+    document.body.appendChild(anchorEl)
+    renderSystemStatus(anchorEl, true)
+
+    await waitFor(() => {
+      expect(screen.getByText(/unable to fetch system health information/i)).toBeInTheDocument()
+    })
+
+    document.body.removeChild(anchorEl)
+  })
 })

--- a/frontend/src/components/common/__tests__/SystemStatus.test.tsx
+++ b/frontend/src/components/common/__tests__/SystemStatus.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import SystemStatus from '../SystemStatus'
@@ -23,6 +23,13 @@ const healthyResponse = {
   },
 }
 
+function renderSystemStatus(anchorEl: HTMLElement | null = null, open = false) {
+  const onOpen = vi.fn()
+  const onClose = vi.fn()
+  render(<SystemStatus anchorEl={anchorEl} open={open} onOpen={onOpen} onClose={onClose} />)
+  return { onOpen, onClose }
+}
+
 describe('SystemStatus', () => {
   beforeEach(() => {
     mockGet.mockReset()
@@ -30,7 +37,7 @@ describe('SystemStatus', () => {
   })
 
   it('renders an icon button and not a chip text label', () => {
-    render(<SystemStatus />)
+    renderSystemStatus()
 
     expect(screen.queryByText('HEALTHY')).not.toBeInTheDocument()
     expect(screen.queryByText('UNHEALTHY')).not.toBeInTheDocument()
@@ -38,7 +45,7 @@ describe('SystemStatus', () => {
   })
 
   it('shows a system tooltip label after data loads', async () => {
-    render(<SystemStatus />)
+    renderSystemStatus()
 
     await waitFor(() => {
       const button = screen.getByRole('button')
@@ -50,10 +57,18 @@ describe('SystemStatus', () => {
   it('shows unknown status state during initial load', () => {
     mockGet.mockReturnValue(new Promise(() => {}))
 
-    render(<SystemStatus />)
+    renderSystemStatus()
 
     expect(screen.queryByText('HEALTHY')).not.toBeInTheDocument()
     expect(screen.queryByText('UNKNOWN')).not.toBeInTheDocument()
     expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+
+  it('calls onOpen when the icon button is clicked', () => {
+    const { onOpen } = renderSystemStatus()
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(onOpen).toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/common/__tests__/TopBar.test.tsx
+++ b/frontend/src/components/common/__tests__/TopBar.test.tsx
@@ -7,16 +7,22 @@ import { MemoryRouter } from 'react-router-dom'
 import TopBar from '../TopBar'
 
 vi.mock('../NotificationPanel', () => ({ default: () => null }))
-vi.mock('../SystemStatus', () => ({ default: () => <div data-testid="system-status" /> }))
+vi.mock('../SystemStatus', () => ({
+  default: ({ onOpen }: { onOpen: (e: React.MouseEvent<HTMLElement>) => void }) => (
+    <button data-testid="system-status" onClick={onOpen}>SystemStatus</button>
+  ),
+}))
 vi.mock('../SearchModal', () => ({
   default: ({ open }: { open: boolean }) => (open ? <div data-testid="search-modal" /> : null),
+}))
+vi.mock('../KeyboardShortcutsModal', () => ({
+  default: ({ open }: { open: boolean }) => (open ? <div data-testid="shortcuts-modal" /> : null),
 }))
 
 const mockUseMatches = vi.fn()
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
-
   return {
     ...actual,
     useMatches: () => mockUseMatches(),
@@ -44,17 +50,13 @@ function renderTopBar(path: string, collapsed = false) {
 describe('TopBar breadcrumbs', () => {
   it('shows leaf segment for a known single-segment path', () => {
     mockUseMatches.mockReturnValue([{ handle: { title: 'Dashboard' } }])
-
     renderTopBar('/dashboard')
-
     expect(screen.getByText('Dashboard')).toBeInTheDocument()
   })
 
   it('shows multi-segment breadcrumb for deep path', () => {
     mockUseMatches.mockReturnValue([{ handle: { title: 'Create Product' } }])
-
     renderTopBar('/inventory/products/create')
-
     expect(screen.getByText('Inventory')).toBeInTheDocument()
     expect(screen.getByText('Products')).toBeInTheDocument()
     expect(screen.getByText('Create Product')).toBeInTheDocument()
@@ -62,17 +64,13 @@ describe('TopBar breadcrumbs', () => {
 
   it('renders nothing in breadcrumb area for unmapped path', () => {
     mockUseMatches.mockReturnValue([])
-
     renderTopBar('/unknown/path')
-
     expect(screen.queryByRole('navigation')).not.toBeInTheDocument()
   })
 
   it('renders ancestor breadcrumb segments as links for navigable paths', () => {
     mockUseMatches.mockReturnValue([{ handle: { title: 'Products' } }])
-
     renderTopBar('/inventory/products')
-
     const inventoryLink = screen.getByRole('link', { name: 'Inventory' })
     expect(inventoryLink).toBeInTheDocument()
     expect(inventoryLink).toHaveAttribute('href', '/inventory')
@@ -80,9 +78,7 @@ describe('TopBar breadcrumbs', () => {
 
   it('shows inventory costing for the renamed settings path', () => {
     mockUseMatches.mockReturnValue([{ handle: { title: 'Inventory Costing' } }])
-
     renderTopBar('/settings/inventory-costing')
-
     expect(screen.getByText('Inventory Costing')).toBeInTheDocument()
   })
 })
@@ -90,43 +86,71 @@ describe('TopBar breadcrumbs', () => {
 describe('TopBar search', () => {
   it('opens search modal when search trigger is clicked', () => {
     mockUseMatches.mockReturnValue([{ handle: { title: 'Dashboard' } }])
-
     renderTopBar('/dashboard')
-    const searchTrigger = screen.getByRole('button', { name: /open global search/i })
-
-    fireEvent.click(searchTrigger)
-
+    fireEvent.click(screen.getByRole('button', { name: /open global search/i }))
     expect(screen.getByTestId('search-modal')).toBeInTheDocument()
   })
 
   it('opens search modal on Ctrl+K', () => {
     mockUseMatches.mockReturnValue([{ handle: { title: 'Dashboard' } }])
-
     renderTopBar('/dashboard')
     fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
-
     expect(screen.getByTestId('search-modal')).toBeInTheDocument()
   })
 
   it('does not open search modal when Ctrl+K fires inside an input', () => {
     mockUseMatches.mockReturnValue([{ handle: { title: 'Dashboard' } }])
-
     renderTopBar('/dashboard')
     const input = document.createElement('input')
     document.body.appendChild(input)
     input.focus()
-
     fireEvent.keyDown(input, { key: 'k', ctrlKey: true })
-
     expect(screen.queryByTestId('search-modal')).not.toBeInTheDocument()
     document.body.removeChild(input)
+  })
+})
+
+describe('TopBar keyboard shortcuts modal', () => {
+  it('opens shortcuts modal when keyboard icon is clicked', () => {
+    mockUseMatches.mockReturnValue([{ handle: { title: 'Dashboard' } }])
+    renderTopBar('/dashboard')
+    fireEvent.click(screen.getByRole('button', { name: /keyboard shortcuts/i }))
+    expect(screen.getByTestId('shortcuts-modal')).toBeInTheDocument()
+  })
+
+  it('opens shortcuts modal when ? key is pressed', () => {
+    mockUseMatches.mockReturnValue([{ handle: { title: 'Dashboard' } }])
+    renderTopBar('/dashboard')
+    fireEvent.keyDown(window, { key: '?' })
+    expect(screen.getByTestId('shortcuts-modal')).toBeInTheDocument()
+  })
+
+  it('does not open shortcuts modal when ? fires inside an input', () => {
+    mockUseMatches.mockReturnValue([{ handle: { title: 'Dashboard' } }])
+    renderTopBar('/dashboard')
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+    fireEvent.keyDown(input, { key: '?' })
+    expect(screen.queryByTestId('shortcuts-modal')).not.toBeInTheDocument()
+    document.body.removeChild(input)
+  })
+
+  it('does not open shortcuts modal when ? fires inside a textarea', () => {
+    mockUseMatches.mockReturnValue([{ handle: { title: 'Dashboard' } }])
+    renderTopBar('/dashboard')
+    const textarea = document.createElement('textarea')
+    document.body.appendChild(textarea)
+    textarea.focus()
+    fireEvent.keyDown(textarea, { key: '?' })
+    expect(screen.queryByTestId('shortcuts-modal')).not.toBeInTheDocument()
+    document.body.removeChild(textarea)
   })
 })
 
 describe('TopBar mobile layout', () => {
   it('shows leaf page title on mobile and hides search trigger', () => {
     mockUseMatches.mockReturnValue([{ handle: { title: 'Create Product' } }])
-
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
       value: vi.fn().mockImplementation((query: string) => ({
@@ -140,9 +164,7 @@ describe('TopBar mobile layout', () => {
         dispatchEvent: vi.fn(),
       })),
     })
-
     renderTopBar('/inventory/products/create')
-
     expect(screen.getByText('Create Product')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /open drawer/i })).toBeInTheDocument()
   })


### PR DESCRIPTION
## Summary
- Add `KeyboardShortcutsModal` accessible via `KeyboardIcon` button in TopBar or `?` key, listing all standardized navigation shortcuts in two groups (List Navigation, Global) with a footer note
- Standardize all four TopBar overlay state patterns — `SystemStatus` refactored to accept `anchorEl`/`open`/`onOpen`/`onClose` props, matching `NotificationPanel`'s pattern; all overlay state now lives in `TopBar.tsx`
- Fix `SystemStatus` quality issues: `finally` block for loading reset, remove dead `frontendStatus` state, add error state test

## Test Plan
- [x] 26 tests pass across `TopBar.test.tsx`, `KeyboardShortcutsModal.test.tsx`, `SystemStatus.test.tsx`
- [x] `?` key opens shortcuts modal from any list/table page
- [x] `?` suppressed when focus is inside an input or textarea
- [x] `KeyboardIcon` button click opens the modal
- [x] Modal shows both shortcut groups and footer note
- [x] Modal closes via X button, Escape, or backdrop click
- [x] `SystemStatus` popover still works correctly
- [x] Ctrl+K search still works (no regression)
- [x] TypeScript type check passes

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)