### PR TITLE
feat(accounting): standardize selection state to Redux across 6 accounting pages

### DIFF
--- a/frontend/src/__tests__/integration/accounting-auto-posting.integration.test.tsx
+++ b/frontend/src/__tests__/integration/accounting-auto-posting.integration.test.tsx
@@ -2,7 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BrowserRouter, MemoryRouter, Route, Routes } from 'react-router-dom'
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
 import { JournalEntryStatus } from '@/types'
+import accountingReducer from '@/store/slices/accountingSlice'
 
 const mockedApi = vi.hoisted(() => ({
   useGetAccountMappingsQuery: vi.fn(),
@@ -67,12 +70,15 @@ const renderWithRouter = (component: React.ReactElement) => {
 }
 
 const renderJournalEntriesPage = (initialEntryUrl = '/accounting/journal-entries') => {
+  const store = configureStore({ reducer: { accounting: accountingReducer } })
   return render(
-    <MemoryRouter initialEntries={[initialEntryUrl]}>
-      <Routes>
-        <Route path="*" element={<JournalEntriesPage />} />
-      </Routes>
-    </MemoryRouter>,
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[initialEntryUrl]}>
+        <Routes>
+          <Route path="*" element={<JournalEntriesPage />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
   )
 }
 
@@ -125,7 +131,7 @@ describe('Accounting Auto-Posting Integration Tests', () => {
       error: undefined,
       refetch: mockRefetch,
     })
-    mockedApi.useLazyGetJournalEntryQuery.mockReturnValue([vi.fn().mockResolvedValue({})])
+    mockedApi.useLazyGetJournalEntryQuery.mockReturnValue([vi.fn(() => ({ unwrap: vi.fn().mockResolvedValue({}) }))])
   })
 
   describe('End-to-End User Flow: Configuring Account Mappings', () => {
@@ -308,19 +314,21 @@ describe('Accounting Auto-Posting Integration Tests', () => {
       const user = createUser()
 
       mockedApi.useLazyGetJournalEntryQuery.mockReturnValue([
-        vi.fn().mockResolvedValue({
-          id: 'je-2',
-          referenceNumber: 'JE-2026-002',
-          entryDate: '2026-02-02',
-          description: 'Sales order SO-123 fulfillment',
-          sourceType: 'sales_order',
-          sourceId: 'so-123',
-          sourceRefNumber: 'SO-0123',
-          status: JournalEntryStatus.POSTED,
-          totalDebits: 5000,
-          totalCredits: 5000,
-          lines: [],
-        }),
+        vi.fn(() => ({
+          unwrap: vi.fn().mockResolvedValue({
+            id: 'je-2',
+            referenceNumber: 'JE-2026-002',
+            entryDate: '2026-02-02',
+            description: 'Sales order SO-123 fulfillment',
+            sourceType: 'sales_order',
+            sourceId: 'so-123',
+            sourceRefNumber: 'SO-0123',
+            status: JournalEntryStatus.POSTED,
+            totalDebits: 5000,
+            totalCredits: 5000,
+            lines: [],
+          }),
+        })),
       ])
 
       renderJournalEntriesPage()

--- a/frontend/src/pages/accounting/BankReconciliationsPage.tsx
+++ b/frontend/src/pages/accounting/BankReconciliationsPage.tsx
@@ -3,7 +3,9 @@ import React, { useCallback, useMemo, useState } from 'react'
 import BankReconciliationFormDialog from '@/components/accounting/BankReconciliationFormDialog'
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import { useGetBankReconciliationsQuery } from '@/store/api/accountingApi'
+import { selectSelectedBankReconciliation } from '@/store/slices/accountingSlice'
 import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
 import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
 
@@ -58,11 +60,13 @@ const BankReconciliationsPage: React.FC = () => {
   const reconciliations = data?.data ?? []
   const total = data?.meta?.total ?? 0
 
+  const dispatch = useAppDispatch()
+  const selected = useAppSelector(selectSelectedBankReconciliation)
   const workspace = useBankReconciliationsWorkspace({
     reconciliations,
-    refetch: () => {
-      void refetch()
-    },
+    refetch: () => { void refetch() },
+    dispatch,
+    selected,
   })
 
   const handleSort = useCallback((field: string) => {
@@ -97,7 +101,7 @@ const BankReconciliationsPage: React.FC = () => {
           reconciliations={reconciliations}
           loading={isLoading}
           total={total}
-          selectedId={workspace.selected?.id ?? null}
+          selectedId={selected?.id ?? null}
           focusedIndex={workspace.focusedIndex}
           onSelect={workspace.handleSelect}
           listRef={workspace.listRef}
@@ -105,15 +109,15 @@ const BankReconciliationsPage: React.FC = () => {
       )}
       headerSlot={(
         <BankReconciliationContextHeader
-          selected={workspace.selected}
-          onComplete={() => workspace.selected && workspace.setCompleteTarget(workspace.selected)}
-          onReopen={() => workspace.selected && workspace.setReopenTarget(workspace.selected)}
-          onDelete={() => workspace.selected && workspace.setDeleteTarget(workspace.selected)}
+          selected={selected}
+          onComplete={() => selected && workspace.setCompleteTarget(selected)}
+          onReopen={() => selected && workspace.setReopenTarget(selected)}
+          onDelete={() => selected && workspace.setDeleteTarget(selected)}
         />
       )}
       workspaceSlot={(
         <BankReconciliationWorkspaceCard
-          selected={workspace.selected}
+          selected={selected}
           onToggleCleared={workspace.handleToggleCleared}
         />
       )}

--- a/frontend/src/pages/accounting/ExpensesPage.tsx
+++ b/frontend/src/pages/accounting/ExpensesPage.tsx
@@ -2,7 +2,9 @@ import React, { useMemo } from 'react'
 
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import { useGetExpensesQuery } from '@/store/api/accountingApi'
+import { selectSelectedExpense } from '@/store/slices/accountingSlice'
 import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
 import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
 
@@ -57,9 +59,9 @@ const ExpensesPage: React.FC = () => {
   const { data: expensesResponse, isLoading, refetch } = useGetExpensesQuery(filters)
   const rows = expensesResponse?.data ?? []
 
-  const workspace = useExpensesWorkspace(() => {
-    void refetch()
-  }, rows)
+  const dispatch = useAppDispatch()
+  const selected = useAppSelector(selectSelectedExpense)
+  const workspace = useExpensesWorkspace(() => { void refetch() }, rows, dispatch, selected)
 
   const openCreate = () => {
     workspace.setEditTarget(null)
@@ -67,8 +69,8 @@ const ExpensesPage: React.FC = () => {
   }
 
   const openEdit = () => {
-    if (!workspace.selected) return
-    workspace.setEditTarget(workspace.selected)
+    if (!selected) return
+    workspace.setEditTarget(selected)
     workspace.setFormOpen(true)
   }
 
@@ -92,7 +94,7 @@ const ExpensesPage: React.FC = () => {
         <ExpensesTable
           expenses={rows}
           loading={isLoading}
-          selectedId={workspace.selected?.id ?? null}
+          selectedId={selected?.id ?? null}
           focusedIndex={workspace.focusedIndex}
           onSelect={workspace.handleSelect}
           listRef={workspace.listRef}
@@ -100,13 +102,13 @@ const ExpensesPage: React.FC = () => {
       )}
       headerSlot={(
         <ExpenseContextHeader
-          selected={workspace.selected}
+          selected={selected}
           onEdit={openEdit}
-          onPost={() => workspace.selected && workspace.setPostTarget(workspace.selected)}
-          onDelete={() => workspace.selected && workspace.setDeleteTarget(workspace.selected)}
+          onPost={() => selected && workspace.setPostTarget(selected)}
+          onDelete={() => selected && workspace.setDeleteTarget(selected)}
         />
       )}
-      workspaceSlot={<ExpenseWorkspaceCard selected={workspace.selected} />}
+      workspaceSlot={<ExpenseWorkspaceCard selected={selected} />}
       dialogs={(
         <>
           <ExpensesDialogs

--- a/frontend/src/pages/accounting/FundTransfersPage.tsx
+++ b/frontend/src/pages/accounting/FundTransfersPage.tsx
@@ -2,8 +2,9 @@ import React, { useMemo, useState } from 'react'
 
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
-import { useAppSelector } from '@/hooks/useRedux'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import { useCreateFundTransferMutation, useGetChartOfAccountsQuery, useGetFundTransfersQuery } from '@/store/api/accountingApi'
+import { selectSelectedFundTransfer } from '@/store/slices/accountingSlice'
 import { selectCurrentUser } from '@/store/slices/authSlice'
 import type { ChartOfAccount } from '@/types'
 import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
@@ -44,6 +45,8 @@ const defaultForm: FormState = { sourceAccountId: '', destinationAccountId: '', 
 
 const FundTransfersPage: React.FC = () => {
   const currentUser = useAppSelector(selectCurrentUser)
+  const dispatch = useAppDispatch()
+  const selected = useAppSelector(selectSelectedFundTransfer)
   const canManageTransfers = currentUser?.role === 'admin' || currentUser?.role === 'manager'
   const [dialogOpen, setDialogOpen] = useState(false)
   const [form, setForm] = useState<FormState>(defaultForm)
@@ -75,7 +78,7 @@ const FundTransfersPage: React.FC = () => {
     if (!term) return rows
     return rows.filter((row) => [row.referenceNumber, row.description, row.sourceAccount.name, row.destinationAccount.name].filter(Boolean).join(' ').toLowerCase().includes(term))
   }, [appliedFilters.search, data?.data])
-  const workspace = useFundTransfersWorkspace(() => { void refetch() }, transfers)
+  const workspace = useFundTransfersWorkspace(() => { void refetch() }, transfers, dispatch, selected)
 
   const resetForm = () => { setDialogOpen(false); setForm(defaultForm) }
 
@@ -97,9 +100,9 @@ const FundTransfersPage: React.FC = () => {
       hasActiveFilters={hasActiveFilters}
       searchInputRef={workspace.searchInputRef}
       sort={{ field: 'transferDate', sortBy: 'transferDate', sortOrder: 'desc', onSort: () => {} }}
-      listSlot={<FundTransfersList transfers={transfers} loading={isLoading} selectedId={workspace.selected?.id ?? null} focusedIndex={workspace.focusedIndex} onSelect={workspace.handleSelect} listRef={workspace.listRef} />}
-      headerSlot={<FundTransferContextHeader selected={workspace.selected} onCancel={() => workspace.selected && workspace.setCancelTarget(workspace.selected)} canManageTransfers={canManageTransfers} />}
-      workspaceSlot={<FundTransferWorkspaceCard selected={workspace.selected} />}
+      listSlot={<FundTransfersList transfers={transfers} loading={isLoading} selectedId={selected?.id ?? null} focusedIndex={workspace.focusedIndex} onSelect={workspace.handleSelect} listRef={workspace.listRef} />}
+      headerSlot={<FundTransferContextHeader selected={selected} onCancel={() => selected && workspace.setCancelTarget(selected)} canManageTransfers={canManageTransfers} />}
+      workspaceSlot={<FundTransferWorkspaceCard selected={selected} />}
       dialogs={<FundTransfersDialogs dialogOpen={dialogOpen} canManageTransfers={canManageTransfers} creating={creating} form={form} cashAccounts={cashAccounts} availableDestinations={availableDestinations} onCloseDialog={resetForm} onFormChange={(field, value) => setForm((current) => ({ ...current, [field]: value, ...(field === 'sourceAccountId' && value === current.destinationAccountId ? { destinationAccountId: '' } : {}) }))} onCreate={() => void handleCreate()} cancelTarget={workspace.cancelTarget} cancelling={workspace.cancelling} onConfirmCancel={() => void workspace.handleConfirmCancel()} onCancelCancel={() => workspace.setCancelTarget(null)} />}
     />
   )

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -4,7 +4,9 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import AccountMappingWarning from '@/components/accounting/AccountMappingWarning'
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import { useGetJournalEntriesQuery } from '@/store/api/accountingApi'
+import { selectSelectedJournalEntry } from '@/store/slices/accountingSlice'
 import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
 import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
 
@@ -78,7 +80,9 @@ export const JournalEntriesPage: React.FC = () => {
   const entries = data?.data ?? []
   const pagination = data?.meta
 
-  const workspace = useJournalEntriesWorkspace({ entries, refetch })
+  const dispatch = useAppDispatch()
+  const selectedEntry = useAppSelector(selectSelectedJournalEntry)
+  const workspace = useJournalEntriesWorkspace({ entries, refetch, dispatch, selectedEntry })
 
   const handleClearAll = useCallback(() => {
     handlers.onClearAll()
@@ -120,7 +124,7 @@ export const JournalEntriesPage: React.FC = () => {
             entries={entries}
             loading={isLoading}
             total={pagination?.total ?? 0}
-            selectedEntryId={workspace.selectedEntry?.id ?? null}
+            selectedEntryId={selectedEntry?.id ?? null}
             focusedIndex={workspace.focusedIndex}
             onSelect={workspace.handleSelect}
             listRef={workspace.listRef}
@@ -128,10 +132,10 @@ export const JournalEntriesPage: React.FC = () => {
         )}
         headerSlot={(
           <JournalEntryContextHeader
-            selectedEntry={workspace.selectedEntry}
+            selectedEntry={selectedEntry}
           />
         )}
-        workspaceSlot={<JournalEntryWorkspaceCard selectedEntry={workspace.selectedEntry} />}
+        workspaceSlot={<JournalEntryWorkspaceCard selectedEntry={selectedEntry} />}
       />
     </>
   )

--- a/frontend/src/pages/accounting/OwnerEquityPage.tsx
+++ b/frontend/src/pages/accounting/OwnerEquityPage.tsx
@@ -2,12 +2,14 @@ import React, { useMemo, useState } from 'react'
 
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import {
   useCreateOwnerEquityTransactionMutation,
   useGetOwnerEquityTransactionsQuery,
   useGetPaymentMethodsQuery,
   useUpdateOwnerEquityTransactionMutation,
 } from '@/store/api/accountingApi'
+import { selectSelectedOwnerEquityTransaction } from '@/store/slices/accountingSlice'
 import type { OwnerEquityTransaction, PaymentMethodConfig } from '@/types'
 import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
 import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
@@ -92,7 +94,9 @@ const OwnerEquityPage: React.FC = () => {
     )
   }, [appliedFilters.search, ownerEquityResponse?.data])
 
-  const workspace = useOwnerEquityWorkspace(rows, () => { void refetch() })
+  const dispatch = useAppDispatch()
+  const selected = useAppSelector(selectSelectedOwnerEquityTransaction)
+  const workspace = useOwnerEquityWorkspace(rows, () => { void refetch() }, dispatch, selected)
 
   const filterHandlers = useMemo(() => ({
     ...handlers,
@@ -155,7 +159,7 @@ const OwnerEquityPage: React.FC = () => {
           transactions={rows}
           loading={isLoading}
           total={rows.length}
-          selectedId={workspace.selected?.id ?? null}
+          selectedId={selected?.id ?? null}
           focusedIndex={workspace.focusedIndex}
           onSelect={workspace.handleSelect}
           listRef={workspace.listRef}
@@ -163,14 +167,14 @@ const OwnerEquityPage: React.FC = () => {
       )}
       headerSlot={(
         <OwnerEquityContextHeader
-          selected={workspace.selected}
-          onEdit={() => workspace.selected && openEdit(workspace.selected)}
-          onPost={() => workspace.selected && workspace.setPostTarget(workspace.selected)}
-          onDelete={() => workspace.selected && workspace.setDeleteTarget(workspace.selected)}
-          onReverse={() => workspace.selected && workspace.setReverseTarget(workspace.selected)}
+          selected={selected}
+          onEdit={() => selected && openEdit(selected)}
+          onPost={() => selected && workspace.setPostTarget(selected)}
+          onDelete={() => selected && workspace.setDeleteTarget(selected)}
+          onReverse={() => selected && workspace.setReverseTarget(selected)}
         />
       )}
-      workspaceSlot={<OwnerEquityWorkspaceCard selected={workspace.selected} />}
+      workspaceSlot={<OwnerEquityWorkspaceCard selected={selected} />}
       dialogs={(
         <OwnerEquityDialogs
           dialogOpen={workspace.dialogOpen}

--- a/frontend/src/pages/accounting/SettlementsPage.tsx
+++ b/frontend/src/pages/accounting/SettlementsPage.tsx
@@ -2,7 +2,9 @@ import React, { useCallback, useMemo, useState } from 'react'
 
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import { useCreateSettlementMutation, useGetPendingSettlementSummaryQuery, useGetSettlementsQuery } from '@/store/api/accountingApi'
+import { selectSelectedSettlement } from '@/store/slices/accountingSlice'
 import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
 import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
 
@@ -52,7 +54,9 @@ const SettlementsPage: React.FC = () => {
     return rows.filter((row) => [row.settlementNumber, row.reference, row.notes, row.paymentMethod?.name].filter(Boolean).join(' ').toLowerCase().includes(term))
   }, [appliedFilters.search, settlementsResponse?.data])
 
-  const workspace = useSettlementsWorkspace(settlements, () => { void refetch() })
+  const dispatch = useAppDispatch()
+  const selected = useAppSelector(selectSelectedSettlement)
+  const workspace = useSettlementsWorkspace(settlements, () => { void refetch() }, dispatch, selected)
 
   const filterHandlers = useMemo(() => ({
     ...handlers,
@@ -89,7 +93,7 @@ const SettlementsPage: React.FC = () => {
           settlements={settlements}
           loading={isLoading}
           total={settlements.length}
-          selectedId={workspace.selected?.id ?? null}
+          selectedId={selected?.id ?? null}
           focusedIndex={workspace.focusedIndex}
           onSelect={workspace.handleSelect}
           listRef={workspace.listRef}
@@ -97,11 +101,11 @@ const SettlementsPage: React.FC = () => {
       )}
       headerSlot={(
         <SettlementContextHeader
-          selected={workspace.selected}
-          onCancel={() => workspace.selected && workspace.setCancelTarget(workspace.selected)}
+          selected={selected}
+          onCancel={() => selected && workspace.setCancelTarget(selected)}
         />
       )}
-      workspaceSlot={<SettlementWorkspaceCard selected={workspace.selected} />}
+      workspaceSlot={<SettlementWorkspaceCard selected={selected} />}
       dialogs={(
         <SettlementsDialogs
           dialogOpen={workspace.dialogOpen}

--- a/frontend/src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { BrowserRouter } from 'react-router-dom'
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
 
 import { BankReconciliationStatus } from '@/types'
+import accountingReducer, { selectSelectedBankReconciliation } from '@/store/slices/accountingSlice'
 
 import BankReconciliationsPage from '../BankReconciliationsPage'
 
@@ -73,8 +76,20 @@ const mockedApi = vi.hoisted(() => ({
 
 vi.mock('@/store/api/accountingApi', () => mockedApi)
 
-function renderPage() {
-  return render(<BrowserRouter><BankReconciliationsPage /></BrowserRouter>)
+function makeStore() {
+  return configureStore({ reducer: { accounting: accountingReducer } })
+}
+
+function renderPage(initialUrl = '/accounting/bank-reconciliations') {
+  const store = makeStore()
+  const view = render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <BankReconciliationsPage />
+      </MemoryRouter>
+    </Provider>,
+  )
+  return { ...view, store }
 }
 
 describe('BankReconciliationsPage', () => {
@@ -152,5 +167,19 @@ describe('BankReconciliationsPage', () => {
     renderPage()
 
     expect(screen.getByText('Select a reconciliation to view details')).toBeInTheDocument()
+  })
+
+  it('auto-selects the reconciliation matching the ?highlight= URL param', async () => {
+    mockedApi.useGetBankReconciliationsQuery.mockReturnValue({
+      data: { data: [MOCK_RECONCILIATION_IN_PROGRESS], meta: { total: 1 } },
+      isLoading: false,
+      refetch: vi.fn(),
+    })
+
+    const { store } = renderPage('/accounting/bank-reconciliations?highlight=rec-1')
+
+    await waitFor(() => {
+      expect(selectSelectedBankReconciliation(store.getState())?.id).toBe('rec-1')
+    })
   })
 })

--- a/frontend/src/pages/accounting/__tests__/ExpensesPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/ExpensesPage.test.tsx
@@ -1,8 +1,11 @@
-import { fireEvent, render, screen, within } from '@testing-library/react'
-import { BrowserRouter } from 'react-router-dom'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import ExpensesPage from '../ExpensesPage'
+import accountingReducer, { selectSelectedExpense } from '@/store/slices/accountingSlice'
 
 vi.mock('@/hooks/useNotification', () => ({
   useNotification: () => ({
@@ -57,12 +60,21 @@ const expense1 = {
   updatedAt: '2026-02-15',
 }
 
-const renderPage = () =>
-  render(
-    <BrowserRouter>
-      <ExpensesPage />
-    </BrowserRouter>,
+function makeStore() {
+  return configureStore({ reducer: { accounting: accountingReducer } })
+}
+
+const renderPage = (initialUrl = '/accounting/expenses') => {
+  const store = makeStore()
+  const view = render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <ExpensesPage />
+      </MemoryRouter>
+    </Provider>,
   )
+  return { ...view, store }
+}
 
 describe('ExpensesPage', () => {
   beforeEach(() => {
@@ -140,5 +152,19 @@ describe('ExpensesPage', () => {
     const tableBody = container.querySelector('tbody')!
     fireEvent.click(within(tableBody).getByText('EXP-001'))
     expect(screen.getByText('Printer paper and ink')).toBeInTheDocument()
+  })
+
+  it('auto-selects the expense matching the ?highlight= URL param', async () => {
+    mockedApi.useGetExpensesQuery.mockReturnValue({
+      data: { data: [expense1], meta: { total: 1 } },
+      isLoading: false,
+      refetch: vi.fn(),
+    })
+
+    const { store } = renderPage('/accounting/expenses?highlight=ex-1')
+
+    await waitFor(() => {
+      expect(selectSelectedExpense(store.getState())?.id).toBe('ex-1')
+    })
   })
 })

--- a/frontend/src/pages/accounting/__tests__/FundTransfersPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/FundTransfersPage.test.tsx
@@ -1,11 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
-import { BrowserRouter } from 'react-router-dom'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
 
 import FundTransfersPage from '../FundTransfersPage'
+import accountingReducer, { selectSelectedFundTransfer } from '@/store/slices/accountingSlice'
 
 vi.mock('@/hooks/useNotification', () => ({ useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }) }))
-vi.mock('@/hooks/useRedux', () => ({ useAppSelector: () => ({ role: 'admin' }) }))
+vi.mock('@/store/slices/authSlice', () => ({
+  selectCurrentUser: () => ({ role: 'admin' }),
+}))
 vi.mock('@/utils/dateRange', () => ({ getPeriodDateRange: () => ({ from: undefined, to: undefined }), getStartOfWeek: () => 0 }))
 vi.mock('@/utils/formatters', async () => {
   const actual = await vi.importActual<typeof import('@/utils/formatters')>('@/utils/formatters')
@@ -41,6 +46,22 @@ const mockTransfer = {
   updatedAt: '2026-03-12',
 }
 
+function makeStore() {
+  return configureStore({ reducer: { accounting: accountingReducer } })
+}
+
+function renderPage(initialUrl = '/accounting/fund-transfers') {
+  const store = makeStore()
+  const view = render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <FundTransfersPage />
+      </MemoryRouter>
+    </Provider>,
+  )
+  return { ...view, store }
+}
+
 describe('FundTransfersPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -62,19 +83,19 @@ describe('FundTransfersPage', () => {
   })
 
   it('renders page title', () => {
-    render(<BrowserRouter><FundTransfersPage /></BrowserRouter>)
+    renderPage()
     expect(screen.getByText('Fund Transfers')).toBeInTheDocument()
   })
 
   it('renders transfer reference number in the narrow list', () => {
-    const { container } = render(<BrowserRouter><FundTransfersPage /></BrowserRouter>)
+    const { container } = renderPage()
     const listRow = container.querySelector('[data-index="0"]')
     expect(listRow).not.toBeNull()
     expect(within(listRow as HTMLElement).getByText('TRF-26-001')).toBeInTheDocument()
   })
 
   it('does not render date, from/to account, or amount columns in the list', () => {
-    render(<BrowserRouter><FundTransfersPage /></BrowserRouter>)
+    renderPage()
     // The narrow EntityTable list should NOT show these fields as column headers
     expect(screen.queryByRole('columnheader', { name: /date/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('columnheader', { name: /from/i })).not.toBeInTheDocument()
@@ -82,14 +103,22 @@ describe('FundTransfersPage', () => {
   })
 
   it('renders New Transfer button for admin', () => {
-    render(<BrowserRouter><FundTransfersPage /></BrowserRouter>)
+    renderPage()
     expect(screen.getByRole('button', { name: /new transfer/i })).toBeInTheDocument()
   })
 
   it('shows ACTIVE status chip in list', () => {
-    const { container } = render(<BrowserRouter><FundTransfersPage /></BrowserRouter>)
+    const { container } = renderPage()
     const listRow = container.querySelector('[data-index="0"]')
     expect(listRow).not.toBeNull()
     expect(within(listRow as HTMLElement).getByText('ACTIVE')).toBeInTheDocument()
+  })
+
+  it('auto-selects the transfer matching the ?highlight= URL param', async () => {
+    const { store } = renderPage('/accounting/fund-transfers?highlight=trf-1')
+
+    await waitFor(() => {
+      expect(selectSelectedFundTransfer(store.getState())?.id).toBe('trf-1')
+    })
   })
 })

--- a/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { BrowserRouter } from 'react-router-dom'
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
 
 import JournalEntriesPage from '../JournalEntriesPage'
+import accountingReducer, { selectSelectedJournalEntry } from '@/store/slices/accountingSlice'
 import { JournalEntryStatus } from '@/types'
 
 vi.mock('@/hooks/useNotification', () => ({
@@ -60,6 +63,24 @@ const mockEntry = {
   updatedAt: '2026-01-01',
 }
 
+function makeStore() {
+  return configureStore({ reducer: { accounting: accountingReducer } })
+}
+
+function renderPage(initialUrl = '/accounting/journal-entries') {
+  const [pathname, search = ''] = initialUrl.split('?')
+  mockLocation = { pathname, search: search ? `?${search}` : '' }
+  const store = makeStore()
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <JournalEntriesPage />
+      </MemoryRouter>
+    </Provider>,
+  )
+  return { store }
+}
+
 describe('JournalEntriesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -73,17 +94,17 @@ describe('JournalEntriesPage', () => {
   })
 
   it('renders the page title', () => {
-    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    renderPage()
     expect(screen.getByText('Journal Entries')).toBeInTheDocument()
   })
 
   it('renders journal entry rows', () => {
-    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    renderPage()
     expect(screen.getAllByText('JE-001').length).toBeGreaterThan(0)
   })
 
   it('clicking a row selects it instead of navigating', async () => {
-    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    renderPage()
     fireEvent.click(screen.getAllByText('JE-001')[0])
     await waitFor(() => {
       expect(screen.getByText('Journal Entry Details - JE-001')).toBeInTheDocument()
@@ -92,34 +113,46 @@ describe('JournalEntriesPage', () => {
   })
 
   it('does not render a New Journal Entry button', () => {
-    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    renderPage()
     expect(screen.queryByText(/new journal entry/i)).not.toBeInTheDocument()
   })
 
   it('does not render bulk action buttons', () => {
-    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    renderPage()
     expect(screen.queryByText(/post selected/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/delete selected/i)).not.toBeInTheDocument()
   })
 
   it('shows Reset button when ?sourceId= URL param is present', () => {
-    mockLocation = { search: '?sourceType=sales_order&sourceId=so-1', pathname: '/accounting/journal-entries' }
-    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    renderPage('/accounting/journal-entries?sourceType=sales_order&sourceId=so-1')
     expect(screen.getByRole('button', { name: /reset/i })).toBeInTheDocument()
   })
 
   it('shows Reset button when ?ids= URL param is present', () => {
-    mockLocation = { search: '?ids=je-1,je-2', pathname: '/accounting/journal-entries' }
-    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    renderPage('/accounting/journal-entries?ids=je-1,je-2')
     expect(screen.getByRole('button', { name: /reset/i })).toBeInTheDocument()
   })
 
   it('navigates to clean URL when Reset is clicked with URL params active', async () => {
-    mockLocation = { search: '?ids=je-1,je-2', pathname: '/accounting/journal-entries' }
-    render(<BrowserRouter><JournalEntriesPage /></BrowserRouter>)
+    renderPage('/accounting/journal-entries?ids=je-1,je-2')
     fireEvent.click(screen.getByRole('button', { name: /reset/i }))
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/accounting/journal-entries', { replace: true })
+    })
+  })
+
+  it('auto-selects the entry matching the ?highlight= URL param', async () => {
+    mockedApi.useGetJournalEntriesQuery.mockReturnValue({
+      data: { data: [mockEntry], meta: { total: 1 } },
+      isLoading: false,
+      refetch: vi.fn(),
+    })
+    mockedApi.useLazyGetJournalEntryQuery.mockReturnValue([vi.fn().mockResolvedValue(mockEntry)])
+
+    const { store } = renderPage('/accounting/journal-entries?highlight=1')
+
+    await waitFor(() => {
+      expect(selectSelectedJournalEntry(store.getState())?.id).toBe('1')
     })
   })
 })

--- a/frontend/src/pages/accounting/__tests__/OwnerEquityPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/OwnerEquityPage.test.tsx
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
-import { BrowserRouter } from 'react-router-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
 
 import OwnerEquityPage from '../OwnerEquityPage'
+import accountingReducer, { selectSelectedOwnerEquityTransaction } from '@/store/slices/accountingSlice'
 
 const mockNavigate = vi.fn()
 
@@ -68,6 +71,22 @@ const TX_2 = {
   updatedAt: '2026-03-01',
 }
 
+function makeStore() {
+  return configureStore({ reducer: { accounting: accountingReducer } })
+}
+
+function renderPage(initialUrl = '/accounting/owner-equity') {
+  const store = makeStore()
+  const view = render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <OwnerEquityPage />
+      </MemoryRouter>
+    </Provider>,
+  )
+  return { ...view, store }
+}
+
 describe('OwnerEquityPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -90,24 +109,32 @@ describe('OwnerEquityPage', () => {
   })
 
   it('renders title and transaction rows', () => {
-    render(<BrowserRouter><OwnerEquityPage /></BrowserRouter>)
+    renderPage()
     expect(screen.getByText('Owner Equity')).toBeInTheDocument()
     expect(screen.getAllByText('EQ-001')[0]).toBeInTheDocument()
     expect(screen.getByText('EQ-002')).toBeInTheDocument()
   })
 
   it('shows detail content after clicking a row', () => {
-    render(<BrowserRouter><OwnerEquityPage /></BrowserRouter>)
+    renderPage()
     fireEvent.click(screen.getAllByText('EQ-001')[0])
     expect(screen.getByText('Initial owner capital')).toBeInTheDocument()
   })
 
   it('navigates the list with keyboard arrow keys', () => {
-    render(<BrowserRouter><OwnerEquityPage /></BrowserRouter>)
+    renderPage()
     // First item is auto-selected on load — its description should be visible
     expect(screen.getByText('Initial owner capital')).toBeInTheDocument()
     // ArrowDown moves selection to second item
     fireEvent.keyDown(document, { key: 'ArrowDown' })
     expect(screen.getByText('Owner withdrawal')).toBeInTheDocument()
+  })
+
+  it('auto-selects the transaction matching the ?highlight= URL param', async () => {
+    const { store } = renderPage('/accounting/owner-equity?highlight=tx-1')
+
+    await waitFor(() => {
+      expect(selectSelectedOwnerEquityTransaction(store.getState())?.id).toBe('tx-1')
+    })
   })
 })

--- a/frontend/src/pages/accounting/__tests__/SettlementsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/SettlementsPage.test.tsx
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import { BrowserRouter } from 'react-router-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
 
 import SettlementsPage from '../SettlementsPage'
+import accountingReducer, { selectSelectedSettlement } from '@/store/slices/accountingSlice'
 
 const mocked = vi.hoisted(() => ({
   showSuccess: vi.fn(),
@@ -33,6 +36,22 @@ vi.mock('@/utils/formatters', async () => {
 vi.mock('@/store/api/accountingApi', () => mocked)
 vi.mock('@/components/accounting/CreateSettlementDialog', () => ({ default: () => null }))
 
+function makeStore() {
+  return configureStore({ reducer: { accounting: accountingReducer } })
+}
+
+function renderPage(initialUrl = '/accounting/settlements') {
+  const store = makeStore()
+  const view = render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <SettlementsPage />
+      </MemoryRouter>
+    </Provider>,
+  )
+  return { ...view, store }
+}
+
 describe('SettlementsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -59,13 +78,21 @@ describe('SettlementsPage', () => {
   })
 
   it('renders title and settlement row', () => {
-    render(<BrowserRouter><SettlementsPage /></BrowserRouter>)
+    renderPage()
     expect(screen.getByText('Settlements')).toBeInTheDocument()
     expect(screen.getAllByText('SET-001')).toHaveLength(2)
   })
 
   it('renders create action', () => {
-    render(<BrowserRouter><SettlementsPage /></BrowserRouter>)
+    renderPage()
     expect(screen.getByRole('button', { name: 'Create Settlement' })).toBeInTheDocument()
+  })
+
+  it('auto-selects the settlement matching the ?highlight= URL param', async () => {
+    const { store } = renderPage('/accounting/settlements?highlight=s-1')
+
+    await waitFor(() => {
+      expect(selectSelectedSettlement(store.getState())?.id).toBe('s-1')
+    })
   })
 })

--- a/frontend/src/pages/accounting/hooks/useBankReconciliationsWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useBankReconciliationsWorkspace.ts
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import { useNotification } from '@/hooks/useNotification'
+import type { AppDispatch } from '@/store'
 import {
   useCompleteBankReconciliationMutation,
   useDeleteBankReconciliationMutation,
@@ -11,21 +12,25 @@ import {
   useReopenBankReconciliationMutation,
   useUnmarkBankReconciliationClearedMutation,
 } from '@/store/api/accountingApi'
+import { setSelectedBankReconciliation } from '@/store/slices/accountingSlice'
 import { BankReconciliation, ReconciledTransaction } from '@/types'
 import { getErrorMessage } from '@/utils/errorMessage'
 
 interface UseBankReconciliationsWorkspaceConfig {
   reconciliations: BankReconciliation[]
   refetch: () => void
+  dispatch: AppDispatch
+  selected: BankReconciliation | null
 }
 
 export function useBankReconciliationsWorkspace({
   reconciliations,
   refetch,
+  dispatch,
+  selected,
 }: UseBankReconciliationsWorkspaceConfig) {
   const navigate = useNavigate()
   const { showSuccess, showError } = useNotification()
-  const [selected, setSelected] = useState<BankReconciliation | null>(null)
   const [completeTarget, setCompleteTarget] = useState<BankReconciliation | null>(null)
   const [reopenTarget, setReopenTarget] = useState<BankReconciliation | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<BankReconciliation | null>(null)
@@ -41,9 +46,10 @@ export function useBankReconciliationsWorkspace({
   const workspace = useEntityWorkspace<BankReconciliation>({
     entities: reconciliations,
     selectedEntity: selected,
-    selectEntity: setSelected,
+    selectEntity: (entity) => dispatch(setSelectedBankReconciliation(entity)),
     refetch,
     navigate,
+    highlightParam: 'highlight',
     routes: {
       create: '/accounting/bank-reconciliations',
       edit: () => '/accounting/bank-reconciliations',
@@ -51,16 +57,22 @@ export function useBankReconciliationsWorkspace({
     notifications: { showSuccess, showError },
     deleteMutation: async () => {},
     onEnter: () => {},
+    onEscape: () => {
+      dispatch(setSelectedBankReconciliation(null))
+      setCompleteTarget(null)
+      setReopenTarget(null)
+      setDeleteTarget(null)
+    },
   })
 
   const handleSelect = useCallback(async (item: BankReconciliation) => {
     workspace.handleSelect(item)
     try {
       const fresh = await fetchItem(item.id).unwrap()
-      setSelected(fresh)
+      dispatch(setSelectedBankReconciliation(fresh))
     }
     catch { /* keep list-row data */ }
-  }, [fetchItem, workspace])
+  }, [fetchItem, workspace, dispatch])
 
   const handleToggleCleared = useCallback(async (txn: ReconciledTransaction) => {
     if (!selected) return
@@ -68,13 +80,13 @@ export function useBankReconciliationsWorkspace({
       const fresh = txn.cleared
         ? await unmarkCleared({ id: selected.id, journalEntryLineIds: [txn.journalEntryLineId] }).unwrap()
         : await markCleared({ id: selected.id, journalEntryLineIds: [txn.journalEntryLineId] }).unwrap()
-      setSelected(fresh)
+      dispatch(setSelectedBankReconciliation(fresh))
       refetch()
     }
     catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to update transaction'))
     }
-  }, [selected, markCleared, unmarkCleared, refetch, showError])
+  }, [selected, markCleared, unmarkCleared, refetch, showError, dispatch])
 
   const handleConfirmComplete = useCallback(async () => {
     if (!completeTarget) return
@@ -83,7 +95,7 @@ export function useBankReconciliationsWorkspace({
       const fresh = await completeReconciliation(completeTarget.id).unwrap()
       showSuccess('Reconciliation completed')
       setCompleteTarget(null)
-      setSelected(fresh)
+      dispatch(setSelectedBankReconciliation(fresh))
       refetch()
     }
     catch (error: unknown) {
@@ -92,7 +104,7 @@ export function useBankReconciliationsWorkspace({
     finally {
       setActionLoading(false)
     }
-  }, [completeTarget, completeReconciliation, showSuccess, showError, refetch])
+  }, [completeTarget, completeReconciliation, showSuccess, showError, refetch, dispatch])
 
   const handleConfirmReopen = useCallback(async () => {
     if (!reopenTarget) return
@@ -101,7 +113,7 @@ export function useBankReconciliationsWorkspace({
       const fresh = await reopenReconciliation(reopenTarget.id).unwrap()
       showSuccess('Reconciliation reopened')
       setReopenTarget(null)
-      setSelected(fresh)
+      dispatch(setSelectedBankReconciliation(fresh))
       refetch()
     }
     catch (error: unknown) {
@@ -110,7 +122,7 @@ export function useBankReconciliationsWorkspace({
     finally {
       setActionLoading(false)
     }
-  }, [reopenTarget, reopenReconciliation, showSuccess, showError, refetch])
+  }, [reopenTarget, reopenReconciliation, showSuccess, showError, refetch, dispatch])
 
   const handleConfirmDelete = useCallback(async () => {
     if (!deleteTarget) return
@@ -119,7 +131,7 @@ export function useBankReconciliationsWorkspace({
       await deleteReconciliation(deleteTarget.id).unwrap()
       showSuccess('Reconciliation deleted')
       setDeleteTarget(null)
-      setSelected(null)
+      dispatch(setSelectedBankReconciliation(null))
       refetch()
     }
     catch (error: unknown) {
@@ -128,11 +140,9 @@ export function useBankReconciliationsWorkspace({
     finally {
       setActionLoading(false)
     }
-  }, [deleteTarget, deleteReconciliation, showSuccess, showError, refetch])
+  }, [deleteTarget, deleteReconciliation, showSuccess, showError, refetch, dispatch])
 
   return {
-    selected,
-    setSelected,
     completeTarget,
     setCompleteTarget,
     reopenTarget,

--- a/frontend/src/pages/accounting/hooks/useBankReconciliationsWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useBankReconciliationsWorkspace.ts
@@ -65,14 +65,16 @@ export function useBankReconciliationsWorkspace({
     },
   })
 
+  const { handleSelect: workspaceHandleSelect } = workspace
+
   const handleSelect = useCallback(async (item: BankReconciliation) => {
-    workspace.handleSelect(item)
+    workspaceHandleSelect(item)
     try {
       const fresh = await fetchItem(item.id).unwrap()
       dispatch(setSelectedBankReconciliation(fresh))
     }
     catch { /* keep list-row data */ }
-  }, [fetchItem, workspace, dispatch])
+  }, [fetchItem, workspaceHandleSelect, dispatch])
 
   const handleToggleCleared = useCallback(async (txn: ReconciledTransaction) => {
     if (!selected) return

--- a/frontend/src/pages/accounting/hooks/useExpensesWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useExpensesWorkspace.ts
@@ -3,17 +3,23 @@ import { useNavigate } from 'react-router-dom'
 
 import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import { useNotification } from '@/hooks/useNotification'
+import type { AppDispatch } from '@/store'
 import {
   useDeleteExpenseMutation,
   usePostExpenseMutation,
 } from '@/store/api/accountingApi'
+import { setSelectedExpense } from '@/store/slices/accountingSlice'
 import type { ExpenseRecord } from '@/types'
 import { getErrorMessage } from '@/utils/errorMessage'
 
-export function useExpensesWorkspace(refetch: () => void, expenses: ExpenseRecord[] = []) {
+export function useExpensesWorkspace(
+  refetch: () => void,
+  expenses: ExpenseRecord[] = [],
+  dispatch: AppDispatch,
+  selected: ExpenseRecord | null,
+) {
   const navigate = useNavigate()
   const { showSuccess, showError } = useNotification()
-  const [selected, setSelected] = useState<ExpenseRecord | null>(null)
   const [postTarget, setPostTarget] = useState<ExpenseRecord | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<ExpenseRecord | null>(null)
   const [actionLoading, setActionLoading] = useState(false)
@@ -26,9 +32,10 @@ export function useExpensesWorkspace(refetch: () => void, expenses: ExpenseRecor
   const workspace = useEntityWorkspace<ExpenseRecord>({
     entities: expenses,
     selectedEntity: selected,
-    selectEntity: setSelected,
+    selectEntity: (entity) => dispatch(setSelectedExpense(entity)),
     refetch,
     navigate,
+    highlightParam: 'highlight',
     routes: {
       create: '/accounting/expenses',
       edit: () => '/accounting/expenses',
@@ -41,7 +48,7 @@ export function useExpensesWorkspace(refetch: () => void, expenses: ExpenseRecor
       if (selected) setFormOpen(true)
     },
     onEscape: () => {
-      setSelected(null)
+      dispatch(setSelectedExpense(null))
       setPostTarget(null)
       setDeleteTarget(null)
     },
@@ -54,7 +61,7 @@ export function useExpensesWorkspace(refetch: () => void, expenses: ExpenseRecor
       await postExpense(postTarget.id).unwrap()
       showSuccess(`Expense ${postTarget.referenceNumber} posted`)
       setPostTarget(null)
-      setSelected(null)
+      dispatch(setSelectedExpense(null))
       refetch()
     }
     catch (error: unknown) {
@@ -63,7 +70,7 @@ export function useExpensesWorkspace(refetch: () => void, expenses: ExpenseRecor
     finally {
       setActionLoading(false)
     }
-  }, [postTarget, postExpense, showSuccess, showError, refetch])
+  }, [postTarget, postExpense, showSuccess, showError, refetch, dispatch])
 
   const handleConfirmDelete = useCallback(async () => {
     if (!deleteTarget) return
@@ -72,7 +79,7 @@ export function useExpensesWorkspace(refetch: () => void, expenses: ExpenseRecor
       await deleteExpense(deleteTarget.id).unwrap()
       showSuccess(`Expense ${deleteTarget.referenceNumber} deleted`)
       setDeleteTarget(null)
-      setSelected(null)
+      dispatch(setSelectedExpense(null))
       refetch()
     }
     catch (error: unknown) {
@@ -81,11 +88,9 @@ export function useExpensesWorkspace(refetch: () => void, expenses: ExpenseRecor
     finally {
       setActionLoading(false)
     }
-  }, [deleteTarget, deleteExpense, showSuccess, showError, refetch])
+  }, [deleteTarget, deleteExpense, showSuccess, showError, refetch, dispatch])
 
   return {
-    selected,
-    setSelected,
     focusedIndex: workspace.focusedIndex,
     listRef: workspace.listRef,
     searchInputRef: workspace.searchInputRef,

--- a/frontend/src/pages/accounting/hooks/useFundTransfersWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useFundTransfersWorkspace.ts
@@ -3,13 +3,19 @@ import { useNavigate } from 'react-router-dom'
 
 import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import { useNotification } from '@/hooks/useNotification'
+import type { AppDispatch } from '@/store'
 import { useCancelFundTransferMutation, useLazyGetFundTransferQuery } from '@/store/api/accountingApi'
+import { setSelectedFundTransfer } from '@/store/slices/accountingSlice'
 import type { FundTransfer } from '@/types'
 
-export function useFundTransfersWorkspace(refetch: () => void, transfers: FundTransfer[] = []) {
+export function useFundTransfersWorkspace(
+  refetch: () => void,
+  transfers: FundTransfer[] = [],
+  dispatch: AppDispatch,
+  selected: FundTransfer | null,
+) {
   const navigate = useNavigate()
   const { showError, showSuccess } = useNotification()
-  const [selected, setSelected] = useState<FundTransfer | null>(null)
   const [cancelTarget, setCancelTarget] = useState<FundTransfer | null>(null)
   const [fetchItem] = useLazyGetFundTransferQuery()
   const [cancelFundTransfer, { isLoading: cancelling }] = useCancelFundTransferMutation()
@@ -17,9 +23,10 @@ export function useFundTransfersWorkspace(refetch: () => void, transfers: FundTr
   const workspace = useEntityWorkspace<FundTransfer>({
     entities: transfers,
     selectedEntity: selected,
-    selectEntity: setSelected,
+    selectEntity: (entity) => dispatch(setSelectedFundTransfer(entity)),
     refetch,
     navigate,
+    highlightParam: 'highlight',
     routes: {
       create: '/accounting/fund-transfers',
       edit: () => '/accounting/fund-transfers',
@@ -27,7 +34,7 @@ export function useFundTransfersWorkspace(refetch: () => void, transfers: FundTr
     notifications: { showSuccess, showError },
     deleteMutation: async () => {},
     onEscape: () => {
-      setSelected(null)
+      dispatch(setSelectedFundTransfer(null))
       setCancelTarget(null)
     },
   })
@@ -35,32 +42,29 @@ export function useFundTransfersWorkspace(refetch: () => void, transfers: FundTr
   const { handleSelect: workspaceHandleSelect } = workspace
 
   const handleSelect = useCallback(async (item: FundTransfer) => {
-    setSelected(item)
     workspaceHandleSelect(item)
     try {
       const fresh = await fetchItem(item.id).unwrap()
-      setSelected(fresh)
+      dispatch(setSelectedFundTransfer(fresh))
     }
     catch { /* keep list-row data */ }
-  }, [fetchItem, workspaceHandleSelect])
+  }, [fetchItem, workspaceHandleSelect, dispatch])
 
   const handleConfirmCancel = useCallback(async () => {
     if (!cancelTarget) return
     try {
       const next = await cancelFundTransfer(cancelTarget.id).unwrap()
       showSuccess(`Transfer ${cancelTarget.referenceNumber} cancelled`)
-      setSelected(next)
+      dispatch(setSelectedFundTransfer(next))
       setCancelTarget(null)
       refetch()
     }
     catch (error: any) {
       showError(error?.data?.message ?? error?.message ?? 'Operation failed')
     }
-  }, [cancelFundTransfer, cancelTarget, refetch, showError, showSuccess])
+  }, [cancelFundTransfer, cancelTarget, refetch, showError, showSuccess, dispatch])
 
   return {
-    selected,
-    setSelected,
     focusedIndex: workspace.focusedIndex,
     listRef: workspace.listRef,
     searchInputRef: workspace.searchInputRef,

--- a/frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
@@ -37,14 +37,16 @@ export function useJournalEntriesWorkspace({ entries, refetch, dispatch, selecte
     },
   })
 
+  const { handleSelect: workspaceHandleSelect } = workspace
+
   const handleSelect = useCallback(async (entry: JournalEntry) => {
-    workspace.handleSelect(entry)
+    workspaceHandleSelect(entry)
     try {
       const fresh = await fetchEntry(entry.id).unwrap()
       dispatch(setSelectedJournalEntry(fresh))
     }
     catch { /* keep list-row data */ }
-  }, [fetchEntry, workspace, dispatch])
+  }, [fetchEntry, workspaceHandleSelect, dispatch])
 
   const navigateToSource = useCallback((sourceType: string, sourceId: string) => {
     const routes: Record<string, (id: string) => string> = {

--- a/frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
@@ -1,26 +1,30 @@
-import { useCallback, useState } from 'react'
+import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
+import type { AppDispatch } from '@/store'
 import { useLazyGetJournalEntryQuery } from '@/store/api/accountingApi'
+import { setSelectedJournalEntry } from '@/store/slices/accountingSlice'
 import { JournalEntry } from '@/types'
 
 interface UseJournalEntriesWorkspaceConfig {
   entries: JournalEntry[]
   refetch: () => void
+  dispatch: AppDispatch
+  selectedEntry: JournalEntry | null
 }
 
-export function useJournalEntriesWorkspace({ entries, refetch }: UseJournalEntriesWorkspaceConfig) {
+export function useJournalEntriesWorkspace({ entries, refetch, dispatch, selectedEntry }: UseJournalEntriesWorkspaceConfig) {
   const navigate = useNavigate()
-  const [selectedEntry, setSelectedEntry] = useState<JournalEntry | null>(null)
   const [fetchEntry] = useLazyGetJournalEntryQuery()
 
   const workspace = useEntityWorkspace<JournalEntry>({
     entities: entries,
     selectedEntity: selectedEntry,
-    selectEntity: setSelectedEntry,
+    selectEntity: (entry) => dispatch(setSelectedJournalEntry(entry)),
     refetch,
     navigate,
+    highlightParam: 'highlight',
     routes: {
       create: '/accounting/journal-entries',
       edit: () => '/accounting/journal-entries',
@@ -28,16 +32,19 @@ export function useJournalEntriesWorkspace({ entries, refetch }: UseJournalEntri
     notifications: { showSuccess: () => {}, showError: () => {} },
     deleteMutation: async () => {},
     onEnter: () => {},
+    onEscape: () => {
+      dispatch(setSelectedJournalEntry(null))
+    },
   })
 
   const handleSelect = useCallback(async (entry: JournalEntry) => {
     workspace.handleSelect(entry)
     try {
       const fresh = await fetchEntry(entry.id).unwrap()
-      setSelectedEntry(fresh)
+      dispatch(setSelectedJournalEntry(fresh))
     }
     catch { /* keep list-row data */ }
-  }, [fetchEntry, workspace])
+  }, [fetchEntry, workspace, dispatch])
 
   const navigateToSource = useCallback((sourceType: string, sourceId: string) => {
     const routes: Record<string, (id: string) => string> = {
@@ -56,7 +63,6 @@ export function useJournalEntriesWorkspace({ entries, refetch }: UseJournalEntri
 
   return {
     ...workspace,
-    selectedEntry,
     handleSelect,
     navigateToSource,
   }

--- a/frontend/src/pages/accounting/hooks/useOwnerEquityWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useOwnerEquityWorkspace.ts
@@ -3,18 +3,24 @@ import { useNavigate } from 'react-router-dom'
 
 import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import { useNotification } from '@/hooks/useNotification'
+import type { AppDispatch } from '@/store'
 import {
   useDeleteOwnerEquityTransactionMutation,
   usePostOwnerEquityTransactionMutation,
   useReverseOwnerEquityTransactionMutation,
 } from '@/store/api/accountingApi'
+import { setSelectedOwnerEquityTransaction } from '@/store/slices/accountingSlice'
 import type { OwnerEquityTransaction } from '@/types'
 
-export function useOwnerEquityWorkspace(entities: OwnerEquityTransaction[], refetch: () => void) {
+export function useOwnerEquityWorkspace(
+  entities: OwnerEquityTransaction[],
+  refetch: () => void,
+  dispatch: AppDispatch,
+  selected: OwnerEquityTransaction | null,
+) {
   const navigate = useNavigate()
   const { showSuccess, showError } = useNotification()
 
-  const [selected, setSelected] = useState<OwnerEquityTransaction | null>(null)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [postTarget, setPostTarget] = useState<OwnerEquityTransaction | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<OwnerEquityTransaction | null>(null)
@@ -27,9 +33,10 @@ export function useOwnerEquityWorkspace(entities: OwnerEquityTransaction[], refe
   const workspace = useEntityWorkspace<OwnerEquityTransaction>({
     entities,
     selectedEntity: selected,
-    selectEntity: setSelected,
+    selectEntity: (entity) => dispatch(setSelectedOwnerEquityTransaction(entity)),
     refetch,
     navigate,
+    highlightParam: 'highlight',
     routes: {
       create: '/accounting/owner-equity',
       edit: () => '/accounting/owner-equity',
@@ -39,50 +46,52 @@ export function useOwnerEquityWorkspace(entities: OwnerEquityTransaction[], refe
     onEnter: () => {
       if (selected) setDialogOpen(true)
     },
+    onEscape: () => {
+      dispatch(setSelectedOwnerEquityTransaction(null))
+    },
   })
 
   const handlePost = useCallback(async () => {
     if (!postTarget) return
     try {
       const next = await postOwnerEquityTransaction(postTarget.id).unwrap()
-      setSelected(next)
+      dispatch(setSelectedOwnerEquityTransaction(next))
       setPostTarget(null)
       showSuccess('Transaction posted')
       refetch()
     } catch (error: any) {
       showError(error?.data?.message || String(error))
     }
-  }, [postOwnerEquityTransaction, postTarget, refetch, showError, showSuccess])
+  }, [postOwnerEquityTransaction, postTarget, refetch, showError, showSuccess, dispatch])
 
   const handleDelete = useCallback(async () => {
     if (!deleteTarget) return
     try {
       await deleteOwnerEquityTransaction(deleteTarget.id).unwrap()
       showSuccess('Transaction deleted')
-      if (selected?.id === deleteTarget.id) setSelected(null)
+      if (selected?.id === deleteTarget.id) dispatch(setSelectedOwnerEquityTransaction(null))
       setDeleteTarget(null)
       refetch()
     } catch (error: any) {
       showError(error?.data?.message || String(error))
     }
-  }, [deleteOwnerEquityTransaction, deleteTarget, refetch, selected?.id, showError, showSuccess])
+  }, [deleteOwnerEquityTransaction, deleteTarget, refetch, selected?.id, showError, showSuccess, dispatch])
 
   const handleReverse = useCallback(async () => {
     if (!reverseTarget) return
     try {
       const next = await reverseOwnerEquityTransaction(reverseTarget.id).unwrap()
-      setSelected(next)
+      dispatch(setSelectedOwnerEquityTransaction(next))
       setReverseTarget(null)
       showSuccess('Transaction reversed')
       refetch()
     } catch (error: any) {
       showError(error?.data?.message || String(error))
     }
-  }, [refetch, reverseOwnerEquityTransaction, reverseTarget, showError, showSuccess])
+  }, [refetch, reverseOwnerEquityTransaction, reverseTarget, showError, showSuccess, dispatch])
 
   return {
     ...workspace,
-    selected,
     dialogOpen,
     setDialogOpen,
     postTarget,

--- a/frontend/src/pages/accounting/hooks/useOwnerEquityWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useOwnerEquityWorkspace.ts
@@ -46,9 +46,6 @@ export function useOwnerEquityWorkspace(
     onEnter: () => {
       if (selected) setDialogOpen(true)
     },
-    onEscape: () => {
-      dispatch(setSelectedOwnerEquityTransaction(null))
-    },
   })
 
   const handlePost = useCallback(async () => {

--- a/frontend/src/pages/accounting/hooks/useSettlementsWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useSettlementsWorkspace.ts
@@ -3,23 +3,30 @@ import { useNavigate } from 'react-router-dom'
 
 import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import { useNotification } from '@/hooks/useNotification'
+import type { AppDispatch } from '@/store'
 import { useCancelSettlementMutation } from '@/store/api/accountingApi'
+import { setSelectedSettlement } from '@/store/slices/accountingSlice'
 import type { Settlement } from '@/types'
 
-export function useSettlementsWorkspace(entities: Settlement[], refetch: () => void) {
+export function useSettlementsWorkspace(
+  entities: Settlement[],
+  refetch: () => void,
+  dispatch: AppDispatch,
+  selected: Settlement | null,
+) {
   const navigate = useNavigate()
   const { showSuccess, showError } = useNotification()
   const [dialogOpen, setDialogOpen] = useState(false)
   const [cancelTarget, setCancelTarget] = useState<Settlement | null>(null)
-  const [selected, setSelected] = useState<Settlement | null>(null)
   const [cancelSettlement] = useCancelSettlementMutation()
 
   const workspace = useEntityWorkspace<Settlement>({
     entities,
     selectedEntity: selected,
-    selectEntity: setSelected,
+    selectEntity: (entity) => dispatch(setSelectedSettlement(entity)),
     refetch,
     navigate,
+    highlightParam: 'highlight',
     routes: {
       create: '/accounting/settlements',
       edit: () => '/accounting/settlements',
@@ -27,24 +34,27 @@ export function useSettlementsWorkspace(entities: Settlement[], refetch: () => v
     notifications: { showSuccess: () => {}, showError: () => {} },
     deleteMutation: async () => {},
     onEnter: () => {},
+    onEscape: () => {
+      dispatch(setSelectedSettlement(null))
+      setCancelTarget(null)
+    },
   })
 
   const handleConfirmCancel = useCallback(async () => {
     if (!cancelTarget) return
     try {
       const next = await cancelSettlement(cancelTarget.id).unwrap()
-      setSelected(next)
+      dispatch(setSelectedSettlement(next))
       setCancelTarget(null)
       showSuccess('Settlement cancelled successfully')
       refetch()
     } catch (error: any) {
       showError(error?.message || String(error) || 'Failed to cancel settlement')
     }
-  }, [cancelSettlement, cancelTarget, refetch, showError, showSuccess])
+  }, [cancelSettlement, cancelTarget, refetch, showError, showSuccess, dispatch])
 
   return {
     ...workspace,
-    selected,
     dialogOpen,
     setDialogOpen,
     cancelTarget,

--- a/frontend/src/store/slices/accountingSlice.ts
+++ b/frontend/src/store/slices/accountingSlice.ts
@@ -1,14 +1,34 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 
 import type { RootState } from '@/store'
-import type { ChartOfAccount } from '@/types'
+import type {
+  BankReconciliation,
+  ChartOfAccount,
+  ExpenseRecord,
+  FundTransfer,
+  JournalEntry,
+  OwnerEquityTransaction,
+  Settlement,
+} from '@/types'
 
 interface AccountingState {
   selectedAccount: ChartOfAccount | null
+  selectedJournalEntry: JournalEntry | null
+  selectedExpense: ExpenseRecord | null
+  selectedFundTransfer: FundTransfer | null
+  selectedOwnerEquityTransaction: OwnerEquityTransaction | null
+  selectedBankReconciliation: BankReconciliation | null
+  selectedSettlement: Settlement | null
 }
 
 const initialState: AccountingState = {
   selectedAccount: null,
+  selectedJournalEntry: null,
+  selectedExpense: null,
+  selectedFundTransfer: null,
+  selectedOwnerEquityTransaction: null,
+  selectedBankReconciliation: null,
+  selectedSettlement: null,
 }
 
 const accountingSlice = createSlice({
@@ -18,10 +38,43 @@ const accountingSlice = createSlice({
     setSelectedAccount: (state, action: PayloadAction<ChartOfAccount | null>) => {
       state.selectedAccount = action.payload
     },
+    setSelectedJournalEntry: (state, action: PayloadAction<JournalEntry | null>) => {
+      state.selectedJournalEntry = action.payload
+    },
+    setSelectedExpense: (state, action: PayloadAction<ExpenseRecord | null>) => {
+      state.selectedExpense = action.payload
+    },
+    setSelectedFundTransfer: (state, action: PayloadAction<FundTransfer | null>) => {
+      state.selectedFundTransfer = action.payload
+    },
+    setSelectedOwnerEquityTransaction: (state, action: PayloadAction<OwnerEquityTransaction | null>) => {
+      state.selectedOwnerEquityTransaction = action.payload
+    },
+    setSelectedBankReconciliation: (state, action: PayloadAction<BankReconciliation | null>) => {
+      state.selectedBankReconciliation = action.payload
+    },
+    setSelectedSettlement: (state, action: PayloadAction<Settlement | null>) => {
+      state.selectedSettlement = action.payload
+    },
   },
 })
 
-export const { setSelectedAccount } = accountingSlice.actions
-export const selectSelectedAccount = (state: RootState) => state.accounting.selectedAccount
-export default accountingSlice.reducer
+export const {
+  setSelectedAccount,
+  setSelectedJournalEntry,
+  setSelectedExpense,
+  setSelectedFundTransfer,
+  setSelectedOwnerEquityTransaction,
+  setSelectedBankReconciliation,
+  setSelectedSettlement,
+} = accountingSlice.actions
 
+export const selectSelectedAccount = (state: RootState) => state.accounting.selectedAccount
+export const selectSelectedJournalEntry = (state: RootState) => state.accounting.selectedJournalEntry
+export const selectSelectedExpense = (state: RootState) => state.accounting.selectedExpense
+export const selectSelectedFundTransfer = (state: RootState) => state.accounting.selectedFundTransfer
+export const selectSelectedOwnerEquityTransaction = (state: RootState) => state.accounting.selectedOwnerEquityTransaction
+export const selectSelectedBankReconciliation = (state: RootState) => state.accounting.selectedBankReconciliation
+export const selectSelectedSettlement = (state: RootState) => state.accounting.selectedSettlement
+
+export default accountingSlice.reducer


### PR DESCRIPTION
## Summary

- Expands `accountingSlice` with 6 new entity selections (Journal Entries, Expenses, Fund Transfers, Owner's Equity, Bank Reconciliations, Settlements)
- Migrates all 6 workspace hooks from local `useState` to Redux dispatch, matching the Sales/Purchasing selection pattern
- Adds `?highlight=ID` URL param support to all 6 pages via `highlightParam: 'highlight'` in `useEntityWorkspace`
- Updates page and integration tests with Redux store wrappers and deep-link selection coverage

Closes #521

## Test plan

- [x] `cd frontend && npm run lint` passed
- [x] `cd frontend && npm run type-check` passed
- [x] `cd frontend && npx vitest run src/pages/accounting/__tests__/JournalEntriesPage.test.tsx src/pages/accounting/__tests__/ExpensesPage.test.tsx src/pages/accounting/__tests__/FundTransfersPage.test.tsx src/pages/accounting/__tests__/OwnerEquityPage.test.tsx src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx src/pages/accounting/__tests__/SettlementsPage.test.tsx src/__tests__/integration/accounting-auto-posting.integration.test.tsx` passed: 7 files, 50 tests
- [x] `cd frontend && timeout 900s npm run test` passed: 154 files, 984 tests