### PR TITLE
fix(accounting): workspace hook consistency cleanup (issue #523)

### DIFF
--- a/frontend/src/hooks/useEntityWorkspace.test.ts
+++ b/frontend/src/hooks/useEntityWorkspace.test.ts
@@ -183,6 +183,22 @@ describe('useEntityWorkspace', () => {
     expect(result.current.deleteConfirmOpen).toBe(false)
   })
 
+  it('handleDelete returns without side effects when deleteMutation is omitted', async () => {
+    const { deleteMutation, notifications, ...config } = makeConfig({
+      selectedEntity: makeEntity('1'),
+    })
+    const { result } = renderHook(() => useEntityWorkspace(config), {
+      wrapper: makeWrapper('/entities'),
+    })
+
+    await act(async () => {
+      await result.current.handleDelete()
+    })
+
+    expect(config.refetch).not.toHaveBeenCalled()
+    expect(config.selectEntity).not.toHaveBeenCalledWith(null)
+  })
+
   it('uses custom enter action instead of navigating to edit route', () => {
     const onEnter = vi.fn()
     const config = makeConfig({

--- a/frontend/src/hooks/useEntityWorkspace.ts
+++ b/frontend/src/hooks/useEntityWorkspace.ts
@@ -15,11 +15,11 @@ export interface UseEntityWorkspaceConfig<T extends { id: string }> {
     create: string
     edit: (id: string) => string
   }
-  notifications: {
+  notifications?: {
     showSuccess: (message: string) => void
     showError: (message: string) => void
   }
-  deleteMutation: (id: string) => Promise<void>
+  deleteMutation?: (id: string) => Promise<void>
   onEnter?: () => void
   onEscape?: () => void
   highlightParam?: string
@@ -298,17 +298,20 @@ export function useEntityWorkspace<T extends { id: string }>(
     if (!selectedEntity) {
       return
     }
+    if (!deleteMutation) {
+      return
+    }
 
     try {
       await deleteMutation(selectedEntity.id)
-      notifications.showSuccess('Deleted successfully')
+      notifications?.showSuccess('Deleted successfully')
       selectEntity(null)
       setFocusedIndex(-1)
       setDeleteConfirmOpen(false)
       refetch()
     } catch (error: any) {
       const message = error?.data?.message || error?.message || 'An unexpected error occurred.'
-      notifications.showError(message)
+      notifications?.showError(message)
     }
   }, [deleteMutation, notifications, refetch, selectEntity, selectedEntity])
 

--- a/frontend/src/pages/accounting/hooks/useBankReconciliationsWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useBankReconciliationsWorkspace.ts
@@ -13,7 +13,7 @@ import {
   useUnmarkBankReconciliationClearedMutation,
 } from '@/store/api/accountingApi'
 import { setSelectedBankReconciliation } from '@/store/slices/accountingSlice'
-import { BankReconciliation, ReconciledTransaction } from '@/types'
+import type { BankReconciliation, ReconciledTransaction } from '@/types'
 import { getErrorMessage } from '@/utils/errorMessage'
 
 interface UseBankReconciliationsWorkspaceConfig {
@@ -55,7 +55,6 @@ export function useBankReconciliationsWorkspace({
       edit: () => '/accounting/bank-reconciliations',
     },
     notifications: { showSuccess, showError },
-    deleteMutation: async () => {},
     onEnter: () => {},
     onEscape: () => {
       dispatch(setSelectedBankReconciliation(null))

--- a/frontend/src/pages/accounting/hooks/useExpensesWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useExpensesWorkspace.ts
@@ -41,9 +41,6 @@ export function useExpensesWorkspace(
       edit: () => '/accounting/expenses',
     },
     notifications: { showSuccess, showError },
-    deleteMutation: async (id) => {
-      await deleteExpense(id).unwrap()
-    },
     onEnter: () => {
       if (selected) setFormOpen(true)
     },

--- a/frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useJournalEntriesWorkspace.ts
@@ -5,7 +5,7 @@ import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import type { AppDispatch } from '@/store'
 import { useLazyGetJournalEntryQuery } from '@/store/api/accountingApi'
 import { setSelectedJournalEntry } from '@/store/slices/accountingSlice'
-import { JournalEntry } from '@/types'
+import type { JournalEntry } from '@/types'
 
 interface UseJournalEntriesWorkspaceConfig {
   entries: JournalEntry[]
@@ -29,8 +29,6 @@ export function useJournalEntriesWorkspace({ entries, refetch, dispatch, selecte
       create: '/accounting/journal-entries',
       edit: () => '/accounting/journal-entries',
     },
-    notifications: { showSuccess: () => {}, showError: () => {} },
-    deleteMutation: async () => {},
     onEnter: () => {},
     onEscape: () => {
       dispatch(setSelectedJournalEntry(null))

--- a/frontend/src/pages/accounting/hooks/useOwnerEquityWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useOwnerEquityWorkspace.ts
@@ -41,8 +41,6 @@ export function useOwnerEquityWorkspace(
       create: '/accounting/owner-equity',
       edit: () => '/accounting/owner-equity',
     },
-    notifications: { showSuccess: () => {}, showError: () => {} },
-    deleteMutation: async () => {},
     onEnter: () => {
       if (selected) setDialogOpen(true)
     },

--- a/frontend/src/pages/accounting/hooks/useSettlementsWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useSettlementsWorkspace.ts
@@ -31,8 +31,6 @@ export function useSettlementsWorkspace(
       create: '/accounting/settlements',
       edit: () => '/accounting/settlements',
     },
-    notifications: { showSuccess: () => {}, showError: () => {} },
-    deleteMutation: async () => {},
     onEnter: () => {},
     onEscape: () => {
       dispatch(setSelectedSettlement(null))

--- a/frontend/src/pages/sales/hooks/useInvoicesWorkspace.ts
+++ b/frontend/src/pages/sales/hooks/useInvoicesWorkspace.ts
@@ -72,11 +72,6 @@ export function useInvoicesWorkspace({
       create: '/sales/invoices/create',
       edit: (id) => `/sales/invoices/${id}/edit`,
     },
-    notifications: {
-      showSuccess: () => {},
-      showError: () => {},
-    },
-    deleteMutation: async () => {},
     onEnter: () => {},
     onEscape: () => {
       workspaceRef.current?.setFocusedIndex(-1)

--- a/frontend/src/pages/sales/hooks/useOrdersWorkspace.ts
+++ b/frontend/src/pages/sales/hooks/useOrdersWorkspace.ts
@@ -89,8 +89,6 @@ export function useOrdersWorkspace({
       create: '/sales/orders/create',
       edit: (id) => `/sales/orders/${id}/edit`,
     },
-    notifications: { showSuccess: () => {}, showError: () => {} },
-    deleteMutation: async () => {},
     isLoading: ordersLoading,
     onEnter: () => {
       if (workspaceRef.current?.focusedIndex != null && workspaceRef.current.focusedIndex >= 0) {

--- a/frontend/src/pages/sales/hooks/usePaymentsWorkspace.ts
+++ b/frontend/src/pages/sales/hooks/usePaymentsWorkspace.ts
@@ -87,8 +87,6 @@ export function usePaymentsWorkspace({
       create: '/sales/payments/create',
       edit: (id) => `/sales/payments/${id}/edit`,
     },
-    notifications: { showSuccess: () => {}, showError: () => {} },
-    deleteMutation: async () => {},
     onEnter: () => {},
   })
   const { focusedIndex } = workspace


### PR DESCRIPTION
## Summary

- Convert value imports to `import type` for type-only symbols in `useBankReconciliationsWorkspace` and `useJournalEntriesWorkspace`
- Remove dead `deleteMutation` wiring from `useExpensesWorkspace` (delete flow owned by `handleConfirmDelete`)
- Make `notifications` and `deleteMutation` optional in `useEntityWorkspace`; remove no-op stubs from hooks across accounting and sales modules
- Add regression coverage for omitted `deleteMutation` in `useEntityWorkspace`

Closes #523

## Verification

- `cd frontend && npx vitest run src/hooks/useEntityWorkspace.test.ts` - passed, 19 tests
- `cd frontend && npm run type-check` - passed after each plan task and final verification
- `cd frontend && npm run lint` - passed
- `cd frontend && npx vitest run src/hooks/useEntityWorkspace.test.ts src/pages/accounting/hooks/useChartOfAccountsWorkspace.test.tsx src/pages/sales/hooks/useOrdersWorkspace.test.tsx src/pages/sales/hooks/useInvoicesWorkspace.test.tsx src/pages/sales/hooks/usePaymentsWorkspace.test.tsx` - passed, 5 files / 40 tests
- `cd frontend && npm run test` - passed, 154 files / 985 tests