### PR TITLE
fix(accounting): JE source reference, multi-ref display, and filter reset (#468)

### DIFF
--- a/backend/src/modules/accounting/accounting.module.ts
+++ b/backend/src/modules/accounting/accounting.module.ts
@@ -20,6 +20,7 @@ import { PurchaseOrder } from '../../database/entities/purchase-order.entity';
 import { GoodsReceivedNote } from '../../database/entities/goods-received-note.entity';
 import { VendorPayment } from '../../database/entities/vendor-payment.entity';
 import { StockAdjustment } from '../../database/entities/stock-adjustment.entity';
+import { Invoice } from '../../database/entities/invoice.entity';
 
 // Services
 import { AccountingService } from './services/accounting.service';
@@ -71,6 +72,7 @@ import { AuditLogsModule } from '../audit-logs/audit-logs.module';
       GoodsReceivedNote,
       VendorPayment,
       StockAdjustment,
+      Invoice,
     ]),
     SettingsModule,
     AuditLogsModule,

--- a/backend/src/modules/accounting/dto/journal-entry.dto.ts
+++ b/backend/src/modules/accounting/dto/journal-entry.dto.ts
@@ -278,6 +278,11 @@ export class QueryJournalEntriesDto {
   @IsString()
   sortBy?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by comma-separated entry UUIDs' })
+  @IsOptional()
+  @IsString()
+  ids?: string;
+
   @ApiPropertyOptional({ description: 'Sort direction', enum: ['ASC', 'DESC'] })
   @IsOptional()
   @IsString()

--- a/backend/src/modules/accounting/dto/journal-entry.dto.ts
+++ b/backend/src/modules/accounting/dto/journal-entry.dto.ts
@@ -13,6 +13,7 @@ import {
   IsDecimal,
   IsDateString,
   ArrayMinSize,
+  Matches,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional, OmitType, PartialType } from '@nestjs/swagger';
@@ -280,7 +281,7 @@ export class QueryJournalEntriesDto {
 
   @ApiPropertyOptional({ description: 'Filter by comma-separated entry UUIDs' })
   @IsOptional()
-  @IsString()
+  @Matches(/^[0-9a-f-]+(,[0-9a-f-]+)*$/i, { message: 'ids must be a comma-separated list of UUIDs' })
   ids?: string;
 
   @ApiPropertyOptional({ description: 'Sort direction', enum: ['ASC', 'DESC'] })

--- a/backend/src/modules/accounting/services/journal-entry.service.spec.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.spec.ts
@@ -475,6 +475,48 @@ describe('JournalEntryService', () => {
         status: JournalEntryStatus.POSTED,
       });
     });
