### PR TITLE
fix(backup): harden uploaded backup paths

### DIFF
--- a/backend/src/modules/backup/backup.controller.spec.ts
+++ b/backend/src/modules/backup/backup.controller.spec.ts
@@ -91,8 +91,8 @@ describe('BackupController - upload fileFilter', () => {
     const cb = runFileFilter('backup;rm.tar.gz');
 
     expect(cb).toHaveBeenCalledWith(expect.any(BadRequestException), false);
-    expect(cb.mock.calls[0][0].message).toBe(
-      'Invalid filename. Only alphanumeric characters, dots, underscores, and hyphens are allowed.',
+    expect(cb.mock.calls[0][0].message).toContain(
+      'Only alphanumeric characters, dots, underscores, and hyphens are allowed',
     );
   });
 
@@ -100,9 +100,22 @@ describe('BackupController - upload fileFilter', () => {
     const cb = runFileFilter('../../etc/passwd.tar.gz');
 
     expect(cb).toHaveBeenCalledWith(expect.any(BadRequestException), false);
-    expect(cb.mock.calls[0][0].message).toBe(
-      'Invalid filename. Only alphanumeric characters, dots, underscores, and hyphens are allowed.',
+    expect(cb.mock.calls[0][0].message).toContain(
+      'Only alphanumeric characters, dots, underscores, and hyphens are allowed',
     );
+  });
+
+  it('rejects filenames containing parent-directory traversal segments', () => {
+    const cb = runFileFilter('safe..name.tar.gz');
+
+    expect(cb).toHaveBeenCalledWith(expect.any(BadRequestException), false);
+    expect(cb.mock.calls[0][0].message).toContain('".." is prohibited');
+  });
+
+  it('rejects nested traversal filenames even when the extension is valid', () => {
+    const cb = runFileFilter('../../../malicious.tar.gz');
+
+    expect(cb).toHaveBeenCalledWith(expect.any(BadRequestException), false);
   });
 
   it('accepts valid tar.gz backup filenames', () => {

--- a/backend/src/modules/backup/backup.controller.ts
+++ b/backend/src/modules/backup/backup.controller.ts
@@ -16,6 +16,7 @@ import { ApiTags, ApiOperation, ApiResponse, ApiConsumes } from '@nestjs/swagger
 import { Response } from 'express';
 import { diskStorage } from 'multer';
 import * as fs from 'fs';
+import * as crypto from 'crypto';
 import { BackupService } from './backup.service';
 import { BackupSchedulerService } from './backup-scheduler.service';
 import { CreateBackupDto } from './dto/create-backup.dto';
@@ -35,10 +36,10 @@ export const backupUploadFileFilter = (
   cb: (error: Error | null, acceptFile: boolean) => void,
 ): void => {
   const safeFilenameRegex = /^[a-zA-Z0-9._-]+$/;
-  if (!safeFilenameRegex.test(file.originalname)) {
+  if (!safeFilenameRegex.test(file.originalname) || file.originalname.includes('..')) {
     return cb(
       new BadRequestException(
-        'Invalid filename. Only alphanumeric characters, dots, underscores, and hyphens are allowed.',
+        'Invalid filename. Only alphanumeric characters, dots, underscores, and hyphens are allowed, and ".." is prohibited.',
       ),
       false,
     );
@@ -168,7 +169,8 @@ export class BackupController {
           cb(null, uploadPath);
         },
         filename: (_req, file, cb) => {
-          cb(null, file.originalname);
+          const ext = file.originalname.endsWith('.tar.gz') ? '.tar.gz' : '.tgz';
+          cb(null, `upload_${Date.now()}_${crypto.randomUUID()}${ext}`);
         },
       }),
       fileFilter: backupUploadFileFilter,

--- a/backend/src/modules/backup/backup.service.spec.ts
+++ b/backend/src/modules/backup/backup.service.spec.ts
@@ -84,6 +84,7 @@ jest.mock('ioredis', () => ({
 
 describe('BackupService - settings backup', () => {
   let service: BackupService;
+  let backupLogRepo: ReturnType<typeof mockRepository>;
   let companySettingsRepo: ReturnType<typeof mockRepository>;
   let regionalSettingsRepo: ReturnType<typeof mockRepository>;
   let documentNumberSettingRepo: ReturnType<typeof mockRepository>;
@@ -104,6 +105,7 @@ describe('BackupService - settings backup', () => {
     }).compile();
 
     service = module.get<BackupService>(BackupService);
+    backupLogRepo = module.get(getRepositoryToken(BackupLog));
     companySettingsRepo = module.get(getRepositoryToken(CompanySettings));
     regionalSettingsRepo = module.get(getRepositoryToken(RegionalSettings));
     documentNumberSettingRepo = module.get(getRepositoryToken(DocumentNumberSetting));
@@ -113,6 +115,65 @@ describe('BackupService - settings backup', () => {
   afterEach(() => {
     jest.restoreAllMocks();
     mockSpawn.mockReset();
+  });
+
+  describe('processUploadedBackup', () => {
+    const fsPromises = require('fs/promises');
+    const nodeCrypto = require('crypto');
+
+    beforeEach(() => {
+      mockConfigService.get.mockImplementation((key: string, defaultVal?: any) => {
+        if (key === 'BACKUP_DIRECTORY') {
+          return '/app/backups';
+        }
+        return defaultVal ?? null;
+      });
+    });
+
+    afterEach(() => {
+      mockConfigService.get.mockImplementation(
+        (_key: string, defaultVal?: any) => defaultVal ?? null,
+      );
+    });
+
+    it('stores uploaded backups under a generated archive filename and preserves the original name in metadata', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(1770000000000);
+      jest.spyOn(nodeCrypto, 'randomUUID').mockReturnValue('uuid-123');
+      jest.spyOn(fsPromises, 'mkdir').mockResolvedValue(undefined);
+      jest.spyOn(fsPromises, 'rename').mockResolvedValue(undefined);
+      jest.spyOn(fsPromises, 'readFile').mockResolvedValue(
+        JSON.stringify({ description: 'Uploaded backup' }),
+      );
+      jest.spyOn(fsPromises, 'stat').mockResolvedValue({ size: 42 });
+      jest.spyOn(fsPromises, 'readdir').mockResolvedValue([
+        'erp_db_20260430_120000.sql.gz',
+      ]);
+      jest.spyOn(fsPromises, 'rm').mockResolvedValue(undefined);
+      jest.spyOn(service as any, 'extractArchive').mockResolvedValue(undefined);
+      jest.spyOn(service as any, 'calculateChecksum').mockResolvedValue('checksum-123');
+      backupLogRepo.create.mockImplementation((input) => input);
+      backupLogRepo.save.mockImplementation(async (input) => input);
+
+      const result = await service.processUploadedBackup({
+        originalname: 'customer_backup.tar.gz',
+        path: '/app/backups/uploads/upload_1770000000000_uuid-123.tar.gz',
+      } as Express.Multer.File);
+
+      expect(fsPromises.rename).toHaveBeenCalledWith(
+        '/app/backups/uploads/upload_1770000000000_uuid-123.tar.gz',
+        '/app/backups/archives/uploaded_backup_1770000000000_uuid-123.tar.gz',
+      );
+      expect(result.filename).toBe('uploaded_backup_1770000000000_uuid-123.tar.gz');
+      expect(result.filepath).toBe(
+        '/app/backups/archives/uploaded_backup_1770000000000_uuid-123.tar.gz',
+      );
+      expect(result.metadata).toEqual(
+        expect.objectContaining({
+          originalFilename: 'customer_backup.tar.gz',
+          checksum: 'checksum-123',
+        }),
+      );
+    });
   });
 
   describe('command execution', () => {

--- a/backend/src/modules/backup/backup.service.ts
+++ b/backend/src/modules/backup/backup.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException, InternalServerErrorException, OnModuleDestroy } from '@nestjs/common';
+import { BadRequestException, Injectable, InternalServerErrorException, Logger, NotFoundException, OnModuleDestroy } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, LessThan } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
@@ -991,11 +991,19 @@ export class BackupService implements OnModuleDestroy {
     this.logger.log(`Processing uploaded backup: ${file.originalname}`);
 
     const uploadPath = file.path;
-    const archivePath = path.join(this.backupDir, 'archives', file.originalname);
+    const originalFilename = path.basename(file.originalname);
+    const archivesDir = path.resolve(this.backupDir, 'archives');
+    const ext = originalFilename.endsWith('.tar.gz') ? '.tar.gz' : '.tgz';
+    const archiveFilename = `uploaded_backup_${Date.now()}_${crypto.randomUUID()}${ext}`;
+    const archivePath = path.resolve(archivesDir, archiveFilename);
+
+    if (!archivePath.startsWith(`${archivesDir}${path.sep}`)) {
+      throw new BadRequestException('Invalid backup path detected');
+    }
 
     try {
       // Ensure archives directory exists
-      await fs.mkdir(path.join(this.backupDir, 'archives'), { recursive: true });
+      await fs.mkdir(archivesDir, { recursive: true });
 
       // Move file from uploads to archives
       await fs.rename(uploadPath, archivePath);
@@ -1039,7 +1047,7 @@ export class BackupService implements OnModuleDestroy {
 
       // Create backup log entry
       const backupLog = this.backupLogRepository.create({
-        filename: file.originalname,
+        filename: archiveFilename,
         filepath: archivePath,
         backupType: 'manual',
         status: 'completed',
@@ -1050,6 +1058,7 @@ export class BackupService implements OnModuleDestroy {
         size: stats.size,
         metadata: {
           ...metadata,
+          originalFilename,
           checksum,
           uploadedAt: new Date().toISOString(),
         },
@@ -1058,7 +1067,7 @@ export class BackupService implements OnModuleDestroy {
       await this.backupLogRepository.save(backupLog);
 
       this.logger.log(
-        `Uploaded backup processed successfully: ${file.originalname} (${this.formatBytes(stats.size)})`,
+        `Uploaded backup processed successfully: ${archiveFilename} from ${originalFilename} (${this.formatBytes(stats.size)})`,
       );
 
       return backupLog;

--- a/backend/src/modules/backup/interfaces/backup-metadata.interface.ts
+++ b/backend/src/modules/backup/interfaces/backup-metadata.interface.ts
@@ -5,6 +5,7 @@ export interface BackupMetadata {
   settingsIncluded?: boolean;
   description?: string;
   checksum?: string;
+  originalFilename?: string;
   uploadedAt?: string;
   systemInfo?: {
     nodeVersion: string;


### PR DESCRIPTION
## Summary
- Fixes #487 by preventing uploaded backup filenames from controlling temporary or archive filesystem paths.
- Generates Multer temporary filenames and final archive filenames with server-controlled names.
- Preserves the client-provided filename only as `metadata.originalFilename` and adds regression coverage for controller/service behavior.

## Impacted Modules
- `backend/src/modules/backup`

## Test Evidence
- [x] `cd backend && npm run test -- src/modules/backup/backup.controller.spec.ts` - passed, 25 tests
- [x] `cd backend && npm run test -- src/modules/backup/backup.service.spec.ts` - passed, 18 tests
- [x] `cd backend && npm run test -- src/modules/backup/backup.controller.spec.ts src/modules/backup/backup.service.spec.ts` - passed, 43 tests
- [x] `cd backend && npm run lint` - passed
- [x] `cd backend && npm run test` - passed, 878 tests

## Notes
- No database migrations or environment changes.
- No frontend UI changes.
