### PR TITLE
fix(security): resolve ReDoS in sanitizeUserAgent (closes #493)

### DIFF
--- a/backend/src/common/filters/security/data-sanitizer.service.spec.ts
+++ b/backend/src/common/filters/security/data-sanitizer.service.spec.ts
@@ -1,0 +1,56 @@
+import { DataSanitizerService } from './data-sanitizer.service';
+
+describe('DataSanitizerService', () => {
+  let service: DataSanitizerService;
+
+  beforeEach(() => {
+    service = new DataSanitizerService();
+  });
+
+  describe('sanitizeUserAgent', () => {
+    it('replaces three-part version numbers in a normal UA string', () => {
+      const ua =
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36.0 Chrome/120.0.6099 Safari/537.36.0';
+
+      expect(service.sanitizeUserAgent(ua)).toBe(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/x.x.x Chrome/x.x.x Safari/x.x.x',
+      );
+    });
+
+    it('returns [UNKNOWN] for empty string', () => {
+      expect(service.sanitizeUserAgent('')).toBe('[UNKNOWN]');
+    });
+
+    it('returns [UNKNOWN] for null/undefined', () => {
+      expect(service.sanitizeUserAgent(null as any)).toBe('[UNKNOWN]');
+      expect(service.sanitizeUserAgent(undefined as any)).toBe('[UNKNOWN]');
+    });
+
+    it('applies regex to a string of exactly 1000 chars', () => {
+      const ua = `${'a'.repeat(995)}1.2.3`;
+
+      const result = service.sanitizeUserAgent(ua);
+
+      expect(ua).toHaveLength(1000);
+      expect(result).not.toBe('[USER_AGENT_TOO_LONG]');
+      expect(result).toContain('x.x.x');
+    });
+
+    it('returns [USER_AGENT_TOO_LONG] for a string of 1001 chars', () => {
+      const ua = 'a'.repeat(1001);
+
+      expect(service.sanitizeUserAgent(ua)).toBe('[USER_AGENT_TOO_LONG]');
+    });
+
+    it('returns [USER_AGENT_TOO_LONG] for a crafted ReDoS input without hanging', () => {
+      const malicious = `1.${'1'.repeat(1000)}`;
+      const start = Date.now();
+
+      const result = service.sanitizeUserAgent(malicious);
+      const elapsed = Date.now() - start;
+
+      expect(result).toBe('[USER_AGENT_TOO_LONG]');
+      expect(elapsed).toBeLessThan(50);
+    });
+  });
+});

--- a/backend/src/common/filters/security/data-sanitizer.service.ts
+++ b/backend/src/common/filters/security/data-sanitizer.service.ts
@@ -33,7 +33,9 @@ export class DataSanitizerService {
    */
   sanitizeUserAgent(userAgent: string): string {
     if (!userAgent) return '[UNKNOWN]';
+    // ReDoS guard: reject oversized inputs before regex processing (fixes #493)
     if (userAgent.length > 1000) return '[USER_AGENT_TOO_LONG]';
+    // Bounded quantifiers prevent catastrophic backtracking
     return userAgent.replace(/\d{1,10}\.\d{1,10}\.\d{1,10}/g, 'x.x.x');
   }
 

--- a/backend/src/common/filters/security/data-sanitizer.service.ts
+++ b/backend/src/common/filters/security/data-sanitizer.service.ts
@@ -33,8 +33,8 @@ export class DataSanitizerService {
    */
   sanitizeUserAgent(userAgent: string): string {
     if (!userAgent) return '[UNKNOWN]';
-    // Keep browser info but remove detailed version numbers
-    return userAgent.replace(/\d+\.\d+\.\d+/g, 'x.x.x');
+    if (userAgent.length > 1000) return '[USER_AGENT_TOO_LONG]';
+    return userAgent.replace(/\d{1,10}\.\d{1,10}\.\d{1,10}/g, 'x.x.x');
   }
 
   /**


### PR DESCRIPTION
## Summary

- Added `userAgent.length > 1000` guard — returns `[USER_AGENT_TOO_LONG]` immediately, consistent with the existing pattern in `sanitizeErrorMessage`
- Replaced unbounded regex `/\d+\.\d+\.\d+/g` with bounded `/\d{1,10}\.\d{1,10}\.\d{1,10}/g` to eliminate catastrophic backtracking
- Added `data-sanitizer.service.spec.ts` with 6 tests covering normal UA, empty/null, exact boundary (1000 chars), oversized (1001 chars), and a crafted ReDoS input verified to complete in <50ms

## Test plan

- [x] RED → GREEN TDD cycle confirmed
- [x] 6/6 targeted tests pass
- [x] Full backend suite passes: 901/901 tests, 69/69 suites
- [x] `npm run lint` clean

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)