### PR TITLE
feat(accounting): refactor Account Mappings page to gold standard workspace pattern

### DIFF
--- a/frontend/src/__tests__/integration/accounting-auto-posting.integration.test.tsx
+++ b/frontend/src/__tests__/integration/accounting-auto-posting.integration.test.tsx
@@ -66,7 +66,12 @@ const createUser = () => {
 }
 
 const renderWithRouter = (component: React.ReactElement) => {
-  return render(<BrowserRouter>{component}</BrowserRouter>)
+  const store = configureStore({ reducer: { accounting: accountingReducer } })
+  return render(
+    <Provider store={store}>
+      <BrowserRouter>{component}</BrowserRouter>
+    </Provider>,
+  )
 }
 
 const renderJournalEntriesPage = (initialEntryUrl = '/accounting/journal-entries') => {

--- a/frontend/src/pages/accounting/AccountMappingsPage.tsx
+++ b/frontend/src/pages/accounting/AccountMappingsPage.tsx
@@ -1,16 +1,17 @@
 import React, { useMemo } from 'react'
 import { Alert } from '@mui/material'
-import { AppButton } from '@/components/common/AppButton'
 
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
+import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import { useGetAccountMappingsQuery, useGetPaymentMethodsQuery, useValidateAccountMappingsQuery } from '@/store/api/accountingApi'
-import type { FilterBarConfig } from '@/types/filterBar.types'
+import { selectSelectedAccountMapping } from '@/store/slices/accountingSlice'
 import { MappingType, type AccountMapping } from '@/types/accountMapping'
+import type { FilterBarConfig } from '@/types/filterBar.types'
 
 import { AccountMappingContextHeader } from './components/AccountMappingContextHeader'
 import { AccountMappingsDialogs } from './components/AccountMappingsDialogs'
-import { AccountMappingsTable } from './components/AccountMappingsTable'
+import { AccountMappingsTable, type MappingRow } from './components/AccountMappingsTable'
 import { AccountMappingWorkspaceCard } from './components/AccountMappingWorkspaceCard'
 import { useAccountMappingsWorkspace } from './hooks/useAccountMappingsWorkspace'
 
@@ -23,7 +24,7 @@ const MAPPING_TYPE_LABELS: Record<MappingType, { label: string; category: string
   [MappingType.PURCHASE_AP]: { label: 'Accounts Payable (Purchases)', category: 'Purchasing', description: 'Liability account credited when goods are received' },
   [MappingType.PAYMENT_AR]: { label: 'Accounts Receivable (Payments)', category: 'Payments', description: 'Asset account credited when customer payments are received' },
   [MappingType.VENDOR_PAYMENT_AP]: { label: 'Accounts Payable (Vendor Payments)', category: 'Vendor Payments', description: 'Liability account debited when vendor payments are made' },
-  [MappingType.EQUITY_OWNERS_EQUITY]: { label: "Owner's Equity", category: 'Equity', description: "Equity account credited for owner capital contributions" },
+  [MappingType.EQUITY_OWNERS_EQUITY]: { label: "Owner's Equity", category: 'Equity', description: 'Equity account credited for owner capital contributions' },
   [MappingType.EQUITY_DRAWINGS]: { label: 'Owner Drawings', category: 'Equity', description: 'Equity contra account debited for owner withdrawals' },
   [MappingType.INVENTORY_ASSET]: { label: 'Inventory Asset', category: 'Inventory', description: 'Asset account for inventory adjustments' },
   [MappingType.INVENTORY_ADJUSTMENT_GAIN]: { label: 'Inventory Adjustment Gain', category: 'Inventory', description: 'Revenue account credited for positive inventory adjustments' },
@@ -33,64 +34,109 @@ const MAPPING_TYPE_LABELS: Record<MappingType, { label: string; category: string
 const staticCategories = ['Sales', 'Purchasing', 'Equity', 'Inventory']
 interface MappingFilters { search: string }
 const filterConfig: FilterBarConfig<MappingFilters> = { search: { placeholder: 'Search account mappings...' }, fields: [], defaults: { search: '' } }
-type MappingOption = { type: string; label: string; category: string; description: string }
 
 const AccountMappingsPage: React.FC = () => {
+  const dispatch = useAppDispatch()
+  const selected = useAppSelector(selectSelectedAccountMapping)
+
   const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
   const { data: mappings = [], isLoading, error, refetch: refetchMappings } = useGetAccountMappingsQuery()
   const { data: validationResult, refetch: refetchValidation } = useValidateAccountMappingsQuery()
   const { data: paymentMethodsResponse } = useGetPaymentMethodsQuery({ page: 1, isActive: true })
   const paymentMethods = useMemo(() => ((paymentMethodsResponse?.data ?? []) as Array<{ code: string; name: string; requiresSettlement: boolean; useForPurchases: boolean }>), [paymentMethodsResponse])
-  const workspace = useAccountMappingsWorkspace(refetchMappings, refetchValidation)
 
-  const getAllMappingTypes = (): MappingOption[] => Object.values(MappingType).map((type) => ({ type, ...MAPPING_TYPE_LABELS[type] }))
-  const getPaymentMappingTypes = (): MappingOption[] => {
-    const items: MappingOption[] = [{ type: MappingType.PAYMENT_AR, label: 'Accounts Receivable (Payments)', category: 'Payments', description: 'Asset account credited when customer payments are received' }]
+  const tableRows = useMemo(() => {
+    const accountMappings = mappings as AccountMapping[]
+    const staticRows: MappingRow[] = staticCategories.flatMap((category) =>
+      Object.values(MappingType)
+        .filter((type) => MAPPING_TYPE_LABELS[type].category === category)
+        .map((type) => ({
+          id: type,
+          mappingType: type,
+          ...MAPPING_TYPE_LABELS[type],
+          mapping: accountMappings.find((mapping) => mapping.mappingType === type),
+        })),
+    )
+
+    const paymentRows: MappingRow[] = [{
+      id: MappingType.PAYMENT_AR,
+      mappingType: MappingType.PAYMENT_AR,
+      label: 'Accounts Receivable (Payments)',
+      category: 'Payments',
+      description: 'Asset account credited when customer payments are received',
+      mapping: accountMappings.find((mapping) => mapping.mappingType === MappingType.PAYMENT_AR),
+    }]
+
     for (const paymentMethod of paymentMethods) {
       const code = paymentMethod.code.toLowerCase()
-      items.push({ type: `payment_${code}`, label: `${paymentMethod.name} Payment Account`, category: 'Payments', description: `Account debited when ${paymentMethod.name} payments are received` })
-      if (paymentMethod.requiresSettlement) items.push({ type: `payment_${code}_settlement`, label: `${paymentMethod.name} Settlement Account`, category: 'Payments', description: `Bank account debited when ${paymentMethod.name} payments are settled` })
+      paymentRows.push({
+        id: `payment_${code}`,
+        mappingType: `payment_${code}`,
+        label: `${paymentMethod.name} Payment Account`,
+        category: 'Payments',
+        description: `Account debited when ${paymentMethod.name} payments are received`,
+        mapping: accountMappings.find((mapping) => mapping.mappingType === `payment_${code}`),
+      })
+      if (paymentMethod.requiresSettlement) {
+        paymentRows.push({
+          id: `payment_${code}_settlement`,
+          mappingType: `payment_${code}_settlement`,
+          label: `${paymentMethod.name} Settlement Account`,
+          category: 'Payments',
+          description: `Bank account debited when ${paymentMethod.name} payments are settled`,
+          mapping: accountMappings.find((mapping) => mapping.mappingType === `payment_${code}_settlement`),
+        })
+      }
     }
-    return items
-  }
-  const getVendorPaymentMappingTypes = (): MappingOption[] => {
-    const items: MappingOption[] = [{ type: MappingType.VENDOR_PAYMENT_AP, label: 'Accounts Payable (Vendor Payments)', category: 'Vendor Payments', description: 'Liability account debited when vendor payments are made' }]
+
+    const vendorPaymentRows: MappingRow[] = [{
+      id: MappingType.VENDOR_PAYMENT_AP,
+      mappingType: MappingType.VENDOR_PAYMENT_AP,
+      label: 'Accounts Payable (Vendor Payments)',
+      category: 'Vendor Payments',
+      description: 'Liability account debited when vendor payments are made',
+      mapping: accountMappings.find((mapping) => mapping.mappingType === MappingType.VENDOR_PAYMENT_AP),
+    }]
+
     for (const paymentMethod of paymentMethods) {
       if (!paymentMethod.useForPurchases) continue
       const code = paymentMethod.code.toLowerCase()
-      items.push({ type: `vendor_payment_${code}`, label: `${paymentMethod.name} Vendor Payment Account`, category: 'Vendor Payments', description: `Account credited when ${paymentMethod.name} vendor payments are made` })
+      vendorPaymentRows.push({
+        id: `vendor_payment_${code}`,
+        mappingType: `vendor_payment_${code}`,
+        label: `${paymentMethod.name} Vendor Payment Account`,
+        category: 'Vendor Payments',
+        description: `Account credited when ${paymentMethod.name} vendor payments are made`,
+        mapping: accountMappings.find((mapping) => mapping.mappingType === `vendor_payment_${code}`),
+      })
     }
-    return items
-  }
-  const allSections: Array<{ category: string; items: MappingOption[] }> = useMemo(() => [
-    ...staticCategories.map((category) => ({ category, items: getAllMappingTypes().filter((mapping) => mapping.category === category) })),
-    { category: 'Payments', items: getPaymentMappingTypes() },
-    { category: 'Vendor Payments', items: getVendorPaymentMappingTypes() },
-  ], [paymentMethods])
 
-  const tableRows = useMemo(() => {
-    const rows = allSections.flatMap(({ items }) => items.map((item) => ({ mappingType: item.type, label: item.label, category: item.category, description: item.description, mapping: (mappings as AccountMapping[]).find((mapping) => mapping.mappingType === item.type) })))
+    const allRows = [...staticRows, ...paymentRows, ...vendorPaymentRows]
     const term = appliedFilters.search.trim().toLowerCase()
-    if (!term) return rows
-    return rows.filter((row) => [row.label, row.category, row.description, row.mapping?.account?.name, row.mapping?.account?.code].filter(Boolean).join(' ').toLowerCase().includes(term))
-  }, [allSections, appliedFilters.search, mappings])
+    if (!term) return allRows
+    return allRows.filter((row) =>
+      [row.label, row.category, row.description, row.mapping?.account?.name, row.mapping?.account?.code]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase()
+        .includes(term),
+    )
+  }, [appliedFilters.search, mappings, paymentMethods])
 
-  const selectedMeta = useMemo(() => tableRows.find((row) => row.mapping?.id === workspace.selected?.id), [tableRows, workspace.selected?.id])
+  const workspace = useAccountMappingsWorkspace(refetchMappings, refetchValidation, tableRows, selected, dispatch)
+  const focusedRow = workspace.focusedIndex >= 0 ? tableRows[workspace.focusedIndex] ?? null : null
 
   return (
     <>
       {!validationResult?.isValid && validationResult?.missingMappings?.length ? (
-        <Alert severity="warning" sx={{ mb: 2 }}>
-          Configuration Incomplete
-        </Alert>
+        <Alert severity="warning" sx={{ mb: 2 }}>Configuration Incomplete</Alert>
       ) : validationResult?.isValid ? (
-        <Alert severity="success" sx={{ mb: 2 }}>
-          All required account mappings are configured.
-        </Alert>
+        <Alert severity="success" sx={{ mb: 2 }}>All required account mappings are configured.</Alert>
       ) : null}
       <GenericListPage
         title="Account Mappings"
         subtitle="Configure default account assignments for transactions"
+        secondaryAction={{ label: 'Refresh', onClick: () => { void refetchMappings(); void refetchValidation() } }}
         filterConfig={filterConfig}
         draftFilters={draftFilters}
         handlers={handlers}
@@ -99,11 +145,41 @@ const AccountMappingsPage: React.FC = () => {
         sort={{ field: 'mappingType', sortBy: 'mappingType', sortOrder: 'asc', onSort: () => {} }}
         error={(error as any)?.data ?? null}
         onErrorClose={() => {}}
-        filterExtra={<AppButton size="small" variant="outlined" onClick={() => { void refetchMappings(); void refetchValidation() }}>Refresh</AppButton>}
-        listSlot={<AccountMappingsTable mappings={tableRows} loading={isLoading} selectedId={workspace.selected?.id ?? null} onSelect={workspace.setSelected} listRef={workspace.listRef} />}
-        headerSlot={<AccountMappingContextHeader selected={workspace.selected} label={selectedMeta?.label || 'Account Mapping'} category={selectedMeta?.category || ''} onEdit={() => { workspace.setSelectedMapping(workspace.selected); workspace.setSelectedMappingType(null); workspace.setDialogOpen(true) }} onDelete={() => workspace.selected && workspace.setMappingToClear(workspace.selected)} />}
-        workspaceSlot={<AccountMappingWorkspaceCard selected={workspace.selected} />}
-        dialogs={<AccountMappingsDialogs dialogOpen={workspace.dialogOpen} selectedMapping={workspace.selectedMapping} selectedMappingType={workspace.selectedMappingType} onCloseDialog={() => { workspace.setDialogOpen(false); workspace.setSelectedMapping(null); workspace.setSelectedMappingType(null) }} onSaveSuccess={() => { workspace.setDialogOpen(false); workspace.setSelectedMapping(null); workspace.setSelectedMappingType(null); void refetchMappings(); void refetchValidation() }} mappingToClear={workspace.mappingToClear} clearing={workspace.clearing} onConfirmClear={() => void workspace.handleClear()} onCancelClear={() => !workspace.clearing && workspace.setMappingToClear(null)} />}
+        listSlot={(
+          <AccountMappingsTable
+            rows={tableRows}
+            loading={isLoading}
+            selectedId={selected?.mappingType ?? null}
+            focusedIndex={workspace.focusedIndex}
+            onSelect={workspace.handleSelect}
+            listRef={workspace.listRef}
+          />
+        )}
+        headerSlot={(
+          <AccountMappingContextHeader
+            row={focusedRow}
+            onConfigure={() => {
+              if (focusedRow) workspace.openDialogForRow(focusedRow)
+            }}
+            onClear={() => {
+              if (focusedRow?.mapping) workspace.setMappingToClear(focusedRow.mapping)
+            }}
+          />
+        )}
+        workspaceSlot={<AccountMappingWorkspaceCard mapping={focusedRow?.mapping} />}
+        dialogs={(
+          <AccountMappingsDialogs
+            dialogOpen={workspace.dialogOpen}
+            selectedMapping={workspace.selectedMapping}
+            selectedMappingType={workspace.selectedMappingType}
+            onCloseDialog={() => { workspace.setDialogOpen(false); workspace.setSelectedMapping(null); workspace.setSelectedMappingType(null) }}
+            onSaveSuccess={() => { workspace.setDialogOpen(false); workspace.setSelectedMapping(null); workspace.setSelectedMappingType(null); void refetchMappings(); void refetchValidation() }}
+            mappingToClear={workspace.mappingToClear}
+            clearing={workspace.clearing}
+            onConfirmClear={() => void workspace.handleClear()}
+            onCancelClear={() => !workspace.clearing && workspace.setMappingToClear(null)}
+          />
+        )}
       />
     </>
   )

--- a/frontend/src/pages/accounting/__tests__/AccountMappingsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/AccountMappingsPage.test.tsx
@@ -12,17 +12,63 @@ const mockedApi = vi.hoisted(() => ({
   useDeleteAccountMappingMutation: vi.fn(),
 }))
 
+const mockedWorkspace = vi.hoisted(() => ({
+  useEntityWorkspace: vi.fn(),
+}))
+
+const mockDispatch = vi.fn()
+
 vi.mock('@/store/api/accountingApi', () => mockedApi)
 vi.mock('@/hooks/useNotification', () => ({ useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }) }))
 vi.mock('@/components/accounting/AccountMappingDialog', () => ({ default: () => null }))
+vi.mock('@/hooks/useRedux', () => ({
+  useAppDispatch: () => mockDispatch,
+  useAppSelector: () => null,
+}))
+vi.mock('@/hooks/useEntityWorkspace', () => mockedWorkspace)
+
+const configuredMapping = {
+  id: '1',
+  mappingType: MappingType.SALES_REVENUE,
+  accountId: 'acc-1',
+  description: 'Sales revenue account',
+  isActive: true,
+  account: { id: 'acc-1', code: '4000', name: 'Sales Revenue', accountType: 'Revenue' },
+  createdAt: '2024-01-01',
+  updatedAt: '2024-01-01',
+}
+
+const workspaceDefaults = {
+  focusedIndex: -1,
+  listRef: { current: null },
+  searchInputRef: { current: null },
+  handleSelect: vi.fn(),
+  setFocusedIndex: vi.fn(),
+  deleteConfirmOpen: false,
+  setDeleteConfirmOpen: vi.fn(),
+  deletedEntitiesDialogOpen: false,
+  setDeletedEntitiesDialogOpen: vi.fn(),
+  setShouldPreserveSearchFocus: vi.fn(),
+  handleDelete: vi.fn(),
+  handleCancelDelete: vi.fn(),
+  handleNavigateUp: vi.fn(),
+  handleNavigateDown: vi.fn(),
+  handleEnterAction: vi.fn(),
+  handleEscapeAction: vi.fn(),
+  handlePageUpNavigation: vi.fn(),
+  handlePageDownNavigation: vi.fn(),
+  handleNavigateToFirst: vi.fn(),
+  handleNavigateToLast: vi.fn(),
+}
 
 describe('AccountMappingsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockedApi.useGetAccountMappingsQuery.mockReturnValue({ data: [{ id: '1', mappingType: MappingType.SALES_REVENUE, accountId: 'acc-1', description: 'Sales revenue account', isActive: true, account: { id: 'acc-1', code: '4000', name: 'Sales Revenue', accountType: 'Revenue' }, createdAt: '2024-01-01', updatedAt: '2024-01-01' }], isLoading: false, error: undefined, refetch: vi.fn() })
+    mockedApi.useGetAccountMappingsQuery.mockReturnValue({ data: [configuredMapping], isLoading: false, error: undefined, refetch: vi.fn() })
     mockedApi.useValidateAccountMappingsQuery.mockReturnValue({ data: { isValid: true, missingMappings: [], configuredMappings: [], totalRequired: 0, totalConfigured: 0 }, refetch: vi.fn() })
     mockedApi.useGetPaymentMethodsQuery.mockReturnValue({ data: { data: [] } })
     mockedApi.useDeleteAccountMappingMutation.mockReturnValue([vi.fn()])
+    mockedWorkspace.useEntityWorkspace.mockReturnValue(workspaceDefaults)
   })
 
   it('renders title and mapping rows', async () => {
@@ -30,6 +76,28 @@ describe('AccountMappingsPage', () => {
     await waitFor(() => {
       expect(screen.getByText('Account Mappings')).toBeInTheDocument()
       expect(screen.getByText('Sales Revenue')).toBeInTheDocument()
+    })
+  })
+
+  it('shows Edit and Clear buttons when a configured row is focused', async () => {
+    mockedWorkspace.useEntityWorkspace.mockReturnValue({ ...workspaceDefaults, focusedIndex: 0 })
+
+    render(<BrowserRouter><AccountMappingsPage /></BrowserRouter>)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument()
+    })
+  })
+
+  it('shows Configure button without Clear when an unconfigured row is focused', async () => {
+    mockedWorkspace.useEntityWorkspace.mockReturnValue({ ...workspaceDefaults, focusedIndex: 1 })
+
+    render(<BrowserRouter><AccountMappingsPage /></BrowserRouter>)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /configure/i })).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /clear/i })).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/pages/accounting/components/AccountMappingContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/AccountMappingContextHeader.tsx
@@ -121,7 +121,7 @@ export function AccountMappingContextHeader({ row, onConfigure, onClear }: Props
                   <TableCell sx={labelCellSx}>Account Name</TableCell>
                   <TableCell sx={valueCellSx}>
                     {row.mapping?.account?.name ?? (
-                      <Typography component="span" sx={{ fontStyle: 'italic', color: 'text.secondary', fontSize: '0.8rem' }}>-</Typography>
+                      <Typography component="span" sx={{ fontStyle: 'italic', color: 'text.secondary', fontSize: '0.8rem' }}>—</Typography>
                     )}
                   </TableCell>
                 </TableRow>
@@ -129,7 +129,7 @@ export function AccountMappingContextHeader({ row, onConfigure, onClear }: Props
                   <TableCell sx={labelCellSx}>Account Type</TableCell>
                   <TableCell sx={valueCellSx}>
                     {row.mapping?.account?.accountType ?? (
-                      <Typography component="span" sx={{ fontStyle: 'italic', color: 'text.secondary', fontSize: '0.8rem' }}>-</Typography>
+                      <Typography component="span" sx={{ fontStyle: 'italic', color: 'text.secondary', fontSize: '0.8rem' }}>—</Typography>
                     )}
                   </TableCell>
                 </TableRow>

--- a/frontend/src/pages/accounting/components/AccountMappingContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/AccountMappingContextHeader.tsx
@@ -1,36 +1,143 @@
-import { Paper, Stack, Typography } from '@mui/material'
+import { Box, Paper, Stack, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
+import Grid from '@mui/material/Grid'
 import { default as ClearIcon } from '@mui/icons-material/Clear'
 import { default as EditIcon } from '@mui/icons-material/Edit'
+import { default as SettingsIcon } from '@mui/icons-material/Settings'
+
 import { AppButton } from '@/components/common/AppButton'
 import { EntityContextHeaderBar } from '@/components/common/EntityContextHeaderBar'
-import type { AccountMapping } from '@/types/accountMapping'
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { MappingRow } from './AccountMappingsTable'
 
 interface Props {
-  selected: AccountMapping | null
-  label: string
-  category: string
-  onEdit: () => void
-  onDelete: () => void
+  row: MappingRow | null
+  onConfigure: () => void
+  onClear: () => void
 }
 
-export function AccountMappingContextHeader({ selected, label, category, onEdit, onDelete }: Props) {
-  if (!selected) return <Paper sx={{ p: 2 }}><Typography variant="body2" color="text.secondary">Select an account mapping to view details</Typography></Paper>
+const detailTableSx = {
+  tableLayout: 'fixed' as const,
+  '& .MuiTableCell-root': {
+    border: 'none',
+    py: TABLE_STYLES.cell.padding.py,
+    px: TABLE_STYLES.cell.padding.px,
+    '&:nth-of-type(1)': { width: '40%' },
+    '&:nth-of-type(2)': { width: '60%' },
+  },
+}
+
+const labelCellSx = { fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }
+const valueCellSx = { fontSize: '0.8rem' }
+
+const sectionHeaderSx = {
+  fontWeight: 600,
+  color: 'primary.main',
+  fontSize: '0.8rem',
+}
+
+export function AccountMappingContextHeader({ row, onConfigure, onClear }: Props) {
+  if (!row) {
+    return (
+      <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
+        <Typography variant="body2" color="text.secondary">
+          Select an account mapping to view details
+        </Typography>
+      </Paper>
+    )
+  }
+
+  const isConfigured = !!row.mapping
+
   return (
-    <Paper>
+    <Paper sx={{ overflow: 'hidden' }}>
       <EntityContextHeaderBar
-        title={label}
-        statusChip={<Typography variant="body2" color="text.secondary">{category}</Typography>}
+        title={row.label}
         actions={(
           <Stack direction="row" spacing={0.5}>
-            <AppButton size="small" variant="outlined" startIcon={<EditIcon />} onClick={onEdit}>
-              Edit
+            <AppButton
+              size="small"
+              variant="outlined"
+              startIcon={isConfigured ? <EditIcon /> : <SettingsIcon />}
+              onClick={onConfigure}
+            >
+              {isConfigured ? 'Edit' : 'Configure'}
             </AppButton>
-            <AppButton size="small" variant="warning" startIcon={<ClearIcon />} onClick={onDelete}>
-              Clear
-            </AppButton>
+            {isConfigured && (
+              <AppButton
+                size="small"
+                variant="warning"
+                startIcon={<ClearIcon />}
+                onClick={onClear}
+              >
+                Clear
+              </AppButton>
+            )}
           </Stack>
         )}
       />
+      <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+              <TableBody>
+                <TableRow>
+                  <TableCell colSpan={2} sx={{ py: TABLE_STYLES.cell.padding.py * 0.67, borderTop: TABLE_STYLES.cell.border }}>
+                    <Typography sx={sectionHeaderSx}>Mapping Info</Typography>
+                  </TableCell>
+                </TableRow>
+                <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                  <TableCell sx={labelCellSx}>Name</TableCell>
+                  <TableCell sx={valueCellSx}>{row.label}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell sx={labelCellSx}>Category</TableCell>
+                  <TableCell sx={valueCellSx}>{row.category}</TableCell>
+                </TableRow>
+                <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                  <TableCell sx={labelCellSx}>Description</TableCell>
+                  <TableCell sx={valueCellSx}>{row.description}</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Table size={TABLE_STYLES.size} sx={detailTableSx}>
+              <TableBody>
+                <TableRow>
+                  <TableCell colSpan={2} sx={{ py: TABLE_STYLES.cell.padding.py * 0.67, borderTop: TABLE_STYLES.cell.border }}>
+                    <Typography sx={sectionHeaderSx}>Account Details</Typography>
+                  </TableCell>
+                </TableRow>
+                <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                  <TableCell sx={labelCellSx}>Account Code</TableCell>
+                  <TableCell sx={valueCellSx}>
+                    {row.mapping?.account?.code ?? (
+                      <Typography component="span" sx={{ fontStyle: 'italic', color: 'text.secondary', fontSize: '0.8rem' }}>Not configured</Typography>
+                    )}
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell sx={labelCellSx}>Account Name</TableCell>
+                  <TableCell sx={valueCellSx}>
+                    {row.mapping?.account?.name ?? (
+                      <Typography component="span" sx={{ fontStyle: 'italic', color: 'text.secondary', fontSize: '0.8rem' }}>-</Typography>
+                    )}
+                  </TableCell>
+                </TableRow>
+                <TableRow sx={{ backgroundColor: 'grey.50' }}>
+                  <TableCell sx={labelCellSx}>Account Type</TableCell>
+                  <TableCell sx={valueCellSx}>
+                    {row.mapping?.account?.accountType ?? (
+                      <Typography component="span" sx={{ fontStyle: 'italic', color: 'text.secondary', fontSize: '0.8rem' }}>-</Typography>
+                    )}
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </Grid>
+        </Grid>
+      </Box>
     </Paper>
   )
 }

--- a/frontend/src/pages/accounting/components/AccountMappingWorkspaceCard.tsx
+++ b/frontend/src/pages/accounting/components/AccountMappingWorkspaceCard.tsx
@@ -1,12 +1,13 @@
 import { Box, Paper, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
-import type { AccountMapping } from '@/types/accountMapping'
-import { TABLE_STYLES } from '@/constants/tableStyles'
 
-interface Props { selected: AccountMapping | null }
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { AccountMapping } from '@/types/accountMapping'
+
+interface Props { mapping: AccountMapping | undefined }
 const cellSx = { border: 'none', py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px }
 
-export function AccountMappingWorkspaceCard({ selected }: Props) {
-  if (!selected) return <Paper sx={{ flex: 1 }} />
+export function AccountMappingWorkspaceCard({ mapping }: Props) {
+  if (!mapping) return <Paper sx={{ flex: 1 }} />
   return (
     <Paper sx={{ flex: 1 }}>
       <Box sx={{ px: 2, py: 1, borderBottom: TABLE_STYLES.cell.border }}>
@@ -14,9 +15,9 @@ export function AccountMappingWorkspaceCard({ selected }: Props) {
       </Box>
       <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': cellSx }}>
         <TableBody>
-          <TableRow><TableCell sx={{ ...cellSx, color: 'text.secondary', width: '35%' }}>Mapped Account</TableCell><TableCell>{selected.account?.code} - {selected.account?.name}</TableCell></TableRow>
-          <TableRow><TableCell sx={{ ...cellSx, color: 'text.secondary' }}>Account Type</TableCell><TableCell>{selected.account?.accountType || '—'}</TableCell></TableRow>
-          <TableRow><TableCell sx={{ ...cellSx, color: 'text.secondary' }}>Description</TableCell><TableCell>{selected.description || '—'}</TableCell></TableRow>
+          <TableRow><TableCell sx={{ ...cellSx, color: 'text.secondary', width: '35%' }}>Mapped Account</TableCell><TableCell>{mapping.account?.code} - {mapping.account?.name}</TableCell></TableRow>
+          <TableRow><TableCell sx={{ ...cellSx, color: 'text.secondary' }}>Account Type</TableCell><TableCell>{mapping.account?.accountType || '-'}</TableCell></TableRow>
+          <TableRow><TableCell sx={{ ...cellSx, color: 'text.secondary' }}>Description</TableCell><TableCell>{mapping.description || '-'}</TableCell></TableRow>
         </TableBody>
       </Table>
     </Paper>

--- a/frontend/src/pages/accounting/components/AccountMappingsTable.tsx
+++ b/frontend/src/pages/accounting/components/AccountMappingsTable.tsx
@@ -1,43 +1,54 @@
-import type { RefObject } from 'react'
-import { Chip, CircularProgress, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from '@mui/material'
-import type { AccountMapping } from '@/types/accountMapping'
-import { TABLE_STYLES } from '@/constants/tableStyles'
+import React from 'react'
+import { Chip } from '@mui/material'
 
-interface Props {
-  mappings: Array<{ category: string; label: string; description: string; mapping: AccountMapping | undefined; mappingType: string }>
-  loading: boolean
-  selectedId: string | null
-  onSelect: (item: AccountMapping) => void
-  listRef?: RefObject<HTMLDivElement | null>
+import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
+import type { AccountMapping } from '@/types/accountMapping'
+
+export type MappingRow = {
+  id: string
+  mappingType: string
+  label: string
+  category: string
+  description: string
+  mapping: AccountMapping | undefined
 }
 
-export function AccountMappingsTable({ mappings, loading, selectedId, onSelect, listRef }: Props) {
+const COLUMNS: ColumnConfig<MappingRow>[] = [
+  {
+    key: 'category',
+    width: 140,
+    render: (row) => (
+      <Chip size="small" label={row.category} color="primary" variant="outlined" />
+    ),
+  },
+  {
+    key: 'label',
+    render: (row) => row.label,
+  },
+]
+
+interface Props {
+  rows: MappingRow[]
+  loading: boolean
+  selectedId: string | null
+  focusedIndex: number
+  onSelect: (row: MappingRow) => void
+  listRef: React.RefObject<HTMLDivElement | null>
+}
+
+export function AccountMappingsTable({ rows, loading, selectedId, focusedIndex, onSelect, listRef }: Props) {
   return (
-    <Paper ref={listRef} sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
-        <Table size={TABLE_STYLES.size} stickyHeader>
-          <TableHead>
-            <TableRow>
-              <TableCell sx={{ fontWeight: 600 }}>Category</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Mapping Type</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Assigned Account</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {loading ? (
-              <TableRow><TableCell colSpan={3} align="center" sx={{ py: 4 }}><CircularProgress /></TableCell></TableRow>
-            ) : mappings.length === 0 ? (
-              <TableRow><TableCell colSpan={3} align="center" sx={{ py: 4 }}><Typography variant="body2" color="text.secondary">No account mappings found</Typography></TableCell></TableRow>
-            ) : mappings.map((item) => (
-              <TableRow key={item.mappingType} hover selected={item.mapping?.id === selectedId} onClick={() => item.mapping && onSelect(item.mapping)} sx={{ cursor: item.mapping ? 'pointer' : 'default', height: TABLE_STYLES.row.height }}>
-                <TableCell><Chip size="small" label={item.category} color="primary" variant="outlined" /></TableCell>
-                <TableCell>{item.label}</TableCell>
-                <TableCell>{item.mapping ? `${item.mapping.account?.code} - ${item.mapping.account?.name}` : 'Not configured'}</TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </Paper>
+    <EntityTable
+      rows={rows}
+      columns={COLUMNS}
+      loading={loading}
+      total={rows.length}
+      label="Account Mappings List"
+      selectedId={selectedId ?? undefined}
+      focusedIndex={focusedIndex}
+      onSelect={onSelect}
+      listRef={listRef}
+      dataAttr="mapping"
+    />
   )
 }

--- a/frontend/src/pages/accounting/hooks/useAccountMappingsWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useAccountMappingsWorkspace.ts
@@ -1,19 +1,61 @@
 import { useCallback, useRef, useState } from 'react'
-import { useNotification } from '@/hooks/useNotification'
-import { useDeleteAccountMappingMutation } from '@/store/api/accountingApi'
-import type { AccountMapping } from '@/types/accountMapping'
+import { useNavigate } from 'react-router-dom'
 
-export function useAccountMappingsWorkspace(refetchMappings: () => Promise<any> | any, refetchValidation: () => Promise<any> | any) {
+import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
+import { useNotification } from '@/hooks/useNotification'
+import type { AppDispatch } from '@/store'
+import { useDeleteAccountMappingMutation } from '@/store/api/accountingApi'
+import { setSelectedAccountMapping } from '@/store/slices/accountingSlice'
+import type { AccountMapping } from '@/types/accountMapping'
+import type { MappingRow } from '../components/AccountMappingsTable'
+
+export function useAccountMappingsWorkspace(
+  refetchMappings: () => Promise<any> | any,
+  refetchValidation: () => Promise<any> | any,
+  rows: MappingRow[],
+  selected: AccountMapping | null,
+  dispatch: AppDispatch,
+) {
+  const navigate = useNavigate()
   const { showSuccess, showError } = useNotification()
-  const [selected, setSelected] = useState<AccountMapping | null>(null)
+
   const [dialogOpen, setDialogOpen] = useState(false)
   const [selectedMapping, setSelectedMapping] = useState<AccountMapping | null>(null)
   const [selectedMappingType, setSelectedMappingType] = useState<string | null>(null)
   const [mappingToClear, setMappingToClear] = useState<AccountMapping | null>(null)
   const [clearing, setClearing] = useState(false)
-  const searchInputRef = useRef<HTMLInputElement | null>(null)
-  const listRef = useRef<HTMLDivElement | null>(null)
+  const workspaceRef = useRef<ReturnType<typeof useEntityWorkspace<MappingRow>> | null>(null)
+
   const [deleteAccountMapping] = useDeleteAccountMappingMutation()
+
+  const openDialogForRow = useCallback((row: MappingRow) => {
+    setSelectedMapping(row.mapping ?? null)
+    setSelectedMappingType(row.mapping ? null : row.mappingType)
+    setDialogOpen(true)
+  }, [])
+
+  const workspace = useEntityWorkspace<MappingRow>({
+    entities: rows,
+    selectedEntity: rows.find((row) => row.mapping?.id === selected?.id) ?? null,
+    selectEntity: (row) => dispatch(setSelectedAccountMapping(row?.mapping ?? null)),
+    refetch: () => { void refetchMappings() },
+    navigate,
+    routes: {
+      create: '/accounting/account-mappings',
+      edit: () => '/accounting/account-mappings',
+    },
+    onEnter: () => {
+      const focusedIndex = workspaceRef.current?.focusedIndex ?? -1
+      const focusedRow = focusedIndex >= 0 ? rows[focusedIndex] : null
+      if (focusedRow) openDialogForRow(focusedRow)
+    },
+    onEscape: () => {
+      workspaceRef.current?.setFocusedIndex(-1)
+      dispatch(setSelectedAccountMapping(null))
+      setMappingToClear(null)
+    },
+  })
+  workspaceRef.current = workspace
 
   const handleClear = useCallback(async () => {
     if (!mappingToClear) return
@@ -23,14 +65,30 @@ export function useAccountMappingsWorkspace(refetchMappings: () => Promise<any> 
       await refetchMappings()
       await refetchValidation()
       showSuccess(`Mapping "${mappingToClear.mappingType}" cleared successfully`)
-      if (selected?.id === mappingToClear.id) setSelected(null)
+      if (selected?.id === mappingToClear.id) dispatch(setSelectedAccountMapping(null))
     } catch (err: any) {
       showError(err || 'Failed to clear mapping')
     } finally {
       setClearing(false)
       setMappingToClear(null)
     }
-  }, [deleteAccountMapping, mappingToClear, refetchMappings, refetchValidation, selected?.id, showError, showSuccess])
+  }, [deleteAccountMapping, dispatch, mappingToClear, refetchMappings, refetchValidation, selected?.id, showError, showSuccess])
 
-  return { selected, setSelected, dialogOpen, setDialogOpen, selectedMapping, setSelectedMapping, selectedMappingType, setSelectedMappingType, mappingToClear, setMappingToClear, clearing, searchInputRef, listRef, handleClear }
+  return {
+    focusedIndex: workspace.focusedIndex,
+    listRef: workspace.listRef,
+    searchInputRef: workspace.searchInputRef,
+    handleSelect: workspace.handleSelect,
+    dialogOpen,
+    setDialogOpen,
+    selectedMapping,
+    setSelectedMapping,
+    selectedMappingType,
+    setSelectedMappingType,
+    mappingToClear,
+    setMappingToClear,
+    clearing,
+    openDialogForRow,
+    handleClear,
+  }
 }

--- a/frontend/src/pages/accounting/hooks/useAccountMappingsWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useAccountMappingsWorkspace.ts
@@ -67,7 +67,7 @@ export function useAccountMappingsWorkspace(
       showSuccess(`Mapping "${mappingToClear.mappingType}" cleared successfully`)
       if (selected?.id === mappingToClear.id) dispatch(setSelectedAccountMapping(null))
     } catch (err: any) {
-      showError(err || 'Failed to clear mapping')
+      showError(err?.data?.message || err?.message || 'Failed to clear mapping')
     } finally {
       setClearing(false)
       setMappingToClear(null)

--- a/frontend/src/store/slices/accountingSlice.ts
+++ b/frontend/src/store/slices/accountingSlice.ts
@@ -1,6 +1,7 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 
 import type { RootState } from '@/store'
+import type { AccountMapping } from '@/types/accountMapping'
 import type {
   BankReconciliation,
   ChartOfAccount,
@@ -21,6 +22,7 @@ interface AccountingState {
   selectedOwnerEquityTransaction: OwnerEquityTransaction | null
   selectedBankReconciliation: BankReconciliation | null
   selectedSettlement: Settlement | null
+  selectedAccountMapping: AccountMapping | null
 }
 
 const initialState: AccountingState = {
@@ -32,6 +34,7 @@ const initialState: AccountingState = {
   selectedOwnerEquityTransaction: null,
   selectedBankReconciliation: null,
   selectedSettlement: null,
+  selectedAccountMapping: null,
 }
 
 const accountingSlice = createSlice({
@@ -62,6 +65,9 @@ const accountingSlice = createSlice({
     setSelectedSettlement: (state, action: PayloadAction<Settlement | null>) => {
       state.selectedSettlement = action.payload
     },
+    setSelectedAccountMapping: (state, action: PayloadAction<AccountMapping | null>) => {
+      state.selectedAccountMapping = action.payload
+    },
   },
 })
 
@@ -74,6 +80,7 @@ export const {
   setSelectedOwnerEquityTransaction,
   setSelectedBankReconciliation,
   setSelectedSettlement,
+  setSelectedAccountMapping,
 } = accountingSlice.actions
 
 export const selectSelectedAccount = (state: RootState) => state.accounting.selectedAccount
@@ -84,5 +91,6 @@ export const selectSelectedFundTransfer = (state: RootState) => state.accounting
 export const selectSelectedOwnerEquityTransaction = (state: RootState) => state.accounting.selectedOwnerEquityTransaction
 export const selectSelectedBankReconciliation = (state: RootState) => state.accounting.selectedBankReconciliation
 export const selectSelectedSettlement = (state: RootState) => state.accounting.selectedSettlement
+export const selectSelectedAccountMapping = (state: RootState) => state.accounting.selectedAccountMapping
 
 export default accountingSlice.reducer


### PR DESCRIPTION
## Summary

- Migrates selection state from local `useState` to Redux (`accountingSlice`) with `selectedAccountMapping`
- Replaces raw 3-column MUI Table with `EntityTable` (2 columns: category chip + mapping type label)
- Rewrites `AccountMappingContextHeader` as a two-column Grid (Mapping Info + Account Details) with dynamic "Configure"/"Edit" button and conditional "Clear" button
- Migrates `useAccountMappingsWorkspace` to `useEntityWorkspace` for full keyboard navigation (Arrow keys, Enter, Escape)
- Moves Refresh from `filterExtra` to `secondaryAction` on `GenericListPage`

## Test Plan

- [ ] All mapping types (configured and unconfigured) visible in list
- [ ] Arrow Up/Down navigates rows; Enter opens dialog; Escape clears selection
- [ ] Configured row shows "Edit" + "Clear" in context header
- [ ] Unconfigured row shows "Configure" only (no Clear)
- [ ] Context header two-column layout shows mapping info and account details
- [ ] `npm run type-check` passes
- [ ] `npm run lint` passes
- [ ] `npm run test` passes (154 files, 987 tests)

Closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)