### PR TITLE
feat(accounting): refactor Fiscal Periods to gold standard UI/UX pattern

### DIFF
--- a/frontend/src/pages/accounting/FiscalPeriodsPage.tsx
+++ b/frontend/src/pages/accounting/FiscalPeriodsPage.tsx
@@ -5,7 +5,7 @@ import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
 import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import { useGetFiscalPeriodsQuery } from '@/store/api/accountingApi'
-import { selectSelectedFiscalPeriod } from '@/store/slices/accountingSlice'
+import { selectSelectedFiscalPeriod, setSelectedFiscalPeriod } from '@/store/slices/accountingSlice'
 import { FiscalPeriodStatus } from '@/types'
 import type { FilterBarConfig } from '@/types/filterBar.types'
 
@@ -50,7 +50,7 @@ const FiscalPeriodsPage: React.FC = () => {
       <GenericListPage
         title="Fiscal Periods"
         subtitle="Manage accounting periods and year boundaries"
-        primaryAction={{ label: 'Add Period', onClick: () => { workspace.setFormDialogOpen(true) } }}
+        primaryAction={{ label: 'Add Period', onClick: () => { dispatch(setSelectedFiscalPeriod(null)); workspace.setFormDialogOpen(true) } }}
         secondaryAction={{ label: 'Generate Periods', onClick: () => workspace.setGenerateDialogOpen(true) }}
         filterConfig={filterConfig}
         draftFilters={draftFilters}

--- a/frontend/src/pages/accounting/FiscalPeriodsPage.tsx
+++ b/frontend/src/pages/accounting/FiscalPeriodsPage.tsx
@@ -3,7 +3,9 @@ import React, { useMemo } from 'react'
 import AccountMappingWarning from '@/components/accounting/AccountMappingWarning'
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import { useGetFiscalPeriodsQuery } from '@/store/api/accountingApi'
+import { selectSelectedFiscalPeriod } from '@/store/slices/accountingSlice'
 import { FiscalPeriodStatus } from '@/types'
 import type { FilterBarConfig } from '@/types/filterBar.types'
 
@@ -26,9 +28,21 @@ const filterConfig: FilterBarConfig<FiscalPeriodFilters> = {
 
 const FiscalPeriodsPage: React.FC = () => {
   const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
-  const { data: periodsResponse, isLoading, refetch } = useGetFiscalPeriodsQuery({ page: 1, sortBy: 'startDate', sortOrder: 'DESC', status: appliedFilters.status ? appliedFilters.status.toUpperCase() as FiscalPeriodStatus : undefined, search: appliedFilters.search || undefined })
+
+  const queryParams = useMemo(() => ({
+    page: 1,
+    sortBy: 'startDate',
+    sortOrder: 'DESC' as const,
+    status: appliedFilters.status ? appliedFilters.status.toUpperCase() as FiscalPeriodStatus : undefined,
+    search: appliedFilters.search || undefined,
+  }), [appliedFilters.search, appliedFilters.status])
+
+  const { data: periodsResponse, isLoading, refetch } = useGetFiscalPeriodsQuery(queryParams)
   const periods = periodsResponse?.data ?? []
-  const workspace = useFiscalPeriodsWorkspace(() => { void refetch() })
+
+  const dispatch = useAppDispatch()
+  const selected = useAppSelector(selectSelectedFiscalPeriod)
+  const workspace = useFiscalPeriodsWorkspace(() => { void refetch() }, periods, dispatch, selected)
 
   return (
     <>
@@ -36,7 +50,7 @@ const FiscalPeriodsPage: React.FC = () => {
       <GenericListPage
         title="Fiscal Periods"
         subtitle="Manage accounting periods and year boundaries"
-        primaryAction={{ label: 'Add Period', onClick: () => { workspace.setSelected(null); workspace.setFormDialogOpen(true) } }}
+        primaryAction={{ label: 'Add Period', onClick: () => { workspace.setFormDialogOpen(true) } }}
         secondaryAction={{ label: 'Generate Periods', onClick: () => workspace.setGenerateDialogOpen(true) }}
         filterConfig={filterConfig}
         draftFilters={draftFilters}
@@ -44,10 +58,47 @@ const FiscalPeriodsPage: React.FC = () => {
         hasActiveFilters={hasActiveFilters}
         searchInputRef={workspace.searchInputRef}
         sort={{ field: 'startDate', sortBy: 'startDate', sortOrder: 'desc', onSort: () => {} }}
-        listSlot={<FiscalPeriodsTable periods={periods} loading={isLoading} selectedId={workspace.selected?.id ?? null} onSelect={workspace.setSelected} listRef={workspace.listRef} />}
-        headerSlot={<FiscalPeriodContextHeader selected={workspace.selected} onClose={() => workspace.selected && workspace.setCloseTarget(workspace.selected)} onReopen={() => workspace.selected && workspace.setReopenTarget(workspace.selected)} onEdit={() => workspace.setFormDialogOpen(true)} onDelete={() => workspace.selected && workspace.setDeleteTarget(workspace.selected)} />}
-        workspaceSlot={<FiscalPeriodWorkspaceCard selected={workspace.selected} />}
-        dialogs={<FiscalPeriodsDialogs formDialogOpen={workspace.formDialogOpen} selected={workspace.selected} onCloseForm={() => workspace.setFormDialogOpen(false)} onFormSuccess={() => { workspace.setFormDialogOpen(false); void refetch() }} generateDialogOpen={workspace.generateDialogOpen} onCloseGenerate={() => workspace.setGenerateDialogOpen(false)} onGenerate={workspace.handleGenerate} deleteTarget={workspace.deleteTarget} closeTarget={workspace.closeTarget} reopenTarget={workspace.reopenTarget} onConfirmDelete={() => void workspace.handleDelete()} onConfirmClose={() => void workspace.handleClose()} onConfirmReopen={() => void workspace.handleReopen()} onCancelDelete={() => workspace.setDeleteTarget(null)} onCancelClose={() => workspace.setCloseTarget(null)} onCancelReopen={() => workspace.setReopenTarget(null)} />}
+        listSlot={(
+          <FiscalPeriodsTable
+            periods={periods}
+            loading={isLoading}
+            total={periodsResponse?.meta?.total ?? periods.length}
+            selectedId={selected?.id ?? null}
+            focusedIndex={workspace.focusedIndex}
+            onSelect={workspace.handleSelect}
+            listRef={workspace.listRef}
+          />
+        )}
+        headerSlot={(
+          <FiscalPeriodContextHeader
+            selected={selected}
+            onClose={() => selected && workspace.setCloseTarget(selected)}
+            onReopen={() => selected && workspace.setReopenTarget(selected)}
+            onEdit={() => workspace.setFormDialogOpen(true)}
+            onDelete={() => selected && workspace.setDeleteTarget(selected)}
+          />
+        )}
+        workspaceSlot={<FiscalPeriodWorkspaceCard selected={selected} />}
+        dialogs={(
+          <FiscalPeriodsDialogs
+            formDialogOpen={workspace.formDialogOpen}
+            selected={selected}
+            onCloseForm={() => workspace.setFormDialogOpen(false)}
+            onFormSuccess={() => { workspace.setFormDialogOpen(false); void refetch() }}
+            generateDialogOpen={workspace.generateDialogOpen}
+            onCloseGenerate={() => workspace.setGenerateDialogOpen(false)}
+            onGenerate={workspace.handleGenerate}
+            deleteTarget={workspace.deleteTarget}
+            closeTarget={workspace.closeTarget}
+            reopenTarget={workspace.reopenTarget}
+            onConfirmDelete={() => void workspace.handleDelete()}
+            onConfirmClose={() => void workspace.handleClose()}
+            onConfirmReopen={() => void workspace.handleReopen()}
+            onCancelDelete={() => workspace.setDeleteTarget(null)}
+            onCancelClose={() => workspace.setCloseTarget(null)}
+            onCancelReopen={() => workspace.setReopenTarget(null)}
+          />
+        )}
       />
     </>
   )

--- a/frontend/src/pages/accounting/__tests__/FiscalPeriodsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/FiscalPeriodsPage.test.tsx
@@ -15,15 +15,48 @@ const mockedApi = vi.hoisted(() => ({
   useUpdateFiscalPeriodMutation: vi.fn(),
 }))
 
+const mockDispatch = vi.fn()
+
 vi.mock('@/store/api/accountingApi', () => mockedApi)
 vi.mock('@/hooks/useNotification', () => ({ useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }) }))
 vi.mock('@/components/accounting/AccountMappingWarning', () => ({ default: () => null }))
 vi.mock('@/utils/formatters', async () => await vi.importActual('@/utils/formatters'))
+vi.mock('@/hooks/useRedux', () => ({
+  useAppDispatch: () => mockDispatch,
+  useAppSelector: () => null,
+}))
+vi.mock('@/hooks/useEntityWorkspace', () => ({
+  useEntityWorkspace: () => ({
+    focusedIndex: -1,
+    listRef: { current: null },
+    searchInputRef: { current: null },
+    handleSelect: vi.fn(),
+  }),
+}))
 
 describe('FiscalPeriodsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockedApi.useGetFiscalPeriodsQuery.mockReturnValue({ data: { data: [{ id: '1', code: '2026-01', name: 'January 2026', startDate: '2026-01-01T00:00:00Z', endDate: '2026-01-31T00:00:00Z', status: FiscalPeriodStatus.OPEN, isOpen: true, isClosed: false, durationDays: 31, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' }] }, isLoading: false, refetch: vi.fn() })
