### PR TITLE
feat(expenses): master-detail layout refactor (closes #509)

### DIFF
--- a/frontend/src/pages/accounting/ExpensesPage.tsx
+++ b/frontend/src/pages/accounting/ExpensesPage.tsx
@@ -1,48 +1,21 @@
-import React, { useMemo, useState } from 'react'
-import {
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
-  Stack,
-  TextField,
-} from '@mui/material'
-import { AppButton } from '@/components/common/AppButton'
+import React, { useMemo } from 'react'
+import { Stack } from '@mui/material'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as PostIcon } from '@mui/icons-material/PostAdd'
 
+import { AppButton } from '@/components/common/AppButton'
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
-import {
-  useCreateExpenseMutation,
-  useGetChartOfAccountsQuery,
-  useGetExpensesQuery,
-  useGetPaymentMethodsQuery,
-  useUpdateExpenseMutation,
-} from '@/store/api/accountingApi'
-import type { ChartOfAccount, ExpenseRecord } from '@/types'
+import { useGetExpensesQuery } from '@/store/api/accountingApi'
 import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
 import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
 
 import { ExpenseContextHeader } from './components/ExpenseContextHeader'
+import { ExpenseFormDialog } from './components/ExpenseFormDialog'
 import { ExpensesDialogs } from './components/ExpensesDialogs'
 import { ExpensesTable } from './components/ExpensesTable'
 import { ExpenseWorkspaceCard } from './components/ExpenseWorkspaceCard'
 import { useExpensesWorkspace } from './hooks/useExpensesWorkspace'
-
-type FormState = {
-  id?: string
-  expenseDate: string
-  expenseAccountId: string
-  amount: string
-  paymentMethodId: string
-  vendor: string
-  description: string
-}
 
 interface ExpenseFilters {
   search: string
@@ -63,18 +36,7 @@ const filterConfig: FilterBarConfig<ExpenseFilters> = {
   },
 }
 
