### PR TITLE
feat(settings): wrap settings and audit-log pages in GenericOverviewPage

### DIFF
--- a/frontend/src/pages/audit-logs/AuditLogsPage.tsx
+++ b/frontend/src/pages/audit-logs/AuditLogsPage.tsx
@@ -9,6 +9,7 @@ import {
   setLimit,
   setActiveTab,
 } from '@/store/slices/auditLogSlice'
+import GenericOverviewPage from '@/components/common/GenericOverviewPage'
 import { useGetAuditLogsQuery, useGetAuditLogStatisticsQuery } from '@/store/api/auditLogApi'
 import { priceListApiSlice } from '@/store/api/priceListApi'
 import FilterSidebar from './components/FilterSidebar'
@@ -130,53 +131,55 @@ const AuditLogsPage: React.FC = () => {
   const entityTypes = statistics?.byEntityType.map((e) => e.entityType) ?? []
 
   return (
-    <Box sx={{ display: 'flex', height: '100%', gap: 2 }}>
-      {/* Sidebar */}
-      <Box sx={{ flexShrink: 0, width: sidebarCollapsed ? 48 : 260, transition: 'width 0.2s' }}>
-        <FilterSidebar entityTypes={entityTypes} onApply={handleApply} />
-      </Box>
-
-      {/* Main content */}
-      <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2 }}>
-        <PageHeader
-          variant="system"
-          title="Audit Logs"
-          subtitle="View all system changes and user activities"
-        />
-
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 3 }}>
-          <ExportButton logs={auditLogs} disabled={loading} />
+    <GenericOverviewPage>
+      <Box sx={{ display: 'flex', gap: 2 }}>
+        {/* Sidebar */}
+        <Box sx={{ flexShrink: 0, width: sidebarCollapsed ? 48 : 260, transition: 'width 0.2s' }}>
+          <FilterSidebar entityTypes={entityTypes} onApply={handleApply} />
         </Box>
 
-        {/* Tabs */}
-        <Tabs
-          value={activeTab}
-          onChange={(_e, val) => dispatch(setActiveTab(val))}
-          sx={{ borderBottom: 1, borderColor: 'divider' }}
-        >
-          <Tab label="Logs" value="logs" />
-          <Tab label="Analytics" value="analytics" />
-        </Tabs>
-
-        {/* Tab content */}
-        {activeTab === 'logs' && (
-          <LogsTab
-            logs={auditLogs}
-            loading={loading}
-            error={error}
-            priceListNameById={priceListNameById}
-            total={logsResponse?.meta?.total ?? 0}
-            page={pagination.page}
-            limit={pagination.limit}
-            onPageChange={handlePageChange}
-            onLimitChange={handleLimitChange}
+        {/* Main content */}
+        <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <PageHeader
+            variant="system"
+            title="Audit Logs"
+            subtitle="View all system changes and user activities"
           />
-        )}
-        {activeTab === 'analytics' && (
-          <AnalyticsTab statistics={statistics} loading={loading} />
-        )}
+
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 3 }}>
+            <ExportButton logs={auditLogs} disabled={loading} />
+          </Box>
+
+          {/* Tabs */}
+          <Tabs
+            value={activeTab}
+            onChange={(_e, val) => dispatch(setActiveTab(val))}
+            sx={{ borderBottom: 1, borderColor: 'divider' }}
+          >
+            <Tab label="Logs" value="logs" />
+            <Tab label="Analytics" value="analytics" />
+          </Tabs>
+
+          {/* Tab content */}
+          {activeTab === 'logs' && (
+            <LogsTab
+              logs={auditLogs}
+              loading={loading}
+              error={error}
+              priceListNameById={priceListNameById}
+              total={logsResponse?.meta?.total ?? 0}
+              page={pagination.page}
+              limit={pagination.limit}
+              onPageChange={handlePageChange}
+              onLimitChange={handleLimitChange}
+            />
+          )}
+          {activeTab === 'analytics' && (
+            <AnalyticsTab statistics={statistics} loading={loading} />
+          )}
+        </Box>
       </Box>
-    </Box>
+    </GenericOverviewPage>
   )
 }
 

--- a/frontend/src/pages/settings/BackupManagement.tsx
+++ b/frontend/src/pages/settings/BackupManagement.tsx
@@ -13,6 +13,7 @@ import { default as AddIcon } from '@mui/icons-material/Add'
 import { default as BackupIcon } from '@mui/icons-material/Backup'
 import { default as UploadIcon } from '@mui/icons-material/CloudUpload';
 import PageHeader from '@/components/common/PageHeader';
