### PR TITLE
fix: eliminate workspace card flicker after creating sales/purchase orders

### DIFF
--- a/frontend/src/hooks/useEntityWorkspace.test.ts
+++ b/frontend/src/hooks/useEntityWorkspace.test.ts
@@ -221,6 +221,18 @@ describe('useEntityWorkspace', () => {
     expect(onEscape).toHaveBeenCalledTimes(1)
     expect(config.selectEntity).not.toHaveBeenCalledWith(null)
   })
+
+  it('does not clear selection when entities list is empty but isLoading is true', () => {
+    const config = makeConfig({
+      entities: [],
+      selectedEntity: makeEntity('1'),
+      isLoading: true,
+    })
+
+    renderHook(() => useEntityWorkspace(config), { wrapper: makeWrapper('/entities') })
+
+    expect(config.selectEntity).not.toHaveBeenCalledWith(null)
+  })
 })
 
 describe('highlightParam', () => {

--- a/frontend/src/hooks/useEntityWorkspace.test.ts
+++ b/frontend/src/hooks/useEntityWorkspace.test.ts
@@ -222,16 +222,19 @@ describe('useEntityWorkspace', () => {
     expect(config.selectEntity).not.toHaveBeenCalledWith(null)
   })
 
-  it('does not clear selection when entities list is empty but isLoading is true', () => {
+  it('does not clear selection or focused index when entities list is empty but isLoading is true', () => {
     const config = makeConfig({
       entities: [],
       selectedEntity: makeEntity('1'),
       isLoading: true,
     })
 
-    renderHook(() => useEntityWorkspace(config), { wrapper: makeWrapper('/entities') })
+    const { result } = renderHook(() => useEntityWorkspace(config), {
+      wrapper: makeWrapper('/entities'),
+    })
 
     expect(config.selectEntity).not.toHaveBeenCalledWith(null)
+    expect(result.current.focusedIndex).toBe(-1)
   })
 })
 

--- a/frontend/src/hooks/useEntityWorkspace.ts
+++ b/frontend/src/hooks/useEntityWorkspace.ts
@@ -25,6 +25,7 @@ export interface UseEntityWorkspaceConfig<T extends { id: string }> {
   highlightParam?: string
   locationStateHighlightKey?: string
   locationStateHighlightKeys?: string[]
+  isLoading?: boolean
 }
 
 export interface EntityWorkspaceReturn<T extends { id: string }> {
@@ -67,6 +68,7 @@ export function useEntityWorkspace<T extends { id: string }>(
     highlightParam,
     locationStateHighlightKey,
     locationStateHighlightKeys,
+    isLoading = false,
   } = config
 
   const [focusedIndex, setFocusedIndex] = useState(-1)
@@ -87,7 +89,9 @@ export function useEntityWorkspace<T extends { id: string }>(
     if (entities.length === 0) {
       hasAutoSelected.current = false
       setFocusedIndex(-1)
-      selectEntity(null)
+      if (!isLoading) {
+        selectEntity(null)
+      }
       return
     }
 
@@ -118,7 +122,7 @@ export function useEntityWorkspace<T extends { id: string }>(
       setFocusedIndex(0)
       selectEntity(entities[0])
     }
-  }, [entities, focusedIndex, highlightParam, location.state, locationStateHighlightKey, locationStateHighlightKeys, searchParams, selectedEntity, selectEntity])
+  }, [entities, focusedIndex, highlightParam, isLoading, location.state, locationStateHighlightKey, locationStateHighlightKeys, searchParams, selectedEntity, selectEntity])
 
   useEffect(() => {
     if (focusedIndex < 0 || !listRef.current) {

--- a/frontend/src/hooks/useEntityWorkspace.ts
+++ b/frontend/src/hooks/useEntityWorkspace.ts
@@ -88,8 +88,8 @@ export function useEntityWorkspace<T extends { id: string }>(
   useEffect(() => {
     if (entities.length === 0) {
       hasAutoSelected.current = false
-      setFocusedIndex(-1)
       if (!isLoading) {
+        setFocusedIndex(-1)
         selectEntity(null)
       }
       return

--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -262,11 +262,10 @@ const CreatePurchaseOrderPage: React.FC = () => {
       if (isEditMode && id) {
         const updatedOrder = await updatePurchaseOrder({ id, data: orderData as any }).unwrap()
 
-        // Update Redux state directly - this will auto-refresh the list
         dispatch(updatePurchaseOrderInPlace(updatedOrder))
+        dispatch(setSelectedPurchaseOrder(updatedOrder as any))
 
         showSuccess('Purchase order updated successfully')
-        // Navigate to orders page with the updated order selected
         navigate(`/purchasing/orders?highlight=${id}`)
       } else {
         const result = await createPurchaseOrder(orderData as any).unwrap()

--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -32,7 +32,7 @@ import TransactionForm from '@/components/common/TransactionForm'
 import { useNotification } from '@/hooks/useNotification'
 import { useProductSearch } from '@/hooks/useProductSearch'
 import { useAppDispatch } from '@/hooks/useRedux'
-import { updatePurchaseOrderInPlace } from '@/store/slices/purchasingSlice'
+import { setSelectedPurchaseOrder, updatePurchaseOrderInPlace } from '@/store/slices/purchasingSlice'
 import {
   useCreatePurchaseOrderMutation,
   useGetSuppliersQuery,
@@ -270,10 +270,10 @@ const CreatePurchaseOrderPage: React.FC = () => {
         navigate(`/purchasing/orders?highlight=${id}`)
       } else {
         const result = await createPurchaseOrder(orderData as any).unwrap()
-        const newOrderId = (result as any).id
+        dispatch(setSelectedPurchaseOrder(result as any))
         showSuccess('Purchase order created successfully')
         // Navigate to orders page with the new order selected
-        navigate(`/purchasing/orders?highlight=${newOrderId}`)
+        navigate(`/purchasing/orders?highlight=${(result as any).id}`)
       }
     } catch (err: any) {
       console.error('Error creating purchase order:', err)

--- a/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
@@ -118,6 +118,7 @@ export const PurchaseOrdersPage: React.FC = () => {
     purchaseOrders,
     selectedOrder,
     refetchOrders: loadOrders,
+    isLoading: loading,
   })
 
   const handleSort = useCallback((field: string) => {

--- a/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
@@ -338,7 +338,11 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
     })
 
     expect(mockNavigate).toHaveBeenCalledWith('/purchasing/orders?highlight=new-po-id')
-    expect(mockDispatch.mock.invocationCallOrder[0]).toBeLessThan(
+    const dispatchCallIndex = mockDispatch.mock.calls.findIndex((call) =>
+      String(call[0]?.type).includes('setSelectedPurchaseOrder'),
+    )
+    expect(dispatchCallIndex).toBeGreaterThanOrEqual(0)
+    expect(mockDispatch.mock.invocationCallOrder[dispatchCallIndex]).toBeLessThan(
       mockNavigate.mock.invocationCallOrder[0],
     )
   })

--- a/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
@@ -19,6 +19,7 @@ const createDeferred = <T,>() => {
 
 const {
   mockDispatch,
+  mockNavigate,
   mockGet,
   mockCreatePurchaseOrder,
   mockUpdatePurchaseOrder,
@@ -26,6 +27,7 @@ const {
   mockParams,
 } = vi.hoisted(() => ({
   mockDispatch: vi.fn(),
+  mockNavigate: vi.fn(),
   mockGet: vi.fn(),
   mockCreatePurchaseOrder: vi.fn(),
   mockUpdatePurchaseOrder: vi.fn(),
@@ -37,7 +39,7 @@ vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom')
   return {
     ...actual,
-    useNavigate: () => vi.fn(),
+    useNavigate: () => mockNavigate,
     useParams: () => mockParams(),
   }
 })
@@ -55,6 +57,17 @@ vi.mock('@/hooks/useNotification', () => ({
 
 vi.mock('@/hooks/useCurrency', () => ({
   useCurrency: () => ({ currency: '$' }),
+}))
+
+vi.mock('@/store/slices/purchasingSlice', () => ({
+  updatePurchaseOrderInPlace: vi.fn((value) => ({
+    type: 'purchasing/updatePurchaseOrderInPlace',
+    payload: value,
+  })),
+  setSelectedPurchaseOrder: vi.fn((value) => ({
+    type: 'purchasing/setSelectedPurchaseOrder',
+    payload: value,
+  })),
 }))
 
 vi.mock('@/services/api', () => ({
@@ -289,5 +302,44 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
       expect(within(listbox).getByText('Beta Gadget')).toBeInTheDocument()
       expect(within(listbox).queryByText('Alpha Widget')).toBeNull()
     })
+  })
+
+  it('dispatches the created purchase order before navigating back to the orders list', async () => {
+    const createdOrder = { id: 'new-po-id', orderNumber: 'PO-NEW' }
+    mockCreatePurchaseOrder.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue(createdOrder),
+    })
+
+    render(
+      <BrowserRouter>
+        <CreatePurchaseOrderPage />
+      </BrowserRouter>
+    )
+
+    const supplierInput = screen.getByLabelText(/supplier/i)
+    fireEvent.mouseDown(supplierInput)
+    const supplierListbox = await screen.findByRole('listbox')
+    fireEvent.click(within(supplierListbox).getByText('Acme Supplies'))
+
+    const productInput = screen.getByPlaceholderText('Search by name or barcode...')
+    fireEvent.mouseDown(productInput)
+    const productListbox = await screen.findByRole('listbox')
+    fireEvent.click(within(productListbox).getByText('Alpha Widget'))
+
+    await userEvent.click(screen.getByRole('button', { name: /create order/i }))
+
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: expect.stringContaining('setSelectedPurchaseOrder'),
+          payload: expect.objectContaining({ id: 'new-po-id' }),
+        }),
+      )
+    })
+
+    expect(mockNavigate).toHaveBeenCalledWith('/purchasing/orders?highlight=new-po-id')
+    expect(mockDispatch.mock.invocationCallOrder[0]).toBeLessThan(
+      mockNavigate.mock.invocationCallOrder[0],
+    )
   })
 })

--- a/frontend/src/pages/purchasing/hooks/usePurchaseOrdersWorkspace.test.tsx
+++ b/frontend/src/pages/purchasing/hooks/usePurchaseOrdersWorkspace.test.tsx
@@ -76,6 +76,7 @@ const renderPurchaseOrdersWorkspace = (
         purchaseOrders,
         selectedOrder: null,
         refetchOrders: vi.fn(),
+        isLoading: false,
       }),
     { wrapper, initialProps: { purchaseOrders: initialPurchaseOrders } },
   )
@@ -119,5 +120,47 @@ describe('keyboard navigation', () => {
   it('exposes focusedIndex from useEntityWorkspace', () => {
     const { result } = renderPurchaseOrdersWorkspace('/purchasing/orders')
     expect(typeof result.current.focusedOrderIndex).toBe('number')
+  })
+})
+
+describe('loading state', () => {
+  it('does not clear the selected purchase order while purchase orders are loading', () => {
+    const selectedOrder = makePurchaseOrder('po-1') as any
+    const store = configureStore({
+      reducer: { purchasing: purchasingReducer },
+      preloadedState: {
+        purchasing: {
+          selectedPurchaseOrder: selectedOrder,
+          selectedGRN: null,
+          selectedVendorPayment: null,
+          selectedSupplier: null,
+          supplierFilters: {
+            search: '',
+            sortBy: 'companyName',
+            sortOrder: 'ASC',
+            isActive: true,
+          },
+        },
+      },
+    })
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/purchasing/orders']}>{children}</MemoryRouter>
+      </Provider>
+    )
+
+    renderHook(
+      () =>
+        usePurchaseOrdersWorkspace({
+          dispatch: store.dispatch,
+          purchaseOrders: [],
+          selectedOrder,
+          refetchOrders: vi.fn(),
+          isLoading: true,
+        }),
+      { wrapper },
+    )
+
+    expect(selectSelectedPurchaseOrder(store.getState())?.id).toBe('po-1')
   })
 })

--- a/frontend/src/pages/purchasing/hooks/usePurchaseOrdersWorkspace.ts
+++ b/frontend/src/pages/purchasing/hooks/usePurchaseOrdersWorkspace.ts
@@ -29,6 +29,7 @@ export interface UsePurchaseOrdersWorkspaceConfig {
   purchaseOrders: PurchaseOrder[]
   selectedOrder: PurchaseOrder | null
   refetchOrders: () => void
+  isLoading: boolean
 }
 
 export function usePurchaseOrdersWorkspace({
@@ -36,6 +37,7 @@ export function usePurchaseOrdersWorkspace({
   purchaseOrders,
   selectedOrder,
   refetchOrders,
+  isLoading: ordersLoading,
 }: UsePurchaseOrdersWorkspaceConfig) {
   const navigate = useNavigate()
   const { showSuccess, showError } = useNotification()
@@ -73,6 +75,7 @@ export function usePurchaseOrdersWorkspace({
     deleteMutation: async (id) => {
       await deletePurchaseOrder(id).unwrap()
     },
+    isLoading: ordersLoading,
     onEscape: () => {
       dispatch(setSelectedPurchaseOrder(null))
       setDeleteConfirmOpen(false)

--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -345,10 +345,10 @@ const CreateSalesOrderPage: React.FC = () => {
         navigate(`/sales/orders?highlight=${id}`)
       } else {
         const createdOrder = await createSalesOrder(orderData as any).unwrap()
-        const newOrderId = (createdOrder as any).id
+        dispatch(setSelectedOrder(createdOrder as any))
         showSuccess('Sales order created successfully')
         // Navigate to orders page with the new order selected
-        navigate(`/sales/orders?highlight=${newOrderId}`)
+        navigate(`/sales/orders?highlight=${(createdOrder as any).id}`)
       }
     } catch (err: any) {
       console.error('Error creating sales order:', err)

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -101,7 +101,7 @@ export const OrdersPage: React.FC = () => {
     toDate: dateRange.toDate,
   }), [appliedFilters, dateRange, sortBy, sortOrder])
 
-  const { data: ordersData, isLoading: loading, refetch: refetchOrders } = useGetSalesOrdersQuery(orderQueryArgs)
+  const { data: ordersData, isFetching: loading, refetch: refetchOrders } = useGetSalesOrdersQuery(orderQueryArgs)
   const orders = ordersData?.data ?? []
   const pagination = ordersData?.meta
 

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -115,6 +115,7 @@ export const OrdersPage: React.FC = () => {
     orders,
     selectedOrder,
     refetchOrders: loadOrders,
+    isLoading: loading,
   })
 
   const handleSort = useCallback((field: string) => {

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -248,7 +248,11 @@ describe('CreateSalesOrderPage product search', { timeout: 60000 }, () => {
     })
 
     expect(mockNavigate).toHaveBeenCalledWith('/sales/orders?highlight=new-order-id')
-    expect(mockDispatch.mock.invocationCallOrder[0]).toBeLessThan(
+    const dispatchCallIndex = mockDispatch.mock.calls.findIndex((call) =>
+      String(call[0]?.type).includes('setSelectedOrder'),
+    )
+    expect(dispatchCallIndex).toBeGreaterThanOrEqual(0)
+    expect(mockDispatch.mock.invocationCallOrder[dispatchCallIndex]).toBeLessThan(
       mockNavigate.mock.invocationCallOrder[0],
     )
   })

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -13,6 +13,7 @@ const customersResponse = {
 
 const {
   mockDispatch,
+  mockNavigate,
   mockGet,
   mockCreateSalesOrder,
   mockUpdateSalesOrder,
@@ -20,6 +21,7 @@ const {
   mockParams,
 } = vi.hoisted(() => ({
   mockDispatch: vi.fn(),
+  mockNavigate: vi.fn(),
   mockGet: vi.fn(),
   mockCreateSalesOrder: vi.fn(),
   mockUpdateSalesOrder: vi.fn(),
@@ -32,7 +34,7 @@ vi.mock('react-router-dom', async () => {
 
   return {
     ...actual,
-    useNavigate: () => vi.fn(),
+    useNavigate: () => mockNavigate,
     useParams: () => mockParams(),
   }
 })
@@ -210,5 +212,44 @@ describe('CreateSalesOrderPage product search', { timeout: 60000 }, () => {
     await waitFor(() => {
       expect(firstProductInput).toHaveValue('Hydrated Product')
     })
+  })
+
+  it('dispatches the created order before navigating back to the orders list', async () => {
+    const createdOrder = { id: 'new-order-id', orderNumber: 'SO-NEW' }
+    mockCreateSalesOrder.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue(createdOrder),
+    })
+
+    render(
+      <BrowserRouter>
+        <CreateSalesOrderPage />
+      </BrowserRouter>
+    )
+
+    const customerInput = screen.getByLabelText(/customer/i)
+    fireEvent.mouseDown(customerInput)
+    const customerListbox = await screen.findByRole('listbox')
+    fireEvent.click(within(customerListbox).getByText('Test Customer'))
+
+    const [productInput] = screen.getAllByPlaceholderText('Search by name or barcode...')
+    fireEvent.mouseDown(productInput)
+    const productListbox = await screen.findByRole('listbox')
+    fireEvent.click(within(productListbox).getByText('Alpha Widget'))
+
+    await userEvent.click(screen.getByRole('button', { name: /create order/i }))
+
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: expect.stringContaining('setSelectedOrder'),
+          payload: expect.objectContaining({ id: 'new-order-id' }),
+        }),
+      )
+    })
+
+    expect(mockNavigate).toHaveBeenCalledWith('/sales/orders?highlight=new-order-id')
+    expect(mockDispatch.mock.invocationCallOrder[0]).toBeLessThan(
+      mockNavigate.mock.invocationCallOrder[0],
+    )
   })
 })

--- a/frontend/src/pages/sales/hooks/useOrdersWorkspace.test.tsx
+++ b/frontend/src/pages/sales/hooks/useOrdersWorkspace.test.tsx
@@ -99,6 +99,7 @@ const renderOrdersWorkspace = (initialUrl = '/sales/orders?highlight=ord-2') => 
         orders: [makeOrder('ord-1') as any, makeOrder('ord-2') as any],
         selectedOrder: null,
         refetchOrders: vi.fn(),
+        isLoading: false,
       }),
     { wrapper },
   )
