### PR TITLE
fix(inventory): harden CSV parser import limits

### DIFF
--- a/backend/src/modules/inventory/services/product.service.spec.ts
+++ b/backend/src/modules/inventory/services/product.service.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -92,6 +93,67 @@ describe('ProductService pagination removal', () => {
 
     service = module.get(ProductService);
     productRepository = module.get(getRepositoryToken(Product));
+  });
+
+  describe('CSV import parser hardening', () => {
+    const requiredHeader = 'name,type,categoryName,baseCost';
+    const validDataRow = 'Widget,GOODS,Hardware,12.50';
+
+    it('parseCsvContent rejects non-string content', () => {
+      expect(() => (service as any).parseCsvContent({ length: 2 })).toThrow(BadRequestException);
+      expect(() => (service as any).parseCsvContent({ length: 2 })).toThrow('CSV content must be a string');
+    });
+
+    it('parseCsvContent accepts exactly 1000 data rows plus a header row', () => {
+      const content = `${requiredHeader}\n${Array.from({ length: 1000 }, () => validDataRow).join('\n')}`;
+
+      const rows = (service as any).parseCsvContent(content);
+
+      expect(rows).toHaveLength(1000);
+      expect(rows[0]).toEqual({
+        name: 'Widget',
+        type: 'GOODS',
+        categoryname: 'Hardware',
+        basecost: '12.50',
+      });
+    });
+
+    it('parseCsvContent rejects 1001 data rows plus a header row', () => {
+      const content = `${requiredHeader}\n${Array.from({ length: 1001 }, () => validDataRow).join('\n')}`;
+
+      expect(() => (service as any).parseCsvContent(content)).toThrow(BadRequestException);
+      expect(() => (service as any).parseCsvContent(content)).toThrow(
+        'Import file exceeds maximum allowed data rows (1000)',
+      );
+    });
+
+    it('parseCsvLine rejects non-string input', () => {
+      expect(() => (service as any).parseCsvLine({ length: 8192 })).toThrow(BadRequestException);
+      expect(() => (service as any).parseCsvLine({ length: 8192 })).toThrow('CSV line must be a string');
+    });
+
+    it('parseCsvLine accepts a line exactly 8192 characters long', () => {
+      const line = 'a'.repeat(8192);
+
+      expect((service as any).parseCsvLine(line)).toEqual([line]);
+    });
+
+    it('parseCsvLine rejects a line longer than 8192 characters', () => {
+      const line = 'a'.repeat(8193);
+
+      expect(() => (service as any).parseCsvLine(line)).toThrow(BadRequestException);
+      expect(() => (service as any).parseCsvLine(line)).toThrow(
+        'CSV line exceeds maximum allowed length (8192 characters)',
+      );
+    });
+
+    it('parseCsvLine preserves quoted comma parsing for valid CSV lines', () => {
+      expect((service as any).parseCsvLine('Widget,"Hardware, Tools",12.50')).toEqual([
+        'Widget',
+        'Hardware, Tools',
+        '12.50',
+      ]);
+    });
   });
 
   it('findAll returns all matching products with total-only metadata', async () => {

--- a/backend/src/modules/inventory/services/product.service.ts
+++ b/backend/src/modules/inventory/services/product.service.ts
@@ -64,6 +64,8 @@ export class ProductService extends BaseCrudService<
   QueryProductsDto
 > {
   private readonly logger = new Logger(ProductService.name);
+  private readonly MAX_IMPORT_DATA_ROWS = 1000;
+  private readonly MAX_CSV_LINE_LENGTH = 8192;
 
   constructor(
     @InjectRepository(Product)
@@ -1652,10 +1654,21 @@ export class ProductService extends BaseCrudService<
    * Parse CSV content
    */
   private parseCsvContent(content: string): any[] {
+    if (typeof content !== 'string') {
+      throw new BadRequestException('CSV content must be a string');
+    }
+
     const lines = content.split('\n').filter(line => line.trim());
-    
+
     if (lines.length < 2) {
       throw new BadRequestException('File must contain at least a header row and one data row');
+    }
+
+    const dataRowCount = lines.length - 1;
+    if (dataRowCount > this.MAX_IMPORT_DATA_ROWS) {
+      throw new BadRequestException(
+        `Import file exceeds maximum allowed data rows (${this.MAX_IMPORT_DATA_ROWS})`,
+      );
     }
 
     // Parse header
@@ -1665,7 +1678,7 @@ export class ProductService extends BaseCrudService<
     // Validate required headers
     const requiredHeaders = ['name', 'type', 'categoryname', 'basecost'];
     const missingHeaders = requiredHeaders.filter(req => !headers.includes(req));
-    
+
     if (missingHeaders.length > 0) {
       throw new BadRequestException(`Missing required headers: ${missingHeaders.join(', ')}`);
     }
@@ -1678,7 +1691,7 @@ export class ProductService extends BaseCrudService<
 
       const values = this.parseCsvLine(line);
       const rowData: any = {};
-      
+
       headers.forEach((header, index) => {
         rowData[header] = values[index] || '';
       });
@@ -1693,13 +1706,23 @@ export class ProductService extends BaseCrudService<
    * Parse a single CSV line handling quoted values
    */
   private parseCsvLine(line: string): string[] {
+    if (typeof line !== 'string') {
+      throw new BadRequestException('CSV line must be a string');
+    }
+
+    if (line.length > this.MAX_CSV_LINE_LENGTH) {
+      throw new BadRequestException(
+        `CSV line exceeds maximum allowed length (${this.MAX_CSV_LINE_LENGTH} characters)`,
+      );
+    }
+
     const values = [];
     let currentValue = '';
     let inQuotes = false;
-    
+
     for (let i = 0; i < line.length; i++) {
       const char = line[i];
-      
+
       if (char === '"' && (i === 0 || line[i - 1] === ',')) {
         inQuotes = true;
       } else if (char === '"' && inQuotes && (i === line.length - 1 || line[i + 1] === ',')) {
@@ -1711,7 +1734,7 @@ export class ProductService extends BaseCrudService<
         currentValue += char;
       }
     }
-    
+
     values.push(currentValue.trim());
     return values;
   }


### PR DESCRIPTION
## Summary
- Harden product CSV import parsing against loop-bound injection from uploaded content.
- Add fixed parser limits: 1,000 data rows per import and 8,192 characters per CSV line.
- Add unit coverage for type validation, row/line boundaries, and quoted comma parsing.

## Linked Issue
Closes #484

## Test Plan
- [x] `cd backend && npx jest src/modules/inventory/services/product.service.spec.ts` - PASS
- [x] `cd backend && npm run lint` - PASS
- [x] `cd backend && npm run test` - PASS, 67 suites / 875 tests

## Notes
- No migrations or environment changes.
- Jest emits expected error logs from existing negative-path tests; all tests pass.