### PR TITLE
fix(security): validate invoice IDs and report date queries

### DIFF
--- a/backend/src/common/dto/report-date-query.dto.spec.ts
+++ b/backend/src/common/dto/report-date-query.dto.spec.ts
@@ -1,0 +1,68 @@
+import { validate } from 'class-validator';
+import {
+  AsOfDateQueryDto,
+  DateRangeQueryDto,
+  PaymentStatisticsQueryDto,
+} from './report-date-query.dto';
+
+describe('report date query DTOs', () => {
+  it('rejects array-valued asOfDate', async () => {
+    const dto = Object.assign(new AsOfDateQueryDto(), {
+      asOfDate: ['2026-01-01', '2026-01-02'],
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.some((error) => error.property === 'asOfDate')).toBe(true);
+  });
+
+  it('rejects invalid asOfDate strings', async () => {
+    const dto = Object.assign(new AsOfDateQueryDto(), {
+      asOfDate: 'not-a-date',
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.some((error) => error.property === 'asOfDate')).toBe(true);
+  });
+
+  it('accepts valid optional asOfDate', async () => {
+    const dto = Object.assign(new AsOfDateQueryDto(), {
+      asOfDate: '2026-01-01',
+    });
+
+    await expect(validate(dto)).resolves.toHaveLength(0);
+  });
+
+  it('rejects array-valued fromDate and toDate', async () => {
+    const dto = Object.assign(new DateRangeQueryDto(), {
+      fromDate: ['2026-01-01', '2026-01-02'],
+      toDate: ['2026-01-03', '2026-01-04'],
+    });
+
+    const errors = await validate(dto);
+    const properties = errors.map((error) => error.property);
+
+    expect(properties).toEqual(expect.arrayContaining(['fromDate', 'toDate']));
+  });
+
+  it('accepts valid optional fromDate and toDate', async () => {
+    const dto = Object.assign(new DateRangeQueryDto(), {
+      fromDate: '2026-01-01',
+      toDate: '2026-01-31',
+    });
+
+    await expect(validate(dto)).resolves.toHaveLength(0);
+  });
+
+  it('validates optional customerId for payment statistics', async () => {
+    const dto = Object.assign(new PaymentStatisticsQueryDto(), {
+      customerId: 'not-a-uuid',
+      fromDate: '2026-01-01',
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.some((error) => error.property === 'customerId')).toBe(true);
+  });
+});

--- a/backend/src/common/dto/report-date-query.dto.ts
+++ b/backend/src/common/dto/report-date-query.dto.ts
@@ -1,0 +1,26 @@
+import { IsDateString, IsOptional, IsString, IsUUID } from 'class-validator';
+
+export class DateRangeQueryDto {
+  @IsOptional()
+  @IsString()
+  @IsDateString()
+  fromDate?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsDateString()
+  toDate?: string;
+}
+
+export class AsOfDateQueryDto {
+  @IsOptional()
+  @IsString()
+  @IsDateString()
+  asOfDate?: string;
+}
+
+export class PaymentStatisticsQueryDto extends DateRangeQueryDto {
+  @IsOptional()
+  @IsUUID()
+  customerId?: string;
+}

--- a/backend/src/modules/accounting/controllers/accounting-reports.controller.spec.ts
+++ b/backend/src/modules/accounting/controllers/accounting-reports.controller.spec.ts
@@ -1,0 +1,43 @@
+import { AccountingReportsController } from './accounting-reports.controller';
+import { AccountingReportsService } from '../services/accounting-reports.service';
+
+describe('AccountingReportsController', () => {
+  let controller: AccountingReportsController;
+  let service: Pick<
+    AccountingReportsService,
+    'generateTrialBalance' | 'generateBalanceSheet'
+  >;
+
+  beforeEach(() => {
+    service = {
+      generateTrialBalance: jest.fn().mockResolvedValue({ accounts: [] }),
+      generateBalanceSheet: jest.fn().mockResolvedValue({ assets: [] }),
+    } as any;
+
+    controller = new AccountingReportsController(service as AccountingReportsService);
+  });
+
+  it('passes validated asOfDate to generateTrialBalance', async () => {
+    await controller.getTrialBalance(
+      { asOfDate: '2026-01-01' },
+      'true',
+    );
+
+    expect(service.generateTrialBalance).toHaveBeenCalledWith(
+      new Date('2026-01-01'),
+      true,
+    );
+  });
+
+  it('passes validated asOfDate to generateBalanceSheet', async () => {
+    await controller.getBalanceSheet(
+      { asOfDate: '2026-01-01' },
+      'false',
+    );
+
+    expect(service.generateBalanceSheet).toHaveBeenCalledWith(
+      new Date('2026-01-01'),
+      false,
+    );
+  });
+});

--- a/backend/src/modules/accounting/controllers/accounting-reports.controller.ts
+++ b/backend/src/modules/accounting/controllers/accounting-reports.controller.ts
@@ -16,6 +16,7 @@ import { Response } from 'express';
 import { AccountingReportsService } from '../services/accounting-reports.service';
 import { JournalEntryStatus } from '../../../database/entities/journal-entry.entity';
 import { Auth } from '../../auth/decorators/auth.decorator';
+import { AsOfDateQueryDto } from '../../../common/dto/report-date-query.dto';
 
 @ApiTags('Accounting Reports')
 @Controller('accounting/reports')
@@ -57,10 +58,10 @@ export class AccountingReportsController {
     description: 'Invalid date or date is in the future',
   })
   async getTrialBalance(
-    @Query('asOfDate') asOfDate?: string,
+    @Query() query: AsOfDateQueryDto,
     @Query('includeInactive') includeInactive?: string,
   ) {
-    const date = asOfDate ? new Date(asOfDate) : new Date();
+    const date = query.asOfDate ? new Date(query.asOfDate) : new Date();
     const includeInactiveBool = includeInactive === 'true';
 
     if (isNaN(date.getTime())) {
@@ -107,10 +108,10 @@ export class AccountingReportsController {
   })
   async exportTrialBalance(
     @Res() res: Response,
-    @Query('asOfDate') asOfDate?: string,
+    @Query() query: AsOfDateQueryDto,
     @Query('includeInactive') includeInactive?: string,
   ) {
-    const date = asOfDate ? new Date(asOfDate) : new Date();
+    const date = query.asOfDate ? new Date(query.asOfDate) : new Date();
     const includeInactiveBool = includeInactive === 'true';
 
     if (isNaN(date.getTime())) {
@@ -169,10 +170,10 @@ export class AccountingReportsController {
     description: 'Invalid date or date is in the future',
   })
   async getBalanceSheet(
-    @Query('asOfDate') asOfDate?: string,
+    @Query() query: AsOfDateQueryDto,
     @Query('includeInactive') includeInactive?: string,
   ) {
-    const date = asOfDate ? new Date(asOfDate) : new Date();
+    const date = query.asOfDate ? new Date(query.asOfDate) : new Date();
     const includeInactiveBool = includeInactive === 'true';
 
     if (isNaN(date.getTime())) {
@@ -219,10 +220,10 @@ export class AccountingReportsController {
   })
   async exportBalanceSheet(
     @Res() res: Response,
-    @Query('asOfDate') asOfDate?: string,
+    @Query() query: AsOfDateQueryDto,
     @Query('includeInactive') includeInactive?: string,
   ) {
-    const date = asOfDate ? new Date(asOfDate) : new Date();
+    const date = query.asOfDate ? new Date(query.asOfDate) : new Date();
     const includeInactiveBool = includeInactive === 'true';
 
     if (isNaN(date.getTime())) {

--- a/backend/src/modules/sales/controllers/invoice.controller.spec.ts
+++ b/backend/src/modules/sales/controllers/invoice.controller.spec.ts
@@ -1,0 +1,24 @@
+import { InvoiceController } from './invoice.controller';
+import { InvoiceService } from '../services/invoice.service';
+
+describe('InvoiceController', () => {
+  let controller: InvoiceController;
+  let invoiceService: Pick<InvoiceService, 'batchSendInvoices' | 'getRevenueStatistics'>;
+
+  beforeEach(() => {
+    invoiceService = {
+      batchSendInvoices: jest.fn().mockResolvedValue({ sent: 1, failed: 0 }),
+      getRevenueStatistics: jest.fn().mockResolvedValue({ totalRevenue: 0 }),
+    } as any;
+
+    controller = new InvoiceController(invoiceService as InvoiceService);
+  });
+
+  it('passes validated invoice IDs to batchSendInvoices', async () => {
+    const invoiceIds = ['550e8400-e29b-41d4-a716-446655440000'];
+
+    await controller.batchSendInvoices({ invoiceIds });
+
+    expect(invoiceService.batchSendInvoices).toHaveBeenCalledWith(invoiceIds);
+  });
+});

--- a/backend/src/modules/sales/controllers/invoice.controller.spec.ts
+++ b/backend/src/modules/sales/controllers/invoice.controller.spec.ts
@@ -21,4 +21,16 @@ describe('InvoiceController', () => {
 
     expect(invoiceService.batchSendInvoices).toHaveBeenCalledWith(invoiceIds);
   });
+
+  it('passes validated revenue stats dates to getRevenueStatistics', async () => {
+    await controller.getRevenueStats({
+      fromDate: '2026-01-01',
+      toDate: '2026-01-31',
+    });
+
+    expect(invoiceService.getRevenueStatistics).toHaveBeenCalledWith(
+      '2026-01-01',
+      '2026-01-31',
+    );
+  });
 });

--- a/backend/src/modules/sales/controllers/invoice.controller.ts
+++ b/backend/src/modules/sales/controllers/invoice.controller.ts
@@ -34,6 +34,7 @@ import {
 import { UserRole } from '../../../database/entities/user.entity';
 import { Auth } from '../../auth/decorators/auth.decorator';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { DateRangeQueryDto } from '../../../common/dto/report-date-query.dto';
 
 @ApiTags('Invoices')
 @Controller('invoices')
@@ -330,11 +331,8 @@ export class InvoiceController {
     status: 200,
     description: 'Revenue statistics retrieved successfully',
   })
-  async getRevenueStats(
-    @Query('fromDate') fromDate?: string,
-    @Query('toDate') toDate?: string,
-  ) {
-    return this.invoiceService.getRevenueStatistics(fromDate, toDate);
+  async getRevenueStats(@Query() query: DateRangeQueryDto) {
+    return this.invoiceService.getRevenueStatistics(query.fromDate, query.toDate);
   }
 
   @Post(':id/restore')

--- a/backend/src/modules/sales/controllers/invoice.controller.ts
+++ b/backend/src/modules/sales/controllers/invoice.controller.ts
@@ -27,6 +27,7 @@ import {
   InvoiceResponseDto,
   InvoiceSummaryDto,
   SendInvoiceDto,
+  BatchSendInvoicesDto,
   InvoicePaymentAllocationDto,
   VoidInvoiceDto,
 } from '../dto/invoice.dto';
@@ -319,8 +320,8 @@ export class InvoiceController {
     description: 'Batch send completed',
   })
   @ApiResponse({ status: 400, description: 'Invalid invoice IDs provided' })
-  async batchSendInvoices(@Body('invoiceIds') invoiceIds: string[]) {
-    return this.invoiceService.batchSendInvoices(invoiceIds);
+  async batchSendInvoices(@Body() dto: BatchSendInvoicesDto) {
+    return this.invoiceService.batchSendInvoices(dto.invoiceIds);
   }
 
   @Get('stats/revenue')

--- a/backend/src/modules/sales/controllers/payment.controller.spec.ts
+++ b/backend/src/modules/sales/controllers/payment.controller.spec.ts
@@ -1,0 +1,29 @@
+import { PaymentController } from './payment.controller';
+import { PaymentService } from '../services/payment.service';
+
+describe('PaymentController', () => {
+  let controller: PaymentController;
+  let paymentService: Pick<PaymentService, 'getPaymentStatistics'>;
+
+  beforeEach(() => {
+    paymentService = {
+      getPaymentStatistics: jest.fn().mockResolvedValue({ totalPayments: 0 }),
+    } as any;
+
+    controller = new PaymentController(paymentService as PaymentService);
+  });
+
+  it('passes validated statistics query values to getPaymentStatistics', async () => {
+    await controller.getPaymentStatistics({
+      customerId: '550e8400-e29b-41d4-a716-446655440000',
+      fromDate: '2026-01-01',
+      toDate: '2026-01-31',
+    });
+
+    expect(paymentService.getPaymentStatistics).toHaveBeenCalledWith(
+      '550e8400-e29b-41d4-a716-446655440000',
+      new Date('2026-01-01'),
+      new Date('2026-01-31'),
+    );
+  });
+});

--- a/backend/src/modules/sales/controllers/payment.controller.ts
+++ b/backend/src/modules/sales/controllers/payment.controller.ts
@@ -30,6 +30,7 @@ import {
 import { UserRole } from '../../../database/entities/user.entity';
 import { Auth } from '../../auth/decorators/auth.decorator';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { PaymentStatisticsQueryDto } from '../../../common/dto/report-date-query.dto';
 
 @ApiTags('Payments')
 @Controller('payments')
@@ -240,15 +241,11 @@ export class PaymentController {
     status: 200,
     description: 'Payment statistics retrieved successfully',
   })
-  async getPaymentStatistics(
-    @Query('customerId') customerId?: string,
-    @Query('fromDate') fromDate?: string,
-    @Query('toDate') toDate?: string,
-  ) {
-    const fromDateObj = fromDate ? new Date(fromDate) : undefined;
-    const toDateObj = toDate ? new Date(toDate) : undefined;
+  async getPaymentStatistics(@Query() query: PaymentStatisticsQueryDto) {
+    const fromDateObj = query.fromDate ? new Date(query.fromDate) : undefined;
+    const toDateObj = query.toDate ? new Date(query.toDate) : undefined;
 
-    return this.paymentService.getPaymentStatistics(customerId, fromDateObj, toDateObj);
+    return this.paymentService.getPaymentStatistics(query.customerId, fromDateObj, toDateObj);
   }
 
   @Post(':id/restore')

--- a/backend/src/modules/sales/dto/invoice.dto.spec.ts
+++ b/backend/src/modules/sales/dto/invoice.dto.spec.ts
@@ -1,0 +1,46 @@
+import { validate } from 'class-validator';
+import { BatchSendInvoicesDto } from './invoice.dto';
+
+describe('BatchSendInvoicesDto', () => {
+  const validInvoiceId = '550e8400-e29b-41d4-a716-446655440000';
+
+  it('rejects invoiceIds when it is a single string', async () => {
+    const dto = Object.assign(new BatchSendInvoicesDto(), {
+      invoiceIds: validInvoiceId,
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.some((error) => error.property === 'invoiceIds')).toBe(true);
+  });
+
+  it('rejects invoiceIds entries that are not UUID v4 strings', async () => {
+    const dto = Object.assign(new BatchSendInvoicesDto(), {
+      invoiceIds: ['not-a-uuid'],
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.some((error) => error.property === 'invoiceIds')).toBe(true);
+  });
+
+  it('rejects an empty invoiceIds array', async () => {
+    const dto = Object.assign(new BatchSendInvoicesDto(), {
+      invoiceIds: [],
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.some((error) => error.property === 'invoiceIds')).toBe(true);
+  });
+
+  it('accepts a non-empty UUID v4 invoiceIds array', async () => {
+    const dto = Object.assign(new BatchSendInvoicesDto(), {
+      invoiceIds: [validInvoiceId],
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/backend/src/modules/sales/dto/invoice.dto.ts
+++ b/backend/src/modules/sales/dto/invoice.dto.ts
@@ -8,6 +8,7 @@ import {
   IsDateString,
   Min,
   IsArray,
+  ArrayNotEmpty,
   ValidateNested,
   IsInt,
   IsBoolean,
@@ -325,6 +326,18 @@ export class SendInvoiceDto {
   message?: string;
 
   // Mark as sent functionality removed
+}
+
+export class BatchSendInvoicesDto {
+  @ApiProperty({
+    description: 'Invoice IDs to send',
+    type: [String],
+    example: ['550e8400-e29b-41d4-a716-446655440000'],
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsUUID('4', { each: true })
+  invoiceIds: string[];
 }
 
 export class InvoicePaymentAllocationDto {


### PR DESCRIPTION
## Summary
- Add DTO validation for invoice batch-send IDs to reject non-array and non-UUID payloads.
- Add strict shared date query DTOs for affected report/stat endpoints.
- Wire invoice revenue stats, payment stats, and accounting as-of report endpoints through validated query DTOs.

## Test Plan
- [x] cd backend && npx jest src/modules/sales/dto/invoice.dto.spec.ts src/common/dto/report-date-query.dto.spec.ts src/modules/sales/controllers/invoice.controller.spec.ts src/modules/sales/controllers/payment.controller.spec.ts src/modules/accounting/controllers/accounting-reports.controller.spec.ts --no-coverage
- [x] cd backend && npm run lint
- [x] cd backend && npm run test

Fixes #474