@@ -152,6 +153,7 @@ describe('useOrdersWorkspace', () => {
           orders: [makeOrderWithPayments('ord-1') as any],
           selectedOrder: makeOrderWithPayments('ord-1') as any,
           refetchOrders: vi.fn(),
+          isLoading: false,
         }),
       { wrapper },
     )
@@ -188,6 +190,7 @@ describe('useOrdersWorkspace', () => {
           orders: [selectedOrder as any],
           selectedOrder: selectedOrder as any,
           refetchOrders: vi.fn(),
+          isLoading: false,
         }),
       { wrapper },
     )
@@ -202,5 +205,41 @@ describe('useOrdersWorkspace', () => {
     expect(fetchJournalEntries).not.toHaveBeenCalledWith(
       expect.objectContaining({ sourceType: 'invoice' }),
     )
+  })
+
+  it('does not clear the selected order while orders are loading', () => {
+    const selectedOrder = makeOrder('ord-1') as any
+    const store = configureStore({
+      reducer: { sales: salesReducer },
+      preloadedState: {
+        sales: {
+          selectedOrder,
+          selectedInvoice: null,
+          selectedPayment: null,
+          selectedCustomer: null,
+          error: null,
+        },
+      },
+    })
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/sales/orders']}>{children}</MemoryRouter>
+      </Provider>
+    )
+
+    renderHook(
+      () =>
+        useOrdersWorkspace({
+          dispatch: store.dispatch,
+          getState: () => store.getState() as any,
+          orders: [],
+          selectedOrder,
+          refetchOrders: vi.fn(),
+          isLoading: true,
+        }),
+      { wrapper },
+    )
+
+    expect(selectSelectedOrder(store.getState())?.id).toBe('ord-1')
   })
 })

