### PR TITLE
feat(accounting): slim JE table to single column and rewrite context header with Grid layout

### DIFF
--- a/backend/src/modules/accounting/accounting.module.ts
+++ b/backend/src/modules/accounting/accounting.module.ts
@@ -15,6 +15,11 @@ import { Payment } from '../../database/entities/payment.entity';
 import { OwnerEquityTransaction } from '../../database/entities/owner-equity-transaction.entity';
 import { Expense } from '../../database/entities/expense.entity';
 import { FundTransfer } from '../../database/entities/fund-transfer.entity';
+import { SalesOrder } from '../../database/entities/sales-order.entity';
+import { PurchaseOrder } from '../../database/entities/purchase-order.entity';
+import { GoodsReceivedNote } from '../../database/entities/goods-received-note.entity';
+import { VendorPayment } from '../../database/entities/vendor-payment.entity';
+import { StockAdjustment } from '../../database/entities/stock-adjustment.entity';
 
 // Services
 import { AccountingService } from './services/accounting.service';
@@ -61,6 +66,11 @@ import { AuditLogsModule } from '../audit-logs/audit-logs.module';
       OwnerEquityTransaction,
       Expense,
       FundTransfer,
+      SalesOrder,
+      PurchaseOrder,
+      GoodsReceivedNote,
+      VendorPayment,
+      StockAdjustment,
     ]),
     SettingsModule,
     AuditLogsModule,

