### PR TITLE
chore(deps): bump @mui/x-date-pickers from 9.0.2 to 9.0.3

### DIFF
--- a/docs/superpowers/plans/2026-04-27-issue-460-mui-x-date-pickers-9.0.3-upgrade.md
+++ b/docs/superpowers/plans/2026-04-27-issue-460-mui-x-date-pickers-9.0.3-upgrade.md
@@ -1,0 +1,125 @@
+# @mui/x-date-pickers 9.0.3 Upgrade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bump `@mui/x-date-pickers` from 9.0.2 to 9.0.3 in the frontend to pick up four bug fixes (disabled-state border color, `data-*`/`aria-*` attribute forwarding, `AdapterDayjs` drag fix, `K`/`k` hour token support).
+
+**Architecture:** Single version change in `frontend/package.json`, followed by a lockfile refresh. No code changes required — 9.0.3 contains only bug fixes and no breaking changes for `@mui/x-date-pickers`.
+
+**Tech Stack:** Node.js ≥20, npm, @mui/x-date-pickers, Vitest
+
+---
+
+### Task 1: Bump @mui/x-date-pickers and refresh lockfile
+
+**Files:**
+- Modify: `frontend/package.json`
+- Modify: `frontend/package-lock.json` (auto-generated)
+
+- [ ] **Step 1: Create a feature branch**
+
+```bash
+git checkout -b chore/issue-460-mui-x-date-pickers-9.0.3
+```
+
+Expected: switched to a new branch `chore/issue-460-mui-x-date-pickers-9.0.3`
+
+- [ ] **Step 2: Update the version pin**
+
+In `frontend/package.json`, change:
+
+```json
+"@mui/x-date-pickers": "9.0.2",
+```
+
+to:
+
+```json
+"@mui/x-date-pickers": "9.0.3",
+```
+
+- [ ] **Step 3: Install and refresh the lockfile**
+
+```bash
+cd frontend && npm install
+```
+
+Expected: npm resolves `@mui/x-date-pickers` 9.0.3 and updates `package-lock.json`. No peer dependency errors or ERESOLVE warnings.
+
+- [ ] **Step 4: Verify the installed version**
+
+```bash
+cd frontend && npm ls @mui/x-date-pickers
+```
+
+Expected output includes:
+
+```
+@mui/x-date-pickers@9.0.3
+```
+
+- [ ] **Step 5: Run the frontend type-check**
+
+```bash
+cd frontend && npm run type-check
+```
+
+Expected: exits with 0 errors.
+
+- [ ] **Step 6: Run a targeted smoke test on date-picker-related tests**
+
+```bash
+cd frontend && npx vitest run --reporter=verbose 2>&1 | grep -i "date\|picker\|calendar" | head -30
+```
+
+If no date/picker test files exist, run the full suite smoke sample instead:
+
+```bash
+cd frontend && npx vitest run src/components --reporter=verbose 2>&1 | tail -20
+```
+
+Expected: all matched tests pass, no failures.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/package.json frontend/package-lock.json
+git commit -m "chore(deps): bump @mui/x-date-pickers from 9.0.2 to 9.0.3"
+```
+
+---
+
+### Task 2: Open PR and close issue
+
+**Files:** (none — GitHub operations only)
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin chore/issue-460-mui-x-date-pickers-9.0.3
+```
+
+- [ ] **Step 2: Create the pull request**
+
+```bash
+gh pr create \
+  --title "chore(deps): bump @mui/x-date-pickers from 9.0.2 to 9.0.3" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Bumps `@mui/x-date-pickers` from 9.0.2 to 9.0.3 in `frontend/package.json`
+- Patch release — bug fixes only, no breaking changes for date pickers
+- Release highlights: disabled-state border color fix, `data-*`/`aria-*` attribute forwarding, AdapterDayjs drag fix, K/k hour token support
+
+Closes #460
+EOF
+)"
+```
+
+- [ ] **Step 3: Merge the PR**
+
+```bash
+gh pr merge --merge --delete-branch
+```
+
+Expected: PR merged and branch deleted.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,7 @@
         "@hookform/resolvers": "5.2.2",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
-        "@mui/x-date-pickers": "9.0.2",
+        "@mui/x-date-pickers": "9.0.3",
         "@reduxjs/toolkit": "^2.11.2",
         "@tanstack/react-query": "^5.96.0",
         "@tanstack/react-query-devtools": "^5.96.0",
@@ -1334,12 +1334,12 @@
       }
     },
     "node_modules/@mui/x-date-pickers": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-9.0.2.tgz",
-      "integrity": "sha512-rnyc2wFPnprTS5i8Lq9aX2Rlx+ZRvNZERTd7sPMErf/8HnMCYzxwErITbd+TuImlvo2vaLF1gNynqT8AJMusYw==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-9.0.3.tgz",
+      "integrity": "sha512-1geYekK9XaZBy38GDpR1749AaDG335iB2cHPWPfWskFLpqx/ZU/IQ0tymFZ1u8jKCT2cwKzb6UdM3bq6kmtcdw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
+        "@babel/runtime": "^7.29.2",
         "@mui/utils": "9.0.0",
         "@mui/x-internals": "^9.0.0",
         "@types/react-transition-group": "^4.4.12",
@@ -3001,6 +3001,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cross-spawn": {
@@ -6391,15 +6400,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "@hookform/resolvers": "5.2.2",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
-    "@mui/x-date-pickers": "9.0.2",
+    "@mui/x-date-pickers": "9.0.3",
     "@reduxjs/toolkit": "^2.11.2",
     "@tanstack/react-query": "^5.96.0",
     "@tanstack/react-query-devtools": "^5.96.0",


### PR DESCRIPTION
## Summary

- Bumps `@mui/x-date-pickers` from 9.0.2 to 9.0.3 in `frontend/package.json`
- Patch release - bug fixes only, no breaking changes for date pickers
- Release highlights: disabled-state border color fix, `data-*`/`aria-*` attribute forwarding, AdapterDayjs drag fix, K/k hour token support

## Verification

- `cd frontend && npm ls @mui/x-date-pickers` -> `@mui/x-date-pickers@9.0.3`
- `cd frontend && npm run type-check` -> passed
- `cd frontend && npx vitest run src/components/filters/FilterPeriod.test.tsx src/pages/inventory/__tests__/StockAdjustmentsPage.filterbar.test.tsx src/pages/sales/__tests__/InvoicesPage.filterbar.test.tsx src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx src/pages/accounting/reports/__tests__/AccountActivityPage.test.tsx src/pages/accounting/reports/__tests__/GeneralLedgerPage.test.tsx src/pages/accounting/reports/__tests__/BalanceSheetPage.test.tsx src/pages/accounting/reports/__tests__/TrialBalancePage.test.tsx src/pages/accounting/reports/__tests__/ProfitAndLossPage.test.tsx --reporter=verbose` -> 9 files, 75 tests passed
- `cd frontend && npm run lint` -> passed

Closes #460