--- a/frontend/src/pages/sales/hooks/useOrdersWorkspace.ts
+++ b/frontend/src/pages/sales/hooks/useOrdersWorkspace.ts
@@ -33,6 +33,7 @@ interface UseOrdersWorkspaceConfig {
   orders: SalesOrder[]
   selectedOrder: SalesOrder | null
   refetchOrders: () => void
+  isLoading: boolean
 }
 
 export function useOrdersWorkspace({
@@ -41,6 +42,7 @@ export function useOrdersWorkspace({
   orders,
   selectedOrder,
   refetchOrders,
+  isLoading: ordersLoading,
 }: UseOrdersWorkspaceConfig) {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
@@ -89,6 +91,7 @@ export function useOrdersWorkspace({
     },
     notifications: { showSuccess: () => {}, showError: () => {} },
     deleteMutation: async () => {},
+    isLoading: ordersLoading,
     onEnter: () => {
       if (workspaceRef.current?.focusedIndex != null && workspaceRef.current.focusedIndex >= 0) {
         const order = orders[workspaceRef.current.focusedIndex]
@@ -233,11 +236,14 @@ export function useOrdersWorkspace({
         }
       }
     } else if (orders.length === 0) {
+      if (ordersLoading) {
+        return
+      }
       dispatch(setSelectedOrder(null))
       dispatch(clearError())
       workspace.setFocusedIndex(-1)
     }
-  }, [dispatch, orders, searchParams, selectedOrder, triggerGetSalesOrder, workspace])
+  }, [dispatch, orders, ordersLoading, searchParams, selectedOrder, triggerGetSalesOrder, workspace])
 
   useEffect(() => {
     if (!selectedOrder || orders.length === 0) {


### PR DESCRIPTION
## Summary

- Dispatch setSelectedOrder / setSelectedPurchaseOrder before navigating after a successful create, so the list page has a non-null selection on mount
- Add isLoading to useEntityWorkspace to guard against clearing a valid selection when the entity list is momentarily empty during refetch
- Forward isLoading from both OrdersPage and PurchaseOrdersPage into their workspace hooks

Closes #477

## Test plan

- [x] cd frontend && npx vitest run src/hooks/useEntityWorkspace.test.ts src/pages/sales/hooks/useOrdersWorkspace.test.tsx src/pages/purchasing/hooks/usePurchaseOrdersWorkspace.test.tsx src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx --no-coverage
- [x] cd frontend && npm run test -- src/hooks/useEntityWorkspace.test.ts src/pages/sales/hooks/useOrdersWorkspace.test.tsx src/pages/purchasing/hooks/usePurchaseOrdersWorkspace.test.tsx src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx --no-coverage
- [x] cd frontend && npm run type-check
- [x] cd frontend && npm run lint
- [x] cd frontend && npm run test -- --no-coverage (started but did not complete within ~7 minutes; terminated without a Vitest summary)

## Manual test plan

- [x] Create a new sales order -> lands on list page with workspace card populated instantly (no flicker)
- [x] Create a new purchase order -> same result
- [x] Edit an existing order -> workspace card still shows correctly on return
- [x] Filter the orders list -> filtering still works, selection clears correctly when list is empty after filter