### PR TITLE
fix: permanently delete purchase order lifecycle deadlock and error masking

### DIFF
--- a/backend/src/modules/purchasing/services/purchase-order-lifecycle.service.spec.ts
+++ b/backend/src/modules/purchasing/services/purchase-order-lifecycle.service.spec.ts
@@ -198,6 +198,14 @@ describe('PurchaseOrderLifecycleService', () => {
       });
     });
 
+    it('throws when the purchase order is not found', async () => {
+      const count = jest.fn().mockResolvedValue(0);
+      (poRepository.manager.getRepository as jest.Mock).mockReturnValue({ count });
+      poRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.assertPermanentDeleteAllowed('po-1')).rejects.toThrow(NotFoundException);
+    });
+
     it('throws when the purchase order has a paid amount greater than zero', async () => {
       const count = jest.fn().mockResolvedValue(0);
       (poRepository.manager.getRepository as jest.Mock).mockReturnValue({ count });

--- a/backend/src/modules/purchasing/services/purchase-order-lifecycle.service.spec.ts
+++ b/backend/src/modules/purchasing/services/purchase-order-lifecycle.service.spec.ts
@@ -198,19 +198,30 @@ describe('PurchaseOrderLifecycleService', () => {
       });
     });
 
-    it('throws when vendor payments exist for the purchase order', async () => {
+    it('throws when the purchase order has a paid amount greater than zero', async () => {
       const count = jest.fn().mockResolvedValue(0);
       (poRepository.manager.getRepository as jest.Mock).mockReturnValue({ count });
-      vpRepository.find.mockResolvedValue([mockVendorPayment]);
+      poRepository.findOne.mockResolvedValue({ ...mockOrder, paidAmount: 50 } as PurchaseOrder);
+      vpRepository.find.mockResolvedValue([]);
 
       await expect(service.assertPermanentDeleteAllowed('po-1')).rejects.toThrow(
-        'Cannot permanently delete purchase order with existing vendor payments.',
+        'Cannot permanently delete purchase order that has payments recorded. Please unpay first.',
       );
     });
 
-    it('resolves when neither stock movements nor vendor payments exist', async () => {
+    it('allows deletion when soft-deleted vendor payments exist but paidAmount is zero', async () => {
       const count = jest.fn().mockResolvedValue(0);
       (poRepository.manager.getRepository as jest.Mock).mockReturnValue({ count });
+      poRepository.findOne.mockResolvedValue({ ...mockOrder, paidAmount: 0 } as PurchaseOrder);
+      vpRepository.find.mockResolvedValue([mockVendorPayment]);
+
+      await expect(service.assertPermanentDeleteAllowed('po-1')).resolves.toBeUndefined();
+    });
+
+    it('resolves when neither stock movements nor paid amount exist', async () => {
+      const count = jest.fn().mockResolvedValue(0);
+      (poRepository.manager.getRepository as jest.Mock).mockReturnValue({ count });
+      poRepository.findOne.mockResolvedValue(mockOrder);
       vpRepository.find.mockResolvedValue([]);
 
       await expect(service.assertPermanentDeleteAllowed('po-1')).resolves.toBeUndefined();

--- a/backend/src/modules/purchasing/services/purchase-order-lifecycle.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order-lifecycle.service.ts
@@ -161,14 +161,14 @@ export class PurchaseOrderLifecycleService {
       );
     }
 
-    const vendorPayments = await this.vendorPaymentRepository.find({
-      where: { purchaseOrderId },
+    const purchaseOrder = await this.purchaseOrderRepository.findOne({
+      where: { id: purchaseOrderId },
       withDeleted: true,
     });
 
-    if (vendorPayments.length > 0) {
+    if (Number(purchaseOrder?.paidAmount || 0) > 0) {
       throw new BadRequestException(
-        'Cannot permanently delete purchase order with existing vendor payments.',
+        'Cannot permanently delete purchase order that has payments recorded. Please unpay first.',
       );
     }
   }

--- a/backend/src/modules/purchasing/services/purchase-order-lifecycle.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order-lifecycle.service.ts
@@ -166,7 +166,11 @@ export class PurchaseOrderLifecycleService {
       withDeleted: true,
     });
 
-    if (Number(purchaseOrder?.paidAmount || 0) > 0) {
+    if (!purchaseOrder) {
+      throw new NotFoundException('Purchase order not found');
+    }
+
+    if (Number(purchaseOrder.paidAmount || 0) > 0) {
       throw new BadRequestException(
         'Cannot permanently delete purchase order that has payments recorded. Please unpay first.',
       );

--- a/frontend/src/components/common/GenericDeletedDialog.test.tsx
+++ b/frontend/src/components/common/GenericDeletedDialog.test.tsx
@@ -271,4 +271,79 @@ describe('GenericDeletedDialog', () => {
     expect(screen.getByPlaceholderText('Search...')).toHaveValue('')
     expect(screen.getByText('Beta')).toBeInTheDocument()
   })
+
+  describe('error message display', () => {
+    const rtkError = {
+      data: 'Cannot permanently delete purchase order that has payments recorded. Please unpay first.',
+    }
+
+    it('shows backend error message from error.data string on permanent delete', async () => {
+      const permanentDeleteFn = vi.fn(() => ({
+        unwrap: () => Promise.reject(rtkError),
+      }))
+
+      renderDialog({
+        usePermanentDeleteMutation: vi.fn(() => [permanentDeleteFn, { isLoading: false }] as const),
+      })
+
+      await userEvent.click(screen.getAllByRole('button', { name: 'Permanently Delete (Cannot be undone)' })[0])
+      await userEvent.click(screen.getByRole('button', { name: 'Permanently Delete' }))
+
+      await waitFor(() => {
+        expect(notifications.showError).toHaveBeenCalledWith(rtkError.data)
+      })
+    })
+
+    it('shows backend error message from error.data string on restore', async () => {
+      const restoreFn = vi.fn(() => ({
+        unwrap: () => Promise.reject(rtkError),
+      }))
+
+      renderDialog({
+        useRestoreMutation: vi.fn(() => [restoreFn, { isLoading: false }] as const),
+      })
+
+      await userEvent.click(screen.getAllByRole('button', { name: 'Restore item' })[0])
+
+      await waitFor(() => {
+        expect(notifications.showError).toHaveBeenCalledWith(rtkError.data)
+      })
+    })
+
+    it('shows backend error message from error.data string on bulk restore', async () => {
+      const bulkRestoreFn = vi.fn(() => ({
+        unwrap: () => Promise.reject(rtkError),
+      }))
+
+      renderDialog({
+        useBulkRestoreMutation: vi.fn(() => [bulkRestoreFn, { isLoading: false }] as const),
+      })
+
+      await userEvent.click(screen.getAllByRole('checkbox')[1])
+      await userEvent.click(screen.getByRole('button', { name: /Restore Selected \(1\)/i }))
+      await userEvent.click(screen.getByRole('button', { name: /Restore 1 items/i }))
+
+      await waitFor(() => {
+        expect(notifications.showError).toHaveBeenCalledWith(rtkError.data)
+      })
+    })
+
+    it('shows backend error message from error.data string on bulk permanent delete', async () => {
+      const bulkPermanentDeleteFn = vi.fn(() => ({
+        unwrap: () => Promise.reject(rtkError),
+      }))
+
+      renderDialog({
+        useBulkPermanentDeleteMutation: vi.fn(() => [bulkPermanentDeleteFn, { isLoading: false }] as const),
+      })
+
+      await userEvent.click(screen.getAllByRole('checkbox')[1])
+      await userEvent.click(screen.getByRole('button', { name: /Delete Selected \(1\)/i }))
+      await userEvent.click(screen.getByRole('button', { name: /Delete 1 items/i }))
+
+      await waitFor(() => {
+        expect(notifications.showError).toHaveBeenCalledWith(rtkError.data)
+      })
+    })
+  })
 })

--- a/frontend/src/components/common/GenericDeletedDialog.tsx
+++ b/frontend/src/components/common/GenericDeletedDialog.tsx
@@ -182,7 +182,7 @@ function GenericDeletedDialog<T extends { id: string }>({
       showSuccess(`${entityLabel} "${getItemLabel(item)}" restored successfully`)
       await afterSuccessfulChange()
     } catch (error: any) {
-      showError(error?.data?.message || error?.message || `Failed to restore ${entityLabel}`)
+      showError(error?.data || error?.message || `Failed to restore ${entityLabel}`)
     } finally {
       setRestoringId(null)
     }
@@ -199,7 +199,7 @@ function GenericDeletedDialog<T extends { id: string }>({
       showSuccess(`${entityLabel} "${getItemLabel(item)}" permanently deleted`)
       await afterSuccessfulChange()
     } catch (error: any) {
-      showError(error?.data?.message || error?.message || `Failed to permanently delete ${entityLabel}`)
+      showError(error?.data || error?.message || `Failed to permanently delete ${entityLabel}`)
     } finally {
       setDeletingId(null)
       setConfirmDelete(null)
@@ -228,7 +228,7 @@ function GenericDeletedDialog<T extends { id: string }>({
       setSelectedItems(new Set())
       await afterSuccessfulChange()
     } catch (error: any) {
-      showError(error?.data?.message || error?.message || `Failed to bulk restore ${entityLabelPlural}`)
+      showError(error?.data || error?.message || `Failed to bulk restore ${entityLabelPlural}`)
     } finally {
       setBulkRestoring(false)
       setShowBulkRestoreConfirm(false)
@@ -257,7 +257,7 @@ function GenericDeletedDialog<T extends { id: string }>({
       setSelectedItems(new Set())
       await afterSuccessfulChange()
     } catch (error: any) {
-      showError(error?.data?.message || error?.message || `Failed to bulk delete ${entityLabelPlural}`)
+      showError(error?.data || error?.message || `Failed to bulk delete ${entityLabelPlural}`)
     } finally {
       setBulkDeleting(false)
       setShowBulkDeleteConfirm(false)


### PR DESCRIPTION
## Summary

- **Backend**: Relaxed `assertPermanentDeleteAllowed` in `PurchaseOrderLifecycleService` to only block when `stockMovementCount > 0` or `paidAmount > 0`. Previously it blocked if any `VendorPayment` records existed (even soft-deleted/unpaid), which prevented `permanentDelete` from ever reaching its own cleanup code.
- **Backend**: Added `NotFoundException` guard for missing PO in `assertPermanentDeleteAllowed`, making it consistent with `assertItemsNotLocked`.
- **Frontend**: Fixed all four catch blocks in `GenericDeletedDialog` (`handleRestore`, `handlePermanentDelete`, `handleBulkRestore`, `handleBulkPermanentDelete`) to use `error?.data` (a string, as shaped by `axiosBaseQuery`) instead of `error?.data?.message` (always `undefined` on a string), so the real backend error message is shown.

## Test plan

- [x] `cd backend && npx jest src/modules/purchasing/services/purchase-order-lifecycle.service.spec.ts --no-coverage` — 12 tests pass, including new NotFoundException and paidAmount guard tests
- [x] `cd frontend && npx vitest run src/components/common/GenericDeletedDialog.test.tsx` — error-message tests pass for all four handlers
- [ ] Manual: soft-delete a PO with unpaid vendor payments, then permanently delete it from the Deleted POs dialog — should succeed
- [ ] Manual: attempt to permanently delete a PO with `paidAmount > 0` — should show the real backend error message

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)