-const defaultFormState = (): FormState => ({
-  expenseDate: new Date().toISOString().slice(0, 10),
-  expenseAccountId: '',
-  amount: '',
-  paymentMethodId: '',
-  vendor: '',
-  description: '',
-})
-
 const ExpensesPage: React.FC = () => {
-  const [form, setForm] = useState<FormState>(defaultFormState())
-
   const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
   const weekStartsOn = getStartOfWeek()
   const dateRange = useMemo(() => {
@@ -98,71 +60,26 @@ const ExpensesPage: React.FC = () => {
 
   const { data: expensesResponse, isLoading, refetch } = useGetExpensesQuery(filters)
   const rows = expensesResponse?.data ?? []
-  const { data: paymentMethodsResponse } = useGetPaymentMethodsQuery({ page: 1, isActive: true })
-  const paymentMethods = paymentMethodsResponse?.data ?? []
-  const { data: expenseAccountsResponse } = useGetChartOfAccountsQuery({ page: 1, type: 'EXPENSE', isActive: true })
-  const expenseAccounts = (expenseAccountsResponse?.data ?? []) as ChartOfAccount[]
-  const [createExpense] = useCreateExpenseMutation()
-  const [updateExpense] = useUpdateExpenseMutation()
 
   const workspace = useExpensesWorkspace(() => {
     void refetch()
-  })
+  }, rows)
 
   const openCreate = () => {
-    setForm({
-      ...defaultFormState(),
-      expenseAccountId: expenseAccounts[0]?.id ?? '',
-      paymentMethodId: paymentMethods[0]?.id ?? '',
-    })
     workspace.setEditTarget(null)
-    workspace.setCreateOpen(true)
+    workspace.setFormOpen(true)
   }
 
-  const openEdit = (row: ExpenseRecord) => {
-    setForm({
-      id: row.id,
-      expenseDate: String(row.expenseDate).slice(0, 10),
-      expenseAccountId: row.expenseAccountId,
-      amount: String(row.amount),
-      paymentMethodId: row.paymentMethodId,
-      vendor: row.vendor || '',
-      description: row.description || '',
-    })
-    workspace.setEditTarget(row)
+  const openEdit = () => {
+    if (!workspace.selected) return
+    workspace.setEditTarget(workspace.selected)
+    workspace.setFormOpen(true)
   }
 
   const closeForm = () => {
-    workspace.setCreateOpen(false)
+    workspace.setFormOpen(false)
     workspace.setEditTarget(null)
-    setForm(defaultFormState())
   }
-
-  const save = async () => {
-    if (!form.expenseAccountId || !form.paymentMethodId || !form.amount || Number(form.amount) <= 0) {
-      return
-    }
-
-    const payload = {
-      expenseDate: form.expenseDate,
-      expenseAccountId: form.expenseAccountId,
-      amount: Number(form.amount),
-      paymentMethodId: form.paymentMethodId,
-      vendor: form.vendor || undefined,
-      description: form.description || undefined,
-    }
-
-    if (form.id) {
-      await updateExpense({ id: form.id, data: payload }).unwrap()
-    } else {
-      await createExpense(payload).unwrap()
-    }
-
-    closeForm()
-    void refetch()
-  }
-
-  const formOpen = workspace.createOpen || workspace.editTarget !== null
 
   return (
     <GenericListPage
@@ -190,20 +107,18 @@ const ExpensesPage: React.FC = () => {
           expenses={rows}
           loading={isLoading}
           selectedId={workspace.selected?.id ?? null}
-          selectedIds={workspace.selectedIds}
-          onSelect={workspace.setSelected}
-          onToggleCheck={workspace.handleToggleCheck}
-          onSelectAll={() => workspace.handleSelectAll(rows)}
-          onPost={(item) => workspace.setPostTarget(item)}
-          onEdit={openEdit}
-          onDelete={(item) => workspace.setDeleteTarget(item)}
+          focusedIndex={workspace.focusedIndex}
+          onSelect={(item) => {
+            workspace.handleSelect(item)
+            workspace.setFocusedIndex(rows.findIndex((row) => row.id === item.id))
+          }}
           listRef={workspace.listRef}
         />
       )}
       headerSlot={(
         <ExpenseContextHeader
           selected={workspace.selected}
-          onEdit={() => workspace.selected && openEdit(workspace.selected)}
+          onEdit={openEdit}
           onPost={() => workspace.selected && workspace.setPostTarget(workspace.selected)}
           onDelete={() => workspace.selected && workspace.setDeleteTarget(workspace.selected)}
         />
@@ -226,37 +141,12 @@ const ExpensesPage: React.FC = () => {
             onCancelBulkPost={() => workspace.setBulkPostOpen(false)}
             onCancelBulkDelete={() => workspace.setBulkDeleteOpen(false)}
           />
-          <Dialog open={formOpen} onClose={closeForm} maxWidth="sm" fullWidth>
-            <DialogTitle>{workspace.editTarget ? 'Edit Expense' : 'New Expense'}</DialogTitle>
-            <DialogContent>
-              <Stack spacing={2} sx={{ mt: 1 }}>
-                <TextField label="Date" type="date" size="small" value={form.expenseDate} onChange={(event) => setForm((current) => ({ ...current, expenseDate: event.target.value }))} slotProps={{ inputLabel: { shrink: true } }} />
-                <FormControl fullWidth size="small">
-                  <InputLabel>Expense Account</InputLabel>
-                  <Select value={form.expenseAccountId} label="Expense Account" onChange={(event) => setForm((current) => ({ ...current, expenseAccountId: event.target.value }))}>
-                    {expenseAccounts.map((account) => (
-                      <MenuItem key={account.id} value={account.id}>{account.code} - {account.name}</MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-                <TextField label="Amount" size="small" type="number" value={form.amount} onChange={(event) => setForm((current) => ({ ...current, amount: event.target.value }))} />
-                <FormControl fullWidth size="small">
-                  <InputLabel>Payment Method</InputLabel>
-                  <Select value={form.paymentMethodId} label="Payment Method" onChange={(event) => setForm((current) => ({ ...current, paymentMethodId: event.target.value }))}>
-                    {paymentMethods.map((paymentMethod) => (
-                      <MenuItem key={paymentMethod.id} value={paymentMethod.id}>{paymentMethod.name}</MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-                <TextField label="Vendor" value={form.vendor} onChange={(event) => setForm((current) => ({ ...current, vendor: event.target.value }))} />
-                <TextField label="Description" multiline minRows={2} value={form.description} onChange={(event) => setForm((current) => ({ ...current, description: event.target.value }))} />
-              </Stack>
-            </DialogContent>
-            <DialogActions>
-              <AppButton variant="outlined" onClick={closeForm}>Cancel</AppButton>
-              <AppButton variant="primary" onClick={() => void save()}>Save</AppButton>
-            </DialogActions>
-          </Dialog>
+          <ExpenseFormDialog
+            open={workspace.formOpen}
+            editTarget={workspace.editTarget}
+            onClose={closeForm}
+            onSaved={() => { void refetch() }}
+          />
         </>
       )}
     />

--- a/frontend/src/pages/accounting/ExpensesPage.tsx
+++ b/frontend/src/pages/accounting/ExpensesPage.tsx
@@ -1,9 +1,5 @@
 import React, { useMemo } from 'react'
-import { Stack } from '@mui/material'
-import { default as DeleteIcon } from '@mui/icons-material/Delete'
-import { default as PostIcon } from '@mui/icons-material/PostAdd'
 
-import { AppButton } from '@/components/common/AppButton'
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
 import { useGetExpensesQuery } from '@/store/api/accountingApi'
@@ -92,26 +88,13 @@ const ExpensesPage: React.FC = () => {
       hasActiveFilters={hasActiveFilters}
       searchInputRef={workspace.searchInputRef}
       sort={{ field: 'expenseDate', sortBy: 'expenseDate', sortOrder: 'desc', onSort: () => {} }}
-      contentSlot={workspace.selectedIds.size > 0 ? (
-        <Stack direction="row" spacing={1} sx={{ mb: 1 }}>
-          <AppButton size="small" variant="primary" startIcon={<PostIcon />} onClick={() => workspace.setBulkPostOpen(true)}>
-            Bulk Post ({workspace.selectedIds.size})
-          </AppButton>
-          <AppButton size="small" variant="danger" startIcon={<DeleteIcon />} onClick={() => workspace.setBulkDeleteOpen(true)}>
-            Bulk Delete ({workspace.selectedIds.size})
-          </AppButton>
-        </Stack>
-      ) : null}
       listSlot={(
         <ExpensesTable
           expenses={rows}
           loading={isLoading}
           selectedId={workspace.selected?.id ?? null}
           focusedIndex={workspace.focusedIndex}
-          onSelect={(item) => {
-            workspace.handleSelect(item)
-            workspace.setFocusedIndex(rows.findIndex((row) => row.id === item.id))
-          }}
+          onSelect={workspace.handleSelect}
           listRef={workspace.listRef}
         />
       )}
@@ -129,17 +112,11 @@ const ExpensesPage: React.FC = () => {
           <ExpensesDialogs
             postTarget={workspace.postTarget}
             deleteTarget={workspace.deleteTarget}
-            bulkPostIds={workspace.bulkPostOpen ? workspace.selectedIds : new Set<string>()}
-            bulkDeleteIds={workspace.bulkDeleteOpen ? workspace.selectedIds : new Set<string>()}
             actionLoading={workspace.actionLoading}
             onConfirmPost={workspace.handleConfirmPost}
             onConfirmDelete={workspace.handleConfirmDelete}
-            onConfirmBulkPost={workspace.handleBulkPost}
-            onConfirmBulkDelete={workspace.handleBulkDelete}
             onCancelPost={() => workspace.setPostTarget(null)}
             onCancelDelete={() => workspace.setDeleteTarget(null)}
-            onCancelBulkPost={() => workspace.setBulkPostOpen(false)}
-            onCancelBulkDelete={() => workspace.setBulkDeleteOpen(false)}
           />
           <ExpenseFormDialog
             open={workspace.formOpen}

--- a/frontend/src/pages/accounting/__tests__/ExpensesPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/ExpensesPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -27,8 +27,6 @@ const mockedApi = vi.hoisted(() => ({
   useUpdateExpenseMutation: vi.fn(),
   useDeleteExpenseMutation: vi.fn(),
   usePostExpenseMutation: vi.fn(),
-  useBulkPostExpensesMutation: vi.fn(),
-  useBulkDeleteExpensesMutation: vi.fn(),
 }))
 
 vi.mock('@/utils/dateRange', () => ({
@@ -42,8 +40,6 @@ vi.mock('@/utils/formatters', async () => {
 })
 
 vi.mock('@/store/api/accountingApi', () => mockedApi)
-
-const expenseListRow = () => screen.getAllByText('EXP-001')[0]
 
 const expense1 = {
   id: 'ex-1',
@@ -86,8 +82,6 @@ describe('ExpensesPage', () => {
     mockedApi.useUpdateExpenseMutation.mockReturnValue([vi.fn()])
     mockedApi.useDeleteExpenseMutation.mockReturnValue([vi.fn()])
     mockedApi.usePostExpenseMutation.mockReturnValue([vi.fn()])
-    mockedApi.useBulkPostExpensesMutation.mockReturnValue([vi.fn()])
-    mockedApi.useBulkDeleteExpensesMutation.mockReturnValue([vi.fn()])
   })
 
   it('renders the page title', () => {
@@ -100,7 +94,7 @@ describe('ExpensesPage', () => {
     expect(screen.getAllByText('EXP-001').length).toBeGreaterThan(0)
   })
 
-  it('bulk action buttons are hidden when no rows are selected', () => {
+  it('bulk action buttons are never shown (feature removed)', () => {
     renderPage()
     expect(screen.queryByText(/Bulk Post/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/Bulk Delete/i)).not.toBeInTheDocument()
@@ -117,8 +111,12 @@ describe('ExpensesPage', () => {
   })
 
   it('selecting a row shows detail in the context header', () => {
-    renderPage()
-    fireEvent.click(expenseListRow())
+    const { container } = renderPage()
+    // Click the row in the list (EntityTable tbody area) by finding the first occurrence
+    // of EXP-001 inside the table body, which is unambiguously in the list panel
+    const tableBody = container.querySelector('tbody')!
+    const listRow = within(tableBody).getByText('EXP-001')
+    fireEvent.click(listRow)
     expect(screen.getByText('Stationery Hub')).toBeInTheDocument()
     expect(screen.getAllByText('Office Supplies').length).toBeGreaterThan(0)
     expect(screen.getByText('$225.5')).toBeInTheDocument()
@@ -138,8 +136,9 @@ describe('ExpensesPage', () => {
   })
 
   it('shows description in workspace card after selecting a row', () => {
-    renderPage()
-    fireEvent.click(expenseListRow())
+    const { container } = renderPage()
+    const tableBody = container.querySelector('tbody')!
+    fireEvent.click(within(tableBody).getByText('EXP-001'))
     expect(screen.getByText('Printer paper and ink')).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/accounting/__tests__/ExpensesPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/ExpensesPage.test.tsx
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import ExpensesPage from '../ExpensesPage'
 
@@ -8,6 +8,14 @@ vi.mock('@/hooks/useNotification', () => ({
   useNotification: () => ({
     showSuccess: vi.fn(),
     showError: vi.fn(),
+  }),
+}))
+
+vi.mock('@/hooks/useJournalEntryRef', () => ({
+  useJournalEntryRef: () => ({
+    journalEntryRef: null,
+    journalEntryRefLoading: false,
+    navigateToJournalEntry: vi.fn(),
   }),
 }))
 
@@ -23,13 +31,35 @@ const mockedApi = vi.hoisted(() => ({
   useBulkDeleteExpensesMutation: vi.fn(),
 }))
 
-vi.mock('@/utils/dateRange', () => ({ getPeriodDateRange: () => ({ from: undefined, to: undefined }), getStartOfWeek: () => 0 }))
+vi.mock('@/utils/dateRange', () => ({
+  getPeriodDateRange: () => ({ from: undefined, to: undefined }),
+  getStartOfWeek: () => 0,
+}))
+
 vi.mock('@/utils/formatters', async () => {
   const actual = await vi.importActual<typeof import('@/utils/formatters')>('@/utils/formatters')
   return { ...actual, formatDate: (value: string) => value, formatCurrency: (value: number) => `$${value}` }
 })
 
 vi.mock('@/store/api/accountingApi', () => mockedApi)
+
+const expenseListRow = () => screen.getAllByText('EXP-001')[0]
+
+const expense1 = {
+  id: 'ex-1',
+  referenceNumber: 'EXP-001',
+  expenseDate: '2026-02-15',
+  expenseAccountId: 'coa-1',
+  expenseAccount: { id: 'coa-1', code: '6000', name: 'Office Supplies' },
+  amount: 225.5,
+  paymentMethodId: 'pm-1',
+  paymentMethod: { id: 'pm-1', code: 'CASH', name: 'Cash' },
+  vendor: 'Stationery Hub',
+  description: 'Printer paper and ink',
+  status: 'draft' as const,
+  createdAt: '2026-02-15',
+  updatedAt: '2026-02-15',
+}
 
 const renderPage = () =>
   render(
@@ -42,25 +72,7 @@ describe('ExpensesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockedApi.useGetExpensesQuery.mockReturnValue({
-      data: {
-        data: [
-          {
-            id: 'ex-1',
-            referenceNumber: 'EXP-001',
-            expenseDate: '2026-02-15',
-            expenseAccountId: 'coa-1',
-            expenseAccount: { id: 'coa-1', code: '6000', name: 'Office Supplies' },
-            amount: 225.5,
-            paymentMethodId: 'pm-1',
-            paymentMethod: { id: 'pm-1', code: 'CASH', name: 'Cash' },
-            vendor: 'Stationery Hub',
-            description: 'Printer paper and ink',
-            status: 'draft',
-            createdAt: '2026-02-15',
-            updatedAt: '2026-02-15',
-          },
-        ],
-      },
+      data: { data: [expense1] },
       isLoading: false,
       refetch: vi.fn(),
     })
@@ -81,7 +93,11 @@ describe('ExpensesPage', () => {
   it('renders the page title', () => {
     renderPage()
     expect(screen.getByText('Expenses')).toBeInTheDocument()
-    expect(screen.getByText('EXP-001')).toBeInTheDocument()
+  })
+
+  it('shows expense reference number in the narrow list', () => {
+    renderPage()
+    expect(screen.getAllByText('EXP-001').length).toBeGreaterThan(0)
   })
 
   it('bulk action buttons are hidden when no rows are selected', () => {
@@ -90,33 +106,40 @@ describe('ExpensesPage', () => {
     expect(screen.queryByText(/Bulk Delete/i)).not.toBeInTheDocument()
   })
 
-  it('shows loading state', () => {
+  it('shows skeleton loading state', () => {
     mockedApi.useGetExpensesQuery.mockReturnValue({
       data: undefined,
       isLoading: true,
       refetch: vi.fn(),
     })
-
     renderPage()
-    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+    expect(document.querySelector('.MuiSkeleton-root')).toBeInTheDocument()
   })
 
-  it('displays expense data in table', () => {
+  it('selecting a row shows detail in the context header', () => {
     renderPage()
-
-    expect(screen.getByText('EXP-001')).toBeInTheDocument()
+    fireEvent.click(expenseListRow())
     expect(screen.getByText('Stationery Hub')).toBeInTheDocument()
-    expect(screen.getByText('Office Supplies')).toBeInTheDocument()
+    expect(screen.getAllByText('Office Supplies').length).toBeGreaterThan(0)
+    expect(screen.getByText('$225.5')).toBeInTheDocument()
+  })
 
-    fireEvent.click(screen.getByText('EXP-001'))
-    expect(screen.getByText('Printer paper and ink')).toBeInTheDocument()
+  it('clicking New Expense opens form dialog', () => {
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'New Expense' }))
+    expect(screen.getByRole('dialog')).toHaveTextContent('New Expense')
   })
 
   it('shows filter controls', () => {
     renderPage()
-
     expect(screen.getByPlaceholderText('Search expenses...')).toBeInTheDocument()
     expect(screen.getAllByText('Status').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Period').length).toBeGreaterThan(0)
+  })
+
+  it('shows description in workspace card after selecting a row', () => {
+    renderPage()
+    fireEvent.click(expenseListRow())
+    expect(screen.getByText('Printer paper and ink')).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/accounting/components/ExpenseContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/ExpenseContextHeader.tsx
@@ -40,7 +40,7 @@ const sectionHeaderCellSx = {
 
 export function ExpenseContextHeader({ selected, onEdit, onPost, onDelete }: Props) {
   const { journalEntryRef, navigateToJournalEntry } = useJournalEntryRef(
-    selected?.status === 'posted'
+    selected?.journalEntryId
       ? [{ sourceType: 'expense', sourceId: selected.id }]
       : [],
   )

--- a/frontend/src/pages/accounting/components/ExpenseContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/ExpenseContextHeader.tsx
@@ -1,4 +1,5 @@
-import { Paper, Stack, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
+import { Paper, Stack, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material'
+import Grid from '@mui/material/Grid'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as EditIcon } from '@mui/icons-material/Edit'
 import { default as PostIcon } from '@mui/icons-material/PostAdd'
@@ -7,7 +8,8 @@ import { AppButton } from '@/components/common/AppButton'
 import { EntityContextHeaderBar } from '@/components/common/EntityContextHeaderBar'
 import { EntityStatusChip } from '@/components/common/EntityStatusChip'
 import { TABLE_STYLES } from '@/constants/tableStyles'
-import { ExpenseRecord } from '@/types'
+import { useJournalEntryRef } from '@/hooks/useJournalEntryRef'
+import type { ExpenseRecord } from '@/types'
 import { formatCurrency, formatDate } from '@/utils/formatters'
 
 interface Props {
@@ -17,13 +19,38 @@ interface Props {
   onDelete: () => void
 }
 
-const cellSx = { border: 'none', py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px }
+const detailTableSx = {
+  tableLayout: 'fixed' as const,
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const labelCellSx = { fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }
+const valueCellSx = { fontSize: '0.8rem' }
+const sectionHeaderCellSx = {
+  pb: TABLE_STYLES.cell.padding.py * 0.67,
+  py: TABLE_STYLES.cell.padding.py * 0.67,
+  borderTop: TABLE_STYLES.cell.border,
+}
 
 export function ExpenseContextHeader({ selected, onEdit, onPost, onDelete }: Props) {
+  const { journalEntryRef, navigateToJournalEntry } = useJournalEntryRef(
+    selected?.status === 'posted'
+      ? [{ sourceType: 'expense', sourceId: selected.id }]
+      : [],
+  )
+
   if (!selected) {
     return (
-      <Paper sx={{ p: 2 }}>
-        <Typography variant="body2" color="text.secondary">Select an expense to view details</Typography>
+      <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
+        <Typography variant="h6" sx={{ color: 'text.secondary' }}>
+          Select an expense to view details
+        </Typography>
       </Paper>
     )
   }
@@ -31,7 +58,7 @@ export function ExpenseContextHeader({ selected, onEdit, onPost, onDelete }: Pro
   const isDraft = selected.status === 'draft'
 
   return (
-    <Paper>
+    <Paper sx={{ overflow: 'hidden' }}>
       <EntityContextHeaderBar
         title={selected.referenceNumber}
         statusChip={<EntityStatusChip status={selected.status} />}
@@ -51,22 +78,81 @@ export function ExpenseContextHeader({ selected, onEdit, onPost, onDelete }: Pro
           ) : null
         }
       />
-      <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': cellSx }}>
-        <TableBody>
-          <TableRow>
-            <TableCell sx={{ ...cellSx, color: 'text.secondary', width: 120 }}>Date</TableCell>
-            <TableCell>{formatDate(selected.expenseDate)}</TableCell>
-            <TableCell sx={{ ...cellSx, color: 'text.secondary', width: 120 }}>Amount</TableCell>
-            <TableCell align="right">{formatCurrency(selected.amount)}</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell sx={{ ...cellSx, color: 'text.secondary' }}>Vendor</TableCell>
-            <TableCell>{selected.vendor ?? '—'}</TableCell>
-            <TableCell sx={{ ...cellSx, color: 'text.secondary' }}>Account</TableCell>
-            <TableCell>{selected.expenseAccount?.name ?? '—'}</TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
+      <Grid container spacing={3} sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <TableContainer>
+            <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+              <TableBody>
+                <TableRow>
+                  <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+                    <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                      Expense Info
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+                <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                  <TableCell sx={labelCellSx}>Date</TableCell>
+                  <TableCell sx={valueCellSx}>{formatDate(selected.expenseDate)}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell sx={labelCellSx}>Vendor</TableCell>
+                  <TableCell sx={valueCellSx}>{selected.vendor ?? '—'}</TableCell>
+                </TableRow>
+                <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                  <TableCell sx={labelCellSx}>Account</TableCell>
+                  <TableCell sx={valueCellSx}>{selected.expenseAccount?.name ?? '—'}</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Grid>
+
+        <Grid size={{ xs: 12, md: 6 }}>
+          <TableContainer>
+            <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+              <TableBody>
+                <TableRow>
+                  <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+                    <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                      Payment & Total
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+                <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                  <TableCell sx={labelCellSx}>Amount</TableCell>
+                  <TableCell sx={{ ...valueCellSx, fontWeight: 600 }}>{formatCurrency(selected.amount)}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell sx={labelCellSx}>Payment Method</TableCell>
+                  <TableCell sx={valueCellSx}>{selected.paymentMethod?.name ?? '—'}</TableCell>
+                </TableRow>
+                {journalEntryRef && (
+                  <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                    <TableCell sx={labelCellSx}>Journal Entry</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      <Typography
+                        component="button"
+                        onClick={navigateToJournalEntry}
+                        sx={{
+                          fontSize: '0.8rem',
+                          color: 'primary.main',
+                          cursor: 'pointer',
+                          textDecoration: 'none',
+                          border: 'none',
+                          background: 'none',
+                          padding: 0,
+                        }}
+                      >
+                        {journalEntryRef.referenceNumber}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Grid>
+      </Grid>
     </Paper>
   )
 }

--- a/frontend/src/pages/accounting/components/ExpenseFormDialog.tsx
+++ b/frontend/src/pages/accounting/components/ExpenseFormDialog.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mui/material'
 
 import { AppButton } from '@/components/common/AppButton'
+import { useNotification } from '@/hooks/useNotification'
 import {
   useCreateExpenseMutation,
   useGetChartOfAccountsQuery,
@@ -21,6 +22,7 @@ import {
   useUpdateExpenseMutation,
 } from '@/store/api/accountingApi'
 import type { ChartOfAccount, ExpenseRecord } from '@/types'
+import { getErrorMessage } from '@/utils/errorMessage'
 
 interface Props {
   open: boolean
@@ -60,6 +62,7 @@ export function ExpenseFormDialog({ open, editTarget, onClose, onSaved }: Props)
     [expenseAccountsResponse?.data],
   )
 
+  const { showError } = useNotification()
   const [createExpense] = useCreateExpenseMutation()
   const [updateExpense] = useUpdateExpenseMutation()
 
@@ -99,14 +102,19 @@ export function ExpenseFormDialog({ open, editTarget, onClose, onSaved }: Props)
       vendor: form.vendor || undefined,
       description: form.description || undefined,
     }
-    if (editTarget) {
-      await updateExpense({ id: editTarget.id, data: payload }).unwrap()
+    try {
+      if (editTarget) {
+        await updateExpense({ id: editTarget.id, data: payload }).unwrap()
+      }
+      else {
+        await createExpense(payload).unwrap()
+      }
+      onSaved()
+      onClose()
     }
-    else {
-      await createExpense(payload).unwrap()
+    catch (error: unknown) {
+      showError(getErrorMessage(error, 'Failed to save expense'))
     }
-    onSaved()
-    onClose()
   }
 
   const set = (field: keyof FormState) => (event: ChangeEvent<HTMLInputElement>) =>

--- a/frontend/src/pages/accounting/components/ExpenseFormDialog.tsx
+++ b/frontend/src/pages/accounting/components/ExpenseFormDialog.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { ChangeEvent } from 'react'
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+} from '@mui/material'
+
+import { AppButton } from '@/components/common/AppButton'
+import {
+  useCreateExpenseMutation,
+  useGetChartOfAccountsQuery,
+  useGetPaymentMethodsQuery,
+  useUpdateExpenseMutation,
+} from '@/store/api/accountingApi'
+import type { ChartOfAccount, ExpenseRecord } from '@/types'
+
+interface Props {
+  open: boolean
+  editTarget: ExpenseRecord | null
+  onClose: () => void
+  onSaved: () => void
+}
+
+type FormState = {
+  expenseDate: string
+  expenseAccountId: string
+  amount: string
+  paymentMethodId: string
+  vendor: string
+  description: string
+}
+
+function defaultForm(): FormState {
+  return {
+    expenseDate: new Date().toISOString().slice(0, 10),
+    expenseAccountId: '',
+    amount: '',
+    paymentMethodId: '',
+    vendor: '',
+    description: '',
+  }
+}
+
+export function ExpenseFormDialog({ open, editTarget, onClose, onSaved }: Props) {
+  const [form, setForm] = useState<FormState>(defaultForm())
+
+  const { data: paymentMethodsResponse } = useGetPaymentMethodsQuery({ page: 1, isActive: true })
+  const paymentMethods = useMemo(() => paymentMethodsResponse?.data ?? [], [paymentMethodsResponse?.data])
+  const { data: expenseAccountsResponse } = useGetChartOfAccountsQuery({ page: 1, type: 'EXPENSE', isActive: true })
+  const expenseAccounts = useMemo(
+    () => (expenseAccountsResponse?.data ?? []) as ChartOfAccount[],
+    [expenseAccountsResponse?.data],
+  )
+
+  const [createExpense] = useCreateExpenseMutation()
+  const [updateExpense] = useUpdateExpenseMutation()
+
+  const firstExpenseAccountId = expenseAccounts[0]?.id ?? ''
+  const firstPaymentMethodId = paymentMethods[0]?.id ?? ''
+
+  useEffect(() => {
+    if (!open) return
+    if (editTarget) {
+      setForm({
+        expenseDate: String(editTarget.expenseDate).slice(0, 10),
+        expenseAccountId: editTarget.expenseAccountId,
+        amount: String(editTarget.amount),
+        paymentMethodId: editTarget.paymentMethodId,
+        vendor: editTarget.vendor ?? '',
+        description: editTarget.description ?? '',
+      })
+    }
+    else {
+      setForm({
+        ...defaultForm(),
+        expenseAccountId: firstExpenseAccountId,
+        paymentMethodId: firstPaymentMethodId,
+      })
+    }
+  }, [open, editTarget, firstExpenseAccountId, firstPaymentMethodId])
+
+  const handleSave = async () => {
+    if (!form.expenseAccountId || !form.paymentMethodId || !form.amount || Number(form.amount) <= 0) {
+      return
+    }
+    const payload = {
+      expenseDate: form.expenseDate,
+      expenseAccountId: form.expenseAccountId,
+      amount: Number(form.amount),
+      paymentMethodId: form.paymentMethodId,
+      vendor: form.vendor || undefined,
+      description: form.description || undefined,
+    }
+    if (editTarget) {
+      await updateExpense({ id: editTarget.id, data: payload }).unwrap()
+    }
+    else {
+      await createExpense(payload).unwrap()
+    }
+    onSaved()
+    onClose()
+  }
+
+  const set = (field: keyof FormState) => (event: ChangeEvent<HTMLInputElement>) =>
+    setForm((current) => ({ ...current, [field]: event.target.value }))
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{editTarget ? 'Edit Expense' : 'New Expense'}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            label="Date"
+            type="date"
+            size="small"
+            value={form.expenseDate}
+            onChange={set('expenseDate')}
+            slotProps={{ inputLabel: { shrink: true } }}
+          />
+          <FormControl fullWidth size="small">
+            <InputLabel>Expense Account</InputLabel>
+            <Select
+              value={form.expenseAccountId}
+              label="Expense Account"
+              onChange={(event) => setForm((current) => ({ ...current, expenseAccountId: event.target.value }))}
+            >
+              {expenseAccounts.map((account) => (
+                <MenuItem key={account.id} value={account.id}>{account.code} - {account.name}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField label="Amount" size="small" type="number" value={form.amount} onChange={set('amount')} />
+          <FormControl fullWidth size="small">
+            <InputLabel>Payment Method</InputLabel>
+            <Select
+              value={form.paymentMethodId}
+              label="Payment Method"
+              onChange={(event) => setForm((current) => ({ ...current, paymentMethodId: event.target.value }))}
+            >
+              {paymentMethods.map((paymentMethod) => (
+                <MenuItem key={paymentMethod.id} value={paymentMethod.id}>{paymentMethod.name}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField label="Vendor" value={form.vendor} onChange={set('vendor')} />
+          <TextField label="Description" multiline minRows={2} value={form.description} onChange={set('description')} />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <AppButton variant="outlined" onClick={onClose}>Cancel</AppButton>
+        <AppButton variant="primary" onClick={() => void handleSave()}>Save</AppButton>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/accounting/components/ExpensesDialogs.tsx
+++ b/frontend/src/pages/accounting/components/ExpensesDialogs.tsx
@@ -4,40 +4,26 @@ import { ExpenseRecord } from '@/types'
 interface Props {
   postTarget: ExpenseRecord | null
   deleteTarget: ExpenseRecord | null
-  bulkPostIds: Set<string>
-  bulkDeleteIds: Set<string>
   actionLoading: boolean
   onConfirmPost: () => void
   onConfirmDelete: () => void
-  onConfirmBulkPost: () => void
-  onConfirmBulkDelete: () => void
   onCancelPost: () => void
   onCancelDelete: () => void
-  onCancelBulkPost: () => void
-  onCancelBulkDelete: () => void
 }
 
 export function ExpensesDialogs({
   postTarget,
   deleteTarget,
-  bulkPostIds,
-  bulkDeleteIds,
   actionLoading,
   onConfirmPost,
   onConfirmDelete,
-  onConfirmBulkPost,
-  onConfirmBulkDelete,
   onCancelPost,
   onCancelDelete,
-  onCancelBulkPost,
-  onCancelBulkDelete,
 }: Props) {
   return (
     <>
       <ConfirmationDialog open={!!postTarget} title="Post Expense" message={`Post expense ${postTarget?.referenceNumber}?`} confirmText="Post" cancelText="Cancel" onConfirm={onConfirmPost} onCancel={onCancelPost} loading={actionLoading} />
       <ConfirmationDialog open={!!deleteTarget} title="Delete Expense" message={`Delete expense ${deleteTarget?.referenceNumber}?`} confirmText="Delete" cancelText="Cancel" onConfirm={onConfirmDelete} onCancel={onCancelDelete} loading={actionLoading} />
-      <ConfirmationDialog open={bulkPostIds.size > 0} title="Bulk Post" message={`Post ${bulkPostIds.size} selected expenses?`} confirmText="Post" cancelText="Cancel" onConfirm={onConfirmBulkPost} onCancel={onCancelBulkPost} loading={actionLoading} />
-      <ConfirmationDialog open={bulkDeleteIds.size > 0} title="Bulk Delete" message={`Delete ${bulkDeleteIds.size} selected expenses?`} confirmText="Delete" cancelText="Cancel" onConfirm={onConfirmBulkDelete} onCancel={onCancelBulkDelete} loading={actionLoading} />
     </>
   )
 }

--- a/frontend/src/pages/accounting/components/ExpensesTable.tsx
+++ b/frontend/src/pages/accounting/components/ExpensesTable.tsx
@@ -1,115 +1,50 @@
 import type { RefObject } from 'react'
-import { Checkbox, Chip, CircularProgress, Paper, Stack, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tooltip, Typography } from '@mui/material'
-import { default as DeleteIcon } from '@mui/icons-material/Delete'
-import { default as EditIcon } from '@mui/icons-material/Edit'
-import { default as PostIcon } from '@mui/icons-material/PostAdd'
+import { Chip } from '@mui/material'
 
-import { AppButton } from '@/components/common/AppButton'
-import { TABLE_STYLES } from '@/constants/tableStyles'
-import { ExpenseRecord } from '@/types'
-import { formatCurrency, formatDate } from '@/utils/formatters'
+import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
+import type { ExpenseRecord } from '@/types'
 
 interface Props {
   expenses: ExpenseRecord[]
   loading: boolean
   selectedId: string | null
-  selectedIds: Set<string>
+  focusedIndex: number
   onSelect: (item: ExpenseRecord) => void
-  onToggleCheck: (id: string) => void
-  onSelectAll: () => void
-  onPost: (item: ExpenseRecord) => void
-  onEdit: (item: ExpenseRecord) => void
-  onDelete: (item: ExpenseRecord) => void
-  listRef?: RefObject<HTMLDivElement | null>
+  listRef: RefObject<HTMLDivElement | null>
 }
 
 function statusColor(status: string) {
   return status === 'posted' ? 'success' as const : 'default' as const
 }
 
-export function ExpensesTable({
-  expenses,
-  loading,
-  selectedId,
-  selectedIds,
-  onSelect,
-  onToggleCheck,
-  onSelectAll,
-  onPost,
-  onEdit,
-  onDelete,
-  listRef,
-}: Props) {
-  const draftExpenses = expenses.filter((expense) => expense.status === 'draft')
-  const allSelected = draftExpenses.length > 0 && selectedIds.size === draftExpenses.length
-  const someSelected = selectedIds.size > 0 && selectedIds.size < draftExpenses.length
+const columns: ColumnConfig<ExpenseRecord>[] = [
+  {
+    key: 'reference',
+    render: (row) => row.referenceNumber,
+    width: '60%',
+  },
+  {
+    key: 'status',
+    raw: true,
+    render: (row) => (
+      <Chip label={row.status} color={statusColor(row.status)} size="small" />
+    ),
+    width: '40%',
+  },
+]
 
+export function ExpensesTable({ expenses, loading, selectedId, focusedIndex, onSelect, listRef }: Props) {
   return (
-    <Paper ref={listRef} sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
-        <Table size={TABLE_STYLES.size} stickyHeader>
-          <TableHead>
-            <TableRow>
-              <TableCell padding="checkbox">
-                <Checkbox indeterminate={someSelected} checked={allSelected} onChange={onSelectAll} />
-              </TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Reference</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Date</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Vendor</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Account</TableCell>
-              <TableCell sx={{ fontWeight: 600 }} align="right">Amount</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Status</TableCell>
-              <TableCell sx={{ fontWeight: 600 }} align="center">Actions</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {loading ? (
-              <TableRow>
-                <TableCell colSpan={8} align="center" sx={{ py: 4 }}>
-                  <CircularProgress />
-                </TableCell>
-              </TableRow>
-            ) : expenses.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={8} align="center" sx={{ py: 4 }}>
-                  <Typography variant="body2" color="text.secondary">No expenses found</Typography>
-                </TableCell>
-              </TableRow>
-            ) : expenses.map((item) => (
-              <TableRow key={item.id} hover selected={item.id === selectedId} onClick={() => onSelect(item)} sx={{ cursor: 'pointer', height: TABLE_STYLES.row.height }}>
-                <TableCell padding="checkbox" onClick={(event) => event.stopPropagation()}>
-                  <Checkbox disabled={item.status !== 'draft'} checked={selectedIds.has(item.id)} onChange={() => onToggleCheck(item.id)} />
-                </TableCell>
-                <TableCell>
-                  <Typography variant="body2" sx={{ fontWeight: 500, color: 'primary.main' }}>{item.referenceNumber}</Typography>
-                </TableCell>
-                <TableCell><Typography variant="body2">{formatDate(item.expenseDate)}</Typography></TableCell>
-                <TableCell><Typography variant="body2">{item.vendor ?? '—'}</Typography></TableCell>
-                <TableCell><Typography variant="body2">{item.expenseAccount?.name ?? '—'}</Typography></TableCell>
-                <TableCell align="right"><Typography variant="body2">{formatCurrency(item.amount)}</Typography></TableCell>
-                <TableCell><Chip label={item.status} color={statusColor(item.status)} size="small" /></TableCell>
-                <TableCell align="center" onClick={(event) => event.stopPropagation()}>
-                  <Stack direction="row" spacing={0.5} sx={{ justifyContent: 'center' }}>
-                    {item.status === 'draft' && (
-                      <>
-                        <Tooltip title="Edit">
-                          <span><AppButton size="small" variant="outlined" onClick={() => onEdit(item)} startIcon={<EditIcon fontSize="small" />} /></span>
-                        </Tooltip>
-                        <Tooltip title="Post">
-                          <span><AppButton size="small" variant="success" onClick={() => onPost(item)} startIcon={<PostIcon fontSize="small" />} /></span>
-                        </Tooltip>
-                        <Tooltip title="Delete">
-                          <span><AppButton size="small" variant="danger" onClick={() => onDelete(item)} startIcon={<DeleteIcon fontSize="small" />} /></span>
-                        </Tooltip>
-                      </>
-                    )}
-                  </Stack>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </Paper>
+    <EntityTable
+      rows={expenses}
+      columns={columns}
+      loading={loading}
+      total={expenses.length}
+      label="Expenses"
+      selectedId={selectedId ?? undefined}
+      focusedIndex={focusedIndex}
+      onSelect={onSelect}
+      listRef={listRef}
+    />
   )
 }

--- a/frontend/src/pages/accounting/components/__tests__/ExpenseContextHeader.test.tsx
+++ b/frontend/src/pages/accounting/components/__tests__/ExpenseContextHeader.test.tsx
@@ -10,12 +10,15 @@ vi.mock('@/utils/formatters', async () => {
   return { ...actual, formatDate: (value: string) => value, formatCurrency: (value: number) => `$${value}` }
 })
 
+const mockNavigateToJournalEntry = vi.fn()
+const mockUseJournalEntryRef = vi.fn(() => ({
+  journalEntryRef: null,
+  journalEntryRefLoading: false,
+  navigateToJournalEntry: mockNavigateToJournalEntry,
+}))
+
 vi.mock('@/hooks/useJournalEntryRef', () => ({
-  useJournalEntryRef: () => ({
-    journalEntryRef: null,
-    journalEntryRefLoading: false,
-    navigateToJournalEntry: vi.fn(),
-  }),
+  useJournalEntryRef: (...args: unknown[]) => mockUseJournalEntryRef(...args),
 }))
 
 const draftExpense = {
@@ -102,5 +105,19 @@ describe('ExpenseContextHeader', () => {
     expect(screen.getByText('Office Supplies')).toBeInTheDocument()
     expect(screen.getByText('$225.5')).toBeInTheDocument()
     expect(screen.getByText('Cash')).toBeInTheDocument()
+  })
+
+  it('renders journal entry ref link for posted expense and fires navigate on click', () => {
+    mockUseJournalEntryRef.mockReturnValueOnce({
+      journalEntryRef: { referenceNumber: 'JE-042', sourceType: 'expense', sourceId: 'ex-1' },
+      journalEntryRefLoading: false,
+      navigateToJournalEntry: mockNavigateToJournalEntry,
+    })
+    const postedExpense = { ...draftExpense, status: 'posted' as const, journalEntryId: 'je-42' }
+    renderHeader({ selected: postedExpense })
+    const link = screen.getByText('JE-042')
+    expect(link).toBeInTheDocument()
+    fireEvent.click(link)
+    expect(mockNavigateToJournalEntry).toHaveBeenCalledOnce()
   })
 })

--- a/frontend/src/pages/accounting/components/__tests__/ExpenseContextHeader.test.tsx
+++ b/frontend/src/pages/accounting/components/__tests__/ExpenseContextHeader.test.tsx
@@ -1,0 +1,106 @@
+import type { ComponentProps } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ExpenseContextHeader } from '../ExpenseContextHeader'
+
+vi.mock('@/utils/formatters', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/formatters')>('@/utils/formatters')
+  return { ...actual, formatDate: (value: string) => value, formatCurrency: (value: number) => `$${value}` }
+})
+
+vi.mock('@/hooks/useJournalEntryRef', () => ({
+  useJournalEntryRef: () => ({
+    journalEntryRef: null,
+    journalEntryRefLoading: false,
+    navigateToJournalEntry: vi.fn(),
+  }),
+}))
+
+const draftExpense = {
+  id: 'ex-1',
+  referenceNumber: 'EXP-001',
+  expenseDate: '2026-02-15',
+  expenseAccountId: 'coa-1',
+  expenseAccount: { id: 'coa-1', code: '6000', name: 'Office Supplies' },
+  amount: 225.5,
+  paymentMethodId: 'pm-1',
+  paymentMethod: { id: 'pm-1', code: 'CASH', name: 'Cash' },
+  vendor: 'Stationery Hub',
+  description: 'Printer paper',
+  status: 'draft' as const,
+  createdAt: '2026-02-15',
+  updatedAt: '2026-02-15',
+}
+
+const renderHeader = (props: Partial<ComponentProps<typeof ExpenseContextHeader>> = {}) =>
+  render(
+    <BrowserRouter>
+      <ExpenseContextHeader
+        selected={null}
+        onEdit={vi.fn()}
+        onPost={vi.fn()}
+        onDelete={vi.fn()}
+        {...props}
+      />
+    </BrowserRouter>,
+  )
+
+describe('ExpenseContextHeader', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('shows placeholder when no expense selected', () => {
+    renderHeader()
+    expect(screen.getByText('Select an expense to view details')).toBeInTheDocument()
+  })
+
+  it('shows reference number and status chip', () => {
+    renderHeader({ selected: draftExpense })
+    expect(screen.getByText('EXP-001')).toBeInTheDocument()
+    expect(screen.getByText('Draft')).toBeInTheDocument()
+  })
+
+  it('shows Edit, Post, Delete buttons for draft expenses', () => {
+    renderHeader({ selected: draftExpense })
+    expect(screen.getByText('Edit')).toBeInTheDocument()
+    expect(screen.getByText('Post')).toBeInTheDocument()
+    expect(screen.getByText('Delete')).toBeInTheDocument()
+  })
+
+  it('does not show action buttons for posted expenses', () => {
+    renderHeader({ selected: { ...draftExpense, status: 'posted' as const } })
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+    expect(screen.queryByText('Post')).not.toBeInTheDocument()
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument()
+  })
+
+  it('calls onEdit when Edit button clicked', () => {
+    const onEdit = vi.fn()
+    renderHeader({ selected: draftExpense, onEdit })
+    fireEvent.click(screen.getByText('Edit'))
+    expect(onEdit).toHaveBeenCalledOnce()
+  })
+
+  it('calls onPost when Post button clicked', () => {
+    const onPost = vi.fn()
+    renderHeader({ selected: draftExpense, onPost })
+    fireEvent.click(screen.getByText('Post'))
+    expect(onPost).toHaveBeenCalledOnce()
+  })
+
+  it('calls onDelete when Delete button clicked', () => {
+    const onDelete = vi.fn()
+    renderHeader({ selected: draftExpense, onDelete })
+    fireEvent.click(screen.getByText('Delete'))
+    expect(onDelete).toHaveBeenCalledOnce()
+  })
+
+  it('displays vendor, account, amount and payment method', () => {
+    renderHeader({ selected: draftExpense })
+    expect(screen.getByText('Stationery Hub')).toBeInTheDocument()
+    expect(screen.getByText('Office Supplies')).toBeInTheDocument()
+    expect(screen.getByText('$225.5')).toBeInTheDocument()
+    expect(screen.getByText('Cash')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/accounting/components/__tests__/ExpenseFormDialog.test.tsx
+++ b/frontend/src/pages/accounting/components/__tests__/ExpenseFormDialog.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ExpenseFormDialog } from '../ExpenseFormDialog'
+
+const mockCreate = vi.fn()
+const mockUpdate = vi.fn()
+
+vi.mock('@/store/api/accountingApi', () => ({
+  useGetPaymentMethodsQuery: () => ({
+    data: { data: [{ id: 'pm-1', name: 'Cash', code: 'CASH', isActive: true }] },
+  }),
+  useGetChartOfAccountsQuery: () => ({
+    data: { data: [{ id: 'coa-1', code: '6000', name: 'Office Supplies', type: 'EXPENSE', isActive: true }] },
+  }),
+  useCreateExpenseMutation: () => [mockCreate],
+  useUpdateExpenseMutation: () => [mockUpdate],
+}))
+
+const baseExpense = {
+  id: 'ex-1',
+  referenceNumber: 'EXP-001',
+  expenseDate: '2026-02-15',
+  expenseAccountId: 'coa-1',
+  expenseAccount: { id: 'coa-1', code: '6000', name: 'Office Supplies' },
+  amount: 100,
+  paymentMethodId: 'pm-1',
+  paymentMethod: { id: 'pm-1', code: 'CASH', name: 'Cash' },
+  vendor: 'ACME Corp',
+  description: 'Printer paper',
+  status: 'draft' as const,
+  createdAt: '2026-02-15',
+  updatedAt: '2026-02-15',
+}
+
+const renderDialog = (editTarget = null as typeof baseExpense | null, open = true) =>
+  render(
+    <BrowserRouter>
+      <ExpenseFormDialog open={open} editTarget={editTarget} onClose={vi.fn()} onSaved={vi.fn()} />
+    </BrowserRouter>,
+  )
+
+describe('ExpenseFormDialog', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('shows "New Expense" title when no editTarget', () => {
+    renderDialog()
+    expect(screen.getByText('New Expense')).toBeInTheDocument()
+  })
+
+  it('shows "Edit Expense" title when editTarget provided', () => {
+    renderDialog(baseExpense)
+    expect(screen.getByText('Edit Expense')).toBeInTheDocument()
+  })
+
+  it('pre-fills form fields from editTarget', () => {
+    renderDialog(baseExpense)
+    expect(screen.getByDisplayValue('2026-02-15')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('100')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('ACME Corp')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Printer paper')).toBeInTheDocument()
+  })
+
+  it('does not render when closed', () => {
+    renderDialog(null, false)
+    expect(screen.queryByText('New Expense')).not.toBeInTheDocument()
+  })
+
+  it('calls create mutation on save with valid new form data', async () => {
+    mockCreate.mockReturnValue({ unwrap: () => Promise.resolve({}) })
+    renderDialog()
+
+    fireEvent.change(screen.getByLabelText(/Amount/i), { target: { value: '50' } })
+    fireEvent.change(screen.getByLabelText(/Vendor/i), { target: { value: 'Test Vendor' } })
+    fireEvent.click(screen.getByText('Save'))
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled())
+  })
+
+  it('calls update mutation on save in edit mode', async () => {
+    mockUpdate.mockReturnValue({ unwrap: () => Promise.resolve({}) })
+    renderDialog(baseExpense)
+
+    fireEvent.change(screen.getByLabelText(/Vendor/i), { target: { value: 'New Vendor' } })
+    fireEvent.click(screen.getByText('Save'))
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith({
+      id: 'ex-1',
+      data: expect.objectContaining({ vendor: 'New Vendor' }),
+    }))
+  })
+
+  it('does not submit when amount is missing', async () => {
+    mockCreate.mockReturnValue({ unwrap: () => Promise.resolve({}) })
+    renderDialog()
+    fireEvent.click(screen.getByText('Save'))
+    await waitFor(() => expect(mockCreate).not.toHaveBeenCalled())
+  })
+})

--- a/frontend/src/pages/accounting/components/__tests__/ExpenseFormDialog.test.tsx
+++ b/frontend/src/pages/accounting/components/__tests__/ExpenseFormDialog.test.tsx
@@ -7,6 +7,10 @@ import { ExpenseFormDialog } from '../ExpenseFormDialog'
 const mockCreate = vi.fn()
 const mockUpdate = vi.fn()
 
+vi.mock('@/hooks/useNotification', () => ({
+  useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
+}))
+
 vi.mock('@/store/api/accountingApi', () => ({
   useGetPaymentMethodsQuery: () => ({
     data: { data: [{ id: 'pm-1', name: 'Cash', code: 'CASH', isActive: true }] },

--- a/frontend/src/pages/accounting/hooks/useExpensesWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useExpensesWorkspace.ts
@@ -1,5 +1,7 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
+import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import { useNotification } from '@/hooks/useNotification'
 import {
   useBulkDeleteExpensesMutation,
@@ -7,27 +9,54 @@ import {
   useDeleteExpenseMutation,
   usePostExpenseMutation,
 } from '@/store/api/accountingApi'
-import { ExpenseRecord } from '@/types'
+import type { ExpenseRecord } from '@/types'
 import { getErrorMessage } from '@/utils/errorMessage'
 
-export function useExpensesWorkspace(refetch: () => void) {
+export function useExpensesWorkspace(refetch: () => void, expenses: ExpenseRecord[] = []) {
+  const navigate = useNavigate()
   const { showSuccess, showError } = useNotification()
   const [selected, setSelected] = useState<ExpenseRecord | null>(null)
-  const [editTarget, setEditTarget] = useState<ExpenseRecord | null>(null)
   const [postTarget, setPostTarget] = useState<ExpenseRecord | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<ExpenseRecord | null>(null)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [bulkPostOpen, setBulkPostOpen] = useState(false)
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false)
   const [actionLoading, setActionLoading] = useState(false)
-  const [createOpen, setCreateOpen] = useState(false)
-  const searchInputRef = useRef<HTMLInputElement | null>(null)
-  const listRef = useRef<HTMLDivElement | null>(null)
+  const [formOpen, setFormOpen] = useState(false)
+  const [editTarget, setEditTarget] = useState<ExpenseRecord | null>(null)
 
   const [postExpense] = usePostExpenseMutation()
   const [deleteExpense] = useDeleteExpenseMutation()
   const [bulkPost] = useBulkPostExpensesMutation()
   const [bulkDelete] = useBulkDeleteExpensesMutation()
+
+  const workspace = useEntityWorkspace<ExpenseRecord>({
+    entities: expenses,
+    selectedEntity: selected,
+    selectEntity: setSelected,
+    refetch,
+    navigate,
+    routes: {
+      create: '/accounting/expenses',
+      edit: () => '/accounting/expenses',
+    },
+    notifications: { showSuccess, showError },
+    deleteMutation: async (id) => {
+      await deleteExpense(id).unwrap()
+    },
+    onEnter: () => {
+      if (selected) setFormOpen(true)
+    },
+    onEscape: () => {
+      setSelected(null)
+      setPostTarget(null)
+      setDeleteTarget(null)
+    },
+  })
+
+  const handleSelect = useCallback((item: ExpenseRecord) => {
+    workspace.handleSelect(item)
+  }, [workspace])
 
   const handleToggleCheck = useCallback((id: string) => {
     setSelectedIds((prev) => {
@@ -39,7 +68,7 @@ export function useExpensesWorkspace(refetch: () => void) {
   }, [])
 
   const handleSelectAll = useCallback((expenses: ExpenseRecord[]) => {
-    const drafts = expenses.filter((expense) => expense.status === 'draft').map((expense) => expense.id)
+    const drafts = expenses.filter((e) => e.status === 'draft').map((e) => e.id)
     setSelectedIds((prev) => (prev.size === drafts.length ? new Set() : new Set(drafts)))
   }, [])
 
@@ -118,6 +147,14 @@ export function useExpensesWorkspace(refetch: () => void) {
   return {
     selected,
     setSelected,
+    focusedIndex: workspace.focusedIndex,
+    setFocusedIndex: workspace.setFocusedIndex,
+    listRef: workspace.listRef,
+    searchInputRef: workspace.searchInputRef,
+    formOpen,
+    setFormOpen,
+    createOpen: formOpen,
+    setCreateOpen: setFormOpen,
     editTarget,
     setEditTarget,
     postTarget,
@@ -129,11 +166,8 @@ export function useExpensesWorkspace(refetch: () => void) {
     setBulkPostOpen,
     bulkDeleteOpen,
     setBulkDeleteOpen,
-    createOpen,
-    setCreateOpen,
     actionLoading,
-    searchInputRef,
-    listRef,
+    handleSelect,
     handleToggleCheck,
     handleSelectAll,
     handleConfirmPost,

--- a/frontend/src/pages/accounting/hooks/useExpensesWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useExpensesWorkspace.ts
@@ -153,8 +153,6 @@ export function useExpensesWorkspace(refetch: () => void, expenses: ExpenseRecor
     searchInputRef: workspace.searchInputRef,
     formOpen,
     setFormOpen,
-    createOpen: formOpen,
-    setCreateOpen: setFormOpen,
     editTarget,
     setEditTarget,
     postTarget,

--- a/frontend/src/pages/accounting/hooks/useExpensesWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useExpensesWorkspace.ts
@@ -4,8 +4,6 @@ import { useNavigate } from 'react-router-dom'
 import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import { useNotification } from '@/hooks/useNotification'
 import {
-  useBulkDeleteExpensesMutation,
-  useBulkPostExpensesMutation,
   useDeleteExpenseMutation,
   usePostExpenseMutation,
 } from '@/store/api/accountingApi'
@@ -18,17 +16,12 @@ export function useExpensesWorkspace(refetch: () => void, expenses: ExpenseRecor
   const [selected, setSelected] = useState<ExpenseRecord | null>(null)
   const [postTarget, setPostTarget] = useState<ExpenseRecord | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<ExpenseRecord | null>(null)
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
-  const [bulkPostOpen, setBulkPostOpen] = useState(false)
-  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false)
   const [actionLoading, setActionLoading] = useState(false)
   const [formOpen, setFormOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<ExpenseRecord | null>(null)
 
   const [postExpense] = usePostExpenseMutation()
   const [deleteExpense] = useDeleteExpenseMutation()
-  const [bulkPost] = useBulkPostExpensesMutation()
-  const [bulkDelete] = useBulkDeleteExpensesMutation()
 
   const workspace = useEntityWorkspace<ExpenseRecord>({
     entities: expenses,
@@ -53,24 +46,6 @@ export function useExpensesWorkspace(refetch: () => void, expenses: ExpenseRecor
       setDeleteTarget(null)
     },
   })
-
-  const handleSelect = useCallback((item: ExpenseRecord) => {
-    workspace.handleSelect(item)
-  }, [workspace])
-
-  const handleToggleCheck = useCallback((id: string) => {
-    setSelectedIds((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }, [])
-
-  const handleSelectAll = useCallback((expenses: ExpenseRecord[]) => {
-    const drafts = expenses.filter((e) => e.status === 'draft').map((e) => e.id)
-    setSelectedIds((prev) => (prev.size === drafts.length ? new Set() : new Set(drafts)))
-  }, [])
 
   const handleConfirmPost = useCallback(async () => {
     if (!postTarget) return
@@ -108,47 +83,10 @@ export function useExpensesWorkspace(refetch: () => void, expenses: ExpenseRecor
     }
   }, [deleteTarget, deleteExpense, showSuccess, showError, refetch])
 
-  const handleBulkPost = useCallback(async () => {
-    setActionLoading(true)
-    try {
-      const result = await bulkPost(Array.from(selectedIds)).unwrap()
-      showSuccess(`Posted ${result.posted} expenses`)
-      if (result.failed > 0) showError(`${result.failed} failed`)
-      setSelectedIds(new Set())
-      setBulkPostOpen(false)
-      refetch()
-    }
-    catch (error: unknown) {
-      showError(getErrorMessage(error, 'Bulk post failed'))
-    }
-    finally {
-      setActionLoading(false)
-    }
-  }, [selectedIds, bulkPost, showSuccess, showError, refetch])
-
-  const handleBulkDelete = useCallback(async () => {
-    setActionLoading(true)
-    try {
-      const result = await bulkDelete(Array.from(selectedIds)).unwrap()
-      showSuccess(`Deleted ${result.deleted} expenses`)
-      if (result.failed > 0) showError(`${result.failed} failed`)
-      setSelectedIds(new Set())
-      setBulkDeleteOpen(false)
-      refetch()
-    }
-    catch (error: unknown) {
-      showError(getErrorMessage(error, 'Bulk delete failed'))
-    }
-    finally {
-      setActionLoading(false)
-    }
-  }, [selectedIds, bulkDelete, showSuccess, showError, refetch])
-
   return {
     selected,
     setSelected,
     focusedIndex: workspace.focusedIndex,
-    setFocusedIndex: workspace.setFocusedIndex,
     listRef: workspace.listRef,
     searchInputRef: workspace.searchInputRef,
     formOpen,
@@ -159,18 +97,9 @@ export function useExpensesWorkspace(refetch: () => void, expenses: ExpenseRecor
     setPostTarget,
     deleteTarget,
     setDeleteTarget,
-    selectedIds,
-    bulkPostOpen,
-    setBulkPostOpen,
-    bulkDeleteOpen,
-    setBulkDeleteOpen,
     actionLoading,
-    handleSelect,
-    handleToggleCheck,
-    handleSelectAll,
+    handleSelect: workspace.handleSelect,
     handleConfirmPost,
     handleConfirmDelete,
-    handleBulkPost,
-    handleBulkDelete,
   }
 }


### PR DESCRIPTION
## Summary
- Refactors `ExpensesTable` to use `EntityTable` (narrow master list: reference + status chip)
- Extracts `ExpenseFormDialog` from `ExpensesPage` (handles New and Edit modes)
- Upgrades `ExpenseContextHeader` to two-column Grid layout with Journal Entry ref link for posted expenses
- Wires `useEntityWorkspace` into `useExpensesWorkspace` for keyboard navigation and `focusedIndex`
- Removes inline form state from `ExpensesPage`

## Test plan
- [x] `cd frontend && npm run type-check 2>&1 | tail -5`
- [x] `cd frontend && npm run lint 2>&1 | tail -10`
- [x] `cd frontend && npx vitest run src/pages/accounting/__tests__/ExpensesPage.test.tsx src/pages/accounting/components/__tests__/ExpenseFormDialog.test.tsx src/pages/accounting/components/__tests__/ExpenseContextHeader.test.tsx`

Closes #509