### PR TITLE
chore(deps): bump NGINX to 1.30.0, Node to 24.15.0, Redis to 8.6.2

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,11 @@
 # Stage 1: Install all dependencies (dev + prod) for building
-FROM node:24.14.1-alpine3.23 AS deps
+FROM node:24.15.0-alpine3.23 AS deps
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci && npm cache clean --force
 
 # Stage 2: Build the application
-FROM node:24.14.1-alpine3.23 AS builder
+FROM node:24.15.0-alpine3.23 AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -14,7 +14,7 @@ RUN npm run build && \
     npm prune --omit=dev && npm cache clean --force
 
 # Stage 3: Production image — only compiled output + prod deps
-FROM node:24.14.1-alpine3.23 AS production
+FROM node:24.15.0-alpine3.23 AS production
 
 # Install security updates and runtime dependencies
 RUN apk update && apk upgrade && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
 
   # Redis for caching and sessions
   redis:
-    image: redis:8.6.1-alpine3.23
+    image: redis:8.6.2-alpine3.23
     container_name: erp_redis
     restart: unless-stopped
     command: >

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:24.14.1-alpine3.23 AS builder
+FROM node:24.15.0-alpine3.23 AS builder
 
 # Set working directory
 WORKDIR /app
@@ -28,7 +28,7 @@ ENV VITE_APP_VERSION=$VITE_APP_VERSION
 RUN npm run build
 
 # Production stage
-FROM nginx:1.29.7-alpine-slim AS production
+FROM nginx:1.30.0-alpine3.23-slim AS production
 
 # Update Alpine packages and install curl for health checks
 RUN apk update && \

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,2 +1,2 @@
-FROM nginx:1.29.7-alpine-slim
+FROM nginx:1.30.0-alpine3.23-slim
 COPY nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
## Summary
- Bumps NGINX from `1.29.7-alpine-slim` to `1.30.0-alpine3.23-slim`
- Bumps Node.js from `24.14.1-alpine3.23` to `24.15.0-alpine3.23`
- Bumps Redis from `8.6.1-alpine3.23` to `8.6.2-alpine3.23`

All target tags verified on Docker Hub. NGINX 1.30.0 changelog reviewed for breaking changes — none found affecting our config. Full `docker compose build` passed.

## Test plan
- [x] All three target image tags confirmed present on Docker Hub via `docker manifest inspect`
- [x] NGINX 1.30.0 changelog reviewed — no breaking changes to our `nginx.conf` directives
- [x] `docker compose build` exits 0 with no errors

Closes #454