+
+    it('filters by comma-separated ids when ids param is provided', async () => {
+      const andWhereMock = jest.fn().mockReturnThis();
+      const queryBuilder = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: andWhereMock,
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      };
+      journalEntryRepository.createQueryBuilder.mockReturnValue(queryBuilder as any);
+
+      await service.findAll({ ids: 'entry-1,entry-2' });
+
+      expect(andWhereMock).toHaveBeenCalledWith(
+        'entry.id IN (:...idList)',
+        { idList: ['entry-1', 'entry-2'] },
+      );
+    });
+
+    it('does not apply ids filter when ids param is absent', async () => {
+      const andWhereMock = jest.fn().mockReturnThis();
+      const queryBuilder = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: andWhereMock,
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      };
+      journalEntryRepository.createQueryBuilder.mockReturnValue(queryBuilder as any);
+
+      await service.findAll({});
+
+      const calls = andWhereMock.mock.calls.map((c: any[]) => c[0] as string);
+      expect(calls.some((c) => c.includes('id IN'))).toBe(false);
+    });
   });
 
   describe('searchGlobal', () => {

--- a/backend/src/modules/accounting/services/journal-entry.service.spec.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.spec.ts
@@ -33,6 +33,7 @@ import { Expense } from '../../../database/entities/expense.entity';
 import { OwnerEquityTransaction } from '../../../database/entities/owner-equity-transaction.entity';
 import { FundTransfer } from '../../../database/entities/fund-transfer.entity';
 import { StockAdjustment } from '../../../database/entities/stock-adjustment.entity';
+import { Invoice } from '../../../database/entities/invoice.entity';
 import {
   CreateJournalEntryDto,
   UpdateJournalEntryDto,
@@ -58,6 +59,7 @@ describe('JournalEntryService', () => {
   let mockOwnerEquityTransactionRepo: { findOne: jest.Mock };
   let mockFundTransferRepo: { findOne: jest.Mock };
   let mockStockAdjustmentRepo: { findOne: jest.Mock };
+  let mockInvoiceRepo: { findOne: jest.Mock };
 
   // Test data
   const mockFiscalPeriod: Partial<FiscalPeriod> = {
@@ -138,6 +140,7 @@ describe('JournalEntryService', () => {
     mockOwnerEquityTransactionRepo = { findOne: jest.fn() };
     mockFundTransferRepo = { findOne: jest.fn() };
     mockStockAdjustmentRepo = { findOne: jest.fn() };
+    mockInvoiceRepo = { findOne: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -189,6 +192,7 @@ describe('JournalEntryService', () => {
         },
         { provide: getRepositoryToken(FundTransfer), useValue: mockFundTransferRepo },
         { provide: getRepositoryToken(StockAdjustment), useValue: mockStockAdjustmentRepo },
+        { provide: getRepositoryToken(Invoice), useValue: mockInvoiceRepo },
         {
           provide: ChartOfAccountsService,
           useValue: {
@@ -584,6 +588,40 @@ describe('JournalEntryService', () => {
 
       const result = await service.findOne('entry-1');
 
+      expect(result.sourceRefNumber).toBeUndefined();
+    });
+  });
+
+  describe('resolveSourceRefNumber for invoice', () => {
+    it('returns invoiceNumber when sourceType is invoice', async () => {
+      const mockEntry = {
+        ...mockJournalEntry,
+        sourceType: 'invoice',
+        sourceId: 'invoice-1',
+        lines: [mockJournalEntryLine1, mockJournalEntryLine2],
+      };
+      journalEntryRepository.findOne.mockResolvedValue(mockEntry as JournalEntry);
+      mockInvoiceRepo.findOne.mockResolvedValue({ invoiceNumber: 'INV-0042' });
+
+      const result = await service.findOne('entry-1');
+      expect(result.sourceRefNumber).toBe('INV-0042');
+      expect(mockInvoiceRepo.findOne).toHaveBeenCalledWith({
+        where: { id: 'invoice-1' },
+        select: ['invoiceNumber'],
+      });
+    });
+
+    it('returns undefined when invoice not found', async () => {
+      const mockEntry = {
+        ...mockJournalEntry,
+        sourceType: 'invoice',
+        sourceId: 'invoice-missing',
+        lines: [mockJournalEntryLine1, mockJournalEntryLine2],
+      };
+      journalEntryRepository.findOne.mockResolvedValue(mockEntry as JournalEntry);
+      mockInvoiceRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.findOne('entry-1');
       expect(result.sourceRefNumber).toBeUndefined();
     });
   });

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -180,6 +180,7 @@ export class JournalEntryService {
       endDate,
       sortBy = 'entryDate',
       sortOrder = 'ASC',
+      ids,
     } = query;
 
     const queryBuilder = this.journalEntryRepository
@@ -205,12 +206,19 @@ export class JournalEntryService {
       queryBuilder.andWhere('entry.fiscalPeriodId = :fiscalPeriodId', { fiscalPeriodId });
     }
 
-    if (sourceType) {
-      queryBuilder.andWhere('entry.sourceType = :sourceType', { sourceType });
-    }
+    if (ids) {
+      const idList = ids.split(',').map((s) => s.trim()).filter(Boolean);
+      if (idList.length > 0) {
+        queryBuilder.andWhere('entry.id IN (:...idList)', { idList });
+      }
+    } else {
+      if (sourceType) {
+        queryBuilder.andWhere('entry.sourceType = :sourceType', { sourceType });
+      }
 
-    if (sourceId) {
-      queryBuilder.andWhere('entry.sourceId = :sourceId', { sourceId });
+      if (sourceId) {
+        queryBuilder.andWhere('entry.sourceId = :sourceId', { sourceId });
+      }
     }
 
     if (startDate && endDate) {

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -23,6 +23,7 @@ import { Expense } from '../../../database/entities/expense.entity';
 import { OwnerEquityTransaction } from '../../../database/entities/owner-equity-transaction.entity';
 import { FundTransfer } from '../../../database/entities/fund-transfer.entity';
 import { StockAdjustment } from '../../../database/entities/stock-adjustment.entity';
+import { Invoice } from '../../../database/entities/invoice.entity';
 import {
   CreateJournalEntryDto,
   UpdateJournalEntryDto,
@@ -80,6 +81,8 @@ export class JournalEntryService {
     private readonly fundTransferRepository: Repository<FundTransfer>,
     @InjectRepository(StockAdjustment)
     private readonly stockAdjustmentRepository: Repository<StockAdjustment>,
+    @InjectRepository(Invoice)
+    private readonly invoiceRepository: Repository<Invoice>,
     private readonly chartOfAccountsService: ChartOfAccountsService,
     private readonly fiscalPeriodService: FiscalPeriodService,
     private readonly settingsService: SettingsService,

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -914,6 +914,13 @@ export class JournalEntryService {
           });
           return record?.adjustmentNumber;
         }
+        case 'invoice': {
+          const record = await this.invoiceRepository.findOne({
+            where: { id: sourceId },
+            select: ['invoiceNumber'],
+          });
+          return record?.invoiceNumber;
+        }
         // settlement: no dedicated list page, source navigation not supported
         // opening_balance: synthetic entry with no source entity UUID
         default:

--- a/frontend/src/components/common/EntityContextHeaderBar.tsx
+++ b/frontend/src/components/common/EntityContextHeaderBar.tsx
@@ -12,7 +12,9 @@ interface EntityContextHeaderBarProps {
   actions?: ReactNode
   journalEntryRef?: JournalEntryRef | null
   journalEntryRefs?: JournalEntryRef[]
+  /** Loading state for either the single-ref or multi-ref path */
   journalEntryRefLoading?: boolean
+  journalEntryRefsLoading?: boolean
   onNavigateToJournalEntry?: () => void
 }
 
@@ -23,8 +25,11 @@ export function EntityContextHeaderBar({
   journalEntryRef,
   journalEntryRefs,
   journalEntryRefLoading,
+  journalEntryRefsLoading,
   onNavigateToJournalEntry,
 }: EntityContextHeaderBarProps) {
+  const isLoading = journalEntryRefsLoading ?? journalEntryRefLoading ?? false
+
   const activeRefs = journalEntryRefs && journalEntryRefs.length > 0
     ? journalEntryRefs
     : journalEntryRef
@@ -63,7 +68,7 @@ export function EntityContextHeaderBar({
       </Box>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
         {actions}
-        {journalEntryRefLoading && activeRefs.length === 0 && (
+        {isLoading && activeRefs.length === 0 && (
           <CircularProgress size={16} sx={{ mx: 0.5 }} />
         )}
         {activeRefs.length > 0 && (

--- a/frontend/src/components/common/EntityContextHeaderBar.tsx
+++ b/frontend/src/components/common/EntityContextHeaderBar.tsx
@@ -11,6 +11,7 @@ interface EntityContextHeaderBarProps {
   statusChip?: ReactNode
   actions?: ReactNode
   journalEntryRef?: JournalEntryRef | null
+  journalEntryRefs?: JournalEntryRef[]
   journalEntryRefLoading?: boolean
   onNavigateToJournalEntry?: () => void
 }
@@ -20,9 +21,22 @@ export function EntityContextHeaderBar({
   statusChip,
   actions,
   journalEntryRef,
+  journalEntryRefs,
   journalEntryRefLoading,
   onNavigateToJournalEntry,
 }: EntityContextHeaderBarProps) {
+  const activeRefs = journalEntryRefs && journalEntryRefs.length > 0
+    ? journalEntryRefs
+    : journalEntryRef
+      ? [journalEntryRef]
+      : []
+
+  const tooltipTitle = activeRefs.length > 1
+    ? `Journal Entries: ${activeRefs.map((r) => r.referenceNumber).join(', ')}`
+    : activeRefs.length === 1
+      ? `Journal Entry: ${activeRefs[0].referenceNumber}`
+      : ''
+
   return (
     <Box
       sx={{
@@ -49,11 +63,11 @@ export function EntityContextHeaderBar({
       </Box>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
         {actions}
-        {journalEntryRefLoading && !journalEntryRef && (
+        {journalEntryRefLoading && activeRefs.length === 0 && (
           <CircularProgress size={16} sx={{ mx: 0.5 }} />
         )}
-        {journalEntryRef && (
-          <Tooltip title={`Journal Entry: ${journalEntryRef.referenceNumber}`}>
+        {activeRefs.length > 0 && (
+          <Tooltip title={tooltipTitle}>
             <IconButton size="small" onClick={onNavigateToJournalEntry}>
               <MenuBookIcon fontSize="small" />
             </IconButton>

--- a/frontend/src/hooks/useJournalEntryRefs.test.ts
+++ b/frontend/src/hooks/useJournalEntryRefs.test.ts
@@ -1,0 +1,100 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useJournalEntryRefs } from './useJournalEntryRefs'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}))
+
+const mockFetchJournalEntries = vi.fn()
+vi.mock('@/store/api/accountingApi', () => ({
+  useLazyGetJournalEntriesQuery: () => [mockFetchJournalEntries],
+}))
+
+function mockJournalEntriesResponse(data: Array<{ id: string; referenceNumber: string }>) {
+  return {
+    unwrap: () => Promise.resolve({ data }),
+  }
+}
+
+describe('useJournalEntryRefs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns empty array when no valid sources', async () => {
+    const { result } = renderHook(() =>
+      useJournalEntryRefs([{ sourceType: 'sales_order', sourceId: undefined }]),
+    )
+
+    expect(result.current.journalEntryRefs).toEqual([])
+    expect(result.current.journalEntryRefsLoading).toBe(false)
+  })
+
+  it('collects refs from all sources', async () => {
+    mockFetchJournalEntries
+      .mockReturnValueOnce(mockJournalEntriesResponse([{ id: 'je-1', referenceNumber: 'JE-001' }]))
+      .mockReturnValueOnce(mockJournalEntriesResponse([{ id: 'je-2', referenceNumber: 'JE-002' }]))
+
+    const { result } = renderHook(() =>
+      useJournalEntryRefs([
+        { sourceType: 'sales_order', sourceId: 'so-1' },
+        { sourceType: 'invoice', sourceId: 'inv-1' },
+      ]),
+    )
+
+    await waitFor(() => expect(result.current.journalEntryRefsLoading).toBe(false))
+    expect(result.current.journalEntryRefs).toHaveLength(2)
+    expect(result.current.journalEntryRefs[0].referenceNumber).toBe('JE-001')
+    expect(result.current.journalEntryRefs[1].referenceNumber).toBe('JE-002')
+  })
+
+  it('navigates with sourceType/sourceId when exactly one ref', async () => {
+    mockFetchJournalEntries.mockReturnValueOnce(
+      mockJournalEntriesResponse([{ id: 'je-1', referenceNumber: 'JE-001' }]),
+    )
+
+    const { result } = renderHook(() =>
+      useJournalEntryRefs([{ sourceType: 'sales_order', sourceId: 'so-1' }]),
+    )
+
+    await waitFor(() => expect(result.current.journalEntryRefsLoading).toBe(false))
+    result.current.navigateToJournalEntries()
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/accounting/journal-entries?sourceType=sales_order&sourceId=so-1',
+    )
+  })
+
+  it('navigates with ids param when multiple refs', async () => {
+    mockFetchJournalEntries
+      .mockReturnValueOnce(mockJournalEntriesResponse([{ id: 'je-1', referenceNumber: 'JE-001' }]))
+      .mockReturnValueOnce(mockJournalEntriesResponse([{ id: 'je-2', referenceNumber: 'JE-002' }]))
+
+    const { result } = renderHook(() =>
+      useJournalEntryRefs([
+        { sourceType: 'sales_order', sourceId: 'so-1' },
+        { sourceType: 'invoice', sourceId: 'inv-1' },
+      ]),
+    )
+
+    await waitFor(() => expect(result.current.journalEntryRefsLoading).toBe(false))
+    result.current.navigateToJournalEntries()
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/accounting/journal-entries?ids=je-1,je-2',
+    )
+  })
+
+  it('does not navigate when no refs', async () => {
+    mockFetchJournalEntries.mockReturnValueOnce(mockJournalEntriesResponse([]))
+
+    const { result } = renderHook(() =>
+      useJournalEntryRefs([{ sourceType: 'sales_order', sourceId: 'so-1' }]),
+    )
+
+    await waitFor(() => expect(result.current.journalEntryRefsLoading).toBe(false))
+    result.current.navigateToJournalEntries()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/hooks/useJournalEntryRefs.ts
+++ b/frontend/src/hooks/useJournalEntryRefs.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { useLazyGetJournalEntriesQuery } from '@/store/api/accountingApi'
+import type { JournalEntryRef } from './useJournalEntryRef'
+
+interface JournalEntryRefWithId extends JournalEntryRef {
+  id: string
+}
+
+export function useJournalEntryRefs(
+  sources: Array<{ sourceType: string; sourceId: string | undefined }>,
+): {
+  journalEntryRefs: JournalEntryRef[]
+  journalEntryRefsLoading: boolean
+  navigateToJournalEntries: () => void
+} {
+  const navigate = useNavigate()
+  const [fetchJournalEntries] = useLazyGetJournalEntriesQuery()
+  const [journalEntryRefs, setJournalEntryRefs] = useState<JournalEntryRefWithId[]>([])
+  const [journalEntryRefsLoading, setJournalEntryRefsLoading] = useState(false)
+
+  const validSources = sources.filter(
+    (s): s is { sourceType: string; sourceId: string } => Boolean(s.sourceId),
+  )
+
+  const sourcesKey = validSources.map((s) => `${s.sourceType}:${s.sourceId}`).join(',')
+
+  useEffect(() => {
+    if (validSources.length === 0) {
+      setJournalEntryRefs([])
+      setJournalEntryRefsLoading(false)
+      return
+    }
+
+    let cancelled = false
+    setJournalEntryRefsLoading(true)
+
+    ;(async () => {
+      try {
+        const collected: JournalEntryRefWithId[] = []
+        for (const source of validSources) {
+          const response = await fetchJournalEntries({
+            sourceType: source.sourceType,
+            sourceId: source.sourceId,
+          }).unwrap()
+
+          if (cancelled) return
+
+          const entries = response.data ?? []
+          for (const entry of entries) {
+            collected.push({
+              id: entry.id,
+              referenceNumber: entry.referenceNumber,
+              sourceType: source.sourceType,
+              sourceId: source.sourceId,
+            })
+          }
+        }
+        if (!cancelled) setJournalEntryRefs(collected)
+      } catch {
+        if (!cancelled) setJournalEntryRefs([])
+      } finally {
+        if (!cancelled) setJournalEntryRefsLoading(false)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchJournalEntries, sourcesKey])
+
+  const navigateToJournalEntries = useCallback(() => {
+    if (journalEntryRefs.length === 0) return
+    if (journalEntryRefs.length === 1) {
+      const ref = journalEntryRefs[0]
+      navigate(
+        `/accounting/journal-entries?sourceType=${ref.sourceType}&sourceId=${ref.sourceId}`,
+      )
+      return
+    }
+
+    const ids = journalEntryRefs.map((r) => r.id).join(',')
+    navigate(`/accounting/journal-entries?ids=${ids}`)
+  }, [journalEntryRefs, navigate])
+
+  return { journalEntryRefs, journalEntryRefsLoading, navigateToJournalEntries }
+}

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { useLocation } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import AccountMappingWarning from '@/components/accounting/AccountMappingWarning'
 import GenericListPage from '@/components/common/GenericListPage'
@@ -25,6 +25,7 @@ export const JournalEntriesPage: React.FC = () => {
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
 
   const location = useLocation()
+  const navigate = useNavigate()
 
   const filterConfig = useMemo<FilterBarConfig<JEFilters>>(
     () => ({
@@ -58,17 +59,20 @@ export const JournalEntriesPage: React.FC = () => {
   const urlParams = useMemo(() => new URLSearchParams(location.search), [location.search])
   const sourceTypeParam = urlParams.get('sourceType')
   const sourceIdParam = urlParams.get('sourceId')
+  const idsParam = urlParams.get('ids')
+  const hasUrlFilters = Boolean(sourceIdParam || idsParam)
 
   const queryArgs = useMemo(() => ({
     search: appliedFilters.search || undefined,
     status: appliedFilters.status ? appliedFilters.status.toUpperCase() : undefined,
     sourceType: sourceIdParam ? sourceTypeParam ?? undefined : appliedFilters.entryType || undefined,
     sourceId: sourceIdParam ?? undefined,
+    ids: idsParam ?? undefined,
     startDate: dateRange.fromDate,
     endDate: dateRange.toDate,
     sortBy,
     sortOrder: sortOrder.toUpperCase() as 'ASC' | 'DESC',
-  }), [appliedFilters, dateRange, sortBy, sortOrder, sourceTypeParam, sourceIdParam])
+  }), [appliedFilters, dateRange, sortBy, sortOrder, sourceTypeParam, sourceIdParam, idsParam])
 
   const { data, isLoading, refetch } = useGetJournalEntriesQuery(queryArgs)
   const entries = data?.data ?? []
@@ -76,15 +80,23 @@ export const JournalEntriesPage: React.FC = () => {
 
   const workspace = useJournalEntriesWorkspace({ entries, refetch })
 
+  const handleClearAll = useCallback(() => {
+    handlers.onClearAll()
+    if (hasUrlFilters) {
+      navigate('/accounting/journal-entries', { replace: true })
+    }
+  }, [handlers, hasUrlFilters, navigate])
+
   const filterHandlers = useMemo(() => ({
     ...handlers,
+    onClearAll: handleClearAll,
     onSearchChange: (value: string) => {
       handlers.onSearchChange(value)
       window.setTimeout(() => {
         workspace.searchInputRef.current?.focus()
       }, 0)
     },
-  }), [handlers, workspace])
+  }), [handlers, handleClearAll, workspace])
 
   const handleSort = useCallback((field: string) => {
     setSortOrder((prev) => (sortBy === field && prev === 'desc' ? 'asc' : 'desc'))
@@ -100,7 +112,7 @@ export const JournalEntriesPage: React.FC = () => {
         filterConfig={filterConfig}
         draftFilters={draftFilters}
         handlers={filterHandlers}
-        hasActiveFilters={hasActiveFilters}
+        hasActiveFilters={hasActiveFilters || hasUrlFilters}
         searchInputRef={workspace.searchInputRef}
         sort={{ field: 'createdAt', sortBy, sortOrder, onSort: handleSort }}
         listSlot={(

--- a/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
@@ -29,7 +29,7 @@ const mockedApi = vi.hoisted(() => ({
 }))
 
 const mockNavigate = vi.fn()
-const mockLocation = { search: '', pathname: '/accounting/journal-entries' }
+let mockLocation = { search: '', pathname: '/accounting/journal-entries' }
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom')
@@ -63,6 +63,7 @@ const mockEntry = {
 describe('JournalEntriesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockLocation = { search: '', pathname: '/accounting/journal-entries' }
     mockedApi.useGetJournalEntriesQuery.mockReturnValue({
       data: { data: [mockEntry], meta: { total: 1 } },
       isLoading: false,
@@ -99,5 +100,26 @@ describe('JournalEntriesPage', () => {
     render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
     expect(screen.queryByText(/post selected/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/delete selected/i)).not.toBeInTheDocument()
+  })
+
+  it('shows Reset button when ?sourceId= URL param is present', () => {
+    mockLocation = { search: '?sourceType=sales_order&sourceId=so-1', pathname: '/accounting/journal-entries' }
+    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    expect(screen.getByRole('button', { name: /reset/i })).toBeInTheDocument()
+  })
+
+  it('shows Reset button when ?ids= URL param is present', () => {
+    mockLocation = { search: '?ids=je-1,je-2', pathname: '/accounting/journal-entries' }
+    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    expect(screen.getByRole('button', { name: /reset/i })).toBeInTheDocument()
+  })
+
+  it('navigates to clean URL when Reset is clicked with URL params active', async () => {
+    mockLocation = { search: '?ids=je-1,je-2', pathname: '/accounting/journal-entries' }
+    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    fireEvent.click(screen.getByRole('button', { name: /reset/i }))
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/accounting/journal-entries', { replace: true })
+    })
   })
 })

--- a/frontend/src/pages/sales/InvoicesPage.tsx
+++ b/frontend/src/pages/sales/InvoicesPage.tsx
@@ -156,12 +156,12 @@ const InvoicesPage: React.FC = () => {
       headerSlot={(
         <InvoiceContextHeader
           selectedInvoice={selectedInvoice}
-          journalEntryRef={workspace.journalEntryRef}
-          journalEntryRefLoading={workspace.journalEntryRefLoading}
+          journalEntryRefs={workspace.journalEntryRefs}
+          journalEntryRefsLoading={workspace.journalEntryRefsLoading}
           onPrint={() => workspace.setPrintDialogOpen(true)}
           onNavigateToSalesOrder={workspace.handleSalesOrderClick}
           onNavigateToPayment={workspace.handleNavigateToPayment}
-          onNavigateToJournalEntry={workspace.navigateToJournalEntry}
+          onNavigateToJournalEntries={workspace.navigateToJournalEntries}
         />
       )}
       workspaceSlot={<InvoiceWorkspaceCard selectedInvoice={selectedInvoice} />}

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -158,14 +158,14 @@ export const OrdersPage: React.FC = () => {
         <OrderContextHeader
           selectedOrder={selectedOrder}
           isLoading={workspace.isLoading}
-          journalEntryRef={workspace.journalEntryRef}
-          journalEntryRefLoading={workspace.journalEntryRefLoading}
+          journalEntryRefs={workspace.journalEntryRefs}
+          journalEntryRefsLoading={workspace.journalEntryRefsLoading}
           onEditOrder={workspace.handleEditOrder}
           onDeleteOrder={() => selectedOrder && void workspace.handleOrderAction('delete', selectedOrder.id)}
           onPrintOrder={() => workspace.setPrintDialogOpen(true)}
           onNavigateToInvoice={workspace.handleNavigateToInvoice}
           onNavigateToPayment={workspace.handleNavigateToPayment}
-          onNavigateToJournalEntry={workspace.navigateToJournalEntry}
+          onNavigateToJournalEntries={workspace.navigateToJournalEntries}
           onRefundOrder={workspace.handleRefundOrder}
           onUnpayOrder={workspace.handleUnpayOrder}
           onOpenPaymentDialog={workspace.openPaymentDialog}

--- a/frontend/src/pages/sales/PaymentsPage.tsx
+++ b/frontend/src/pages/sales/PaymentsPage.tsx
@@ -147,8 +147,8 @@ const PaymentsPage: React.FC = () => {
       headerSlot={(
         <PaymentContextHeader
           selectedPayment={selectedPayment}
-          journalEntryRef={workspace.journalEntryRef}
-          journalEntryRefLoading={workspace.journalEntryRefLoading}
+          journalEntryRefs={workspace.journalEntryRefs}
+          journalEntryRefsLoading={workspace.journalEntryRefsLoading}
           onPrint={() => workspace.setPrintDialogOpen(true)}
           onOrderClick={workspace.handleOrderClick}
           onInvoiceClick={workspace.handleInvoiceClick}

--- a/frontend/src/pages/sales/components/InvoiceContextHeader.tsx
+++ b/frontend/src/pages/sales/components/InvoiceContextHeader.tsx
@@ -13,22 +13,23 @@ import {
 } from '@mui/material'
 import Grid from '@mui/material/Grid'
 
-import type { InvoiceJournalEntryRef, InvoiceListItem } from '../hooks/useInvoicesWorkspace'
+import type { InvoiceListItem } from '../hooks/useInvoicesWorkspace'
 
 import { AppButton } from '@/components/common/AppButton'
 import { EntityContextHeaderBar } from '@/components/common/EntityContextHeaderBar'
 import { EntityStatusChip } from '@/components/common/EntityStatusChip'
 import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { JournalEntryRef } from '@/hooks/useJournalEntryRef'
 import { formatCurrency, formatDate } from '@/utils/formatters'
 
 interface InvoiceContextHeaderProps {
   selectedInvoice: InvoiceListItem | null
-  journalEntryRef: InvoiceJournalEntryRef | null
-  journalEntryRefLoading: boolean
+  journalEntryRefs: JournalEntryRef[]
+  journalEntryRefsLoading: boolean
   onPrint: () => void
   onNavigateToSalesOrder: (salesOrderId: string, event: React.MouseEvent) => void
   onNavigateToPayment: (paymentId: string, event?: React.MouseEvent) => void
-  onNavigateToJournalEntry: () => void
+  onNavigateToJournalEntries: () => void
 }
 
 const detailTableSx = {
@@ -65,12 +66,12 @@ const linkButtonSx = {
 
 const InvoiceContextHeader: React.FC<InvoiceContextHeaderProps> = ({
   selectedInvoice,
-  journalEntryRef,
-  journalEntryRefLoading,
+  journalEntryRefs,
+  journalEntryRefsLoading,
   onPrint,
   onNavigateToSalesOrder,
   onNavigateToPayment,
-  onNavigateToJournalEntry,
+  onNavigateToJournalEntries,
 }) => {
   if (!selectedInvoice) {
     return (
@@ -103,9 +104,9 @@ const InvoiceContextHeader: React.FC<InvoiceContextHeaderProps> = ({
             Print
           </AppButton>
         }
-        journalEntryRef={journalEntryRef}
-        journalEntryRefLoading={journalEntryRefLoading}
-        onNavigateToJournalEntry={onNavigateToJournalEntry}
+        journalEntryRefs={journalEntryRefs}
+        journalEntryRefLoading={journalEntryRefsLoading}
+        onNavigateToJournalEntry={onNavigateToJournalEntries}
       />
 
       <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
@@ -199,20 +200,31 @@ const InvoiceContextHeader: React.FC<InvoiceContextHeaderProps> = ({
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
                     <TableCell sx={labelCellSx}>Journal Entry No</TableCell>
                     <TableCell sx={valueCellSx}>
-                      {journalEntryRefLoading ? (
+                      {journalEntryRefsLoading ? (
                         <Typography
                           sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}
                         >
                           Loading...
                         </Typography>
-                      ) : journalEntryRef ? (
-                        <Typography
-                          component="button"
-                          onClick={onNavigateToJournalEntry}
-                          sx={linkButtonSx}
-                        >
-                          {journalEntryRef.referenceNumber}
-                        </Typography>
+                      ) : journalEntryRefs.length > 0 ? (
+                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                          {journalEntryRefs.map((ref, index) => (
+                            <Box key={ref.referenceNumber} component="span">
+                              <Typography
+                                component="button"
+                                onClick={onNavigateToJournalEntries}
+                                sx={linkButtonSx}
+                              >
+                                {ref.referenceNumber}
+                              </Typography>
+                              {index < journalEntryRefs.length - 1 && (
+                                <Typography component="span" sx={{ fontSize: '0.8rem' }}>
+                                  ,{' '}
+                                </Typography>
+                              )}
+                            </Box>
+                          ))}
+                        </Box>
                       ) : (
                         <Typography
                           sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}

--- a/frontend/src/pages/sales/components/InvoiceContextHeader.tsx
+++ b/frontend/src/pages/sales/components/InvoiceContextHeader.tsx
@@ -105,7 +105,7 @@ const InvoiceContextHeader: React.FC<InvoiceContextHeaderProps> = ({
           </AppButton>
         }
         journalEntryRefs={journalEntryRefs}
-        journalEntryRefLoading={journalEntryRefsLoading}
+        journalEntryRefsLoading={journalEntryRefsLoading}
         onNavigateToJournalEntry={onNavigateToJournalEntries}
       />
 

--- a/frontend/src/pages/sales/components/OrderContextHeader.tsx
+++ b/frontend/src/pages/sales/components/OrderContextHeader.tsx
@@ -25,14 +25,14 @@ import { formatCurrency, formatDate } from '@/utils/formatters'
 interface OrderContextHeaderProps {
   selectedOrder: SalesOrder | null
   isLoading: boolean
-  journalEntryRef: JournalEntryRef | null
-  journalEntryRefLoading: boolean
+  journalEntryRefs: JournalEntryRef[]
+  journalEntryRefsLoading: boolean
   onEditOrder: () => void
   onDeleteOrder: () => void
   onPrintOrder: () => void
   onNavigateToInvoice: (invoice: any, event?: React.MouseEvent) => void
   onNavigateToPayment: (paymentId: string, event?: React.MouseEvent) => void
-  onNavigateToJournalEntry: () => void
+  onNavigateToJournalEntries: () => void
   onRefundOrder: () => void
   onUnpayOrder: () => void
   onOpenPaymentDialog: () => void
@@ -64,14 +64,14 @@ const valueCellSx = {
 const OrderContextHeader: React.FC<OrderContextHeaderProps> = ({
   selectedOrder,
   isLoading,
-  journalEntryRef,
-  journalEntryRefLoading,
+  journalEntryRefs,
+  journalEntryRefsLoading,
   onEditOrder,
   onDeleteOrder,
   onPrintOrder,
   onNavigateToInvoice,
   onNavigateToPayment,
-  onNavigateToJournalEntry,
+  onNavigateToJournalEntries,
   onRefundOrder,
   onUnpayOrder,
   onOpenPaymentDialog,
@@ -150,9 +150,9 @@ const OrderContextHeader: React.FC<OrderContextHeaderProps> = ({
             </AppButton>
           </Box>
         )}
-        journalEntryRef={journalEntryRef}
-        journalEntryRefLoading={journalEntryRefLoading}
-        onNavigateToJournalEntry={onNavigateToJournalEntry}
+        journalEntryRefs={journalEntryRefs}
+        journalEntryRefLoading={journalEntryRefsLoading}
+        onNavigateToJournalEntry={onNavigateToJournalEntries}
       />
       <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
         <Grid container spacing={3}>
@@ -270,28 +270,39 @@ const OrderContextHeader: React.FC<OrderContextHeaderProps> = ({
                         >
                           Not fulfilled
                         </Typography>
-                      ) : journalEntryRefLoading ? (
+                      ) : journalEntryRefsLoading ? (
                         <Typography
                           sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}
                         >
                           Loading...
                         </Typography>
-                      ) : journalEntryRef ? (
-                        <Typography
-                          component="button"
-                          onClick={onNavigateToJournalEntry}
-                          sx={{
-                            fontSize: '0.8rem',
-                            color: 'primary.main',
-                            cursor: 'pointer',
-                            textDecoration: 'none',
-                            border: 'none',
-                            background: 'none',
-                            padding: 0,
-                          }}
-                        >
-                          {journalEntryRef.referenceNumber}
-                        </Typography>
+                      ) : journalEntryRefs.length > 0 ? (
+                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                          {journalEntryRefs.map((ref, index) => (
+                            <Box key={ref.referenceNumber} component="span">
+                              <Typography
+                                component="button"
+                                onClick={onNavigateToJournalEntries}
+                                sx={{
+                                  fontSize: '0.8rem',
+                                  color: 'primary.main',
+                                  cursor: 'pointer',
+                                  textDecoration: 'none',
+                                  border: 'none',
+                                  background: 'none',
+                                  padding: 0,
+                                }}
+                              >
+                                {ref.referenceNumber}
+                              </Typography>
+                              {index < journalEntryRefs.length - 1 && (
+                                <Typography component="span" sx={{ fontSize: '0.8rem' }}>
+                                  ,
+                                </Typography>
+                              )}
+                            </Box>
+                          ))}
+                        </Box>
                       ) : (
                         <Typography
                           sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}

--- a/frontend/src/pages/sales/components/OrderContextHeader.tsx
+++ b/frontend/src/pages/sales/components/OrderContextHeader.tsx
@@ -151,7 +151,7 @@ const OrderContextHeader: React.FC<OrderContextHeaderProps> = ({
           </Box>
         )}
         journalEntryRefs={journalEntryRefs}
-        journalEntryRefLoading={journalEntryRefsLoading}
+        journalEntryRefsLoading={journalEntryRefsLoading}
         onNavigateToJournalEntry={onNavigateToJournalEntries}
       />
       <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>

--- a/frontend/src/pages/sales/components/PaymentContextHeader.tsx
+++ b/frontend/src/pages/sales/components/PaymentContextHeader.tsx
@@ -12,22 +12,23 @@ import {
 } from '@mui/material'
 import Grid from '@mui/material/Grid'
 
-import type { PaymentJournalEntryRef, PaymentListItem } from '../hooks/usePaymentsWorkspace'
+import type { PaymentListItem } from '../hooks/usePaymentsWorkspace'
 
 import { AppButton } from '@/components/common/AppButton'
 import { EntityContextHeaderBar } from '@/components/common/EntityContextHeaderBar'
 import { EntityStatusChip } from '@/components/common/EntityStatusChip'
 import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { JournalEntryRef } from '@/hooks/useJournalEntryRef'
 import { formatCurrency, formatDate } from '@/utils/formatters'
 
 interface PaymentContextHeaderProps {
   selectedPayment: PaymentListItem | null
-  journalEntryRef: PaymentJournalEntryRef | null
-  journalEntryRefLoading: boolean
+  journalEntryRefs: JournalEntryRef[]
+  journalEntryRefsLoading: boolean
   onPrint: () => void
   onOrderClick: (orderId: string, event: React.MouseEvent) => void
   onInvoiceClick: (invoiceId: string, event: React.MouseEvent) => void
-  onNavigateToJournalEntry: (ref: PaymentJournalEntryRef | null) => void
+  onNavigateToJournalEntry: () => void
 }
 
 const detailTableSx = {
@@ -63,8 +64,8 @@ const getPaymentMethodLabel = (payment: PaymentListItem) => {
 
 const PaymentContextHeader: React.FC<PaymentContextHeaderProps> = ({
   selectedPayment,
-  journalEntryRef,
-  journalEntryRefLoading,
+  journalEntryRefs,
+  journalEntryRefsLoading,
   onPrint,
   onOrderClick,
   onInvoiceClick,
@@ -96,9 +97,9 @@ const PaymentContextHeader: React.FC<PaymentContextHeaderProps> = ({
             Print
           </AppButton>
         }
-        journalEntryRef={journalEntryRef}
-        journalEntryRefLoading={journalEntryRefLoading}
-        onNavigateToJournalEntry={() => onNavigateToJournalEntry(journalEntryRef)}
+        journalEntryRefs={journalEntryRefs}
+        journalEntryRefLoading={journalEntryRefsLoading}
+        onNavigateToJournalEntry={onNavigateToJournalEntry}
       />
 
       <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
@@ -225,20 +226,31 @@ const PaymentContextHeader: React.FC<PaymentContextHeaderProps> = ({
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
                     <TableCell sx={labelCellSx}>Journal Entry</TableCell>
                     <TableCell sx={valueCellSx}>
-                      {journalEntryRefLoading ? (
+                      {journalEntryRefsLoading ? (
                         <Typography
                           sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}
                         >
                           Loading...
                         </Typography>
-                      ) : journalEntryRef ? (
-                        <Typography
-                          component="button"
-                          onClick={() => onNavigateToJournalEntry(journalEntryRef)}
-                          sx={linkButtonSx}
-                        >
-                          {journalEntryRef.referenceNumber}
-                        </Typography>
+                      ) : journalEntryRefs.length > 0 ? (
+                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                          {journalEntryRefs.map((ref, index) => (
+                            <Box key={ref.referenceNumber} component="span">
+                              <Typography
+                                component="button"
+                                onClick={onNavigateToJournalEntry}
+                                sx={linkButtonSx}
+                              >
+                                {ref.referenceNumber}
+                              </Typography>
+                              {index < journalEntryRefs.length - 1 && (
+                                <Typography component="span" sx={{ fontSize: '0.8rem' }}>
+                                  ,{' '}
+                                </Typography>
+                              )}
+                            </Box>
+                          ))}
+                        </Box>
                       ) : (
                         <Typography
                           sx={{ fontSize: '0.8rem', color: 'text.secondary', fontStyle: 'italic' }}

--- a/frontend/src/pages/sales/components/PaymentContextHeader.tsx
+++ b/frontend/src/pages/sales/components/PaymentContextHeader.tsx
@@ -98,7 +98,7 @@ const PaymentContextHeader: React.FC<PaymentContextHeaderProps> = ({
           </AppButton>
         }
         journalEntryRefs={journalEntryRefs}
-        journalEntryRefLoading={journalEntryRefsLoading}
+        journalEntryRefsLoading={journalEntryRefsLoading}
         onNavigateToJournalEntry={onNavigateToJournalEntry}
       />
 

--- a/frontend/src/pages/sales/components/__tests__/InvoiceContextHeader.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/InvoiceContextHeader.test.tsx
@@ -22,12 +22,12 @@ describe('InvoiceContextHeader', () => {
     render(
       <InvoiceContextHeader
         selectedInvoice={baseInvoice}
-        journalEntryRef={null}
-        journalEntryRefLoading={false}
+        journalEntryRefs={[]}
+        journalEntryRefsLoading={false}
         onPrint={vi.fn()}
         onNavigateToSalesOrder={vi.fn()}
         onNavigateToPayment={vi.fn()}
-        onNavigateToJournalEntry={vi.fn()}
+        onNavigateToJournalEntries={vi.fn()}
       />,
     )
 

--- a/frontend/src/pages/sales/components/__tests__/PaymentContextHeader.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/PaymentContextHeader.test.tsx
@@ -19,8 +19,8 @@ describe('PaymentContextHeader', () => {
     render(
       <PaymentContextHeader
         selectedPayment={basePayment}
-        journalEntryRef={null}
-        journalEntryRefLoading={false}
+        journalEntryRefs={[]}
+        journalEntryRefsLoading={false}
         onPrint={vi.fn()}
         onOrderClick={vi.fn()}
         onInvoiceClick={vi.fn()}

--- a/frontend/src/pages/sales/hooks/useInvoicesWorkspace.ts
+++ b/frontend/src/pages/sales/hooks/useInvoicesWorkspace.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type MouseEvent } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
-import { useJournalEntryRef } from '@/hooks/useJournalEntryRef'
+import { useJournalEntryRefs } from '@/hooks/useJournalEntryRefs'
 import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import type { EntityWorkspaceReturn } from '@/hooks/useEntityWorkspace'
 import type { AppDispatch } from '@/store'
@@ -88,7 +88,7 @@ export function useInvoicesWorkspace({
   })
   workspaceRef.current = workspace
 
-  const { journalEntryRef, journalEntryRefLoading, navigateToJournalEntry } = useJournalEntryRef([
+  const { journalEntryRefs, journalEntryRefsLoading, navigateToJournalEntries } = useJournalEntryRefs([
     { sourceType: 'invoice', sourceId: selectedInvoice?.id },
     { sourceType: 'sales_order', sourceId: selectedInvoice?.salesOrder?.id },
   ])
@@ -140,12 +140,12 @@ export function useInvoicesWorkspace({
     setDeletedInvoicesDialogOpen,
     printDialogOpen,
     setPrintDialogOpen,
-    journalEntryRef,
-    journalEntryRefLoading,
+    journalEntryRefs,
+    journalEntryRefsLoading,
     handleInvoiceSelect,
     handleSalesOrderClick,
     handleNavigateToPayment,
-    navigateToJournalEntry,
+    navigateToJournalEntries,
     handleViewDeletedAction: () => {
       setDeletedInvoicesDialogOpen(true)
     },

--- a/frontend/src/pages/sales/hooks/useInvoicesWorkspace.ts
+++ b/frontend/src/pages/sales/hooks/useInvoicesWorkspace.ts
@@ -37,12 +37,6 @@ export interface InvoiceListItem {
   items?: InvoiceItem[]
 }
 
-export interface InvoiceJournalEntryRef {
-  referenceNumber: string
-  sourceType: string
-  sourceId: string
-}
-
 export interface UseInvoicesWorkspaceConfig {
   dispatch: AppDispatch
   invoices: InvoiceListItem[]

--- a/frontend/src/pages/sales/hooks/useOrdersWorkspace.ts
+++ b/frontend/src/pages/sales/hooks/useOrdersWorkspace.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
-import { useJournalEntryRef } from '@/hooks/useJournalEntryRef'
+import { useJournalEntryRefs } from '@/hooks/useJournalEntryRefs'
 import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import { useNotification } from '@/hooks/useNotification'
 import type { AppDispatch, RootState } from '@/store'
@@ -108,11 +108,17 @@ export function useOrdersWorkspace({
   })
   workspaceRef.current = workspace
 
-  const { journalEntryRef, journalEntryRefLoading } = useJournalEntryRef([
+  const invoiceSources = (selectedOrder?.invoices ?? []).map((invoice) => ({
+    sourceType: 'invoice' as const,
+    sourceId: invoice.id,
+  }))
+
+  const { journalEntryRefs, journalEntryRefsLoading, navigateToJournalEntries } = useJournalEntryRefs([
     {
       sourceType: 'sales_order',
       sourceId: selectedOrder?.isFulfilled ? selectedOrder?.id : undefined,
     },
+    ...invoiceSources,
   ])
 
   const loadOrders = useCallback(() => {
@@ -767,12 +773,6 @@ export function useOrdersWorkspace({
     setPaymentDialogOpen(true)
   }, [])
 
-  const navigateToJournalEntry = useCallback(() => {
-    if (selectedOrder) {
-      navigate(`/accounting/journal-entries?sourceType=sales_order&sourceId=${selectedOrder.id}`)
-    }
-  }, [navigate, selectedOrder])
-
   return {
     ...workspace,
     focusedOrderIndex: workspace.focusedIndex,
@@ -792,8 +792,8 @@ export function useOrdersWorkspace({
     paymentDialogOpen,
     setPaymentDialogOpen,
     isLoading,
-    journalEntryRef,
-    journalEntryRefLoading,
+    journalEntryRefs,
+    journalEntryRefsLoading,
     handleOrderSelect,
     handleNavigateUp,
     handleNavigateDown,
@@ -803,7 +803,7 @@ export function useOrdersWorkspace({
     handlePageDownNavigation,
     handleNavigateToInvoice,
     handleNavigateToPayment,
-    navigateToJournalEntry,
+    navigateToJournalEntries,
     handleOrderAction,
     handleConfirmDelete,
     handleCancelDelete,

--- a/frontend/src/pages/sales/hooks/useOrdersWorkspace.ts
+++ b/frontend/src/pages/sales/hooks/useOrdersWorkspace.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import { useJournalEntryRefs } from '@/hooks/useJournalEntryRefs'
@@ -108,10 +108,14 @@ export function useOrdersWorkspace({
   })
   workspaceRef.current = workspace
 
-  const invoiceSources = (selectedOrder?.invoices ?? []).map((invoice) => ({
-    sourceType: 'invoice' as const,
-    sourceId: invoice.id,
-  }))
+  const invoiceSources = useMemo(
+    () => (selectedOrder?.invoices ?? []).map((invoice: any) => ({
+      sourceType: 'invoice' as const,
+      sourceId: invoice.id as string,
+    })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedOrder?.invoices?.map((i: any) => i.id).join(',')],
+  )
 
   const { journalEntryRefs, journalEntryRefsLoading, navigateToJournalEntries } = useJournalEntryRefs([
     {

--- a/frontend/src/pages/sales/hooks/usePaymentsWorkspace.ts
+++ b/frontend/src/pages/sales/hooks/usePaymentsWorkspace.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
-import { useJournalEntryRef } from '@/hooks/useJournalEntryRef'
+import { useJournalEntryRefs } from '@/hooks/useJournalEntryRefs'
 import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import type { AppDispatch } from '@/store'
 import { setSelectedPayment } from '@/store/slices/salesSlice'
@@ -96,7 +96,7 @@ export function usePaymentsWorkspace({
   })
   const { focusedIndex } = workspace
 
-  const { journalEntryRef, journalEntryRefLoading, navigateToJournalEntry } = useJournalEntryRef([
+  const { journalEntryRefs, journalEntryRefsLoading, navigateToJournalEntries } = useJournalEntryRefs([
     { sourceType: 'payment', sourceId: selectedPayment?.id },
   ])
 
@@ -140,11 +140,10 @@ export function usePaymentsWorkspace({
   }, [navigate])
 
   const handleNavigateToJournalEntry = useCallback(
-    (journalRef: PaymentJournalEntryRef | null) => {
-      if (!journalRef) return
-      navigateToJournalEntry()
+    () => {
+      navigateToJournalEntries()
     },
-    [navigateToJournalEntry],
+    [navigateToJournalEntries],
   )
 
   return {
@@ -155,8 +154,8 @@ export function usePaymentsWorkspace({
     setDeletedPaymentsDialogOpen,
     printDialogOpen,
     setPrintDialogOpen,
-    journalEntryRef,
-    journalEntryRefLoading,
+    journalEntryRefs,
+    journalEntryRefsLoading,
     handleSelect,
     handlePaymentSelect: handleSelect,
     handleOrderClick,

--- a/frontend/src/pages/sales/hooks/usePaymentsWorkspace.ts
+++ b/frontend/src/pages/sales/hooks/usePaymentsWorkspace.ts
@@ -6,12 +6,6 @@ import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import type { AppDispatch } from '@/store'
 import { setSelectedPayment } from '@/store/slices/salesSlice'
 
-export interface PaymentJournalEntryRef {
-  referenceNumber: string
-  sourceType: string
-  sourceId: string
-}
-
 export interface PaymentListItem {
   id: string
   paymentNumber: string


### PR DESCRIPTION
## Summary
- Adds `invoice` case to `resolveSourceRefNumber` so Invoice-sourced JEs show their reference number
- Adds `ids` comma-separated filter to `GET /accounting/journal-entries` for targeted multi-JE navigation
- New `useJournalEntryRefs` hook fetches all JEs across multiple sources; Sales Order, Invoice, and Payment headers now display all related JE references
- `JournalEntriesPage` shows the Reset button when `sourceId` or `ids` URL params are active, and clears them on reset

## Test plan
- [x] Create a Sales Order, fulfill it (generates SO JE), then create an Invoice from it (generates Invoice JE) - SO header should show both JE reference numbers
- [x] Click the JE link from an SO header - JE list should be filtered to show both JEs
- [x] Navigate to JE list from any transaction - Reset button should appear; clicking it returns to unfiltered list
- [x] Verify Invoice header shows its own JE reference number (was blank before)
- [x] Backend: `npm run test`
- [x] Frontend: `npx vitest run src/hooks/useJournalEntryRefs.test.ts src/pages/accounting/__tests__/JournalEntriesPage.test.tsx`

Closes #468