--- a/backend/src/modules/accounting/dto/journal-entry.dto.ts
+++ b/backend/src/modules/accounting/dto/journal-entry.dto.ts
@@ -315,6 +315,9 @@ export class JournalEntryResponseDto {
   @ApiPropertyOptional({ description: 'Source transaction ID' })
   sourceId?: string;
 
+  @ApiPropertyOptional({ description: 'Human-readable reference of the source document' })
+  sourceRefNumber?: string;
+
   @ApiProperty({ description: 'Whether entry is in DRAFT status' })
   isDraft: boolean;
 

--- a/backend/src/modules/accounting/services/journal-entry.service.spec.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.spec.ts
@@ -24,6 +24,15 @@ import {
   ChartOfAccount,
   AccountType,
 } from '../../../database/entities/chart-of-account.entity';
+import { SalesOrder } from '../../../database/entities/sales-order.entity';
+import { PurchaseOrder } from '../../../database/entities/purchase-order.entity';
+import { GoodsReceivedNote } from '../../../database/entities/goods-received-note.entity';
+import { Payment } from '../../../database/entities/payment.entity';
+import { VendorPayment } from '../../../database/entities/vendor-payment.entity';
+import { Expense } from '../../../database/entities/expense.entity';
+import { OwnerEquityTransaction } from '../../../database/entities/owner-equity-transaction.entity';
+import { FundTransfer } from '../../../database/entities/fund-transfer.entity';
+import { StockAdjustment } from '../../../database/entities/stock-adjustment.entity';
 import {
   CreateJournalEntryDto,
   UpdateJournalEntryDto,
@@ -40,6 +49,15 @@ describe('JournalEntryService', () => {
   let chartOfAccountsService: jest.Mocked<ChartOfAccountsService>;
   let fiscalPeriodService: jest.Mocked<FiscalPeriodService>;
   let settingsService: jest.Mocked<SettingsService>;
+  let mockSalesOrderRepo: { findOne: jest.Mock };
+  let mockPurchaseOrderRepo: { findOne: jest.Mock };
+  let mockGrnRepo: { findOne: jest.Mock };
+  let mockPaymentRepo: { findOne: jest.Mock };
+  let mockVendorPaymentRepo: { findOne: jest.Mock };
+  let mockExpenseRepo: { findOne: jest.Mock };
+  let mockOwnerEquityTransactionRepo: { findOne: jest.Mock };
+  let mockFundTransferRepo: { findOne: jest.Mock };
+  let mockStockAdjustmentRepo: { findOne: jest.Mock };
 
   // Test data
   const mockFiscalPeriod: Partial<FiscalPeriod> = {
@@ -111,6 +129,16 @@ describe('JournalEntryService', () => {
   };
 
   beforeEach(async () => {
+    mockSalesOrderRepo = { findOne: jest.fn() };
+    mockPurchaseOrderRepo = { findOne: jest.fn() };
+    mockGrnRepo = { findOne: jest.fn() };
+    mockPaymentRepo = { findOne: jest.fn() };
+    mockVendorPaymentRepo = { findOne: jest.fn() };
+    mockExpenseRepo = { findOne: jest.fn() };
+    mockOwnerEquityTransactionRepo = { findOne: jest.fn() };
+    mockFundTransferRepo = { findOne: jest.fn() };
+    mockStockAdjustmentRepo = { findOne: jest.fn() };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         JournalEntryService,
@@ -149,6 +177,18 @@ describe('JournalEntryService', () => {
             find: jest.fn(),
           },
         },
+        { provide: getRepositoryToken(SalesOrder), useValue: mockSalesOrderRepo },
+        { provide: getRepositoryToken(PurchaseOrder), useValue: mockPurchaseOrderRepo },
+        { provide: getRepositoryToken(GoodsReceivedNote), useValue: mockGrnRepo },
+        { provide: getRepositoryToken(Payment), useValue: mockPaymentRepo },
+        { provide: getRepositoryToken(VendorPayment), useValue: mockVendorPaymentRepo },
+        { provide: getRepositoryToken(Expense), useValue: mockExpenseRepo },
+        {
+          provide: getRepositoryToken(OwnerEquityTransaction),
+          useValue: mockOwnerEquityTransactionRepo,
+        },
+        { provide: getRepositoryToken(FundTransfer), useValue: mockFundTransferRepo },
+        { provide: getRepositoryToken(StockAdjustment), useValue: mockStockAdjustmentRepo },
         {
           provide: ChartOfAccountsService,
           useValue: {
@@ -484,6 +524,67 @@ describe('JournalEntryService', () => {
       journalEntryRepository.findOne.mockResolvedValue(null);
 
       await expect(service.findOne('non-existent')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('sourceRefNumber resolution', () => {
+    it('resolves sourceRefNumber for sales_order sourceType', async () => {
+      const entry = {
+        ...mockJournalEntry,
+        sourceType: 'sales_order',
+        sourceId: 'so-uuid-1',
+      } as JournalEntry;
+
+      journalEntryRepository.findOne.mockResolvedValue(entry);
+      mockSalesOrderRepo.findOne.mockResolvedValue({ orderNumber: 'SO-0042' });
+
+      const result = await service.findOne('entry-1');
+
+      expect(result.sourceRefNumber).toBe('SO-0042');
+    });
+
+    it('resolves sourceRefNumber for purchase_order sourceType', async () => {
+      const entry = {
+        ...mockJournalEntry,
+        sourceType: 'purchase_order',
+        sourceId: 'po-uuid-1',
+      } as JournalEntry;
+
+      journalEntryRepository.findOne.mockResolvedValue(entry);
+      mockPurchaseOrderRepo.findOne.mockResolvedValue({ orderNumber: 'PO-0007' });
+
+      const result = await service.findOne('entry-1');
+
+      expect(result.sourceRefNumber).toBe('PO-0007');
+    });
+
+    it('returns undefined sourceRefNumber for manual entries', async () => {
+      const entry = {
+        ...mockJournalEntry,
+        sourceType: 'manual',
+        sourceId: undefined,
+      } as JournalEntry;
+
+      journalEntryRepository.findOne.mockResolvedValue(entry);
+
+      const result = await service.findOne('entry-1');
+
+      expect(result.sourceRefNumber).toBeUndefined();
+    });
+
+    it('returns undefined sourceRefNumber when source record not found', async () => {
+      const entry = {
+        ...mockJournalEntry,
+        sourceType: 'sales_order',
+        sourceId: 'so-missing',
+      } as JournalEntry;
+
+      journalEntryRepository.findOne.mockResolvedValue(entry);
+      mockSalesOrderRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.findOne('entry-1');
+
+      expect(result.sourceRefNumber).toBeUndefined();
     });
   });
 

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -14,6 +14,15 @@ import {
 import { JournalEntryLine } from '../../../database/entities/journal-entry-line.entity';
 import { FiscalPeriod, FiscalPeriodStatus } from '../../../database/entities/fiscal-period.entity';
 import { ChartOfAccount } from '../../../database/entities/chart-of-account.entity';
+import { SalesOrder } from '../../../database/entities/sales-order.entity';
+import { PurchaseOrder } from '../../../database/entities/purchase-order.entity';
+import { GoodsReceivedNote } from '../../../database/entities/goods-received-note.entity';
+import { Payment } from '../../../database/entities/payment.entity';
+import { VendorPayment } from '../../../database/entities/vendor-payment.entity';
+import { Expense } from '../../../database/entities/expense.entity';
+import { OwnerEquityTransaction } from '../../../database/entities/owner-equity-transaction.entity';
+import { FundTransfer } from '../../../database/entities/fund-transfer.entity';
+import { StockAdjustment } from '../../../database/entities/stock-adjustment.entity';
 import {
   CreateJournalEntryDto,
   UpdateJournalEntryDto,
@@ -53,6 +62,24 @@ export class JournalEntryService {
     private readonly fiscalPeriodRepository: Repository<FiscalPeriod>,
     @InjectRepository(ChartOfAccount)
     private readonly chartOfAccountRepository: Repository<ChartOfAccount>,
+    @InjectRepository(SalesOrder)
+    private readonly salesOrderRepository: Repository<SalesOrder>,
+    @InjectRepository(PurchaseOrder)
+    private readonly purchaseOrderRepository: Repository<PurchaseOrder>,
+    @InjectRepository(GoodsReceivedNote)
+    private readonly grnRepository: Repository<GoodsReceivedNote>,
+    @InjectRepository(Payment)
+    private readonly paymentRepository: Repository<Payment>,
+    @InjectRepository(VendorPayment)
+    private readonly vendorPaymentRepository: Repository<VendorPayment>,
+    @InjectRepository(Expense)
+    private readonly expenseRepository: Repository<Expense>,
+    @InjectRepository(OwnerEquityTransaction)
+    private readonly ownerEquityTransactionRepository: Repository<OwnerEquityTransaction>,
+    @InjectRepository(FundTransfer)
+    private readonly fundTransferRepository: Repository<FundTransfer>,
+    @InjectRepository(StockAdjustment)
+    private readonly stockAdjustmentRepository: Repository<StockAdjustment>,
     private readonly chartOfAccountsService: ChartOfAccountsService,
     private readonly fiscalPeriodService: FiscalPeriodService,
     private readonly settingsService: SettingsService,

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -528,7 +528,7 @@ export class JournalEntryService {
     );
 
     this.logger.log(`Journal entry posted successfully: ${id}`);
-    return this.toResponseDto(postedEntry);
+    return await this.toResponseDto(postedEntry);
   }
 
   /**
@@ -839,6 +839,7 @@ export class JournalEntryService {
   /**
    * Convert journal entry entity to response DTO
    */
+  // TODO: batch source lookups to avoid N+1 per JE list response
   private async resolveSourceRefNumber(
     sourceType: string | undefined,
     sourceId: string | undefined,
@@ -910,6 +911,8 @@ export class JournalEntryService {
           });
           return record?.adjustmentNumber;
         }
+        // settlement: no dedicated list page, source navigation not supported
+        // opening_balance: synthetic entry with no source entity UUID
         default:
           return undefined;
       }

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -237,7 +237,7 @@ export class JournalEntryService {
 
     const [entries, total] = await queryBuilder.getManyAndCount();
 
-    const data = entries.map((entry) => this.toResponseDto(entry));
+    const data = await Promise.all(entries.map((entry) => this.toResponseDto(entry)));
 
     return {
       data,
@@ -839,7 +839,88 @@ export class JournalEntryService {
   /**
    * Convert journal entry entity to response DTO
    */
-  private toResponseDto(entry: JournalEntry): JournalEntryResponseDto {
+  private async resolveSourceRefNumber(
+    sourceType: string | undefined,
+    sourceId: string | undefined,
+  ): Promise<string | undefined> {
+    if (!sourceType || !sourceId) return undefined;
+
+    try {
+      switch (sourceType) {
+        case 'sales_order': {
+          const record = await this.salesOrderRepository.findOne({
+            where: { id: sourceId },
+            select: ['orderNumber'],
+          });
+          return record?.orderNumber;
+        }
+        case 'purchase_order': {
+          const record = await this.purchaseOrderRepository.findOne({
+            where: { id: sourceId },
+            select: ['orderNumber'],
+          });
+          return record?.orderNumber;
+        }
+        case 'payment': {
+          const record = await this.paymentRepository.findOne({
+            where: { id: sourceId },
+            select: ['paymentNumber'],
+          });
+          return record?.paymentNumber;
+        }
+        case 'goods_received_note': {
+          const record = await this.grnRepository.findOne({
+            where: { id: sourceId },
+            select: ['grnNumber'],
+          });
+          return record?.grnNumber;
+        }
+        case 'vendor_payment': {
+          const record = await this.vendorPaymentRepository.findOne({
+            where: { id: sourceId },
+            select: ['paymentNumber'],
+          });
+          return record?.paymentNumber;
+        }
+        case 'expense': {
+          const record = await this.expenseRepository.findOne({
+            where: { id: sourceId },
+            select: ['referenceNumber'],
+          });
+          return record?.referenceNumber;
+        }
+        case 'owner_equity_transaction': {
+          const record = await this.ownerEquityTransactionRepository.findOne({
+            where: { id: sourceId },
+            select: ['referenceNumber'],
+          });
+          return record?.referenceNumber;
+        }
+        case 'fund_transfer': {
+          const record = await this.fundTransferRepository.findOne({
+            where: { id: sourceId },
+            select: ['referenceNumber'],
+          });
+          return record?.referenceNumber;
+        }
+        case 'stock_adjustment': {
+          const record = await this.stockAdjustmentRepository.findOne({
+            where: { id: sourceId },
+            select: ['adjustmentNumber'],
+          });
+          return record?.adjustmentNumber;
+        }
+        default:
+          return undefined;
+      }
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async toResponseDto(entry: JournalEntry): Promise<JournalEntryResponseDto> {
+    const sourceRefNumber = await this.resolveSourceRefNumber(entry.sourceType, entry.sourceId);
+
     return {
       id: entry.id,
       entryDate: entry.entryDate,
@@ -851,6 +932,7 @@ export class JournalEntryService {
       reversedById: entry.reversedById,
       sourceType: entry.sourceType,
       sourceId: entry.sourceId,
+      sourceRefNumber,
       isDraft: entry.isDraft,
       isPosted: entry.isPosted,
       isReversed: entry.isReversed,
@@ -869,10 +951,10 @@ export class JournalEntryService {
         ? entry.lines.map((line) => this.toLineResponseDto(line))
         : undefined,
       reversalOf: entry.reversalOf
-        ? this.toResponseDto(entry.reversalOf)
+        ? await this.toResponseDto(entry.reversalOf)
         : undefined,
       reversedBy: entry.reversedBy
-        ? this.toResponseDto(entry.reversedBy)
+        ? await this.toResponseDto(entry.reversedBy)
         : undefined,
       createdAt: entry.createdAt,
       updatedAt: entry.updatedAt,

--- a/frontend/src/__tests__/integration/accounting-auto-posting.integration.test.tsx
+++ b/frontend/src/__tests__/integration/accounting-auto-posting.integration.test.tsx
@@ -282,7 +282,7 @@ describe('Accounting Auto-Posting Integration Tests', () => {
       })
     })
 
-    it('displays both manual and auto-posted entries with correct type labels', async () => {
+    it('displays all entries by reference number in the list', async () => {
       renderJournalEntriesPage()
 
       await waitFor(() => {
@@ -290,34 +290,50 @@ describe('Accounting Auto-Posting Integration Tests', () => {
         expect(screen.getAllByText('JE-2026-002').length).toBeGreaterThan(0)
         expect(screen.getAllByText('JE-2026-003').length).toBeGreaterThan(0)
       })
-
-      expect(screen.getAllByText('Manual Entry').length).toBeGreaterThan(0)
-      expect(screen.getAllByText('Sales Order').length).toBeGreaterThan(0)
-      expect(screen.getAllByText('Customer Payment').length).toBeGreaterThan(0)
     })
 
-    it('shows "View Source" link only for auto-posted entries', async () => {
+    it('does not show type labels or View Source links in the list', async () => {
       renderJournalEntriesPage()
 
       await waitFor(() => {
-        expect(screen.getAllByText('JE-2026-002').length).toBeGreaterThan(0)
+        expect(screen.getAllByText('JE-2026-001').length).toBeGreaterThan(0)
       })
 
-      expect(screen.getAllByText('View Source')).toHaveLength(2)
+      expect(screen.queryByText('View Source')).not.toBeInTheDocument()
+      expect(screen.queryByText('Sales Order')).not.toBeInTheDocument()
+      expect(screen.queryByText('Customer Payment')).not.toBeInTheDocument()
     })
 
-    it('navigates to source transaction when clicking View Source', async () => {
+    it('shows entry details in context header when an entry is selected', async () => {
       const user = createUser()
 
+      mockedApi.useLazyGetJournalEntryQuery.mockReturnValue([
+        vi.fn().mockResolvedValue({
+          id: 'je-2',
+          referenceNumber: 'JE-2026-002',
+          entryDate: '2026-02-02',
+          description: 'Sales order SO-123 fulfillment',
+          sourceType: 'sales_order',
+          sourceId: 'so-123',
+          sourceRefNumber: 'SO-0123',
+          status: JournalEntryStatus.POSTED,
+          totalDebits: 5000,
+          totalCredits: 5000,
+          lines: [],
+        }),
+      ])
+
       renderJournalEntriesPage()
 
       await waitFor(() => {
         expect(screen.getAllByText('JE-2026-002').length).toBeGreaterThan(0)
       })
 
-      await user.click(screen.getAllByText('View Source')[0])
+      await user.click(screen.getAllByText('JE-2026-002')[0])
 
-      expect(mockNavigate).toHaveBeenCalledWith('/sales/orders?highlight=so-123')
+      await waitFor(() => {
+        expect(screen.getByText('Journal Entry Details - JE-2026-002')).toBeInTheDocument()
+      })
     })
   })
 

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -112,7 +112,6 @@ export const JournalEntriesPage: React.FC = () => {
             selectedEntryId={workspace.selectedEntry?.id ?? null}
             focusedIndex={workspace.focusedIndex}
             onSelect={workspace.handleSelect}
-            onViewSource={(sourceType, sourceId) => workspace.navigateToSource(sourceType, sourceId)}
             listRef={workspace.listRef}
           />
         )}

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 
 import AccountMappingWarning from '@/components/accounting/AccountMappingWarning'
 import GenericListPage from '@/components/common/GenericListPage'
@@ -25,7 +25,6 @@ export const JournalEntriesPage: React.FC = () => {
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
 
   const location = useLocation()
-  const navigate = useNavigate()
 
   const filterConfig = useMemo<FilterBarConfig<JEFilters>>(
     () => ({
@@ -118,7 +117,6 @@ export const JournalEntriesPage: React.FC = () => {
         headerSlot={(
           <JournalEntryContextHeader
             selectedEntry={workspace.selectedEntry}
-            onNavigateToSource={(path) => navigate(path)}
           />
         )}
         workspaceSlot={<JournalEntryWorkspaceCard selectedEntry={workspace.selectedEntry} />}

--- a/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
@@ -85,7 +85,7 @@ describe('JournalEntriesPage', () => {
     render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
     fireEvent.click(screen.getAllByText('JE-001')[0])
     await waitFor(() => {
-      expect(screen.getAllByText('JE-001').length).toBeGreaterThan(1)
+      expect(screen.getByText('Journal Entry Details - JE-001')).toBeInTheDocument()
     })
     expect(mockNavigate).not.toHaveBeenCalled()
   })

--- a/frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesTable.test.tsx
@@ -5,15 +5,6 @@ import { createRef } from 'react'
 import { JournalEntriesTable } from './JournalEntriesTable'
 import { JournalEntryStatus } from '@/types'
 
-vi.mock('@/utils/formatters', () => ({
-  formatCurrency: (value: number) => `$${value}`,
-  formatDate: (date: string) => date,
-}))
-
-vi.mock('@/components/common/EntityStatusChip', () => ({
-  EntityStatusChip: ({ status }: any) => <span>{status}</span>,
-}))
-
 const makeEntry = (overrides = {}) => ({
   id: '1',
   referenceNumber: 'JE-001',
@@ -39,7 +30,6 @@ describe('JournalEntriesTable', () => {
     selectedEntryId: null,
     focusedIndex: -1,
     onSelect: vi.fn(),
-    onViewSource: vi.fn(),
     listRef,
   }
 
@@ -48,7 +38,7 @@ describe('JournalEntriesTable', () => {
     expect(screen.getByText(/No Journal Entries found/i)).toBeInTheDocument()
   })
 
-  it('renders entry rows', () => {
+  it('renders entry reference number', () => {
     render(<JournalEntriesTable {...defaultProps} entries={[makeEntry()]} total={1} />)
     expect(screen.getByText('JE-001')).toBeInTheDocument()
   })
@@ -65,29 +55,10 @@ describe('JournalEntriesTable', () => {
     expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
   })
 
-  it('does not render Post or Delete action buttons', () => {
-    render(<JournalEntriesTable {...defaultProps} entries={[makeEntry()]} total={1} />)
-    expect(screen.queryByText('Post')).not.toBeInTheDocument()
-    expect(screen.queryByText('Delete')).not.toBeInTheDocument()
-  })
-
-  it('shows View Source link for non-manual entries with a sourceId', () => {
-    const onViewSource = vi.fn()
-    render(
-      <JournalEntriesTable
-        {...defaultProps}
-        entries={[makeEntry({ sourceType: 'sales_order', sourceId: 'so-1' })]}
-        total={1}
-        onViewSource={onViewSource}
-      />,
-    )
-    const link = screen.getByText('View Source')
-    fireEvent.click(link)
-    expect(onViewSource).toHaveBeenCalledWith('sales_order', 'so-1')
-  })
-
-  it('does not show View Source link for manual entries', () => {
-    render(<JournalEntriesTable {...defaultProps} entries={[makeEntry({ sourceType: 'manual' })]} total={1} />)
+  it('does not render source link, type chip, debits, credits, or status columns', () => {
+    render(<JournalEntriesTable {...defaultProps} entries={[makeEntry({ sourceType: 'sales_order', sourceId: 'so-1' })]} total={1} />)
     expect(screen.queryByText('View Source')).not.toBeInTheDocument()
+    expect(screen.queryByText('Sales Order')).not.toBeInTheDocument()
+    expect(screen.queryByText('$100')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntriesTable.tsx
@@ -1,24 +1,11 @@
 import React from 'react'
-import { Chip, Link, Typography } from '@mui/material'
 
 import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
-import { EntityStatusChip } from '@/components/common/EntityStatusChip'
 import { JournalEntry } from '@/types'
-import { formatCurrency, formatDate } from '@/utils/formatters'
 
-const ENTRY_TYPE_LABELS: Record<string, string> = {
-  manual: 'Manual Entry',
-  sales_order: 'Sales Order',
-  payment: 'Customer Payment',
-  settlement: 'Settlement',
-  goods_received_note: 'Goods Receipt',
-  vendor_payment: 'Vendor Payment',
-  stock_adjustment: 'Stock Adjustment',
-  owner_equity_transaction: 'Owner Equity',
-  expense: 'Expense',
-  opening_balance: 'Opening Balance',
-  fund_transfer: 'Fund Transfer',
-}
+const COLUMNS: ColumnConfig<JournalEntry>[] = [
+  { key: 'reference', render: (entry) => entry.referenceNumber },
+]
 
 interface Props {
   entries: JournalEntry[]
@@ -27,7 +14,6 @@ interface Props {
   selectedEntryId: string | null
   focusedIndex: number
   onSelect: (entry: JournalEntry) => void
-  onViewSource: (sourceType: string, sourceId: string) => void
   listRef: React.RefObject<HTMLDivElement | null>
 }
 
@@ -38,89 +24,12 @@ export function JournalEntriesTable({
   selectedEntryId,
   focusedIndex,
   onSelect,
-  onViewSource,
   listRef,
 }: Props) {
-  const columns: ColumnConfig<JournalEntry>[] = [
-    {
-      key: 'reference',
-      width: 120,
-      render: (entry) => (
-        <Typography variant="body2" sx={{ fontWeight: 500, color: 'primary.main', fontSize: '0.8rem' }}>
-          {entry.referenceNumber}
-        </Typography>
-      ),
-      raw: true,
-    },
-    {
-      key: 'date',
-      width: 90,
-      render: (entry) => formatDate(entry.entryDate),
-    },
-    {
-      key: 'description',
-      render: (entry) => (
-        <Typography variant="body2" sx={{ maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: '0.8rem' }}>
-          {entry.description}
-        </Typography>
-      ),
-      raw: true,
-    },
-    {
-      key: 'type',
-      width: 120,
-      render: (entry) => (
-        <Chip label={ENTRY_TYPE_LABELS[entry.sourceType ?? ''] ?? 'Manual Entry'} size="small" />
-      ),
-      raw: true,
-    },
-    {
-      key: 'source',
-      width: 120,
-      render: (entry) =>
-        entry.sourceType && entry.sourceType !== 'manual' && entry.sourceId ? (
-          <Link
-            component="button"
-            variant="body2"
-            onClick={(e) => { e.stopPropagation(); onViewSource(entry.sourceType!, entry.sourceId!) }}
-          >
-            View Source
-          </Link>
-        ) : null,
-      raw: true,
-    },
-    {
-      key: 'debits',
-      width: 90,
-      render: (entry) => (
-        <Typography variant="body2" sx={{ textAlign: 'right', fontSize: '0.8rem' }}>
-          {formatCurrency(entry.totalDebits)}
-        </Typography>
-      ),
-      raw: true,
-    },
-    {
-      key: 'credits',
-      width: 90,
-      render: (entry) => (
-        <Typography variant="body2" sx={{ textAlign: 'right', fontSize: '0.8rem' }}>
-          {formatCurrency(entry.totalCredits)}
-        </Typography>
-      ),
-      raw: true,
-    },
-    {
-      key: 'status',
-      width: 90,
-      render: (entry) => <EntityStatusChip status={entry.status} />,
-      raw: true,
-    },
-  ]
-
   return (
     <EntityTable
       rows={entries}
-      columns={columns}
+      columns={COLUMNS}
       loading={loading}
       total={total}
       label="Journal Entries"

--- a/frontend/src/pages/accounting/components/JournalEntryContextHeader.test.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntryContextHeader.test.tsx
@@ -1,9 +1,16 @@
 import { describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 
 import { JournalEntryContextHeader } from './JournalEntryContextHeader'
 import { JournalEntryStatus } from '@/types'
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('react-router-dom')>()
+  return { ...mod, useNavigate: () => mockNavigate }
+})
 
 vi.mock('@/utils/formatters', () => ({
   formatCurrency: (value: number) => `$${value}`,
@@ -66,11 +73,22 @@ describe('JournalEntryContextHeader', () => {
     expect(screen.getByText('References & Amounts')).toBeInTheDocument()
   })
 
-  it('renders date, description, entry type in left column', () => {
+  it('renders date and description in left column', () => {
     renderHeader(makeEntry())
     expect(screen.getByText('2026-01-01')).toBeInTheDocument()
     expect(screen.getByText('Test entry')).toBeInTheDocument()
-    expect(screen.getByText('Manual Entry')).toBeInTheDocument()
+  })
+
+  it('renders Entry Type row in left column', () => {
+    renderHeader(makeEntry({ sourceType: 'sales_order' }))
+    expect(screen.getByText('Entry Type')).toBeInTheDocument()
+    expect(screen.getAllByText('Sales Order').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders Manual Entry in Entry Type row for manual entries', () => {
+    renderHeader(makeEntry())
+    expect(screen.getByText('Entry Type')).toBeInTheDocument()
+    expect(screen.getAllByText('Manual Entry').length).toBeGreaterThanOrEqual(1)
   })
 
   it('renders debits and credits in right column', () => {
@@ -85,7 +103,7 @@ describe('JournalEntryContextHeader', () => {
 
   it('renders entry type chip in header bar', () => {
     renderHeader(makeEntry({ sourceType: 'sales_order' }))
-    expect(screen.getByText('Sales Order')).toBeInTheDocument()
+    expect(screen.getAllByText('Sales Order').length).toBeGreaterThanOrEqual(1)
   })
 
   it('does not render source row for manual entries', () => {
@@ -105,6 +123,15 @@ describe('JournalEntryContextHeader', () => {
     expect(screen.getByText('SO-0042')).toBeInTheDocument()
     const btn = container.querySelector('button')
     expect(btn).toBeTruthy()
+  })
+
+  it('navigates to source on button click', () => {
+    mockNavigate.mockClear()
+    renderHeader(
+      makeEntry({ sourceType: 'purchase_order', sourceId: 'po-1', sourceRefNumber: 'PO-0007' }),
+    )
+    fireEvent.click(screen.getByText('PO-0007'))
+    expect(mockNavigate).toHaveBeenCalledWith('/purchasing/orders?highlight=po-1')
   })
 
   it('does not render Edit, Post, Delete, or Reverse buttons', () => {

--- a/frontend/src/pages/accounting/components/JournalEntryContextHeader.test.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntryContextHeader.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 
 import { JournalEntryContextHeader } from './JournalEntryContextHeader'
 import { JournalEntryStatus } from '@/types'
@@ -32,68 +33,85 @@ const makeEntry = (overrides = {}) => ({
   totalCredits: 500,
   sourceType: 'manual',
   sourceId: null,
+  sourceRefNumber: undefined,
   lines: [],
   ...overrides,
 })
 
+const renderHeader = (entry: any) =>
+  render(
+    <MemoryRouter>
+      <JournalEntryContextHeader selectedEntry={entry} />
+    </MemoryRouter>,
+  )
+
 describe('JournalEntryContextHeader', () => {
   it('renders empty state when no entry is selected', () => {
-    render(<JournalEntryContextHeader selectedEntry={null} onNavigateToSource={vi.fn()} />)
+    renderHeader(null)
     expect(screen.getByText(/select a journal entry/i)).toBeInTheDocument()
   })
 
-  it('renders reference number, date, description, debits, credits', () => {
-    render(<JournalEntryContextHeader selectedEntry={makeEntry()} onNavigateToSource={vi.fn()} />)
-    expect(screen.getByText('JE-001')).toBeInTheDocument()
+  it('renders title with reference number', () => {
+    renderHeader(makeEntry())
+    expect(screen.getByText('Journal Entry Details - JE-001')).toBeInTheDocument()
+  })
+
+  it('renders left column section title', () => {
+    renderHeader(makeEntry())
+    expect(screen.getByText('Entry Information')).toBeInTheDocument()
+  })
+
+  it('renders right column section title', () => {
+    renderHeader(makeEntry())
+    expect(screen.getByText('References & Amounts')).toBeInTheDocument()
+  })
+
+  it('renders date, description, entry type in left column', () => {
+    renderHeader(makeEntry())
     expect(screen.getByText('2026-01-01')).toBeInTheDocument()
     expect(screen.getByText('Test entry')).toBeInTheDocument()
+    expect(screen.getByText('Manual Entry')).toBeInTheDocument()
+  })
+
+  it('renders debits and credits in right column', () => {
+    renderHeader(makeEntry())
     expect(screen.getAllByText('$500').length).toBe(2)
   })
 
   it('renders status chip', () => {
-    render(<JournalEntryContextHeader selectedEntry={makeEntry()} onNavigateToSource={vi.fn()} />)
+    renderHeader(makeEntry())
     expect(screen.getByText(JournalEntryStatus.POSTED)).toBeInTheDocument()
   })
 
+  it('renders entry type chip in header bar', () => {
+    renderHeader(makeEntry({ sourceType: 'sales_order' }))
+    expect(screen.getByText('Sales Order')).toBeInTheDocument()
+  })
+
+  it('does not render source row for manual entries', () => {
+    renderHeader(makeEntry({ sourceType: 'manual', sourceId: null }))
+    expect(screen.queryByText('Source')).not.toBeInTheDocument()
+  })
+
+  it('does not render source row when sourceId is missing', () => {
+    renderHeader(makeEntry({ sourceType: 'sales_order', sourceId: null }))
+    expect(screen.queryByText('Source')).not.toBeInTheDocument()
+  })
+
+  it('renders clickable sourceRefNumber when present', () => {
+    const { container } = renderHeader(
+      makeEntry({ sourceType: 'sales_order', sourceId: 'so-1', sourceRefNumber: 'SO-0042' }),
+    )
+    expect(screen.getByText('SO-0042')).toBeInTheDocument()
+    const btn = container.querySelector('button')
+    expect(btn).toBeTruthy()
+  })
+
   it('does not render Edit, Post, Delete, or Reverse buttons', () => {
-    render(<JournalEntryContextHeader selectedEntry={makeEntry()} onNavigateToSource={vi.fn()} />)
+    renderHeader(makeEntry())
     expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument()
     expect(screen.queryByText(/^post$/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/delete/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/reverse/i)).not.toBeInTheDocument()
-  })
-
-  it('does not render source link for manual entries', () => {
-    render(<JournalEntryContextHeader selectedEntry={makeEntry({ sourceType: 'manual', sourceId: null })} onNavigateToSource={vi.fn()} />)
-    expect(screen.queryByText(/view/i)).not.toBeInTheDocument()
-  })
-
-  it('does not render source link when sourceId is missing', () => {
-    render(<JournalEntryContextHeader selectedEntry={makeEntry({ sourceType: 'sales_order', sourceId: null })} onNavigateToSource={vi.fn()} />)
-    expect(screen.queryByText(/view sales order/i)).not.toBeInTheDocument()
-  })
-
-  it('renders source link when sourceType and sourceId are present', () => {
-    const onNavigateToSource = vi.fn()
-    render(
-      <JournalEntryContextHeader
-        selectedEntry={makeEntry({ sourceType: 'sales_order', sourceId: 'so-1' })}
-        onNavigateToSource={onNavigateToSource}
-      />,
-    )
-    const link = screen.getByText(/view sales order/i)
-    expect(link).toBeInTheDocument()
-    fireEvent.click(link)
-    expect(onNavigateToSource).toHaveBeenCalledWith('/sales/orders?highlight=so-1')
-  })
-
-  it('does not render source link for sourceType not in SOURCE_ROUTES', () => {
-    render(
-      <JournalEntryContextHeader
-        selectedEntry={makeEntry({ sourceType: 'settlement', sourceId: 'x-1' })}
-        onNavigateToSource={vi.fn()}
-      />,
-    )
-    expect(screen.queryByText(/view/i)).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx
@@ -1,5 +1,6 @@
-import { Link, Paper, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
-import { Chip, Stack } from '@mui/material'
+import { Chip, Paper, Stack, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material'
+import Grid from '@mui/material/Grid'
+import { useNavigate } from 'react-router-dom'
 
 import { EntityContextHeaderBar } from '@/components/common/EntityContextHeaderBar'
 import { EntityStatusChip } from '@/components/common/EntityStatusChip'
@@ -32,15 +33,40 @@ const SOURCE_ROUTES: Record<string, (id: string) => string> = {
   stock_adjustment: (id) => `/inventory/stock-adjustments/${id}/edit`,
 }
 
-const labelSx = { fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem', width: 120, border: 'none', py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px }
-const valueSx = { fontSize: '0.8rem', border: 'none', py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px }
+const detailTableSx = {
+  tableLayout: 'fixed',
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const labelCellSx = {
+  fontWeight: 600,
+  color: 'text.secondary',
+  fontSize: '0.8rem',
+}
+
+const valueCellSx = {
+  fontSize: '0.8rem',
+}
+
+const sectionHeaderCellSx = {
+  pb: TABLE_STYLES.cell.padding.py * 0.67,
+  py: TABLE_STYLES.cell.padding.py * 0.67,
+  borderTop: TABLE_STYLES.cell.border,
+}
 
 interface Props {
   selectedEntry: JournalEntry | null
-  onNavigateToSource: (path: string) => void
 }
 
-export function JournalEntryContextHeader({ selectedEntry, onNavigateToSource }: Props) {
+export function JournalEntryContextHeader({ selectedEntry }: Props) {
+  const navigate = useNavigate()
+
   if (!selectedEntry) {
     return (
       <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
@@ -51,10 +77,21 @@ export function JournalEntryContextHeader({ selectedEntry, onNavigateToSource }:
     )
   }
 
+  const hasSource =
+    !!selectedEntry.sourceType &&
+    selectedEntry.sourceType !== 'manual' &&
+    !!selectedEntry.sourceId
+
+  const handleNavigateToSource = () => {
+    if (!hasSource) return
+    const route = SOURCE_ROUTES[selectedEntry.sourceType!]
+    if (route) navigate(route(selectedEntry.sourceId!))
+  }
+
   return (
     <Paper sx={{ overflow: 'hidden' }}>
       <EntityContextHeaderBar
-        title={selectedEntry.referenceNumber}
+        title={`Journal Entry Details - ${selectedEntry.referenceNumber}`}
         statusChip={(
           <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
             <EntityStatusChip status={selectedEntry.status} />
@@ -68,36 +105,83 @@ export function JournalEntryContextHeader({ selectedEntry, onNavigateToSource }:
           </Stack>
         )}
       />
-      <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': { border: 'none', py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px } }}>
-        <TableBody>
-          <TableRow>
-            <TableCell sx={labelSx}>Date</TableCell>
-            <TableCell sx={valueSx}>{formatDate(selectedEntry.entryDate)}</TableCell>
-            <TableCell sx={labelSx}>Debits</TableCell>
-            <TableCell sx={{ ...valueSx, textAlign: 'right' }}>{formatCurrency(selectedEntry.totalDebits)}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell sx={labelSx}>Description</TableCell>
-            <TableCell sx={valueSx}>{selectedEntry.description}</TableCell>
-            <TableCell sx={labelSx}>Credits</TableCell>
-            <TableCell sx={{ ...valueSx, textAlign: 'right' }}>{formatCurrency(selectedEntry.totalCredits)}</TableCell>
-          </TableRow>
-          {selectedEntry.sourceType && selectedEntry.sourceId && SOURCE_ROUTES[selectedEntry.sourceType] && (
-            <TableRow>
-              <TableCell sx={labelSx}>Source</TableCell>
-              <TableCell colSpan={3} sx={valueSx}>
-                <Link
-                  component="button"
-                  variant="body2"
-                  onClick={() => onNavigateToSource(SOURCE_ROUTES[selectedEntry.sourceType!]!(selectedEntry.sourceId!))}
-                >
-                  View {ENTRY_TYPE_LABELS[selectedEntry.sourceType] ?? selectedEntry.sourceType}
-                </Link>
-              </TableCell>
-            </TableRow>
-          )}
-        </TableBody>
-      </Table>
+      <Grid container spacing={3} sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <TableContainer>
+            <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+              <TableBody>
+                <TableRow>
+                  <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+                    <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                      Entry Information
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+                <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                  <TableCell sx={labelCellSx}>Date</TableCell>
+                  <TableCell sx={valueCellSx}>{formatDate(selectedEntry.entryDate)}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell sx={labelCellSx}>Description</TableCell>
+                  <TableCell sx={valueCellSx}>{selectedEntry.description}</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Grid>
+
+        <Grid size={{ xs: 12, md: 6 }}>
+          <TableContainer>
+            <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+              <TableBody>
+                <TableRow>
+                  <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+                    <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                      References & Amounts
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+                {hasSource && (
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Source</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {selectedEntry.sourceRefNumber ? (
+                        <Typography
+                          component="button"
+                          onClick={handleNavigateToSource}
+                          sx={{
+                            fontSize: '0.8rem',
+                            color: 'primary.main',
+                            cursor: 'pointer',
+                            textDecoration: 'none',
+                            border: 'none',
+                            background: 'none',
+                            padding: 0,
+                          }}
+                        >
+                          {selectedEntry.sourceRefNumber}
+                        </Typography>
+                      ) : (
+                        <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}>
+                          -
+                        </Typography>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                )}
+                <TableRow sx={hasSource ? {} : { backgroundColor: 'grey.50' }}>
+                  <TableCell sx={labelCellSx}>Debits</TableCell>
+                  <TableCell sx={valueCellSx}>{formatCurrency(selectedEntry.totalDebits)}</TableCell>
+                </TableRow>
+                <TableRow sx={hasSource ? { backgroundColor: 'grey.50' } : {}}>
+                  <TableCell sx={labelCellSx}>Credits</TableCell>
+                  <TableCell sx={valueCellSx}>{formatCurrency(selectedEntry.totalCredits)}</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Grid>
+      </Grid>
     </Paper>
   )
 }

--- a/frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntryContextHeader.tsx
@@ -24,6 +24,7 @@ const ENTRY_TYPE_LABELS: Record<string, string> = {
 
 const SOURCE_ROUTES: Record<string, (id: string) => string> = {
   sales_order: (id) => `/sales/orders?highlight=${id}`,
+  purchase_order: (id) => `/purchasing/orders?highlight=${id}`,
   payment: (id) => `/sales/payments?highlight=${id}`,
   goods_received_note: (id) => `/purchasing/goods-received?grnId=${id}`,
   vendor_payment: (id) => `/purchasing/vendor-payments?vpId=${id}`,
@@ -125,6 +126,12 @@ export function JournalEntryContextHeader({ selectedEntry }: Props) {
                   <TableCell sx={labelCellSx}>Description</TableCell>
                   <TableCell sx={valueCellSx}>{selectedEntry.description}</TableCell>
                 </TableRow>
+                <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                  <TableCell sx={labelCellSx}>Entry Type</TableCell>
+                  <TableCell sx={valueCellSx}>
+                    {ENTRY_TYPE_LABELS[selectedEntry.sourceType ?? ''] ?? 'Manual Entry'}
+                  </TableCell>
+                </TableRow>
               </TableBody>
             </Table>
           </TableContainer>
@@ -163,7 +170,7 @@ export function JournalEntryContextHeader({ selectedEntry }: Props) {
                         </Typography>
                       ) : (
                         <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}>
-                          -
+                          —
                         </Typography>
                       )}
                     </TableCell>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -729,6 +729,7 @@ export interface JournalEntry {
   reversedBy?: JournalEntry;
   sourceType?: string;
   sourceId?: string;
+  sourceRefNumber?: string;
   isDraft: boolean;
   isPosted: boolean;
   isReversed: boolean;


### PR DESCRIPTION
## Summary
- Reduces `JournalEntriesTable` to a single reference-number column, matching the PO/SO table pattern
- Rewrites `JournalEntryContextHeader` with a two-column `Grid` layout (Entry Information | References & Amounts) matching `PurchaseOrderContextHeader` / `OrderContextHeader`
- Adds `sourceRefNumber` to the backend JE response so the source document (SO, PO, GRN, etc.) is displayed as a clickable link in the context header

## Test Plan
- [x] Backend: `npx jest src/modules/accounting/services/journal-entry.service.spec.ts --no-coverage` — 41/41 pass
- [x] Frontend: `npx vitest run src/pages/accounting/` — 112/112 pass
- [x] `npm run type-check` passes

Closes #466