### PR TITLE
fix(ci): restrict GITHUB_TOKEN to least privilege (closes #469)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- Adds explicit `permissions: contents: read` block to `.github/workflows/ci.yml`
- Resolves CodeQL security alert #1 (`actions/missing-workflow-permissions`)
- The CI workflow only reads code (checkout, lint, test), so `contents: read` covers all needs

## Test plan

- [ ] Verify CI workflow runs pass on this PR
- [ ] Confirm CodeQL alert #1 is resolved after merge

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)