### PR TITLE
feat(accounting): convert COA chips to plain colored text

### DIFF
--- a/frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router-dom'
 import { configureStore } from '@reduxjs/toolkit'
@@ -81,6 +81,18 @@ function getRenderedAccountCodes() {
   return Array.from(document.querySelectorAll('tr[data-index] td:first-child')).map((cell) =>
     cell.textContent?.trim() ?? '',
   )
+}
+
+function getDetailValueCell(label: string) {
+  const row = Array.from(document.querySelectorAll('tr')).find((tableRow) =>
+    tableRow.children[0]?.textContent?.trim() === label,
+  )
+
+  if (!row) {
+    throw new Error(`Detail row "${label}" was not rendered`)
+  }
+
+  return row.children[1] as HTMLElement
 }
 
 describe('ChartOfAccountsPage', () => {
@@ -188,5 +200,39 @@ describe('ChartOfAccountsPage', () => {
     await user.click(screen.getByRole('button', { name: /sort/i }))
 
     expect(getRenderedAccountCodes()).toEqual(['2000', '1000'])
+  })
+
+  it('renders selected account type and status values as plain text instead of chips', async () => {
+    const parent = {
+      ...mockAccount,
+      id: '1',
+      code: '1000',
+      name: 'Cash',
+      children: [{ ...mockLiabilityAccount, id: '2', code: '2010', name: 'Trade Payables', children: [] }],
+    }
+    setup([parent])
+    const user = userEvent.setup()
+
+    renderPage()
+
+    const accountRow = document.querySelector('tr[data-index="0"]')
+    expect(accountRow).not.toBeNull()
+    await user.click(accountRow as HTMLElement)
+
+    const accountTypeCell = getDetailValueCell('Account Type')
+    expect(accountTypeCell).toHaveTextContent('Asset')
+    expect(accountTypeCell.querySelector('.MuiChip-root')).not.toBeInTheDocument()
+
+    const statusCell = getDetailValueCell('Status')
+    expect(statusCell).toHaveTextContent('Active')
+    expect(statusCell.querySelector('.MuiChip-root')).not.toBeInTheDocument()
+
+    const subAccountsSection = screen.getByText('Sub-Accounts').closest('.MuiPaper-root')
+    expect(subAccountsSection).not.toBeNull()
+    const childRow = within(subAccountsSection as HTMLElement).getByText('2010').closest('tr')
+    expect(childRow).not.toBeNull()
+    const childTypeCell = (childRow as HTMLTableRowElement).children[2] as HTMLElement
+    expect(childTypeCell).toHaveTextContent('Liability')
+    expect(childTypeCell.querySelector('.MuiChip-root')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/ChartOfAccountsPage.test.tsx
@@ -229,10 +229,28 @@ describe('ChartOfAccountsPage', () => {
 
     const subAccountsSection = screen.getByText('Sub-Accounts').closest('.MuiPaper-root')
     expect(subAccountsSection).not.toBeNull()
+    const typeColIndex = within(subAccountsSection as HTMLElement)
+      .getAllByRole('columnheader')
+      .findIndex((th) => th.textContent?.trim() === 'Type')
     const childRow = within(subAccountsSection as HTMLElement).getByText('2010').closest('tr')
     expect(childRow).not.toBeNull()
-    const childTypeCell = (childRow as HTMLTableRowElement).children[2] as HTMLElement
+    const childTypeCell = (childRow as HTMLTableRowElement).children[typeColIndex] as HTMLElement
     expect(childTypeCell).toHaveTextContent('Liability')
     expect(childTypeCell.querySelector('.MuiChip-root')).not.toBeInTheDocument()
+  })
+
+  it('renders inactive status as plain text without a chip', async () => {
+    setup([mockInactiveAccount])
+    const user = userEvent.setup()
+
+    renderPage()
+
+    const accountRow = document.querySelector('tr[data-index="0"]')
+    expect(accountRow).not.toBeNull()
+    await user.click(accountRow as HTMLElement)
+
+    const statusCell = getDetailValueCell('Status')
+    expect(statusCell).toHaveTextContent('Inactive')
+    expect(statusCell.querySelector('.MuiChip-root')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/accounting/components/ChartOfAccountContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/ChartOfAccountContextHeader.tsx
@@ -2,7 +2,6 @@ import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as EditIcon } from '@mui/icons-material/Edit'
 import {
   Box,
-  Chip,
   Paper,
   Stack,
   Table,
@@ -108,13 +107,8 @@ export function ChartOfAccountContextHeader({ selected, onEdit, onDelete }: Prop
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
                     <TableCell sx={labelCellSx}>Account Type</TableCell>
-                    <TableCell sx={valueCellSx}>
-                      <Chip
-                        size="small"
-                        label={selected.type.charAt(0) + selected.type.slice(1).toLowerCase()}
-                        color={ACCOUNT_TYPE_COLORS[selected.type]}
-                        variant="outlined"
-                      />
+                    <TableCell sx={{ ...valueCellSx, color: `${ACCOUNT_TYPE_COLORS[selected.type]}.main` }}>
+                      {selected.type.charAt(0) + selected.type.slice(1).toLowerCase()}
                     </TableCell>
                   </TableRow>
                   <TableRow>
@@ -150,13 +144,8 @@ export function ChartOfAccountContextHeader({ selected, onEdit, onDelete }: Prop
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
                     <TableCell sx={labelCellSx}>Status</TableCell>
-                    <TableCell sx={valueCellSx}>
-                      <Chip
-                        size="small"
-                        label={selected.isActive ? 'Active' : 'Inactive'}
-                        color={selected.isActive ? 'success' : 'default'}
-                        variant="outlined"
-                      />
+                    <TableCell sx={{ ...valueCellSx, color: selected.isActive ? 'success.main' : 'text.disabled' }}>
+                      {selected.isActive ? 'Active' : 'Inactive'}
                     </TableCell>
                   </TableRow>
                   <TableRow>

--- a/frontend/src/pages/accounting/components/ChartOfAccountWorkspaceCard.tsx
+++ b/frontend/src/pages/accounting/components/ChartOfAccountWorkspaceCard.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  Chip,
   Paper,
   Skeleton,
   Table,
@@ -69,13 +68,8 @@ function SubAccountsTable({ accounts }: { accounts: ChartOfAccount[] }) {
           <TableRow key={child.id} sx={index % 2 === 1 ? { backgroundColor: 'grey.50' } : {}}>
             <TableCell sx={tdSx}>{child.code}</TableCell>
             <TableCell sx={tdSx}>{child.name}</TableCell>
-            <TableCell sx={{ ...tdSx }}>
-              <Chip
-                size="small"
-                label={child.type.charAt(0) + child.type.slice(1).toLowerCase()}
-                color={ACCOUNT_TYPE_COLORS[child.type]}
-                variant="outlined"
-              />
+            <TableCell sx={{ ...tdSx, color: `${ACCOUNT_TYPE_COLORS[child.type]}.main` }}>
+              {child.type.charAt(0) + child.type.slice(1).toLowerCase()}
             </TableCell>
           </TableRow>
         ))}


### PR DESCRIPTION
## Summary
- Replace `Chip` for Account Type and Status in `ChartOfAccountContextHeader.tsx` with plain colored text
- Replace `Chip` for Account Type in `ChartOfAccountWorkspaceCard.tsx` Sub-Accounts table with plain colored text
- Remove unused `Chip` imports from both components
- Add regression tests: plain text assertion, inactive status path, column-header-relative index for sub-accounts table

Closes #534

## Test plan
- [ ] Navigate to Accounting > Chart of Accounts, select an account — verify Account Type and Status are plain colored text (not chips)
- [ ] Select a parent account with sub-accounts — verify the Type column in the Sub-Accounts table is plain colored text
- [ ] Verify colors: Active = green, Inactive = grey, Asset = green, Liability = red, Equity = blue, Revenue = light blue, Expense = orange
- [ ] All 9 `ChartOfAccountsPage` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)