### PR TITLE
fix(purchasing): remove notification and deleteMutation stubs from purchasing workspace hooks

### DIFF
--- a/frontend/src/pages/purchasing/hooks/useGRNWorkspace.ts
+++ b/frontend/src/pages/purchasing/hooks/useGRNWorkspace.ts
@@ -39,8 +39,6 @@ export function useGRNWorkspace({
       create: '/purchasing/grn/create',
       edit: (id) => `/purchasing/grn/${id}/edit`,
     },
-    notifications: { showSuccess: () => {}, showError: () => {} },
-    deleteMutation: async () => {},
   })
 
   const grnSources = useMemo(

--- a/frontend/src/pages/purchasing/hooks/useVendorPaymentsWorkspace.ts
+++ b/frontend/src/pages/purchasing/hooks/useVendorPaymentsWorkspace.ts
@@ -37,8 +37,6 @@ export function useVendorPaymentsWorkspace({
       create: '/purchasing/vendor-payments/create',
       edit: (id) => `/purchasing/vendor-payments/${id}/edit`,
     },
-    notifications: { showSuccess: () => {}, showError: () => {} },
-    deleteMutation: async () => {},
   })
 
   const vpSources = useMemo(


### PR DESCRIPTION
Follow-on cleanup from #524. Removes the same no-op `notifications` and `deleteMutation` stub props from the two remaining purchasing hooks that were out of scope for #523.

Both hooks own their own delete/error flow and never invoke the built-in `useEntityWorkspace` delete path, so the stubs were inert.

Closes #525