### PR TITLE
fix(backup): fix critical command injection vulnerability (Alert #4)

### DIFF
--- a/backend/src/modules/backup/backup.controller.spec.ts
+++ b/backend/src/modules/backup/backup.controller.spec.ts
@@ -110,4 +110,10 @@ describe('BackupController - upload fileFilter', () => {
 
     expect(cb).toHaveBeenCalledWith(null, true);
   });
+
+  it('accepts valid tgz backup filenames', () => {
+    const cb = runFileFilter('backup_20260430_120000.tgz');
+
+    expect(cb).toHaveBeenCalledWith(null, true);
+  });
 });

--- a/backend/src/modules/backup/backup.controller.spec.ts
+++ b/backend/src/modules/backup/backup.controller.spec.ts
@@ -1,8 +1,9 @@
+import { BadRequestException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { UserRole } from '@database/entities/user.entity';
-import { BackupController } from './backup.controller';
+import { BackupController, backupUploadFileFilter } from './backup.controller';
 
 /**
  * Returns the guards applied to a class or method via UseGuards metadata.
@@ -70,5 +71,43 @@ describe('BackupController - auth guards', () => {
       expect(methodRoles).not.toContain(UserRole.SALES_STAFF);
       expect(methodRoles).not.toContain(UserRole.PROCUREMENT_STAFF);
     });
+  });
+});
+
+describe('BackupController - upload fileFilter', () => {
+  function runFileFilter(originalname: string) {
+    const cb = jest.fn();
+
+    backupUploadFileFilter(
+      {},
+      { originalname },
+      cb,
+    );
+
+    return cb;
+  }
+
+  it('rejects filenames containing shell metacharacters', () => {
+    const cb = runFileFilter('backup;rm.tar.gz');
+
+    expect(cb).toHaveBeenCalledWith(expect.any(BadRequestException), false);
+    expect(cb.mock.calls[0][0].message).toBe(
+      'Invalid filename. Only alphanumeric characters, dots, underscores, and hyphens are allowed.',
+    );
+  });
+
+  it('rejects filenames containing path traversal characters', () => {
+    const cb = runFileFilter('../../etc/passwd.tar.gz');
+
+    expect(cb).toHaveBeenCalledWith(expect.any(BadRequestException), false);
+    expect(cb.mock.calls[0][0].message).toBe(
+      'Invalid filename. Only alphanumeric characters, dots, underscores, and hyphens are allowed.',
+    );
+  });
+
+  it('accepts valid tar.gz backup filenames', () => {
+    const cb = runFileFilter('backup_20260430_120000.tar.gz');
+
+    expect(cb).toHaveBeenCalledWith(null, true);
   });
 });

--- a/backend/src/modules/backup/backup.controller.ts
+++ b/backend/src/modules/backup/backup.controller.ts
@@ -9,6 +9,7 @@ import {
   StreamableFile,
   UseInterceptors,
   UploadedFile,
+  BadRequestException,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiTags, ApiOperation, ApiResponse, ApiConsumes } from '@nestjs/swagger';
@@ -149,10 +150,14 @@ export class BackupController {
         },
       }),
       fileFilter: (_req, file, cb) => {
+        const safeFilenameRegex = /^[a-zA-Z0-9._-]+$/;
+        if (!safeFilenameRegex.test(file.originalname)) {
+          return cb(new BadRequestException('Invalid filename. Only alphanumeric characters, dots, underscores, and hyphens are allowed.'), false);
+        }
         if (file.originalname.endsWith('.tar.gz') || file.originalname.endsWith('.tgz')) {
           cb(null, true);
         } else {
-          cb(new Error('Only .tar.gz or .tgz files are allowed'), false);
+          cb(new BadRequestException('Only .tar.gz or .tgz files are allowed'), false);
         }
       },
     }),

--- a/backend/src/modules/backup/backup.controller.ts
+++ b/backend/src/modules/backup/backup.controller.ts
@@ -29,6 +29,28 @@ import { BackupSchedule } from '@database/entities/backup-schedule.entity';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { UserRole } from '@database/entities/user.entity';
 
+export const backupUploadFileFilter = (
+  _req: unknown,
+  file: { originalname: string },
+  cb: (error: Error | null, acceptFile: boolean) => void,
+): void => {
+  const safeFilenameRegex = /^[a-zA-Z0-9._-]+$/;
+  if (!safeFilenameRegex.test(file.originalname)) {
+    return cb(
+      new BadRequestException(
+        'Invalid filename. Only alphanumeric characters, dots, underscores, and hyphens are allowed.',
+      ),
+      false,
+    );
+  }
+
+  if (file.originalname.endsWith('.tar.gz') || file.originalname.endsWith('.tgz')) {
+    cb(null, true);
+  } else {
+    cb(new BadRequestException('Only .tar.gz or .tgz files are allowed'), false);
+  }
+};
+
 @ApiTags('Backup')
 @Controller('backup')
 @Auth()
@@ -149,17 +171,7 @@ export class BackupController {
           cb(null, file.originalname);
         },
       }),
-      fileFilter: (_req, file, cb) => {
-        const safeFilenameRegex = /^[a-zA-Z0-9._-]+$/;
-        if (!safeFilenameRegex.test(file.originalname)) {
-          return cb(new BadRequestException('Invalid filename. Only alphanumeric characters, dots, underscores, and hyphens are allowed.'), false);
-        }
-        if (file.originalname.endsWith('.tar.gz') || file.originalname.endsWith('.tgz')) {
-          cb(null, true);
-        } else {
-          cb(new BadRequestException('Only .tar.gz or .tgz files are allowed'), false);
-        }
-      },
+      fileFilter: backupUploadFileFilter,
     }),
   )
   async uploadBackup(

--- a/backend/src/modules/backup/backup.service.spec.ts
+++ b/backend/src/modules/backup/backup.service.spec.ts
@@ -34,6 +34,19 @@ function mockSuccessfulSpawn(stdout = '') {
   });
 }
 
+function mockFailingSpawn(stderr = 'permission denied', code = 1) {
+  mockSpawn.mockImplementationOnce(() => {
+    const child = new EventEmitter() as any;
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    process.nextTick(() => {
+      child.stderr.emit('data', stderr);
+      child.emit('close', code);
+    });
+    return child;
+  });
+}
+
 const mockRepository = () => ({
   findOne: jest.fn(),
   find: jest.fn(),
@@ -197,6 +210,27 @@ describe('BackupService - settings backup', () => {
       ], expect.objectContaining({
         env: expect.objectContaining({ PGPASSWORD: '' }),
       }));
+    });
+
+    it('rejects when a spawned command exits with a non-zero code', async () => {
+      mockFailingSpawn('role "erp_user" does not exist', 1);
+
+      await expect((service as any).backupPostgreSQL('/tmp', '20260430_120000'))
+        .rejects.toThrow('Command failed with code 1');
+    });
+
+    it('rejects when a spawned command is killed by a signal', async () => {
+      jest.spyOn(require('fs/promises'), 'mkdir').mockResolvedValue(undefined);
+      mockSpawn.mockImplementationOnce(() => {
+        const child = new EventEmitter() as any;
+        child.stdout = new EventEmitter();
+        child.stderr = new EventEmitter();
+        process.nextTick(() => child.emit('close', null, 'SIGKILL'));
+        return child;
+      });
+
+      await expect((service as any).extractArchive('/tmp/backup.tar.gz', '/tmp/restore'))
+        .rejects.toThrow('Command killed by signal SIGKILL');
     });
   });
 

--- a/backend/src/modules/backup/backup.service.spec.ts
+++ b/backend/src/modules/backup/backup.service.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ConfigService } from '@nestjs/config';
+import { EventEmitter } from 'events';
+import { spawn } from 'child_process';
 import { BackupService } from './backup.service';
 import { BackupLog } from '@database/entities/backup-log.entity';
 import { BackupRetentionSettings } from '@database/entities/backup-settings.entity';
@@ -8,6 +10,29 @@ import { CompanySettings } from '@database/entities/company-settings.entity';
 import { RegionalSettings } from '@database/entities/regional-settings.entity';
 import { DocumentNumberSetting } from '@database/entities/document-number-settings.entity';
 import { PrintSettings } from '@database/entities/print-settings.entity';
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn(),
+}));
+
+const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
+
+function mockSuccessfulSpawn(stdout = '') {
+  mockSpawn.mockImplementationOnce(() => {
+    const child = new EventEmitter() as any;
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+
+    process.nextTick(() => {
+      if (stdout) {
+        child.stdout.emit('data', stdout);
+      }
+      child.emit('close', 0);
+    });
+
+    return child;
+  });
+}
 
 const mockRepository = () => ({
   findOne: jest.fn(),
@@ -74,6 +99,105 @@ describe('BackupService - settings backup', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+    mockSpawn.mockReset();
+  });
+
+  describe('command execution', () => {
+    it('uses spawn argument arrays for PostgreSQL backup creation', async () => {
+      mockSuccessfulSpawn();
+      mockSuccessfulSpawn();
+
+      const result = await (service as any).backupPostgreSQL('/tmp/backup dir', '20260430_120000');
+
+      expect(result).toBe('erp_db_20260430_120000.sql.gz');
+      expect(mockSpawn).toHaveBeenNthCalledWith(1, 'pg_dump', [
+        '-h', 'postgres',
+        '-p', '5432',
+        '-U', 'erp_user',
+        '-d', 'erp_db',
+        '-F', 'p',
+        '--clean',
+        '--if-exists',
+        '-f', '/tmp/backup dir/erp_db_20260430_120000.sql',
+      ], expect.objectContaining({
+        env: expect.objectContaining({ PGPASSWORD: '' }),
+      }));
+      expect(mockSpawn).toHaveBeenNthCalledWith(2, 'gzip', [
+        '/tmp/backup dir/erp_db_20260430_120000.sql',
+      ], {});
+    });
+
+    it('uses spawn argument arrays for PostgreSQL version checks', async () => {
+      mockSuccessfulSpawn('psql (PostgreSQL) 16.2\n');
+
+      const result = await (service as any).getPostgreSQLVersion();
+
+      expect(result).toBe('psql (PostgreSQL) 16.2');
+      expect(mockSpawn).toHaveBeenCalledWith('psql', ['--version'], {});
+    });
+
+    it('uses spawn argument arrays for PostgreSQL table listing', async () => {
+      mockSuccessfulSpawn(' customers \n invoices \n\n');
+
+      const result = await (service as any).getPostgreSQLTables();
+
+      expect(result).toEqual(['customers', 'invoices']);
+      expect(mockSpawn).toHaveBeenCalledWith('psql', [
+        '-h', 'postgres',
+        '-p', '5432',
+        '-U', 'erp_user',
+        '-d', 'erp_db',
+        '-t',
+        '-c', "SELECT tablename FROM pg_tables WHERE schemaname='public'",
+      ], expect.objectContaining({
+        env: expect.objectContaining({ PGPASSWORD: '' }),
+      }));
+    });
+
+    it('uses spawn argument arrays for tar extraction', async () => {
+      jest.spyOn(require('fs/promises'), 'mkdir').mockResolvedValue(undefined);
+      mockSuccessfulSpawn();
+
+      await (service as any).extractArchive('/tmp/backup;rm.tar.gz', '/tmp/restore dir');
+
+      expect(mockSpawn).toHaveBeenCalledWith('tar', [
+        '-xzf',
+        '/tmp/backup;rm.tar.gz',
+        '-C',
+        '/tmp/restore dir',
+      ], {});
+    });
+
+    it('uses spawn argument arrays for PostgreSQL restore', async () => {
+      jest.spyOn(require('fs/promises'), 'readdir').mockResolvedValue(['erp_db_20260430_120000.sql.gz']);
+      mockSuccessfulSpawn();
+      mockSuccessfulSpawn();
+      mockSuccessfulSpawn();
+
+      await (service as any).restorePostgreSQL('/tmp/restore dir');
+
+      expect(mockSpawn).toHaveBeenNthCalledWith(1, 'gunzip', [
+        '/tmp/restore dir/erp_db_20260430_120000.sql.gz',
+      ], {});
+      expect(mockSpawn).toHaveBeenNthCalledWith(2, '/usr/bin/psql', [
+        '-h', 'postgres',
+        '-p', '5432',
+        '-U', 'erp_user',
+        '-d', 'postgres',
+        '-c', "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'erp_db' AND pid <> pg_backend_pid();",
+      ], expect.objectContaining({
+        env: expect.objectContaining({ PGPASSWORD: '' }),
+      }));
+      expect(mockSpawn).toHaveBeenNthCalledWith(3, '/usr/bin/psql', [
+        '-h', 'postgres',
+        '-p', '5432',
+        '-U', 'erp_user',
+        '-d', 'erp_db',
+        '-f', '/tmp/restore dir/erp_db_20260430_120000.sql',
+      ], expect.objectContaining({
+        env: expect.objectContaining({ PGPASSWORD: '' }),
+      }));
+    });
   });
 
   describe('getCompanySettings', () => {

--- a/backend/src/modules/backup/backup.service.ts
+++ b/backend/src/modules/backup/backup.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, LessThan } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import Redis from 'ioredis';
-import { spawn } from 'child_process';
+import { spawn, SpawnOptions } from 'child_process';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
@@ -66,7 +66,7 @@ export class BackupService implements OnModuleDestroy {
   private async spawnAsync(
     command: string,
     args: string[],
-    options: any = {},
+    options: SpawnOptions = {},
   ): Promise<{ stdout: string; stderr: string }> {
     return new Promise((resolve, reject) => {
       const child = spawn(command, args, options);
@@ -76,9 +76,11 @@ export class BackupService implements OnModuleDestroy {
       child.stdout?.on('data', (data) => (stdout += data));
       child.stderr?.on('data', (data) => (stderr += data));
 
-      child.on('close', (code) => {
+      child.on('close', (code, signal) => {
         if (code === 0) {
           resolve({ stdout, stderr });
+        } else if (signal) {
+          reject(new Error(`Command killed by signal ${signal}: ${stderr}`));
         } else {
           reject(new Error(`Command failed with code ${code}: ${stderr}`));
         }

--- a/backend/src/modules/backup/backup.service.ts
+++ b/backend/src/modules/backup/backup.service.ts
@@ -707,7 +707,7 @@ export class BackupService implements OnModuleDestroy {
     const sqlPath = path.join(restoreDir, sqlFile);
 
     // Decompress the SQL file
-    await execAsync(`gunzip "${sqlPath}"`);
+    await this.spawnAsync('gunzip', [sqlPath]);
     const decompressedPath = sqlPath.replace('.gz', '');
 
     const host = this.configService.get<string>('DB_HOST', 'postgres');
@@ -724,17 +724,26 @@ export class BackupService implements OnModuleDestroy {
     };
 
     // Drop existing connections to the database
-    const dropConnectionsCmd = `${psqlPath} -h ${host} -p ${port} -U ${username} -d postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${database}' AND pid <> pg_backend_pid();"`;
-
     try {
-      await execAsync(dropConnectionsCmd, { env });
+      await this.spawnAsync(psqlPath, [
+        '-h', host,
+        '-p', port,
+        '-U', username,
+        '-d', 'postgres',
+        '-c', `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${database}' AND pid <> pg_backend_pid();`,
+      ], { env });
     } catch (error) {
       this.logger.warn('Failed to drop existing connections, continuing...');
     }
 
     // Restore the database
-    const restoreCommand = `${psqlPath} -h ${host} -p ${port} -U ${username} -d ${database} -f "${decompressedPath}"`;
-    await execAsync(restoreCommand, { env });
+    await this.spawnAsync(psqlPath, [
+      '-h', host,
+      '-p', port,
+      '-U', username,
+      '-d', database,
+      '-f', decompressedPath,
+    ], { env });
 
     this.logger.log('PostgreSQL restore completed');
   }

--- a/backend/src/modules/backup/backup.service.ts
+++ b/backend/src/modules/backup/backup.service.ts
@@ -688,8 +688,7 @@ export class BackupService implements OnModuleDestroy {
   private async extractArchive(archivePath: string, destDir: string): Promise<void> {
     await fs.mkdir(destDir, { recursive: true });
 
-    const command = `tar -xzf "${archivePath}" -C "${destDir}"`;
-    await execAsync(command);
+    await this.spawnAsync('tar', ['-xzf', archivePath, '-C', destDir]);
 
     this.logger.log(`Archive extracted to: ${destDir}`);
   }

--- a/backend/src/modules/backup/backup.service.ts
+++ b/backend/src/modules/backup/backup.service.ts
@@ -235,12 +235,19 @@ export class BackupService implements OnModuleDestroy {
       PGPASSWORD: password,
     };
 
-    const command = `pg_dump -h ${host} -p ${port} -U ${username} -d ${database} -F p --clean --if-exists -f ${filepath}`;
-
-    await execAsync(command, { env });
+    await this.spawnAsync('pg_dump', [
+      '-h', host,
+      '-p', port,
+      '-U', username,
+      '-d', database,
+      '-F', 'p',
+      '--clean',
+      '--if-exists',
+      '-f', filepath,
+    ], { env });
 
     // Compress the SQL file
-    await execAsync(`gzip ${filepath}`);
+    await this.spawnAsync('gzip', [filepath]);
 
     return `${filename}.gz`;
   }
@@ -367,7 +374,7 @@ export class BackupService implements OnModuleDestroy {
 
   private async getPostgreSQLVersion(): Promise<string> {
     try {
-      const { stdout } = await execAsync('psql --version');
+      const { stdout } = await this.spawnAsync('psql', ['--version']);
       return stdout.trim();
     } catch (error) {
       return 'unknown';
@@ -383,9 +390,15 @@ export class BackupService implements OnModuleDestroy {
       const password = this.configService.get<string>('DB_PASSWORD', '');
 
       const env = { ...process.env, PGPASSWORD: password };
-      const command = `psql -h ${host} -p ${port} -U ${username} -d ${database} -t -c "SELECT tablename FROM pg_tables WHERE schemaname='public'"`;
 
-      const { stdout } = await execAsync(command, { env });
+      const { stdout } = await this.spawnAsync('psql', [
+        '-h', host,
+        '-p', port,
+        '-U', username,
+        '-d', database,
+        '-t',
+        '-c', "SELECT tablename FROM pg_tables WHERE schemaname='public'",
+      ], { env });
       return stdout
         .split('\n')
         .map((line) => line.trim())

--- a/backend/src/modules/backup/backup.service.ts
+++ b/backend/src/modules/backup/backup.service.ts
@@ -3,8 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, LessThan } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import Redis from 'ioredis';
-import { exec } from 'child_process';
-import { promisify } from 'util';
+import { spawn } from 'child_process';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
@@ -20,8 +19,6 @@ import { CreateBackupDto, BackupDatabase } from './dto/create-backup.dto';
 import { BackupMetadata } from './interfaces/backup-metadata.interface';
 import { UpdateBackupSettingsDto, BackupSettingsResponseDto } from './dto/backup-settings.dto';
 import { plainToInstance } from 'class-transformer';
-
-const execAsync = promisify(exec);
 
 @Injectable()
 export class BackupService implements OnModuleDestroy {
@@ -64,6 +61,33 @@ export class BackupService implements OnModuleDestroy {
     } catch (_error) {
       // Ignore redis shutdown errors during module teardown.
     }
+  }
+
+  private async spawnAsync(
+    command: string,
+    args: string[],
+    options: any = {},
+  ): Promise<{ stdout: string; stderr: string }> {
+    return new Promise((resolve, reject) => {
+      const child = spawn(command, args, options);
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout?.on('data', (data) => (stdout += data));
+      child.stderr?.on('data', (data) => (stderr += data));
+
+      child.on('close', (code) => {
+        if (code === 0) {
+          resolve({ stdout, stderr });
+        } else {
+          reject(new Error(`Command failed with code ${code}: ${stderr}`));
+        }
+      });
+
+      child.on('error', (err) => {
+        reject(err);
+      });
+    });
   }
 
   async createBackup(createBackupDto: CreateBackupDto): Promise<BackupLog> {


### PR DESCRIPTION
## Summary

- Replaced all `child_process.exec` shell-based calls in `BackupService` with `spawnAsync` (spawn + argument arrays), eliminating shell interpolation across 8 call sites
- Added strict filename validation in Multer's `fileFilter` before any file is written to disk, blocking path traversal and shell metacharacter injection in uploaded backup filenames
- Typed `spawnAsync` options as `SpawnOptions` and added signal-kill handling in the close handler for clearer error messages

## Test plan

- [x] 40 backup module tests pass (`npx jest src/modules/backup/ --no-coverage`)
- [x] Full suite passes (`npm run test` — 865 tests)
- [x] Attempt to upload a file named `test;rm.tar.gz` — expect 400 rejection
- [x] Upload a valid `.tar.gz` backup and restore it — expect success

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)