### PR TITLE
refactor(settlements): gold standard List-Detail pattern (#517)

### DIFF
--- a/frontend/src/pages/accounting/SettlementsPage.tsx
+++ b/frontend/src/pages/accounting/SettlementsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
@@ -28,6 +28,9 @@ const filterConfig: FilterBarConfig<SettlementFilters> = {
 }
 
 const SettlementsPage: React.FC = () => {
+  const [sortBy, setSortBy] = useState('settlementDate')
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
+
   const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
   const weekStartsOn = getStartOfWeek()
   const dateRange = useMemo(() => {
@@ -41,13 +44,28 @@ const SettlementsPage: React.FC = () => {
   const { data: settlementsResponse, isLoading, refetch } = useGetSettlementsQuery({ page: 1, status: appliedFilters.status || undefined, startDate: dateRange.fromDate, endDate: dateRange.toDate })
   useGetPendingSettlementSummaryQuery()
   const [createSettlement] = useCreateSettlementMutation()
-  const workspace = useSettlementsWorkspace(() => { void refetch() })
+
   const settlements = useMemo(() => {
     const rows = settlementsResponse?.data ?? []
     const term = appliedFilters.search.trim().toLowerCase()
     if (!term) return rows
     return rows.filter((row) => [row.settlementNumber, row.reference, row.notes, row.paymentMethod?.name].filter(Boolean).join(' ').toLowerCase().includes(term))
   }, [appliedFilters.search, settlementsResponse?.data])
+
+  const workspace = useSettlementsWorkspace(settlements, () => { void refetch() })
+
+  const filterHandlers = useMemo(() => ({
+    ...handlers,
+    onSearchChange: (value: string) => {
+      handlers.onSearchChange(value)
+      workspace.setShouldPreserveSearchFocus(true)
+    },
+  }), [handlers, workspace])
+
+  const handleSort = useCallback((field: string) => {
+    setSortOrder((prev) => (sortBy === field && prev === 'desc' ? 'asc' : 'desc'))
+    setSortBy(field)
+  }, [sortBy])
 
   const onCreate = async (data: { paymentMethodId: string; settlementDate: string; paymentIds: string[]; reference?: string; notes?: string }) => {
     await createSettlement(data).unwrap()
@@ -62,14 +80,38 @@ const SettlementsPage: React.FC = () => {
       primaryAction={{ label: 'Create Settlement', onClick: () => workspace.setDialogOpen(true) }}
       filterConfig={filterConfig}
       draftFilters={draftFilters}
-      handlers={handlers}
+      handlers={filterHandlers}
       hasActiveFilters={hasActiveFilters}
       searchInputRef={workspace.searchInputRef}
-      sort={{ field: 'settlementDate', sortBy: 'settlementDate', sortOrder: 'desc', onSort: () => {} }}
-      listSlot={<SettlementsTable settlements={settlements} loading={isLoading} selectedId={workspace.selected?.id ?? null} onSelect={workspace.setSelected} listRef={workspace.listRef} />}
-      headerSlot={<SettlementContextHeader selected={workspace.selected} onCancel={() => workspace.selected && workspace.setCancelTarget(workspace.selected)} />}
+      sort={{ field: 'settlementDate', sortBy, sortOrder, onSort: handleSort }}
+      listSlot={(
+        <SettlementsTable
+          settlements={settlements}
+          loading={isLoading}
+          total={settlements.length}
+          selectedId={workspace.selected?.id ?? null}
+          focusedIndex={workspace.focusedIndex}
+          onSelect={workspace.handleSelect}
+          listRef={workspace.listRef}
+        />
+      )}
+      headerSlot={(
+        <SettlementContextHeader
+          selected={workspace.selected}
+          onCancel={() => workspace.selected && workspace.setCancelTarget(workspace.selected)}
+        />
+      )}
       workspaceSlot={<SettlementWorkspaceCard selected={workspace.selected} />}
-      dialogs={<SettlementsDialogs dialogOpen={workspace.dialogOpen} onCloseDialog={() => workspace.setDialogOpen(false)} onCreate={onCreate} cancelTarget={workspace.cancelTarget} onConfirmCancel={() => void workspace.handleConfirmCancel()} onCancelCancel={() => workspace.setCancelTarget(null)} />}
+      dialogs={(
+        <SettlementsDialogs
+          dialogOpen={workspace.dialogOpen}
+          onCloseDialog={() => workspace.setDialogOpen(false)}
+          onCreate={onCreate}
+          cancelTarget={workspace.cancelTarget}
+          onConfirmCancel={() => void workspace.handleConfirmCancel()}
+          onCancelCancel={() => workspace.setCancelTarget(null)}
+        />
+      )}
     />
   )
 }

--- a/frontend/src/pages/accounting/SettlementsPage.tsx
+++ b/frontend/src/pages/accounting/SettlementsPage.tsx
@@ -41,7 +41,7 @@ const SettlementsPage: React.FC = () => {
     return { fromDate: resolved.from, toDate: resolved.to }
   }, [appliedFilters.period, weekStartsOn])
 
-  const { data: settlementsResponse, isLoading, refetch } = useGetSettlementsQuery({ page: 1, status: appliedFilters.status || undefined, startDate: dateRange.fromDate, endDate: dateRange.toDate })
+  const { data: settlementsResponse, isLoading, refetch } = useGetSettlementsQuery({ page: 1, status: appliedFilters.status || undefined, startDate: dateRange.fromDate, endDate: dateRange.toDate, sortBy, sortOrder })
   useGetPendingSettlementSummaryQuery()
   const [createSettlement] = useCreateSettlementMutation()
 
@@ -60,7 +60,7 @@ const SettlementsPage: React.FC = () => {
       handlers.onSearchChange(value)
       workspace.setShouldPreserveSearchFocus(true)
     },
-  }), [handlers, workspace])
+  }), [handlers, workspace.setShouldPreserveSearchFocus])
 
   const handleSort = useCallback((field: string) => {
     setSortOrder((prev) => (sortBy === field && prev === 'desc' ? 'asc' : 'desc'))

--- a/frontend/src/pages/accounting/__tests__/SettlementsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/SettlementsPage.test.tsx
@@ -61,7 +61,7 @@ describe('SettlementsPage', () => {
   it('renders title and settlement row', () => {
     render(<BrowserRouter><SettlementsPage /></BrowserRouter>)
     expect(screen.getByText('Settlements')).toBeInTheDocument()
-    expect(screen.getAllByText('SET-001').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('SET-001')).toHaveLength(2)
   })
 
   it('renders create action', () => {

--- a/frontend/src/pages/accounting/__tests__/SettlementsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/SettlementsPage.test.tsx
@@ -13,6 +13,17 @@ const mocked = vi.hoisted(() => ({
   useCancelSettlementMutation: vi.fn(),
 }))
 
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => ({ search: '', pathname: '/accounting/settlements', state: null }),
+  }
+})
+
 vi.mock('@/hooks/useNotification', () => ({ useNotification: () => ({ showSuccess: mocked.showSuccess, showError: mocked.showError }) }))
 vi.mock('@/utils/dateRange', () => ({ getPeriodDateRange: () => ({ from: undefined, to: undefined }), getStartOfWeek: () => 0 }))
 vi.mock('@/utils/formatters', async () => {
@@ -25,7 +36,23 @@ vi.mock('@/components/accounting/CreateSettlementDialog', () => ({ default: () =
 describe('SettlementsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mocked.useGetSettlementsQuery.mockReturnValue({ data: { data: [{ id: 's-1', settlementNumber: 'SET-001', paymentMethod: { name: 'Cash' }, settlementDate: '2026-02-26', totalAmount: 120, paymentCount: 1, reference: 'ref', status: 'completed' }] }, isLoading: false, refetch: vi.fn() })
+    mocked.useGetSettlementsQuery.mockReturnValue({
+      data: {
+        data: [{
+          id: 's-1',
+          settlementNumber: 'SET-001',
+          paymentMethod: { name: 'Cash' },
+          settlementDate: '2026-02-26',
+          totalAmount: 120,
+          paymentCount: 1,
+          reference: 'ref',
+          notes: null,
+          status: 'completed',
+        }],
+      },
+      isLoading: false,
+      refetch: vi.fn(),
+    })
     mocked.useGetPendingSettlementSummaryQuery.mockReturnValue({})
     mocked.useCreateSettlementMutation.mockReturnValue([vi.fn()])
     mocked.useCancelSettlementMutation.mockReturnValue([vi.fn()])
@@ -34,7 +61,7 @@ describe('SettlementsPage', () => {
   it('renders title and settlement row', () => {
     render(<BrowserRouter><SettlementsPage /></BrowserRouter>)
     expect(screen.getByText('Settlements')).toBeInTheDocument()
-    expect(screen.getByText('SET-001')).toBeInTheDocument()
+    expect(screen.getAllByText('SET-001').length).toBeGreaterThan(0)
   })
 
   it('renders create action', () => {

--- a/frontend/src/pages/accounting/components/SettlementContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/SettlementContextHeader.tsx
@@ -1,4 +1,5 @@
-import { Paper, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
+import { Paper, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material'
+import Grid from '@mui/material/Grid'
 import { default as CancelIcon } from '@mui/icons-material/Cancel'
 
 import { AppButton } from '@/components/common/AppButton'
@@ -13,13 +14,38 @@ interface Props {
   onCancel: () => void
 }
 
-const cellSx = { border: 'none', py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px }
+const detailTableSx = {
+  tableLayout: 'fixed' as const,
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const labelCellSx = { fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }
+const valueCellSx = { fontSize: '0.8rem' }
+const sectionHeaderCellSx = {
+  pb: TABLE_STYLES.cell.padding.py * 0.67,
+  py: TABLE_STYLES.cell.padding.py * 0.67,
+  borderTop: TABLE_STYLES.cell.border,
+}
 
 export function SettlementContextHeader({ selected, onCancel }: Props) {
-  if (!selected) return <Paper sx={{ p: 2 }}><Typography variant="body2" color="text.secondary">Select a settlement to view details</Typography></Paper>
+  if (!selected) {
+    return (
+      <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
+        <Typography variant="h6" sx={{ color: 'text.secondary' }}>
+          Select a settlement to view details
+        </Typography>
+      </Paper>
+    )
+  }
 
   return (
-    <Paper>
+    <Paper sx={{ overflow: 'hidden' }}>
       <EntityContextHeaderBar
         title={selected.settlementNumber}
         statusChip={<EntityStatusChip status={selected.status} />}
@@ -31,11 +57,67 @@ export function SettlementContextHeader({ selected, onCancel }: Props) {
           ) : null
         }
       />
-      <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': cellSx }}>
-        <TableBody>
-          <TableRow><TableCell sx={{ ...cellSx, color: 'text.secondary', width: 120 }}>Date</TableCell><TableCell>{formatDate(selected.settlementDate)}</TableCell><TableCell sx={{ ...cellSx, color: 'text.secondary', width: 120 }}>Total</TableCell><TableCell align="right">{formatCurrency(Number(selected.totalAmount || 0))}</TableCell></TableRow>
-        </TableBody>
-      </Table>
+      <Grid container spacing={3} sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <TableContainer>
+            <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+              <TableBody>
+                <TableRow>
+                  <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+                    <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                      Settlement Information
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+                <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                  <TableCell sx={labelCellSx}>Date</TableCell>
+                  <TableCell sx={valueCellSx}>{formatDate(selected.settlementDate)}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell sx={labelCellSx}>Payment Method</TableCell>
+                  <TableCell sx={valueCellSx}>{selected.paymentMethod?.name || '—'}</TableCell>
+                </TableRow>
+                <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                  <TableCell sx={labelCellSx}>Status</TableCell>
+                  <TableCell sx={valueCellSx}><EntityStatusChip status={selected.status} /></TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Grid>
+
+        <Grid size={{ xs: 12, md: 6 }}>
+          <TableContainer>
+            <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+              <TableBody>
+                <TableRow>
+                  <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+                    <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                      Amounts & Details
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+                <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                  <TableCell sx={labelCellSx}>Total Amount</TableCell>
+                  <TableCell sx={valueCellSx}>{formatCurrency(Number(selected.totalAmount || 0))}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell sx={labelCellSx}>Linked Payments</TableCell>
+                  <TableCell sx={valueCellSx}>{selected.paymentCount}</TableCell>
+                </TableRow>
+                <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                  <TableCell sx={labelCellSx}>Reference</TableCell>
+                  <TableCell sx={valueCellSx}>{selected.reference || '—'}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell sx={labelCellSx}>Notes</TableCell>
+                  <TableCell sx={valueCellSx}>{selected.notes || '—'}</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Grid>
+      </Grid>
     </Paper>
   )
 }

--- a/frontend/src/pages/accounting/components/SettlementWorkspaceCard.tsx
+++ b/frontend/src/pages/accounting/components/SettlementWorkspaceCard.tsx
@@ -4,7 +4,14 @@ import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { Settlement } from '@/types'
 
 interface Props { selected: Settlement | null }
+
 const cellSx = { border: 'none', py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px }
+const labelCellSx = { ...cellSx, color: 'text.secondary', width: '35%' }
+const sectionHeaderCellSx = {
+  pb: TABLE_STYLES.cell.padding.py * 0.67,
+  py: TABLE_STYLES.cell.padding.py * 0.67,
+  borderTop: TABLE_STYLES.cell.border,
+}
 
 export function SettlementWorkspaceCard({ selected }: Props) {
   if (!selected) return <Paper sx={{ flex: 1 }} />
@@ -15,10 +22,17 @@ export function SettlementWorkspaceCard({ selected }: Props) {
       </Box>
       <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': cellSx }}>
         <TableBody>
-          <TableRow><TableCell sx={{ ...cellSx, color: 'text.secondary', width: '35%' }}>Payment Method</TableCell><TableCell>{selected.paymentMethod?.name || '-'}</TableCell></TableRow>
-          <TableRow><TableCell sx={{ ...cellSx, color: 'text.secondary' }}>Linked Payments</TableCell><TableCell>{selected.paymentCount}</TableCell></TableRow>
-          <TableRow><TableCell sx={{ ...cellSx, color: 'text.secondary' }}>Reference</TableCell><TableCell>{selected.reference || '—'}</TableCell></TableRow>
-          <TableRow><TableCell sx={{ ...cellSx, color: 'text.secondary' }}>Notes</TableCell><TableCell>{selected.notes || '—'}</TableCell></TableRow>
+          <TableRow>
+            <TableCell colSpan={2} sx={sectionHeaderCellSx}>
+              <Typography variant="h6" sx={{ fontWeight: 600, color: 'primary.main', fontSize: '0.8rem' }}>
+                Payment Details
+              </Typography>
+            </TableCell>
+          </TableRow>
+          <TableRow><TableCell sx={labelCellSx}>Payment Method</TableCell><TableCell>{selected.paymentMethod?.name || '-'}</TableCell></TableRow>
+          <TableRow><TableCell sx={labelCellSx}>Linked Payments</TableCell><TableCell>{selected.paymentCount}</TableCell></TableRow>
+          <TableRow><TableCell sx={labelCellSx}>Reference</TableCell><TableCell>{selected.reference || '—'}</TableCell></TableRow>
+          <TableRow><TableCell sx={labelCellSx}>Notes</TableCell><TableCell>{selected.notes || '—'}</TableCell></TableRow>
         </TableBody>
       </Table>
     </Paper>

--- a/frontend/src/pages/accounting/components/SettlementsTable.tsx
+++ b/frontend/src/pages/accounting/components/SettlementsTable.tsx
@@ -1,51 +1,35 @@
-import type { RefObject } from 'react'
-import { Chip, CircularProgress, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from '@mui/material'
+import type React from 'react'
 
-import { TABLE_STYLES } from '@/constants/tableStyles'
+import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
 import type { Settlement } from '@/types'
-import { formatCurrency, formatDate } from '@/utils/formatters'
+
+const COLUMNS: ColumnConfig<Settlement>[] = [
+  { key: 'settlementNumber', render: (s) => s.settlementNumber },
+]
 
 interface Props {
   settlements: Settlement[]
   loading: boolean
+  total: number
   selectedId: string | null
+  focusedIndex: number
   onSelect: (item: Settlement) => void
-  listRef?: RefObject<HTMLDivElement | null>
+  listRef: React.RefObject<HTMLDivElement | null>
 }
 
-const statusColor = (status: Settlement['status']) => status === 'completed' ? 'success' : status === 'cancelled' ? 'error' : 'default'
-
-export function SettlementsTable({ settlements, loading, selectedId, onSelect, listRef }: Props) {
+export function SettlementsTable({ settlements, loading, total, selectedId, focusedIndex, onSelect, listRef }: Props) {
   return (
-    <Paper ref={listRef} sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
-        <Table size={TABLE_STYLES.size} stickyHeader>
-          <TableHead>
-            <TableRow>
-              <TableCell sx={{ fontWeight: 600 }}>Settlement #</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Payment Method</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Date</TableCell>
-              <TableCell sx={{ fontWeight: 600 }} align="right">Total</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Status</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {loading ? (
-              <TableRow><TableCell colSpan={5} align="center" sx={{ py: 4 }}><CircularProgress /></TableCell></TableRow>
-            ) : settlements.length === 0 ? (
-              <TableRow><TableCell colSpan={5} align="center" sx={{ py: 4 }}><Typography variant="body2" color="text.secondary">No settlements found</Typography></TableCell></TableRow>
-            ) : settlements.map((item) => (
-              <TableRow key={item.id} hover selected={item.id === selectedId} onClick={() => onSelect(item)} sx={{ cursor: 'pointer', height: TABLE_STYLES.row.height }}>
-                <TableCell><Typography variant="body2" sx={{ fontWeight: 500, color: 'primary.main' }}>{item.settlementNumber}</Typography></TableCell>
-                <TableCell><Typography variant="body2">{item.paymentMethod?.name || '-'}</Typography></TableCell>
-                <TableCell><Typography variant="body2">{formatDate(item.settlementDate)}</Typography></TableCell>
-                <TableCell align="right"><Typography variant="body2">{formatCurrency(Number(item.totalAmount || 0))}</Typography></TableCell>
-                <TableCell><Chip size="small" color={statusColor(item.status) as any} label={item.status} /></TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </Paper>
+    <EntityTable
+      rows={settlements}
+      columns={COLUMNS}
+      loading={loading}
+      total={total}
+      label="Settlements"
+      selectedId={selectedId ?? undefined}
+      focusedIndex={focusedIndex}
+      onSelect={onSelect}
+      listRef={listRef}
+      dataAttr="settlement"
+    />
   )
 }

--- a/frontend/src/pages/accounting/hooks/useSettlementsWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useSettlementsWorkspace.ts
@@ -1,17 +1,33 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
+import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import { useNotification } from '@/hooks/useNotification'
 import { useCancelSettlementMutation } from '@/store/api/accountingApi'
 import type { Settlement } from '@/types'
 
-export function useSettlementsWorkspace(refetch: () => void) {
+export function useSettlementsWorkspace(entities: Settlement[], refetch: () => void) {
+  const navigate = useNavigate()
   const { showSuccess, showError } = useNotification()
-  const [selected, setSelected] = useState<Settlement | null>(null)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [cancelTarget, setCancelTarget] = useState<Settlement | null>(null)
-  const searchInputRef = useRef<HTMLInputElement | null>(null)
-  const listRef = useRef<HTMLDivElement | null>(null)
+  const [selected, setSelected] = useState<Settlement | null>(null)
   const [cancelSettlement] = useCancelSettlementMutation()
+
+  const workspace = useEntityWorkspace<Settlement>({
+    entities,
+    selectedEntity: selected,
+    selectEntity: setSelected,
+    refetch,
+    navigate,
+    routes: {
+      create: '/accounting/settlements',
+      edit: () => '/accounting/settlements',
+    },
+    notifications: { showSuccess: () => {}, showError: () => {} },
+    deleteMutation: async () => {},
+    onEnter: () => {},
+  })
 
   const handleConfirmCancel = useCallback(async () => {
     if (!cancelTarget) return
@@ -26,5 +42,13 @@ export function useSettlementsWorkspace(refetch: () => void) {
     }
   }, [cancelSettlement, cancelTarget, refetch, showError, showSuccess])
 
-  return { selected, setSelected, dialogOpen, setDialogOpen, cancelTarget, setCancelTarget, searchInputRef, listRef, handleConfirmCancel }
+  return {
+    ...workspace,
+    selected,
+    dialogOpen,
+    setDialogOpen,
+    cancelTarget,
+    setCancelTarget,
+    handleConfirmCancel,
+  }
 }


### PR DESCRIPTION
## Summary
- Replaces manual 5-column `SettlementsTable` with `EntityTable` wrapper (single `settlementNumber` column)
- Rewrites `useSettlementsWorkspace` to delegate to `useEntityWorkspace` — adds keyboard navigation (Up/Down/PgUp/PgDn/Home/End/Escape), auto-select, and search focus preservation for free
- Adds page-level `sortBy`/`sortOrder` state and `filterHandlers` with search focus preservation to `SettlementsPage`
- Refactors `SettlementContextHeader` to use the two-column MUI Grid layout matching `JournalEntryContextHeader`
- Aligns `SettlementWorkspaceCard` section-header styling to the shared constant pattern

Closes #517

## Test plan
- [x] Run `npx vitest run src/pages/accounting/__tests__/SettlementsPage.test.tsx` — 2 tests pass
- [x] Run `npm run type-check` — exit 0
- [ ] Manually verify in browser: keyboard Up/Down navigates settlements list, search box retains focus while typing, settlement detail shows two-column layout