### PR TITLE
fix(backup): validate upload path boundary to resolve CodeQL alert #38

### DIFF
--- a/backend/src/modules/backup/backup.service.spec.ts
+++ b/backend/src/modules/backup/backup.service.spec.ts
@@ -174,6 +174,15 @@ describe('BackupService - settings backup', () => {
         }),
       );
     });
+
+    it('rejects file.path values that escape the uploads directory', async () => {
+      await expect(
+        service.processUploadedBackup({
+          originalname: 'backup.tar.gz',
+          path: '/app/backups/uploads/../archives/evil.tar.gz',
+        } as Express.Multer.File),
+      ).rejects.toThrow('Invalid upload path detected');
+    });
   });
 
   describe('command execution', () => {

--- a/backend/src/modules/backup/backup.service.ts
+++ b/backend/src/modules/backup/backup.service.ts
@@ -990,7 +990,12 @@ export class BackupService implements OnModuleDestroy {
   async processUploadedBackup(file: Express.Multer.File): Promise<BackupLog> {
     this.logger.log(`Processing uploaded backup: ${file.originalname}`);
 
-    const uploadPath = file.path;
+    const uploadsDir = path.resolve(this.backupDir, 'uploads');
+    const uploadPath = path.resolve(file.path);
+    if (!uploadPath.startsWith(`${uploadsDir}${path.sep}`)) {
+      throw new BadRequestException('Invalid upload path detected');
+    }
+
     const originalFilename = path.basename(file.originalname);
     const archivesDir = path.resolve(this.backupDir, 'archives');
     const ext = originalFilename.endsWith('.tar.gz') ? '.tar.gz' : '.tgz';


### PR DESCRIPTION
## Summary

- Adds `path.resolve()` + `startsWith` boundary check on `file.path` before passing it to `fs.rename` in `processUploadedBackup`
- Breaks the CodeQL taint chain for alert #38 (CWE-22 path injection): `file.path` is treated as user-controlled by the analyser, so normalising and validating it against `BACKUP_DIRECTORY/uploads` before use satisfies the fix requirement
- Adds a test asserting that a `file.path` escaping the uploads directory (e.g. `../archives/evil.tar.gz`) is rejected with `BadRequestException`

## Test plan

- [x] `cd backend && npx jest src/modules/backup/backup.service.spec.ts --no-coverage` — 19 tests pass including the new escape-path rejection test
- [x] `cd backend && npx jest src/modules/backup/backup.controller.spec.ts src/modules/backup/backup.service.spec.ts --no-coverage` — 44 tests pass
- [x] CodeQL re-scan on this branch should clear alert #38

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)