+    mockedApi.useGetFiscalPeriodsQuery.mockReturnValue({
+      data: {
+        data: [{
+          id: '1',
+          code: '2026-01',
+          name: 'January 2026',
+          startDate: '2026-01-01T00:00:00Z',
+          endDate: '2026-01-31T00:00:00Z',
+          status: FiscalPeriodStatus.OPEN,
+          isOpen: true,
+          isClosed: false,
+          durationDays: 31,
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        }],
+        meta: { total: 1 },
+      },
+      isLoading: false,
+      refetch: vi.fn(),
+    })
     mockedApi.useDeleteFiscalPeriodMutation.mockReturnValue([vi.fn()])
     mockedApi.useCloseFiscalPeriodMutation.mockReturnValue([vi.fn()])
     mockedApi.useReopenFiscalPeriodMutation.mockReturnValue([vi.fn()])

--- a/frontend/src/pages/accounting/components/FiscalPeriodsTable.tsx
+++ b/frontend/src/pages/accounting/components/FiscalPeriodsTable.tsx
@@ -1,47 +1,35 @@
-import type { RefObject } from 'react'
-import { Chip, CircularProgress, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from '@mui/material'
-import { format } from 'date-fns'
+import React from 'react'
 
-import { TABLE_STYLES } from '@/constants/tableStyles'
-import { FiscalPeriod, FiscalPeriodStatus } from '@/types'
+import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
+import type { FiscalPeriod } from '@/types'
+
+const COLUMNS: ColumnConfig<FiscalPeriod>[] = [
+  { key: 'code', render: (period) => period.code },
+]
 
 interface Props {
   periods: FiscalPeriod[]
   loading: boolean
+  total: number
   selectedId: string | null
-  onSelect: (item: FiscalPeriod) => void
-  listRef?: RefObject<HTMLDivElement | null>
+  focusedIndex: number
+  onSelect: (period: FiscalPeriod) => void
+  listRef: React.RefObject<HTMLDivElement | null>
 }
 
-export function FiscalPeriodsTable({ periods, loading, selectedId, onSelect, listRef }: Props) {
+export function FiscalPeriodsTable({ periods, loading, total, selectedId, focusedIndex, onSelect, listRef }: Props) {
   return (
-    <Paper ref={listRef} sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
-        <Table size={TABLE_STYLES.size} stickyHeader>
-          <TableHead>
-            <TableRow>
-              <TableCell sx={{ fontWeight: 600 }}>Code</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Name</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Range</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Status</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {loading ? (
-              <TableRow><TableCell colSpan={4} align="center" sx={{ py: 4 }}><CircularProgress /></TableCell></TableRow>
-            ) : periods.length === 0 ? (
-              <TableRow><TableCell colSpan={4} align="center" sx={{ py: 4 }}><Typography variant="body2" color="text.secondary">No fiscal periods found</Typography></TableCell></TableRow>
-            ) : periods.map((period) => (
-              <TableRow key={period.id} hover selected={period.id === selectedId} onClick={() => onSelect(period)} sx={{ cursor: 'pointer', height: TABLE_STYLES.row.height }}>
-                <TableCell>{period.code}</TableCell>
-                <TableCell>{period.name}</TableCell>
-                <TableCell>{format(new Date(period.startDate), 'yyyy-MM-dd')} - {format(new Date(period.endDate), 'yyyy-MM-dd')}</TableCell>
-                <TableCell><Chip size="small" label={period.status} color={period.status === FiscalPeriodStatus.OPEN ? 'success' : 'error'} /></TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </Paper>
+    <EntityTable
+      rows={periods}
+      columns={COLUMNS}
+      loading={loading}
+      total={total}
+      label="Fiscal Periods List"
+      selectedId={selectedId ?? undefined}
+      focusedIndex={focusedIndex}
+      onSelect={onSelect}
+      listRef={listRef}
+      dataAttr="period"
+    />
   )
 }

--- a/frontend/src/pages/accounting/hooks/useFiscalPeriodsWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useFiscalPeriodsWorkspace.ts
@@ -1,24 +1,58 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
+import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import { useNotification } from '@/hooks/useNotification'
-import { useCloseFiscalPeriodMutation, useDeleteFiscalPeriodMutation, useGenerateFiscalPeriodsMutation, useReopenFiscalPeriodMutation } from '@/store/api/accountingApi'
-import { FiscalPeriod } from '@/types'
+import type { AppDispatch } from '@/store'
+import {
+  useCloseFiscalPeriodMutation,
+  useDeleteFiscalPeriodMutation,
+  useGenerateFiscalPeriodsMutation,
+  useReopenFiscalPeriodMutation,
+} from '@/store/api/accountingApi'
+import { setSelectedFiscalPeriod } from '@/store/slices/accountingSlice'
+import type { FiscalPeriod } from '@/types'
 import { getErrorMessage } from '@/utils/errorMessage'
 
-export function useFiscalPeriodsWorkspace(refetch: () => void) {
+export function useFiscalPeriodsWorkspace(
+  refetch: () => void,
+  periods: FiscalPeriod[],
+  dispatch: AppDispatch,
+  selected: FiscalPeriod | null,
+) {
+  const navigate = useNavigate()
   const { showSuccess, showError } = useNotification()
-  const [selected, setSelected] = useState<FiscalPeriod | null>(null)
+
   const [formDialogOpen, setFormDialogOpen] = useState(false)
   const [generateDialogOpen, setGenerateDialogOpen] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<FiscalPeriod | null>(null)
   const [closeTarget, setCloseTarget] = useState<FiscalPeriod | null>(null)
   const [reopenTarget, setReopenTarget] = useState<FiscalPeriod | null>(null)
-  const searchInputRef = useRef<HTMLInputElement | null>(null)
-  const listRef = useRef<HTMLDivElement | null>(null)
+
   const [deleteFiscalPeriod] = useDeleteFiscalPeriodMutation()
   const [closeFiscalPeriod] = useCloseFiscalPeriodMutation()
   const [reopenFiscalPeriod] = useReopenFiscalPeriodMutation()
   const [generateFiscalPeriods] = useGenerateFiscalPeriodsMutation()
+
+  const workspace = useEntityWorkspace<FiscalPeriod>({
+    entities: periods,
+    selectedEntity: selected,
+    selectEntity: (entity) => dispatch(setSelectedFiscalPeriod(entity)),
+    refetch,
+    navigate,
+    routes: {
+      create: '/accounting/fiscal-periods',
+      edit: () => '/accounting/fiscal-periods',
+    },
+    onEnter: () => {
+      if (selected) setFormDialogOpen(true)
+    },
+    onEscape: () => {
+      dispatch(setSelectedFiscalPeriod(null))
+      setCloseTarget(null)
+      setReopenTarget(null)
+    },
+  })
 
   const handleDelete = useCallback(async () => {
     if (!deleteTarget) return
@@ -26,40 +60,40 @@ export function useFiscalPeriodsWorkspace(refetch: () => void) {
       await deleteFiscalPeriod(deleteTarget.id).unwrap()
       showSuccess(`Period "${deleteTarget.name}" deleted successfully`)
       setDeleteTarget(null)
-      if (selected?.id === deleteTarget.id) setSelected(null)
+      if (selected?.id === deleteTarget.id) dispatch(setSelectedFiscalPeriod(null))
       refetch()
     } catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to delete period'))
     }
-  }, [deleteFiscalPeriod, deleteTarget, refetch, selected?.id, showError, showSuccess])
+  }, [deleteFiscalPeriod, deleteTarget, dispatch, refetch, selected?.id, showError, showSuccess])
 
   const handleClose = useCallback(async () => {
     if (!closeTarget) return
     try {
       const next = await closeFiscalPeriod(closeTarget.id).unwrap()
       showSuccess(`Period "${closeTarget.name}" closed successfully`)
-      setSelected(next)
+      dispatch(setSelectedFiscalPeriod(next))
       setCloseTarget(null)
       refetch()
     } catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to close period'))
       setCloseTarget(null)
     }
-  }, [closeFiscalPeriod, closeTarget, refetch, showError, showSuccess])
+  }, [closeFiscalPeriod, closeTarget, dispatch, refetch, showError, showSuccess])
 
   const handleReopen = useCallback(async () => {
     if (!reopenTarget) return
     try {
       const next = await reopenFiscalPeriod(reopenTarget.id).unwrap()
       showSuccess(`Period "${reopenTarget.name}" reopened successfully`)
-      setSelected(next)
+      dispatch(setSelectedFiscalPeriod(next))
       setReopenTarget(null)
       refetch()
     } catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to reopen period'))
       setReopenTarget(null)
     }
-  }, [refetch, reopenFiscalPeriod, reopenTarget, showError, showSuccess])
+  }, [dispatch, refetch, reopenFiscalPeriod, reopenTarget, showError, showSuccess])
 
   const handleGenerate = useCallback(async (year: number, startMonth: number) => {
     try {
@@ -72,5 +106,24 @@ export function useFiscalPeriodsWorkspace(refetch: () => void) {
     }
   }, [generateFiscalPeriods, refetch, showError, showSuccess])
 
-  return { selected, setSelected, formDialogOpen, setFormDialogOpen, generateDialogOpen, setGenerateDialogOpen, deleteTarget, setDeleteTarget, closeTarget, setCloseTarget, reopenTarget, setReopenTarget, searchInputRef, listRef, handleDelete, handleClose, handleReopen, handleGenerate }
+  return {
+    focusedIndex: workspace.focusedIndex,
+    listRef: workspace.listRef,
+    searchInputRef: workspace.searchInputRef,
+    handleSelect: workspace.handleSelect,
+    formDialogOpen,
+    setFormDialogOpen,
+    generateDialogOpen,
+    setGenerateDialogOpen,
+    deleteTarget,
+    setDeleteTarget,
+    closeTarget,
+    setCloseTarget,
+    reopenTarget,
+    setReopenTarget,
+    handleDelete,
+    handleClose,
+    handleReopen,
+    handleGenerate,
+  }
 }