+import GenericOverviewPage from '@/components/common/GenericOverviewPage';
 import { useGetBackupsQuery, useGetSchedulesQuery } from '@/store/api/backupApi';
 import BackupList from '@/components/backup/BackupList';
 import BackupScheduleList from '@/components/backup/BackupScheduleList';
@@ -81,7 +82,7 @@ const BackupManagement: React.FC = () => {
   };
 
   return (
-    <>
+    <GenericOverviewPage>
       <PageHeader
         variant="system"
         title="Backup & Restore Management"
@@ -184,7 +185,7 @@ const BackupManagement: React.FC = () => {
           {error}
         </Alert>
       </Snackbar>
-    </>
+    </GenericOverviewPage>
   );
 };
 

--- a/frontend/src/pages/settings/CompanySettingsPage.tsx
+++ b/frontend/src/pages/settings/CompanySettingsPage.tsx
@@ -26,6 +26,7 @@ import {
   useDeleteLogoMutation,
 } from '@/store/api/settingsApi'
 import PageHeader from '@/components/common/PageHeader'
+import GenericOverviewPage from '@/components/common/GenericOverviewPage'
 
 interface CompanyFormData {
   name: string
@@ -193,7 +194,7 @@ const CompanySettingsPage: React.FC = () => {
   }
 
   return (
-    <>
+    <GenericOverviewPage>
       {/* Page Header */}
       <PageHeader title="Company Settings" subtitle="Configure your company profile and business information" />
       {/* Error Alert */}
@@ -563,7 +564,7 @@ const CompanySettingsPage: React.FC = () => {
           </Grid>
         </form>
       </Paper>
-    </>
+    </GenericOverviewPage>
   );
 }
 

--- a/frontend/src/pages/settings/DocumentNumbersPage.tsx
+++ b/frontend/src/pages/settings/DocumentNumbersPage.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mui/material'
 import { default as SaveIcon } from '@mui/icons-material/Save'
 import PageHeader from '@/components/common/PageHeader'
+import GenericOverviewPage from '@/components/common/GenericOverviewPage'
 import { useNotification } from '@/hooks/useNotification'
 import {
   useGetDocumentNumberSettingsQuery,
@@ -108,7 +109,7 @@ const DocumentNumbersPage: React.FC = () => {
   }
 
   return (
-    <>
+    <GenericOverviewPage>
       {/* Page Header */}
       <PageHeader title="Document Numbers Settings" subtitle="Configure automatic numbering sequences for orders, invoices, and other documents" />
       {/* Error Alert */}
@@ -230,7 +231,7 @@ const DocumentNumbersPage: React.FC = () => {
           </Button>
         </Box>
       </Paper>
-    </>
+    </GenericOverviewPage>
   );
 }
 

--- a/frontend/src/pages/settings/InventoryCostingPage.tsx
+++ b/frontend/src/pages/settings/InventoryCostingPage.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/store/api/settingsApi'
 import { ApiService } from '@/services/api'
 import PageHeader from '@/components/common/PageHeader'
+import GenericOverviewPage from '@/components/common/GenericOverviewPage'
 
 interface InventoryCostingFormData {
   costingMethod: string
@@ -139,7 +140,7 @@ const InventoryCostingPage: React.FC = () => {
   }
 
   return (
-    <>
+    <GenericOverviewPage>
       <PageHeader title="Inventory Costing Settings" subtitle="Configure costing method and pricing rules for inventory valuation" />
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>
@@ -225,7 +226,7 @@ const InventoryCostingPage: React.FC = () => {
           </Grid>
         </form>
       </Paper>
-    </>
+    </GenericOverviewPage>
   )
 }
 

--- a/frontend/src/pages/settings/PaymentMethodsPage.tsx
+++ b/frontend/src/pages/settings/PaymentMethodsPage.tsx
@@ -23,6 +23,7 @@ import {
 import PaymentMethodFormDialog from '@/components/settings/PaymentMethodFormDialog';
 import DeletedPaymentMethodsDialog from '@/components/settings/DeletedPaymentMethodsDialog';
 import PageHeader from '@/components/common/PageHeader';
+import GenericOverviewPage from '@/components/common/GenericOverviewPage';
 import { useNotification } from '@/hooks/useNotification';
 import {
   useCreatePaymentMethodMutation,
@@ -88,7 +89,7 @@ const PaymentMethodsPage: React.FC = () => {
   };
 
   return (
-    <>
+    <GenericOverviewPage>
       <PageHeader
         title={title}
         subtitle="Manage payment methods and configurations"
@@ -201,7 +202,7 @@ const PaymentMethodsPage: React.FC = () => {
         </DialogActions>
       </Dialog>
       <DeletedPaymentMethodsDialog open={deletedOpen} onClose={() => setDeletedOpen(false)} />
-    </>
+    </GenericOverviewPage>
   );
 };
 

--- a/frontend/src/pages/settings/PriceListsPage.tsx
+++ b/frontend/src/pages/settings/PriceListsPage.tsx
@@ -25,6 +25,7 @@ import { default as StarBorderIcon } from '@mui/icons-material/StarBorder'
 import { default as ViewIcon } from '@mui/icons-material/Visibility'
 import { useNavigate } from 'react-router-dom'
 import PageHeader from '@/components/common/PageHeader'
+import GenericOverviewPage from '@/components/common/GenericOverviewPage'
 import { FilterBar } from '@/components/filters'
 import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import { useFilterBar } from '@/hooks/useFilterBar'
@@ -229,7 +230,7 @@ const PriceListsPage: React.FC = () => {
 
   // Format date
   return (
-    <>
+    <GenericOverviewPage>
       {/* Header */}
       <PageHeader
         title="Price Lists"
@@ -620,7 +621,7 @@ const PriceListsPage: React.FC = () => {
         onConfirm={handleConfirmAction}
         onCancel={handleConfirmClose}
       />
-    </>
+    </GenericOverviewPage>
   );
 }
 

--- a/frontend/src/pages/settings/PrintSettingsPage.tsx
+++ b/frontend/src/pages/settings/PrintSettingsPage.tsx
@@ -11,6 +11,7 @@ import {
 
 import { useGetPrintSettingsQuery } from '@/store/api/printSettingsApi'
 import PageHeader from '@/components/common/PageHeader'
+import GenericOverviewPage from '@/components/common/GenericOverviewPage'
 import GeneralTab from './PrintSettings/GeneralTab'
 import TemplatesTab from './PrintSettings/TemplatesTab'
 
@@ -66,22 +67,24 @@ const PrintSettingsPage: React.FC = () => {
 
   if (loading) {
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 400 }}>
-        <CircularProgress />
-      </Box>
+      <GenericOverviewPage>
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 400 }}>
+          <CircularProgress />
+        </Box>
+      </GenericOverviewPage>
     )
   }
 
   if (error) {
     return (
-      <>
+      <GenericOverviewPage>
         <Alert severity="error">{error}</Alert>
-      </>
+      </GenericOverviewPage>
     )
   }
 
   return (
-    <>
+    <GenericOverviewPage>
       {/* Header */}
       <PageHeader
         title="Print Settings"
@@ -111,7 +114,7 @@ const PrintSettingsPage: React.FC = () => {
           />
         </TabPanel>
       </Paper>
-    </>
+    </GenericOverviewPage>
   )
 }
 

--- a/frontend/src/pages/settings/RegionalSettingsPage.tsx
+++ b/frontend/src/pages/settings/RegionalSettingsPage.tsx
@@ -12,6 +12,7 @@ import {
   MenuItem,
 } from '@mui/material'
 import PageHeader from '@/components/common/PageHeader'
+import GenericOverviewPage from '@/components/common/GenericOverviewPage'
 import { useForm, Controller, useWatch } from 'react-hook-form'
 import * as yup from 'yup'
 import { yupResolver } from '@hookform/resolvers/yup'
@@ -219,7 +220,7 @@ const RegionalSettingsPage: React.FC = () => {
   )
 
   return (
-    <>
+    <GenericOverviewPage>
       <PageHeader title="Regional Settings" subtitle="Configure locale, currency, date format, and timezone preferences" />
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>
@@ -424,7 +425,7 @@ const RegionalSettingsPage: React.FC = () => {
           </Grid>
         </form>
       </Paper>
-    </>
+    </GenericOverviewPage>
   );
 }
 

--- a/frontend/src/pages/settings/RoleManagementPage.tsx
+++ b/frontend/src/pages/settings/RoleManagementPage.tsx
@@ -7,6 +7,7 @@ import { default as InventoryIcon } from '@mui/icons-material/Inventory'
 import { default as ProcurementIcon } from '@mui/icons-material/LocalShipping'
 import { default as CheckIcon } from '@mui/icons-material/Check'
 import PageHeader from '@/components/common/PageHeader'
+import GenericOverviewPage from '@/components/common/GenericOverviewPage'
 
 interface RolePermission {
   description: string
@@ -92,7 +93,7 @@ const roles: RoleInfo[] = [
 
 const RoleManagementPage: React.FC = () => {
   return (
-    <>
+    <GenericOverviewPage>
       {/* Header */}
       <PageHeader
         title="Roles & Permissions"
@@ -183,7 +184,7 @@ const RoleManagementPage: React.FC = () => {
           administrators can manage user accounts and assign roles.
         </Typography>
       </Paper>
-    </>
+    </GenericOverviewPage>
   );
 }
 

--- a/frontend/src/pages/settings/SecuritySettingsPage.tsx
+++ b/frontend/src/pages/settings/SecuritySettingsPage.tsx
@@ -6,10 +6,11 @@ import { default as BlockIcon } from '@mui/icons-material/Block'
 import { default as ScheduleIcon } from '@mui/icons-material/Schedule'
 import { default as InfoIcon } from '@mui/icons-material/Info'
 import PageHeader from '@/components/common/PageHeader'
+import GenericOverviewPage from '@/components/common/GenericOverviewPage'
 
 const SecuritySettingsPage: React.FC = () => {
   return (
-    <>
+    <GenericOverviewPage>
       {/* Header */}
       <PageHeader
         title="Security Settings"
@@ -360,7 +361,7 @@ const SecuritySettingsPage: React.FC = () => {
           </Box>
         </Box>
       </Paper>
-    </>
+    </GenericOverviewPage>
   );
 }
 

--- a/frontend/src/pages/settings/StockLevelSettingsPage.tsx
+++ b/frontend/src/pages/settings/StockLevelSettingsPage.tsx
@@ -13,6 +13,7 @@ import { Controller, useForm } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import PageHeader from '@/components/common/PageHeader'
+import GenericOverviewPage from '@/components/common/GenericOverviewPage'
 import { useNotification } from '@/hooks/useNotification'
 import {
   useGetRegionalSettingsQuery,
@@ -86,7 +87,7 @@ const StockLevelSettingsPage: React.FC = () => {
   }
 
   return (
-    <>
+    <GenericOverviewPage>
       <PageHeader
         title="Stock Level Settings"
         subtitle="Configure thresholds for low stock classification across all products"
@@ -151,7 +152,7 @@ const StockLevelSettingsPage: React.FC = () => {
           </Grid>
         </form>
       </Paper>
-    </>
+    </GenericOverviewPage>
   )
 }
 

--- a/frontend/src/pages/settings/UserManagementPage.tsx
+++ b/frontend/src/pages/settings/UserManagementPage.tsx
@@ -23,6 +23,7 @@ import { default as UnlockIcon } from '@mui/icons-material/LockOpen'
 import { ListSkeleton } from '@/components/common/ListSkeleton'
 import { FilterBar } from '@/components/filters'
 import PageHeader from '@/components/common/PageHeader'
+import GenericOverviewPage from '@/components/common/GenericOverviewPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
 import { useAppSelector } from '@/hooks/useRedux'
 import { useNotification } from '@/hooks/useNotification'
@@ -259,7 +260,7 @@ const UserManagementPage: React.FC = () => {
   }
 
   return (
-    <>
+    <GenericOverviewPage>
       {/* Header */}
       <PageHeader
         title="User Management"
@@ -665,7 +666,7 @@ const UserManagementPage: React.FC = () => {
         onConfirm={handleConfirmAction}
         onCancel={handleConfirmClose}
       />
-    </>
+    </GenericOverviewPage>
   );
 }
 


### PR DESCRIPTION
## Summary

- Wraps all 13 settings and audit-log pages in `GenericOverviewPage` to provide a scrollable flex container
- Matches the existing `DashboardPage` scroll pattern
- `AuditLogsPage` keeps its sidebar + content horizontal layout as a child of the scroll wrapper

Closes #512

## Test plan
- [x] Visit each settings page and confirm it scrolls correctly on a short viewport
- [x] Visit Audit Logs and confirm sidebar + content scroll together
- [x] `cd frontend && npm run type-check`
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run test`