### PR TITLE
fix: systemic XSS prevention in report print templates (#488)

### DIFF
--- a/frontend/src/pages/inventory/HistoricalInventoryReport.tsx
+++ b/frontend/src/pages/inventory/HistoricalInventoryReport.tsx
@@ -40,6 +40,7 @@ import { default as KeyboardDoubleArrowLeftIcon } from '@mui/icons-material/Keyb
 import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 import { useGetProductsQuery, useGetCategoriesQuery } from '@/store/api/inventoryApi'
@@ -339,9 +340,9 @@ const HistoricalInventoryReport: React.FC = () => {
 
     const getPdfGroupLabel = (r: any) => {
       if (groupBy === 'categoryName') {
-        return `Category: ${r.categoryName}`
+        return `Category: ${escapeHtml(r.categoryName)}`
       }
-      return r[groupBy]
+      return escapeHtml(r[groupBy])
     }
 
     sortedData.forEach((row) => {
@@ -370,7 +371,7 @@ const HistoricalInventoryReport: React.FC = () => {
           displayValue = ''
         }
 
-        tableRows += `<td style="${align}">${displayValue}</td>`
+        tableRows += `<td style="${align}">${escapeHtml(displayValue)}</td>`
       })
       tableRows += '</tr>'
     })
@@ -382,11 +383,11 @@ const HistoricalInventoryReport: React.FC = () => {
     if (selectedCategory) {
       const category = categories.find(c => c.id === selectedCategory)
       if (category) {
-        filterText.push(`<p><strong>Category:</strong> ${category.name}</p>`)
+        filterText.push(`<p><strong>Category:</strong> ${escapeHtml(category.name)}</p>`)
       }
     }
     if (targetDate) {
-      filterText.push(`<p><strong>Target Date:</strong> ${formatDate(targetDate)}</p>`)
+      filterText.push(`<p><strong>Target Date:</strong> ${escapeHtml(formatDate(targetDate))}</p>`)
     }
     const filtersText = filterText.join('')
 
@@ -394,12 +395,12 @@ const HistoricalInventoryReport: React.FC = () => {
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>${PRINT_STYLES}</style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${filtersText}
@@ -407,7 +408,7 @@ const HistoricalInventoryReport: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>

--- a/frontend/src/pages/inventory/InventorySummaryReport.tsx
+++ b/frontend/src/pages/inventory/InventorySummaryReport.tsx
@@ -41,6 +41,7 @@ import { default as KeyboardDoubleArrowLeftIcon } from '@mui/icons-material/Keyb
 import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 import { useGetEffectivePriceListsQuery } from '@/store/api/priceListApi'
@@ -434,9 +435,9 @@ const InventorySummaryReport: React.FC = () => {
 
     const getPdfGroupLabel = (r: any) => {
       if (groupBy === 'categoryName') {
-        return `Category: ${r.categoryName}`
+        return `Category: ${escapeHtml(r.categoryName)}`
       }
-      return r[groupBy]
+      return escapeHtml(r[groupBy])
     }
 
     sortedData.forEach((row, idx) => {
@@ -473,7 +474,7 @@ const InventorySummaryReport: React.FC = () => {
           displayValue = value || ''
         }
 
-        tableRows += `<td style="${align}">${displayValue}</td>`
+        tableRows += `<td style="${align}">${escapeHtml(displayValue)}</td>`
       })
       tableRows += '</tr>'
 
@@ -528,7 +529,7 @@ const InventorySummaryReport: React.FC = () => {
     if (selectedCategory) {
       const category = categories.find(c => c.id === selectedCategory)
       if (category) {
-        filterText.push(`<p><strong>Category:</strong> ${category.name}</p>`)
+        filterText.push(`<p><strong>Category:</strong> ${escapeHtml(category.name)}</p>`)
       }
     }
     const dateRangeText = filterText.join('')
@@ -537,12 +538,12 @@ const InventorySummaryReport: React.FC = () => {
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>${PRINT_STYLES}</style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${dateRangeText}
@@ -550,7 +551,7 @@ const InventorySummaryReport: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>

--- a/frontend/src/pages/inventory/MovementSummaryReport.tsx
+++ b/frontend/src/pages/inventory/MovementSummaryReport.tsx
@@ -41,6 +41,7 @@ import { default as KeyboardDoubleArrowLeftIcon } from '@mui/icons-material/Keyb
 import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 import { useGetProductsQuery, useGetCategoriesQuery } from '@/store/api/inventoryApi'
@@ -332,9 +333,9 @@ const MovementSummaryReport: React.FC = () => {
 
     const getPdfGroupLabel = (r: any) => {
       if (groupBy === 'categoryName') {
-        return `Category: ${r.categoryName}`
+        return `Category: ${escapeHtml(r.categoryName)}`
       }
-      return r[groupBy]
+      return escapeHtml(r[groupBy])
     }
 
     sortedData.forEach((row) => {
@@ -360,7 +361,7 @@ const MovementSummaryReport: React.FC = () => {
           displayValue = ''
         }
 
-        tableRows += `<td style="${align}">${displayValue}</td>`
+        tableRows += `<td style="${align}">${escapeHtml(displayValue)}</td>`
       })
       tableRows += '</tr>'
     })
@@ -372,14 +373,14 @@ const MovementSummaryReport: React.FC = () => {
     if (selectedCategory) {
       const category = categories.find(c => c.id === selectedCategory)
       if (category) {
-        filterText.push(`<p><strong>Category:</strong> ${category.name}</p>`)
+        filterText.push(`<p><strong>Category:</strong> ${escapeHtml(category.name)}</p>`)
       }
     }
     if (startDate) {
-      filterText.push(`<p><strong>Start Date:</strong> ${formatDate(startDate)}</p>`)
+      filterText.push(`<p><strong>Start Date:</strong> ${escapeHtml(formatDate(startDate))}</p>`)
     }
     if (endDate) {
-      filterText.push(`<p><strong>End Date:</strong> ${formatDate(endDate)}</p>`)
+      filterText.push(`<p><strong>End Date:</strong> ${escapeHtml(formatDate(endDate))}</p>`)
     }
     const filtersText = filterText.join('')
 
@@ -387,12 +388,12 @@ const MovementSummaryReport: React.FC = () => {
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>${PRINT_STYLES}</style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${filtersText}
@@ -400,7 +401,7 @@ const MovementSummaryReport: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>

--- a/frontend/src/pages/inventory/PriceListReport.tsx
+++ b/frontend/src/pages/inventory/PriceListReport.tsx
@@ -39,6 +39,7 @@ import { default as KeyboardDoubleArrowLeftIcon } from '@mui/icons-material/Keyb
 import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 import { printColors } from '@/styles/printTokens'
@@ -363,9 +364,9 @@ const PriceListReport: React.FC = () => {
 
     const getPdfGroupLabel = (r: any) => {
       if (groupBy === 'categoryName') {
-        return `Category: ${r.categoryName}`
+        return `Category: ${escapeHtml(r.categoryName)}`
       }
-      return r[groupBy]
+      return escapeHtml(r[groupBy])
     }
 
     sortedData.forEach((row) => {
@@ -391,7 +392,7 @@ const PriceListReport: React.FC = () => {
           displayValue = ''
         }
 
-        tableRows += `<td style="${align}">${displayValue}</td>`
+        tableRows += `<td style="${align}">${escapeHtml(displayValue)}</td>`
       })
       tableRows += '</tr>'
     })
@@ -403,19 +404,19 @@ const PriceListReport: React.FC = () => {
     if (selectedCategory) {
       const category = categories.find(c => c.id === selectedCategory)
       if (category) {
-        filterText.push(`<p><strong>Category:</strong> ${category.name}</p>`)
+        filterText.push(`<p><strong>Category:</strong> ${escapeHtml(category.name)}</p>`)
       }
     }
     if (priceListId) {
       const priceList = priceLists.find(pl => pl.id === priceListId)
       if (priceList) {
-        filterText.push(`<p><strong>Price List:</strong> ${priceList.name}</p>`)
+        filterText.push(`<p><strong>Price List:</strong> ${escapeHtml(priceList.name)}</p>`)
       }
     } else {
       filterText.push(`<p><strong>Price List:</strong> Base Cost (No Price List)</p>`)
     }
     if (parseFloat(discountPercent) > 0) {
-      filterText.push(`<p><strong>Discount:</strong> ${discountPercent}%</p>`)
+      filterText.push(`<p><strong>Discount:</strong> ${escapeHtml(discountPercent)}%</p>`)
     }
     const filtersText = filterText.join('')
 
@@ -423,12 +424,12 @@ const PriceListReport: React.FC = () => {
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>${PRINT_STYLES}</style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${filtersText}
@@ -436,7 +437,7 @@ const PriceListReport: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>

--- a/frontend/src/pages/inventory/ProductCostReport.tsx
+++ b/frontend/src/pages/inventory/ProductCostReport.tsx
@@ -39,6 +39,7 @@ import { default as KeyboardDoubleArrowLeftIcon } from '@mui/icons-material/Keyb
 import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 import { useGetProductsQuery, useGetCategoriesQuery } from '@/store/api/inventoryApi'
@@ -360,13 +361,13 @@ const ProductCostReport: React.FC = () => {
 
     const getPdfGroupLabel = (r: any) => {
       if (groupBy === 'categoryName') {
-        return `Category: ${r.categoryName}`
+        return `Category: ${escapeHtml(r.categoryName)}`
       } else if (groupBy === 'productName') {
-        return `Product: ${r.productName}`
+        return `Product: ${escapeHtml(r.productName)}`
       } else if (groupBy === 'categoryAndProduct') {
-        return `${r.categoryName} - ${r.productName}`
+        return `${escapeHtml(r.categoryName)} - ${escapeHtml(r.productName)}`
       }
-      return r[groupBy]
+      return escapeHtml(r[groupBy])
     }
 
     let groupSubtotals = { quantityChange: 0, costChange: 0 }
@@ -407,7 +408,7 @@ const ProductCostReport: React.FC = () => {
           displayValue = ''
         }
 
-        tableRows += `<td style="${align}">${displayValue}</td>`
+        tableRows += `<td style="${align}">${escapeHtml(displayValue)}</td>`
       })
       tableRows += '</tr>'
 
@@ -418,10 +419,10 @@ const ProductCostReport: React.FC = () => {
       filterText.push(`<p><strong>Products:</strong> ${selectedProducts.length} selected</p>`)
     }
     if (startDate) {
-      filterText.push(`<p><strong>Start Date:</strong> ${formatDate(new Date(startDate))}</p>`)
+      filterText.push(`<p><strong>Start Date:</strong> ${escapeHtml(formatDate(new Date(startDate)))}</p>`)
     }
     if (endDate) {
-      filterText.push(`<p><strong>End Date:</strong> ${formatDate(new Date(endDate))}</p>`)
+      filterText.push(`<p><strong>End Date:</strong> ${escapeHtml(formatDate(new Date(endDate)))}</p>`)
     }
     const filtersText = filterText.join('')
 
@@ -429,12 +430,12 @@ const ProductCostReport: React.FC = () => {
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>${PRINT_STYLES}</style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${filtersText}
@@ -442,7 +443,7 @@ const ProductCostReport: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>

--- a/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
@@ -457,15 +457,15 @@ const PurchaseOrderDetailsReport: React.FC = () => {
 
     const getPdfGroupLabel = (r: any) => {
       if (groupBy === 'orderNumber') {
-        return `Order No: ${r.orderNumber}`
+        return `Order No: ${escapeHtml(r.orderNumber)}`
       } else if (groupBy === 'categoryProduct') {
-        return `${r.categoryName} - ${r.productName}`
+        return `${escapeHtml(r.categoryName)} - ${escapeHtml(r.productName)}`
       } else if (groupBy === 'categoryName') {
-        return `Category: ${r.categoryName}`
+        return `Category: ${escapeHtml(r.categoryName)}`
       } else if (groupBy === 'supplierName') {
-        return `Vendor: ${r.supplierName}`
+        return `Vendor: ${escapeHtml(r.supplierName)}`
       }
-      return r[groupBy]
+      return escapeHtml(r[groupBy])
     }
 
     sortedData.forEach((row, idx) => {

--- a/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
@@ -52,6 +52,7 @@ import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { PRINT_STYLES } from '@/styles/printStyles'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import api from '@/services/api'
 
@@ -339,15 +340,15 @@ const PurchaseOrderDetailsReport: React.FC = () => {
 
     const getExportGroupLabel = (r: any) => {
       if (groupBy === 'orderNumber') {
-        return `Order No: ${r.orderNumber}`
+        return `Order No: ${escapeHtml(r.orderNumber)}`
       } else if (groupBy === 'categoryProduct') {
-        return `${r.categoryName} - ${r.productName}`
+        return `${escapeHtml(r.categoryName)} - ${escapeHtml(r.productName)}`
       } else if (groupBy === 'categoryName') {
-        return `Category: ${r.categoryName}`
+        return `Category: ${escapeHtml(r.categoryName)}`
       } else if (groupBy === 'supplierName') {
-        return `Vendor: ${r.supplierName}`
+        return `Vendor: ${escapeHtml(r.supplierName)}`
       }
-      return r[groupBy]
+      return escapeHtml(r[groupBy])
     }
 
     sortedData.forEach((row, idx) => {
@@ -488,7 +489,7 @@ const PurchaseOrderDetailsReport: React.FC = () => {
           displayValue = value ? value.charAt(0).toUpperCase() + value.slice(1) : ''
         }
         const align = (typeof value === 'number') ? 'text-align: right;' : ''
-        tableRows += `<td style="${align}">${displayValue || ''}</td>`
+        tableRows += `<td style="${align}">${escapeHtml(displayValue)}</td>`
       })
       tableRows += '</tr>'
 
@@ -538,23 +539,23 @@ const PurchaseOrderDetailsReport: React.FC = () => {
 
     let dateRangeText = ''
     if (dateFrom && dateTo) {
-      dateRangeText = `<p><strong>Date Range:</strong> ${formatDate(dateFrom)} - ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date Range:</strong> ${escapeHtml(formatDate(dateFrom))} - ${escapeHtml(formatDate(dateTo))}</p>`
     } else if (dateFrom) {
-      dateRangeText = `<p><strong>Date From:</strong> ${formatDate(dateFrom)}</p>`
+      dateRangeText = `<p><strong>Date From:</strong> ${escapeHtml(formatDate(dateFrom))}</p>`
     } else if (dateTo) {
-      dateRangeText = `<p><strong>Date To:</strong> ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date To:</strong> ${escapeHtml(formatDate(dateTo))}</p>`
     }
 
     const html = `
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>${PRINT_STYLES}</style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${dateRangeText}
@@ -562,7 +563,7 @@ const PurchaseOrderDetailsReport: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>

--- a/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
@@ -44,6 +44,7 @@ import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { PRINT_STYLES } from '@/styles/printStyles'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import api from '@/services/api'
 
@@ -319,13 +320,13 @@ const PurchaseOrderStatusReport: React.FC = () => {
 
     const getExportGroupLabel = (r: any) => {
       if (groupBy === 'productName') {
-        return `Product: ${r.productName}`
+        return `Product: ${escapeHtml(r.productName)}`
       } else if (groupBy === 'supplierName') {
-        return `Vendor: ${r.supplierName}`
+        return `Vendor: ${escapeHtml(r.supplierName)}`
       } else if (groupBy === 'orderNumber') {
-        return `Order No.: ${r.orderNumber}`
+        return `Order No.: ${escapeHtml(r.orderNumber)}`
       }
-      return r[groupBy]
+      return escapeHtml(r[groupBy])
     }
 
     sortedData.forEach((row, idx) => {
@@ -463,7 +464,7 @@ const PurchaseOrderStatusReport: React.FC = () => {
           displayValue = value ? value.charAt(0).toUpperCase() + value.slice(1) : ''
         }
         const align = (typeof value === 'number') ? 'text-align: right;' : ''
-        tableRows += `<td style="${align}">${displayValue || ''}</td>`
+        tableRows += `<td style="${align}">${escapeHtml(displayValue)}</td>`
       })
       tableRows += '</tr>'
 
@@ -520,10 +521,10 @@ const PurchaseOrderStatusReport: React.FC = () => {
 
     const filterText = []
     if (status && status !== 'all') {
-      filterText.push(`<p><strong>Inventory Status:</strong> ${status.charAt(0).toUpperCase() + status.slice(1)}</p>`)
+      filterText.push(`<p><strong>Inventory Status:</strong> ${escapeHtml(status.charAt(0).toUpperCase() + status.slice(1))}</p>`)
     }
     if (paymentStatus && paymentStatus !== 'all') {
-      filterText.push(`<p><strong>Payment Status:</strong> ${paymentStatus.charAt(0).toUpperCase() + paymentStatus.slice(1)}</p>`)
+      filterText.push(`<p><strong>Payment Status:</strong> ${escapeHtml(paymentStatus.charAt(0).toUpperCase() + paymentStatus.slice(1))}</p>`)
     }
     const dateRangeText = filterText.join('')
 
@@ -531,12 +532,12 @@ const PurchaseOrderStatusReport: React.FC = () => {
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>${PRINT_STYLES}</style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${dateRangeText}
@@ -544,7 +545,7 @@ const PurchaseOrderStatusReport: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>

--- a/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
@@ -434,13 +434,13 @@ const PurchaseOrderStatusReport: React.FC = () => {
 
     const getPdfGroupLabel = (r: any) => {
       if (groupBy === 'productName') {
-        return `Product: ${r.productName}`
+        return `Product: ${escapeHtml(r.productName)}`
       } else if (groupBy === 'supplierName') {
-        return `Vendor: ${r.supplierName}`
+        return `Vendor: ${escapeHtml(r.supplierName)}`
       } else if (groupBy === 'orderNumber') {
-        return `Order No.: ${r.orderNumber}`
+        return `Order No.: ${escapeHtml(r.orderNumber)}`
       }
-      return r[groupBy]
+      return escapeHtml(r[groupBy])
     }
 
     sortedData.forEach((row, idx) => {

--- a/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
@@ -278,13 +278,13 @@ const PurchaseOrderSummary: React.FC = () => {
 
     const getPdfGroupLabel = (r: any) => {
       if (groupBy === 'supplierName') {
-        return `Vendor: ${r.supplierName}`
+        return `Vendor: ${escapeHtml(r.supplierName)}`
       } else if (groupBy === 'status') {
-        return `Inventory Status: ${r.status.charAt(0).toUpperCase() + r.status.slice(1)}`
+        return `Inventory Status: ${escapeHtml(r.status.charAt(0).toUpperCase() + r.status.slice(1))}`
       } else if (groupBy === 'paymentStatus') {
-        return `Payment Status: ${r.paymentStatus.charAt(0).toUpperCase() + r.paymentStatus.slice(1)}`
+        return `Payment Status: ${escapeHtml(r.paymentStatus.charAt(0).toUpperCase() + r.paymentStatus.slice(1))}`
       }
-      return r[groupBy]
+      return escapeHtml(r[groupBy])
     }
 
     sortedData.forEach((row, idx) => {
@@ -433,7 +433,7 @@ const PurchaseOrderSummary: React.FC = () => {
             </script>
           </div>
           <script>
-            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
+            document.title = ${JSON.stringify(reportTitle)};
 
             window.onload = function() {
               setTimeout(function() {

--- a/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
@@ -33,6 +33,7 @@ import { AppButton } from '@/components/common/AppButton'
 import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import api from '@/services/api'
 
@@ -165,13 +166,13 @@ const PurchaseOrderSummary: React.FC = () => {
 
     const getExportGroupLabel = (r: any) => {
       if (groupBy === 'supplierName') {
-        return `Vendor: ${r.supplierName}`
+        return `Vendor: ${escapeHtml(r.supplierName)}`
       } else if (groupBy === 'status') {
-        return `Inventory Status: ${r.status.charAt(0).toUpperCase() + r.status.slice(1)}`
+        return `Inventory Status: ${escapeHtml(r.status.charAt(0).toUpperCase() + r.status.slice(1))}`
       } else if (groupBy === 'paymentStatus') {
-        return `Payment Status: ${r.paymentStatus.charAt(0).toUpperCase() + r.paymentStatus.slice(1)}`
+        return `Payment Status: ${escapeHtml(r.paymentStatus.charAt(0).toUpperCase() + r.paymentStatus.slice(1))}`
       }
-      return r[groupBy]
+      return escapeHtml(r[groupBy])
     }
 
     sortedData.forEach((row, idx) => {
@@ -307,7 +308,7 @@ const PurchaseOrderSummary: React.FC = () => {
           displayValue = value ? value.charAt(0).toUpperCase() + value.slice(1) : ''
         }
         const align = (typeof value === 'number') ? 'text-align: right;' : ''
-        tableRows += `<td style="${align}">${displayValue || ''}</td>`
+        tableRows += `<td style="${align}">${escapeHtml(displayValue)}</td>`
       })
       tableRows += '</tr>'
 
@@ -358,18 +359,18 @@ const PurchaseOrderSummary: React.FC = () => {
 
     let dateRangeText = ''
     if (dateFrom && dateTo) {
-      dateRangeText = `<p><strong>Date Range:</strong> ${formatDate(dateFrom)} - ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date Range:</strong> ${escapeHtml(formatDate(dateFrom))} - ${escapeHtml(formatDate(dateTo))}</p>`
     } else if (dateFrom) {
-      dateRangeText = `<p><strong>Date From:</strong> ${formatDate(dateFrom)}</p>`
+      dateRangeText = `<p><strong>Date From:</strong> ${escapeHtml(formatDate(dateFrom))}</p>`
     } else if (dateTo) {
-      dateRangeText = `<p><strong>Date To:</strong> ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date To:</strong> ${escapeHtml(formatDate(dateTo))}</p>`
     }
 
     const html = `
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
             body { font-family: 'Roboto', sans-serif; margin: 20px; }
@@ -410,7 +411,7 @@ const PurchaseOrderSummary: React.FC = () => {
           </style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${dateRangeText}
@@ -418,7 +419,7 @@ const PurchaseOrderSummary: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>
@@ -432,7 +433,7 @@ const PurchaseOrderSummary: React.FC = () => {
             </script>
           </div>
           <script>
-            document.title = '${reportTitle.replace(/'/g, "\\'")}';
+            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
 
             window.onload = function() {
               setTimeout(function() {

--- a/frontend/src/pages/purchasing/VendorPaymentDetailsReport.tsx
+++ b/frontend/src/pages/purchasing/VendorPaymentDetailsReport.tsx
@@ -32,6 +32,7 @@ import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { PRINT_STYLES } from '@/styles/printStyles'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import api from '@/services/api'
 
@@ -139,13 +140,13 @@ const VendorPaymentDetailsReport: React.FC = () => {
 
     const getExportGroupLabel = (r: any) => {
       if (groupBy === 'supplierName') {
-        return `Vendor: ${r.supplierName}`
+        return `Vendor: ${escapeHtml(r.supplierName)}`
       } else if (groupBy === 'paymentDate') {
-        return `Payment Date: ${r.paymentDate ? formatDate(r.paymentDate) : 'N/A'}`
+        return `Payment Date: ${r.paymentDate ? escapeHtml(formatDate(r.paymentDate)) : 'N/A'}`
       } else if (groupBy === 'orderNumber') {
-        return `Order No: ${r.orderNumber || 'N/A'}`
+        return `Order No: ${escapeHtml(r.orderNumber || 'N/A')}`
       }
-      return r[groupBy]
+      return escapeHtml(r[groupBy])
     }
 
     sortedData.forEach((row, idx) => {
@@ -271,7 +272,7 @@ const VendorPaymentDetailsReport: React.FC = () => {
           displayValue = formatCurrency(value)
         }
         const align = (typeof value === 'number') ? 'text-align: right;' : ''
-        tableRows += `<td style="${align}">${displayValue || ''}</td>`
+        tableRows += `<td style="${align}">${escapeHtml(displayValue)}</td>`
       })
       tableRows += '</tr>'
 
@@ -319,11 +320,11 @@ const VendorPaymentDetailsReport: React.FC = () => {
 
     const filterText = []
     if (dateFrom && dateTo) {
-      filterText.push(`<p><strong>Payment Date Range:</strong> ${formatDate(dateFrom)} - ${formatDate(dateTo)}</p>`)
+      filterText.push(`<p><strong>Payment Date Range:</strong> ${escapeHtml(formatDate(dateFrom))} - ${escapeHtml(formatDate(dateTo))}</p>`)
     } else if (dateFrom) {
-      filterText.push(`<p><strong>Payment Date From:</strong> ${formatDate(dateFrom)}</p>`)
+      filterText.push(`<p><strong>Payment Date From:</strong> ${escapeHtml(formatDate(dateFrom))}</p>`)
     } else if (dateTo) {
-      filterText.push(`<p><strong>Payment Date To:</strong> ${formatDate(dateTo)}</p>`)
+      filterText.push(`<p><strong>Payment Date To:</strong> ${escapeHtml(formatDate(dateTo))}</p>`)
     }
     const dateRangeText = filterText.join('')
 
@@ -331,12 +332,12 @@ const VendorPaymentDetailsReport: React.FC = () => {
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>${PRINT_STYLES}</style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${dateRangeText}
@@ -344,7 +345,7 @@ const VendorPaymentDetailsReport: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>

--- a/frontend/src/pages/purchasing/VendorPaymentDetailsReport.tsx
+++ b/frontend/src/pages/purchasing/VendorPaymentDetailsReport.tsx
@@ -244,13 +244,13 @@ const VendorPaymentDetailsReport: React.FC = () => {
 
     const getPdfGroupLabel = (r: any) => {
       if (groupBy === 'supplierName') {
-        return `Vendor: ${r.supplierName}`
+        return `Vendor: ${escapeHtml(r.supplierName)}`
       } else if (groupBy === 'paymentDate') {
-        return `Payment Date: ${r.paymentDate ? formatDate(r.paymentDate) : 'N/A'}`
+        return `Payment Date: ${r.paymentDate ? escapeHtml(formatDate(r.paymentDate)) : 'N/A'}`
       } else if (groupBy === 'orderNumber') {
-        return `Order No: ${r.orderNumber || 'N/A'}`
+        return `Order No: ${escapeHtml(r.orderNumber || 'N/A')}`
       }
-      return r[groupBy]
+      return escapeHtml(r[groupBy])
     }
 
     sortedData.forEach((row, idx) => {

--- a/frontend/src/pages/purchasing/VendorProductListReport.tsx
+++ b/frontend/src/pages/purchasing/VendorProductListReport.tsx
@@ -413,13 +413,13 @@ const VendorProductListReport: React.FC = () => {
 
     const getPdfGroupLabel = (r: any) => {
       if (groupBy === 'productName') {
-        return `Product: ${r.productName}`
+        return `Product: ${escapeHtml(r.productName)}`
       } else if (groupBy === 'supplierName') {
-        return `Vendor: ${r.supplierName}`
+        return `Vendor: ${escapeHtml(r.supplierName)}`
       } else if (groupBy === 'categoryName') {
-        return `Category: ${r.categoryName}`
+        return `Category: ${escapeHtml(r.categoryName)}`
       }
-      return r[groupBy]
+      return escapeHtml(r[groupBy])
     }
 
     sortedData.forEach((row, idx) => {

--- a/frontend/src/pages/purchasing/VendorProductListReport.tsx
+++ b/frontend/src/pages/purchasing/VendorProductListReport.tsx
@@ -44,6 +44,7 @@ import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { PRINT_STYLES } from '@/styles/printStyles'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import api from '@/services/api'
 
@@ -326,13 +327,13 @@ const VendorProductListReport: React.FC = () => {
 
     const getExportGroupLabel = (r: any) => {
       if (groupBy === 'productName') {
-        return `Product: ${r.productName}`
+        return `Product: ${escapeHtml(r.productName)}`
       } else if (groupBy === 'supplierName') {
-        return `Vendor: ${r.supplierName}`
+        return `Vendor: ${escapeHtml(r.supplierName)}`
       } else if (groupBy === 'categoryName') {
-        return `Category: ${r.categoryName}`
+        return `Category: ${escapeHtml(r.categoryName)}`
       }
-      return r[groupBy]
+      return escapeHtml(r[groupBy])
     }
 
     sortedData.forEach((row, idx) => {
@@ -460,7 +461,7 @@ const VendorProductListReport: React.FC = () => {
           }
         }
 
-        tableRows += `<td style="${align}">${displayValue || ''}</td>`
+        tableRows += `<td style="${align}">${escapeHtml(displayValue)}</td>`
       })
       tableRows += '</tr>'
     })
@@ -469,13 +470,13 @@ const VendorProductListReport: React.FC = () => {
     if (selectedSupplier) {
       const supplier = suppliers.find(s => s.id === selectedSupplier)
       if (supplier) {
-        filterText.push(`<p><strong>Vendor:</strong> ${supplier.companyName}</p>`)
+        filterText.push(`<p><strong>Vendor:</strong> ${escapeHtml(supplier.companyName)}</p>`)
       }
     }
     if (selectedCategory) {
       const category = categories.find(c => c.id === selectedCategory)
       if (category) {
-        filterText.push(`<p><strong>Category:</strong> ${category.name}</p>`)
+        filterText.push(`<p><strong>Category:</strong> ${escapeHtml(category.name)}</p>`)
       }
     }
     if (selectedProducts.length > 0) {
@@ -487,12 +488,12 @@ const VendorProductListReport: React.FC = () => {
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>${PRINT_STYLES}</style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${dateRangeText}
@@ -500,7 +501,7 @@ const VendorProductListReport: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>

--- a/frontend/src/pages/sales/CustomerOrderHistory.tsx
+++ b/frontend/src/pages/sales/CustomerOrderHistory.tsx
@@ -648,7 +648,7 @@ const CustomerOrderHistory: React.FC = () => {
           </div>
           <script>
             // Set document title for PDF filename
-            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
+            document.title = ${JSON.stringify(reportTitle)};
 
             window.onload = function() {
               // Small delay to ensure content is rendered

--- a/frontend/src/pages/sales/CustomerOrderHistory.tsx
+++ b/frontend/src/pages/sales/CustomerOrderHistory.tsx
@@ -43,6 +43,7 @@ import { default as KeyboardDoubleArrowLeftIcon } from '@mui/icons-material/Keyb
 import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 
@@ -487,11 +488,11 @@ const CustomerOrderHistory: React.FC = () => {
     // Helper to get group label for PDF export
     const getPdfGroupLabel = (r: any) => {
       if (groupBy === 'customerOrder') {
-        return `Customer: ${r.customerName} | Order: ${r.orderNumber}`
+        return `Customer: ${escapeHtml(r.customerName)} | Order: ${escapeHtml(r.orderNumber)}`
       } else if (groupBy === 'customerProduct') {
-        return `Customer: ${r.customerName} | Product: ${r.productName}`
+        return `Customer: ${escapeHtml(r.customerName)} | Product: ${escapeHtml(r.productName)}`
       }
-      return r[groupBy]
+      return escapeHtml(r[groupBy])
     }
 
     sortedData.forEach((row, idx) => {
@@ -517,7 +518,7 @@ const CustomerOrderHistory: React.FC = () => {
           displayValue = value ? value.charAt(0).toUpperCase() + value.slice(1) : ''
         }
         const align = (typeof value === 'number') ? 'text-align: right;' : ''
-        tableRows += `<td style="${align}">${displayValue || ''}</td>`
+        tableRows += `<td style="${align}">${escapeHtml(displayValue)}</td>`
       })
       tableRows += '</tr>'
 
@@ -572,18 +573,18 @@ const CustomerOrderHistory: React.FC = () => {
     // Build date range text
     let dateRangeText = ''
     if (dateFrom && dateTo) {
-      dateRangeText = `<p><strong>Date Range:</strong> ${formatDate(dateFrom)} - ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date Range:</strong> ${escapeHtml(formatDate(dateFrom))} - ${escapeHtml(formatDate(dateTo))}</p>`
     } else if (dateFrom) {
-      dateRangeText = `<p><strong>Date From:</strong> ${formatDate(dateFrom)}</p>`
+      dateRangeText = `<p><strong>Date From:</strong> ${escapeHtml(formatDate(dateFrom))}</p>`
     } else if (dateTo) {
-      dateRangeText = `<p><strong>Date To:</strong> ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date To:</strong> ${escapeHtml(formatDate(dateTo))}</p>`
     }
 
     const html = `
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
             body { font-family: 'Roboto', sans-serif; margin: 20px; }
@@ -624,7 +625,7 @@ const CustomerOrderHistory: React.FC = () => {
           </style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${dateRangeText}
@@ -632,7 +633,7 @@ const CustomerOrderHistory: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>
@@ -647,7 +648,7 @@ const CustomerOrderHistory: React.FC = () => {
           </div>
           <script>
             // Set document title for PDF filename
-            document.title = '${reportTitle.replace(/'/g, "\\'")}';
+            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
 
             window.onload = function() {
               // Small delay to ensure content is rendered

--- a/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
@@ -431,7 +431,7 @@ const CustomerPaymentByOrder: React.FC = () => {
           </div>
           <script>
             // Set document title for PDF filename
-            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
+            document.title = ${JSON.stringify(reportTitle)};
 
             window.onload = function() {
               // Small delay to ensure content is rendered

--- a/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
@@ -34,6 +34,7 @@ import { default as PaymentOrderIcon } from '@mui/icons-material/ReceiptLongOutl
 import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 
@@ -282,9 +283,9 @@ const CustomerPaymentByOrder: React.FC = () => {
 
       // Add group header if group changed
       if (groupBy !== 'none' && currentGroupValue !== prevGroupValue) {
-        const groupLabel = groupBy === 'customerName' ? `Customer: ${currentGroupValue}` :
-                          groupBy === 'inventoryStatus' ? `Inventory: ${currentGroupValue.charAt(0).toUpperCase() + currentGroupValue.slice(1)}` :
-                          groupBy === 'paymentStatus' ? `Payment: ${currentGroupValue.charAt(0).toUpperCase() + currentGroupValue.slice(1)}` : currentGroupValue
+        const groupLabel = groupBy === 'customerName' ? `Customer: ${escapeHtml(currentGroupValue)}` :
+                          groupBy === 'inventoryStatus' ? `Inventory: ${escapeHtml(currentGroupValue.charAt(0).toUpperCase() + currentGroupValue.slice(1))}` :
+                          groupBy === 'paymentStatus' ? `Payment: ${escapeHtml(currentGroupValue.charAt(0).toUpperCase() + currentGroupValue.slice(1))}` : escapeHtml(currentGroupValue)
         tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupValue = currentGroupValue
       }
@@ -301,7 +302,7 @@ const CustomerPaymentByOrder: React.FC = () => {
           displayValue = value ? value.charAt(0).toUpperCase() + value.slice(1) : ''
         }
         const align = (typeof value === 'number') ? 'text-align: right;' : ''
-        tableRows += `<td style="${align}">${displayValue || ''}</td>`
+        tableRows += `<td style="${align}">${escapeHtml(displayValue)}</td>`
       })
       tableRows += '</tr>'
 
@@ -355,18 +356,18 @@ const CustomerPaymentByOrder: React.FC = () => {
     // Build date range text
     let dateRangeText = ''
     if (dateFrom && dateTo) {
-      dateRangeText = `<p><strong>Date Range:</strong> ${formatDate(dateFrom)} - ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date Range:</strong> ${escapeHtml(formatDate(dateFrom))} - ${escapeHtml(formatDate(dateTo))}</p>`
     } else if (dateFrom) {
-      dateRangeText = `<p><strong>Date From:</strong> ${formatDate(dateFrom)}</p>`
+      dateRangeText = `<p><strong>Date From:</strong> ${escapeHtml(formatDate(dateFrom))}</p>`
     } else if (dateTo) {
-      dateRangeText = `<p><strong>Date To:</strong> ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date To:</strong> ${escapeHtml(formatDate(dateTo))}</p>`
     }
 
     const html = `
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
             body { font-family: 'Roboto', sans-serif; margin: 20px; }
@@ -407,7 +408,7 @@ const CustomerPaymentByOrder: React.FC = () => {
           </style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${dateRangeText}
@@ -415,7 +416,7 @@ const CustomerPaymentByOrder: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>
@@ -430,7 +431,7 @@ const CustomerPaymentByOrder: React.FC = () => {
           </div>
           <script>
             // Set document title for PDF filename
-            document.title = '${reportTitle.replace(/'/g, "\\'")}';
+            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
 
             window.onload = function() {
               // Small delay to ensure content is rendered

--- a/frontend/src/pages/sales/CustomerPaymentDetails.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentDetails.tsx
@@ -31,6 +31,7 @@ import { default as PaymentDetailIcon } from '@mui/icons-material/MonetizationOn
 import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 
@@ -266,9 +267,9 @@ const CustomerPaymentDetails: React.FC = () => {
 
       // Add group header if group changed
       if (groupBy !== 'none' && currentGroupValue !== prevGroupValue) {
-        const groupLabel = groupBy === 'customerName' ? `Customer: ${currentGroupValue}` :
-                          groupBy === 'paymentDate' ? `Payment Date: ${currentGroupValue ? formatDate(currentGroupValue) : 'N/A'}` :
-                          groupBy === 'orderNumber' ? `Order: ${currentGroupValue}` : currentGroupValue
+        const groupLabel = groupBy === 'customerName' ? `Customer: ${escapeHtml(currentGroupValue)}` :
+                          groupBy === 'paymentDate' ? `Payment Date: ${currentGroupValue ? escapeHtml(formatDate(currentGroupValue)) : 'N/A'}` :
+                          groupBy === 'orderNumber' ? `Order: ${escapeHtml(currentGroupValue)}` : escapeHtml(currentGroupValue)
         tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupValue = currentGroupValue
       }
@@ -285,7 +286,7 @@ const CustomerPaymentDetails: React.FC = () => {
           displayValue = value ? value.charAt(0).toUpperCase() + value.slice(1) : ''
         }
         const align = (typeof value === 'number') ? 'text-align: right;' : ''
-        tableRows += `<td style="${align}">${displayValue || ''}</td>`
+        tableRows += `<td style="${align}">${escapeHtml(displayValue)}</td>`
       })
       tableRows += '</tr>'
 
@@ -340,18 +341,18 @@ const CustomerPaymentDetails: React.FC = () => {
     // Build date range text
     let dateRangeText = ''
     if (dateFrom && dateTo) {
-      dateRangeText = `<p><strong>Date Range:</strong> ${formatDate(dateFrom)} - ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date Range:</strong> ${escapeHtml(formatDate(dateFrom))} - ${escapeHtml(formatDate(dateTo))}</p>`
     } else if (dateFrom) {
-      dateRangeText = `<p><strong>Date From:</strong> ${formatDate(dateFrom)}</p>`
+      dateRangeText = `<p><strong>Date From:</strong> ${escapeHtml(formatDate(dateFrom))}</p>`
     } else if (dateTo) {
-      dateRangeText = `<p><strong>Date To:</strong> ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date To:</strong> ${escapeHtml(formatDate(dateTo))}</p>`
     }
 
     const html = `
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
             body { font-family: 'Roboto', sans-serif; margin: 20px; }
@@ -392,7 +393,7 @@ const CustomerPaymentDetails: React.FC = () => {
           </style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${dateRangeText}
@@ -400,7 +401,7 @@ const CustomerPaymentDetails: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>
@@ -415,7 +416,7 @@ const CustomerPaymentDetails: React.FC = () => {
           </div>
           <script>
             // Set document title for PDF filename
-            document.title = '${reportTitle.replace(/'/g, "\\'")}';
+            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
 
             window.onload = function() {
               // Small delay to ensure content is rendered

--- a/frontend/src/pages/sales/CustomerPaymentDetails.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentDetails.tsx
@@ -416,7 +416,7 @@ const CustomerPaymentDetails: React.FC = () => {
           </div>
           <script>
             // Set document title for PDF filename
-            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
+            document.title = ${JSON.stringify(reportTitle)};
 
             window.onload = function() {
               // Small delay to ensure content is rendered

--- a/frontend/src/pages/sales/CustomerPaymentSummary.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentSummary.tsx
@@ -34,6 +34,7 @@ import { default as PaymentSummaryIcon } from '@mui/icons-material/AccountBalanc
 import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import api from '@/services/api'
 
@@ -246,7 +247,7 @@ const CustomerPaymentSummary: React.FC = () => {
             displayValue = formatCurrency(value)
           }
           const align = (typeof value === 'number' || col === 'balance') ? 'text-align: right;' : ''
-          tableRows += `<td style="${align}">${displayValue || ''}</td>`
+          tableRows += `<td style="${align}">${escapeHtml(displayValue)}</td>`
         }
       })
       tableRows += '</tr>'
@@ -274,18 +275,18 @@ const CustomerPaymentSummary: React.FC = () => {
     // Build date range text
     let dateRangeText = ''
     if (dateFrom && dateTo) {
-      dateRangeText = `<p><strong>Date Range:</strong> ${formatDate(dateFrom)} - ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date Range:</strong> ${escapeHtml(formatDate(dateFrom))} - ${escapeHtml(formatDate(dateTo))}</p>`
     } else if (dateFrom) {
-      dateRangeText = `<p><strong>Date From:</strong> ${formatDate(dateFrom)}</p>`
+      dateRangeText = `<p><strong>Date From:</strong> ${escapeHtml(formatDate(dateFrom))}</p>`
     } else if (dateTo) {
-      dateRangeText = `<p><strong>Date To:</strong> ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date To:</strong> ${escapeHtml(formatDate(dateTo))}</p>`
     }
 
     const html = `
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
             body { font-family: 'Roboto', sans-serif; margin: 20px; }
@@ -326,7 +327,7 @@ const CustomerPaymentSummary: React.FC = () => {
           </style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${dateRangeText}
@@ -334,7 +335,7 @@ const CustomerPaymentSummary: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>
@@ -349,7 +350,7 @@ const CustomerPaymentSummary: React.FC = () => {
           </div>
           <script>
             // Set document title for PDF filename
-            document.title = '${reportTitle.replace(/'/g, "\\'")}';
+            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
 
             window.onload = function() {
               // Small delay to ensure content is rendered

--- a/frontend/src/pages/sales/CustomerPaymentSummary.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentSummary.tsx
@@ -350,7 +350,7 @@ const CustomerPaymentSummary: React.FC = () => {
           </div>
           <script>
             // Set document title for PDF filename
-            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
+            document.title = ${JSON.stringify(reportTitle)};
 
             window.onload = function() {
               // Small delay to ensure content is rendered

--- a/frontend/src/pages/sales/ProductCustomerReport.tsx
+++ b/frontend/src/pages/sales/ProductCustomerReport.tsx
@@ -43,6 +43,7 @@ import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { PRINT_STYLES } from '@/styles/printStyles'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 
@@ -470,11 +471,11 @@ const ProductCustomerReport: React.FC = () => {
     // Helper to get group label for PDF export
     const getPdfGroupLabel = (r: any) => {
       if (groupBy === 'categoryProduct') {
-        return `Category: ${r.categoryName} | Product: ${r.productName}`
+        return `Category: ${escapeHtml(r.categoryName)} | Product: ${escapeHtml(r.productName)}`
       } else if (groupBy === 'categoryName') {
-        return `Category: ${r.categoryName}`
+        return `Category: ${escapeHtml(r.categoryName)}`
       }
-      return r[groupBy]
+      return escapeHtml(r[groupBy])
     }
 
     sortedData.forEach((row, idx) => {
@@ -500,7 +501,7 @@ const ProductCustomerReport: React.FC = () => {
           displayValue = value ? value.charAt(0).toUpperCase() + value.slice(1) : ''
         }
         const align = (typeof value === 'number') ? 'text-align: right;' : ''
-        tableRows += `<td style="${align}">${displayValue || ''}</td>`
+        tableRows += `<td style="${align}">${escapeHtml(displayValue)}</td>`
       })
       tableRows += '</tr>'
 
@@ -555,18 +556,18 @@ const ProductCustomerReport: React.FC = () => {
     // Build date range text
     let dateRangeText = ''
     if (dateFrom && dateTo) {
-      dateRangeText = `<p><strong>Date Range:</strong> ${formatDate(dateFrom)} - ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date Range:</strong> ${escapeHtml(formatDate(dateFrom))} - ${escapeHtml(formatDate(dateTo))}</p>`
     } else if (dateFrom) {
-      dateRangeText = `<p><strong>Date From:</strong> ${formatDate(dateFrom)}</p>`
+      dateRangeText = `<p><strong>Date From:</strong> ${escapeHtml(formatDate(dateFrom))}</p>`
     } else if (dateTo) {
-      dateRangeText = `<p><strong>Date To:</strong> ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date To:</strong> ${escapeHtml(formatDate(dateTo))}</p>`
     }
 
     const html = `
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>${PRINT_STYLES}
             @media print {
@@ -596,7 +597,7 @@ const ProductCustomerReport: React.FC = () => {
           </style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${dateRangeText}
@@ -604,7 +605,7 @@ const ProductCustomerReport: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>
@@ -619,7 +620,7 @@ const ProductCustomerReport: React.FC = () => {
           </div>
           <script>
             // Set document title for PDF filename
-            document.title = '${reportTitle.replace(/'/g, "\\'")}';
+            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
 
             window.onload = function() {
               // Small delay to ensure content is rendered

--- a/frontend/src/pages/sales/ProductCustomerReport.tsx
+++ b/frontend/src/pages/sales/ProductCustomerReport.tsx
@@ -620,7 +620,7 @@ const ProductCustomerReport: React.FC = () => {
           </div>
           <script>
             // Set document title for PDF filename
-            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
+            document.title = ${JSON.stringify(reportTitle)};
 
             window.onload = function() {
               // Small delay to ensure content is rendered

--- a/frontend/src/pages/sales/SalesByProductDetails.tsx
+++ b/frontend/src/pages/sales/SalesByProductDetails.tsx
@@ -51,6 +51,7 @@ import { default as ViewColumnIcon } from '@mui/icons-material/ViewColumn'
 import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import api from '@/services/api'
 
@@ -325,7 +326,7 @@ const SalesByProductDetails: React.FC = () => {
     if (groupedData) {
       Object.entries(groupedData).forEach(([groupName, items]) => {
         // Group header
-        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupName}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${escapeHtml(groupName)}</td></tr>`
 
         // Items
         items.forEach(row => {
@@ -340,7 +341,7 @@ const SalesByProductDetails: React.FC = () => {
             } else if (typeof value === 'number') {
               displayValue = formatCurrency(value)
             }
-            tableRows += `<td>${displayValue || ''}</td>`
+            tableRows += `<td>${escapeHtml(displayValue)}</td>`
           })
           tableRows += '</tr>'
         })
@@ -378,7 +379,7 @@ const SalesByProductDetails: React.FC = () => {
           } else if (typeof value === 'number') {
             displayValue = formatCurrency(value)
           }
-          tableRows += `<td>${displayValue || ''}</td>`
+          tableRows += `<td>${escapeHtml(displayValue)}</td>`
         })
         tableRows += '</tr>'
       })
@@ -406,18 +407,18 @@ const SalesByProductDetails: React.FC = () => {
     // Build date range text
     let dateRangeText = ''
     if (dateFrom && dateTo) {
-      dateRangeText = `<p><strong>Date Range:</strong> ${formatDate(dateFrom)} - ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date Range:</strong> ${escapeHtml(formatDate(dateFrom))} - ${escapeHtml(formatDate(dateTo))}</p>`
     } else if (dateFrom) {
-      dateRangeText = `<p><strong>Date From:</strong> ${formatDate(dateFrom)}</p>`
+      dateRangeText = `<p><strong>Date From:</strong> ${escapeHtml(formatDate(dateFrom))}</p>`
     } else if (dateTo) {
-      dateRangeText = `<p><strong>Date To:</strong> ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date To:</strong> ${escapeHtml(formatDate(dateTo))}</p>`
     }
 
     const html = `
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
             body { font-family: 'Roboto', sans-serif; margin: 20px; }
@@ -458,7 +459,7 @@ const SalesByProductDetails: React.FC = () => {
           </style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${dateRangeText}
@@ -466,7 +467,7 @@ const SalesByProductDetails: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>
@@ -481,7 +482,7 @@ const SalesByProductDetails: React.FC = () => {
           </div>
           <script>
             // Set document title for PDF filename
-            document.title = '${reportTitle.replace(/'/g, "\\'")}';
+            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
 
             window.onload = function() {
               // Small delay to ensure content is rendered

--- a/frontend/src/pages/sales/SalesByProductDetails.tsx
+++ b/frontend/src/pages/sales/SalesByProductDetails.tsx
@@ -482,7 +482,7 @@ const SalesByProductDetails: React.FC = () => {
           </div>
           <script>
             // Set document title for PDF filename
-            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
+            document.title = ${JSON.stringify(reportTitle)};
 
             window.onload = function() {
               // Small delay to ensure content is rendered

--- a/frontend/src/pages/sales/SalesByProductSummary.tsx
+++ b/frontend/src/pages/sales/SalesByProductSummary.tsx
@@ -51,6 +51,7 @@ import { default as ViewColumnIcon } from '@mui/icons-material/ViewColumn'
 import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 
@@ -317,7 +318,7 @@ const SalesByProductSummary: React.FC = () => {
     if (groupedData) {
       Object.entries(groupedData).forEach(([categoryName, items]) => {
         // Category header
-        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${categoryName}</td></tr>`
+        tableRows += `<tr style="background-color: ${printColors.infoRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${escapeHtml(categoryName)}</td></tr>`
 
         // Items
         items.forEach(row => {
@@ -330,7 +331,7 @@ const SalesByProductSummary: React.FC = () => {
             } else if (typeof value === 'number') {
               displayValue = formatCurrency(value)
             }
-            tableRows += `<td>${displayValue || ''}</td>`
+            tableRows += `<td>${escapeHtml(displayValue)}</td>`
           })
           tableRows += '</tr>'
         })
@@ -366,7 +367,7 @@ const SalesByProductSummary: React.FC = () => {
           } else if (typeof value === 'number') {
             displayValue = formatCurrency(value)
           }
-          tableRows += `<td>${displayValue || ''}</td>`
+          tableRows += `<td>${escapeHtml(displayValue)}</td>`
         })
         tableRows += '</tr>'
       })
@@ -394,18 +395,18 @@ const SalesByProductSummary: React.FC = () => {
     // Build date range text
     let dateRangeText = ''
     if (dateFrom && dateTo) {
-      dateRangeText = `<p><strong>Date Range:</strong> ${formatDate(dateFrom)} - ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date Range:</strong> ${escapeHtml(formatDate(dateFrom))} - ${escapeHtml(formatDate(dateTo))}</p>`
     } else if (dateFrom) {
-      dateRangeText = `<p><strong>Date From:</strong> ${formatDate(dateFrom)}</p>`
+      dateRangeText = `<p><strong>Date From:</strong> ${escapeHtml(formatDate(dateFrom))}</p>`
     } else if (dateTo) {
-      dateRangeText = `<p><strong>Date To:</strong> ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date To:</strong> ${escapeHtml(formatDate(dateTo))}</p>`
     }
 
     const html = `
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
             body { font-family: 'Roboto', sans-serif; margin: 20px; }
@@ -446,7 +447,7 @@ const SalesByProductSummary: React.FC = () => {
           </style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${dateRangeText}
@@ -454,7 +455,7 @@ const SalesByProductSummary: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>
@@ -469,7 +470,7 @@ const SalesByProductSummary: React.FC = () => {
           </div>
           <script>
             // Set document title for PDF filename
-            document.title = '${reportTitle.replace(/'/g, "\\'")}';
+            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
 
             window.onload = function() {
               // Small delay to ensure content is rendered

--- a/frontend/src/pages/sales/SalesByProductSummary.tsx
+++ b/frontend/src/pages/sales/SalesByProductSummary.tsx
@@ -470,7 +470,7 @@ const SalesByProductSummary: React.FC = () => {
           </div>
           <script>
             // Set document title for PDF filename
-            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
+            document.title = ${JSON.stringify(reportTitle)};
 
             window.onload = function() {
               // Small delay to ensure content is rendered

--- a/frontend/src/pages/sales/SalesOrderProfitReport.tsx
+++ b/frontend/src/pages/sales/SalesOrderProfitReport.tsx
@@ -449,7 +449,7 @@ const SalesOrderProfitReport: React.FC = () => {
           </div>
           <script>
             // Set document title for PDF filename
-            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
+            document.title = ${JSON.stringify(reportTitle)};
 
             window.onload = function() {
               // Small delay to ensure content is rendered

--- a/frontend/src/pages/sales/SalesOrderProfitReport.tsx
+++ b/frontend/src/pages/sales/SalesOrderProfitReport.tsx
@@ -33,6 +33,7 @@ import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { PRINT_STYLES } from '@/styles/printStyles'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import api from '@/services/api'
 
@@ -302,9 +303,9 @@ const SalesOrderProfitReport: React.FC = () => {
 
       // Add group header if group changed
       if (groupBy !== 'none' && currentGroupValue !== prevGroupValue) {
-        const groupLabel = groupBy === 'customerName' ? `Customer: ${currentGroupValue}` :
-                          groupBy === 'inventoryStatus' ? `Inventory: ${currentGroupValue.charAt(0).toUpperCase() + currentGroupValue.slice(1)}` :
-                          groupBy === 'paymentStatus' ? `Payment: ${currentGroupValue.charAt(0).toUpperCase() + currentGroupValue.slice(1)}` : currentGroupValue
+        const groupLabel = groupBy === 'customerName' ? `Customer: ${escapeHtml(currentGroupValue)}` :
+                          groupBy === 'inventoryStatus' ? `Inventory: ${escapeHtml(currentGroupValue.charAt(0).toUpperCase() + currentGroupValue.slice(1))}` :
+                          groupBy === 'paymentStatus' ? `Payment: ${escapeHtml(currentGroupValue.charAt(0).toUpperCase() + currentGroupValue.slice(1))}` : escapeHtml(currentGroupValue)
         tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupValue = currentGroupValue
       }
@@ -320,7 +321,7 @@ const SalesOrderProfitReport: React.FC = () => {
         } else if (typeof value === 'number') {
           displayValue = formatCurrency(value)
         }
-        tableRows += `<td>${displayValue || ''}</td>`
+        tableRows += `<td>${escapeHtml(displayValue)}</td>`
       })
       tableRows += '</tr>'
 
@@ -384,18 +385,18 @@ const SalesOrderProfitReport: React.FC = () => {
     // Build date range text
     let dateRangeText = ''
     if (dateFrom && dateTo) {
-      dateRangeText = `<p><strong>Date Range:</strong> ${formatDate(dateFrom)} - ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date Range:</strong> ${escapeHtml(formatDate(dateFrom))} - ${escapeHtml(formatDate(dateTo))}</p>`
     } else if (dateFrom) {
-      dateRangeText = `<p><strong>Date From:</strong> ${formatDate(dateFrom)}</p>`
+      dateRangeText = `<p><strong>Date From:</strong> ${escapeHtml(formatDate(dateFrom))}</p>`
     } else if (dateTo) {
-      dateRangeText = `<p><strong>Date To:</strong> ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date To:</strong> ${escapeHtml(formatDate(dateTo))}</p>`
     }
 
     const html = `
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>${PRINT_STYLES}
             @media print {
@@ -425,7 +426,7 @@ const SalesOrderProfitReport: React.FC = () => {
           </style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${dateRangeText}
@@ -433,7 +434,7 @@ const SalesOrderProfitReport: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>
@@ -448,7 +449,7 @@ const SalesOrderProfitReport: React.FC = () => {
           </div>
           <script>
             // Set document title for PDF filename
-            document.title = '${reportTitle.replace(/'/g, "\\'")}';
+            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
 
             window.onload = function() {
               // Small delay to ensure content is rendered

--- a/frontend/src/pages/sales/SalesOrderSummary.tsx
+++ b/frontend/src/pages/sales/SalesOrderSummary.tsx
@@ -497,7 +497,7 @@ const SalesOrderSummary: React.FC = () => {
           </div>
           <script>
             // Set document title for PDF filename
-            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
+            document.title = ${JSON.stringify(reportTitle)};
 
             window.onload = function() {
               // Small delay to ensure content is rendered

--- a/frontend/src/pages/sales/SalesOrderSummary.tsx
+++ b/frontend/src/pages/sales/SalesOrderSummary.tsx
@@ -32,6 +32,7 @@ import { default as OrderIcon } from '@mui/icons-material/Receipt'
 import PageHeader from '@/components/common/PageHeader'
 import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
+import { escapeHtml } from '@/utils/security'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import api from '@/services/api'
 
@@ -327,9 +328,9 @@ const SalesOrderSummary: React.FC = () => {
 
       // Add group header if group changed
       if (groupBy !== 'none' && currentGroupValue !== prevGroupValue) {
-        const groupLabel = groupBy === 'customerName' ? `Customer: ${currentGroupValue}` :
-                          groupBy === 'inventoryStatus' ? `Inventory: ${currentGroupValue}` :
-                          groupBy === 'paymentStatus' ? `Payment: ${currentGroupValue}` : currentGroupValue
+        const groupLabel = groupBy === 'customerName' ? `Customer: ${escapeHtml(currentGroupValue)}` :
+                          groupBy === 'inventoryStatus' ? `Inventory: ${escapeHtml(currentGroupValue)}` :
+                          groupBy === 'paymentStatus' ? `Payment: ${escapeHtml(currentGroupValue)}` : escapeHtml(currentGroupValue)
         tableRows += `<tr style="background-color: ${printColors.groupRow}; font-weight: bold;"><td colspan="${selectedColumns.length}">${groupLabel}</td></tr>`
         prevGroupValue = currentGroupValue
       }
@@ -349,7 +350,7 @@ const SalesOrderSummary: React.FC = () => {
         } else if (typeof value === 'number') {
           displayValue = formatCurrency(value)
         }
-        tableRows += `<td>${displayValue || ''}</td>`
+        tableRows += `<td>${escapeHtml(displayValue)}</td>`
       })
       tableRows += '</tr>'
 
@@ -421,18 +422,18 @@ const SalesOrderSummary: React.FC = () => {
     // Build date range text
     let dateRangeText = ''
     if (dateFrom && dateTo) {
-      dateRangeText = `<p><strong>Date Range:</strong> ${formatDate(dateFrom)} - ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date Range:</strong> ${escapeHtml(formatDate(dateFrom))} - ${escapeHtml(formatDate(dateTo))}</p>`
     } else if (dateFrom) {
-      dateRangeText = `<p><strong>Date From:</strong> ${formatDate(dateFrom)}</p>`
+      dateRangeText = `<p><strong>Date From:</strong> ${escapeHtml(formatDate(dateFrom))}</p>`
     } else if (dateTo) {
-      dateRangeText = `<p><strong>Date To:</strong> ${formatDate(dateTo)}</p>`
+      dateRangeText = `<p><strong>Date To:</strong> ${escapeHtml(formatDate(dateTo))}</p>`
     }
 
     const html = `
       <!DOCTYPE html>
       <html>
         <head>
-          <title>${reportTitle}</title>
+          <title>${escapeHtml(reportTitle)}</title>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" />
           <style>
             body { font-family: 'Roboto', sans-serif; margin: 20px; }
@@ -473,7 +474,7 @@ const SalesOrderSummary: React.FC = () => {
           </style>
         </head>
         <body>
-          <h1>${reportTitle}</h1>
+          <h1>${escapeHtml(reportTitle)}</h1>
           <div class="header-info">
             <p style="margin: 5px 0;"><strong>Generated on:</strong> ${formatDateTime(new Date())}</p>
             ${dateRangeText}
@@ -481,7 +482,7 @@ const SalesOrderSummary: React.FC = () => {
           <table>
             <thead>
               <tr>
-                ${selectedColumns.map(col => `<th>${columnHeaders[col] || col}</th>`).join('')}
+                ${selectedColumns.map(col => `<th>${escapeHtml(columnHeaders[col] || col)}</th>`).join('')}
               </tr>
             </thead>
             <tbody>
@@ -496,7 +497,7 @@ const SalesOrderSummary: React.FC = () => {
           </div>
           <script>
             // Set document title for PDF filename
-            document.title = '${reportTitle.replace(/'/g, "\\'")}';
+            document.title = ${JSON.stringify(escapeHtml(reportTitle))};
 
             window.onload = function() {
               // Small delay to ensure content is rendered

--- a/frontend/src/pages/settings/RegionalSettingsPage.tsx
+++ b/frontend/src/pages/settings/RegionalSettingsPage.tsx
@@ -194,14 +194,14 @@ const RegionalSettingsPage: React.FC = () => {
       showSuccess('Regional settings saved successfully.')
       refetch()
     } catch (err: any) {
-      const msg = err.response?.data?.message || err.message || 'Failed to save settings'
+      const msg = String(err.response?.data?.message || err.message || 'Failed to save settings')
       showError(msg)
     } finally {
       setSubmitting(false)
     }
   }
 
-  const error = fetchError ? ((fetchError as any)?.message || 'Failed to load settings') : null
+  const error = fetchError ? String((fetchError as any)?.message || 'Failed to load settings') : null
 
   if (loading) {
     return (

--- a/frontend/src/utils/__tests__/security.test.ts
+++ b/frontend/src/utils/__tests__/security.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest'
+
+import { escapeHtml } from '../security'
+
+describe('escapeHtml', () => {
+  it('escapes angle brackets', () => {
+    expect(escapeHtml('<script>')).toBe('&lt;script&gt;')
+  })
+
+  it('escapes ampersands', () => {
+    expect(escapeHtml('fish & chips')).toBe('fish &amp; chips')
+  })
+
+  it('escapes double quotes', () => {
+    expect(escapeHtml('"quoted"')).toBe('&quot;quoted&quot;')
+  })
+
+  it('escapes single quotes', () => {
+    expect(escapeHtml("O'Brien")).toBe('O&#039;Brien')
+  })
+
+  it('handles numbers', () => {
+    expect(escapeHtml(42)).toBe('42')
+  })
+
+  it('handles null', () => {
+    expect(escapeHtml(null)).toBe('')
+  })
+
+  it('handles undefined', () => {
+    expect(escapeHtml(undefined)).toBe('')
+  })
+
+  it('handles boolean', () => {
+    expect(escapeHtml(true)).toBe('true')
+  })
+
+  it('leaves safe strings unchanged', () => {
+    expect(escapeHtml('Hello World')).toBe('Hello World')
+  })
+
+  it('escapes a full XSS payload', () => {
+    expect(escapeHtml('<img src=x onerror="alert(1)">')).toBe(
+      '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;'
+    )
+  })
+})

--- a/frontend/src/utils/security.ts
+++ b/frontend/src/utils/security.ts
@@ -1,0 +1,9 @@
+export const escapeHtml = (unsafe: string | number | boolean | null | undefined): string => {
+  if (unsafe === null || unsafe === undefined) return ''
+  return String(unsafe)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;')
+}


### PR DESCRIPTION
## Summary

- Created centralized `escapeHtml` utility (`frontend/src/utils/security.ts`) with unit tests covering all XSS-relevant characters and edge cases (null, undefined, boolean, numbers)
- Applied `escapeHtml` to all dynamic values injected into print HTML templates across 19 report pages — titles, group labels, cell values, date range/filter text, and column headers
- Fixed unescaped `getPdfGroupLabel` outputs in 5 purchasing reports (missed in initial pass, caught in code review)
- Fixed `document.title` double-encoding — `JSON.stringify` is sufficient for JS string literal context; `escapeHtml` applies only in HTML markup contexts
- Hardened `RegionalSettingsPage.tsx` error message handling by coercing to `String()` before use

## Test Plan

- [x] `npx vitest run src/utils/__tests__/security.test.ts` → 10 tests pass
- [x] `npx vitest run src/pages/sales src/pages/inventory src/pages/purchasing src/pages/settings` → 45 files, 231 tests pass
- [x] `npm run type-check` → no errors
- [x] `npm run lint` → no errors
- [x] All 19 report files confirmed to import and use `escapeHtml`
- [x] No bare `${reportTitle}` in `<title>` or `<h1>` tags remaining

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)