--- a/frontend/src/pages/accounting/hooks/useFiscalPeriodsWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useFiscalPeriodsWorkspace.ts
@@ -51,6 +51,7 @@ export function useFiscalPeriodsWorkspace(
       dispatch(setSelectedFiscalPeriod(null))
       setCloseTarget(null)
       setReopenTarget(null)
+      setDeleteTarget(null)
     },
   })
 

--- a/frontend/src/store/slices/accountingSlice.ts
+++ b/frontend/src/store/slices/accountingSlice.ts
@@ -5,6 +5,7 @@ import type {
   BankReconciliation,
   ChartOfAccount,
   ExpenseRecord,
+  FiscalPeriod,
   FundTransfer,
   JournalEntry,
   OwnerEquityTransaction,
@@ -15,6 +16,7 @@ interface AccountingState {
   selectedAccount: ChartOfAccount | null
   selectedJournalEntry: JournalEntry | null
   selectedExpense: ExpenseRecord | null
+  selectedFiscalPeriod: FiscalPeriod | null
   selectedFundTransfer: FundTransfer | null
   selectedOwnerEquityTransaction: OwnerEquityTransaction | null
   selectedBankReconciliation: BankReconciliation | null
@@ -25,6 +27,7 @@ const initialState: AccountingState = {
   selectedAccount: null,
   selectedJournalEntry: null,
   selectedExpense: null,
+  selectedFiscalPeriod: null,
   selectedFundTransfer: null,
   selectedOwnerEquityTransaction: null,
   selectedBankReconciliation: null,
@@ -43,6 +46,9 @@ const accountingSlice = createSlice({
     },
     setSelectedExpense: (state, action: PayloadAction<ExpenseRecord | null>) => {
       state.selectedExpense = action.payload
+    },
+    setSelectedFiscalPeriod: (state, action: PayloadAction<FiscalPeriod | null>) => {
+      state.selectedFiscalPeriod = action.payload
     },
     setSelectedFundTransfer: (state, action: PayloadAction<FundTransfer | null>) => {
       state.selectedFundTransfer = action.payload
@@ -63,6 +69,7 @@ export const {
   setSelectedAccount,
   setSelectedJournalEntry,
   setSelectedExpense,
+  setSelectedFiscalPeriod,
   setSelectedFundTransfer,
   setSelectedOwnerEquityTransaction,
   setSelectedBankReconciliation,
@@ -72,6 +79,7 @@ export const {
 export const selectSelectedAccount = (state: RootState) => state.accounting.selectedAccount
 export const selectSelectedJournalEntry = (state: RootState) => state.accounting.selectedJournalEntry
 export const selectSelectedExpense = (state: RootState) => state.accounting.selectedExpense
+export const selectSelectedFiscalPeriod = (state: RootState) => state.accounting.selectedFiscalPeriod
 export const selectSelectedFundTransfer = (state: RootState) => state.accounting.selectedFundTransfer
 export const selectSelectedOwnerEquityTransaction = (state: RootState) => state.accounting.selectedOwnerEquityTransaction
 export const selectSelectedBankReconciliation = (state: RootState) => state.accounting.selectedBankReconciliation


### PR DESCRIPTION
## Summary

- Add `selectedFiscalPeriod` to `accountingSlice` (Redux selection state)
- Rewrite `useFiscalPeriodsWorkspace` to wrap `useEntityWorkspace` — matching the `useExpensesWorkspace` pattern used by all other accounting pages
- Update `FiscalPeriodsPage` to use Redux dispatch/selector; extract `queryParams` into `useMemo` to prevent spurious refetches
- Replace manual 4-column `<Table>` in `FiscalPeriodsTable` with `EntityTable` (single `code` column)
- Fix "Add Period" regression: clears Redux selection before opening form (ensures create mode)
- Fix Escape handler: now clears `deleteTarget` alongside `closeTarget`/`reopenTarget`

Closes #530

## Test Plan

- [ ] Period codes render in single-column list
- [ ] Clicking a row selects it and populates context header + workspace card
- [ ] Arrow Up/Down navigates between periods
- [ ] Enter opens the Edit dialog
- [ ] Escape clears selection and all dialog targets
- [ ] "Add Period" always opens in create mode (even when a row is highlighted)
- [ ] Close, Reopen, Edit, Delete all work from the context header
- [ ] "Generate Periods" dialog works and refreshes the list
- [ ] First period auto-selects on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)