### PR TITLE
chore: fix Knip issues - duplicate page exports and REVERSED enum usage

### DIFF
--- a/frontend/src/__tests__/integration/accounting-auto-posting.integration.test.tsx
+++ b/frontend/src/__tests__/integration/accounting-auto-posting.integration.test.tsx
@@ -59,7 +59,7 @@ vi.mock('react-router-dom', async () => {
 import AccountMappingWarning from '@/components/accounting/AccountMappingWarning'
 import AccountingEntryLink from '@/components/accounting/AccountingEntryLink'
 import AccountMappingsPage from '@/pages/accounting/AccountMappingsPage'
-import { JournalEntriesPage } from '@/pages/accounting/JournalEntriesPage'
+import JournalEntriesPage from '@/pages/accounting/JournalEntriesPage'
 
 const createUser = () => {
   return (userEvent as any).setup ? (userEvent as any).setup() : userEvent

--- a/frontend/src/pages/accounting/JournalEntriesPage.tsx
+++ b/frontend/src/pages/accounting/JournalEntriesPage.tsx
@@ -22,7 +22,7 @@ interface JEFilters {
   period: PeriodValue
 }
 
-export const JournalEntriesPage: React.FC = () => {
+const JournalEntriesPage: React.FC = () => {
   const [sortBy, setSortBy] = useState('createdAt')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
 

--- a/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/JournalEntriesPage.test.tsx
@@ -4,7 +4,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router-dom'
 
-import { JournalEntriesPage } from '../JournalEntriesPage'
+import JournalEntriesPage from '../JournalEntriesPage'
 import accountingReducer, { selectSelectedJournalEntry } from '@/store/slices/accountingSlice'
 import { JournalEntryStatus } from '@/types'
 

--- a/frontend/src/pages/accounting/reports/AccountActivityPage.tsx
+++ b/frontend/src/pages/accounting/reports/AccountActivityPage.tsx
@@ -31,6 +31,7 @@ import { useNavigate } from 'react-router-dom';
 import { formatDate, formatDateTime } from '@/utils/formatters';
 import { useGetAccountActivityQuery, useGetChartOfAccountsQuery } from '@/store/api/accountingApi';
 import type { ChartOfAccount } from '@/types';
+import { JournalEntryStatus } from '@/types';
 import { exportReportExcel } from '@/utils/exportReport';
 import { getErrorMessage } from '@/utils/errorMessage';
 
@@ -92,9 +93,9 @@ const getEntryTypeColor = (entryType: string): 'default' | 'primary' | 'warning'
 // Status chip colors
 const getStatusColor = (status: string): 'default' | 'success' | 'error' => {
   const statusUpper = status.toUpperCase();
-  if (statusUpper === 'DRAFT') return 'default';
-  if (statusUpper === 'POSTED') return 'success';
-  if (statusUpper === 'REVERSED') return 'error';
+  if (statusUpper === JournalEntryStatus.DRAFT) return 'default';
+  if (statusUpper === JournalEntryStatus.POSTED) return 'success';
+  if (statusUpper === JournalEntryStatus.REVERSED) return 'error';
   return 'default';
 };
 
@@ -329,9 +330,9 @@ const AccountActivityPage: React.FC = () => {
                 }}
               >
                 <MenuItem value="ALL">All Statuses</MenuItem>
-                <MenuItem value="DRAFT">Draft</MenuItem>
-                <MenuItem value="POSTED">Posted</MenuItem>
-                <MenuItem value="REVERSED">Reversed</MenuItem>
+                <MenuItem value={JournalEntryStatus.DRAFT}>Draft</MenuItem>
+                <MenuItem value={JournalEntryStatus.POSTED}>Posted</MenuItem>
+                <MenuItem value={JournalEntryStatus.REVERSED}>Reversed</MenuItem>
               </Select>
             </FormControl>
           </Stack>

--- a/frontend/src/pages/inventory/ProductsPage.tsx
+++ b/frontend/src/pages/inventory/ProductsPage.tsx
@@ -24,7 +24,7 @@ interface InventoryProductFilters {
   stockStatus: 'low_stock' | 'out_of_stock' | null
 }
 
-export const ProductsPage: React.FC = () => {
+const ProductsPage: React.FC = () => {
   const dispatch = useAppDispatch()
   const selectedProduct = useAppSelector(selectSelectedProduct)
   const [sortBy, setSortBy] = useState('name')

--- a/frontend/src/pages/inventory/__tests__/ProductsPage.filterbar.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/ProductsPage.filterbar.test.tsx
@@ -4,7 +4,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ProductsPage } from '../ProductsPage'
+import ProductsPage from '../ProductsPage'
 import inventoryReducer from '@/store/slices/inventorySlice'
 
 const { useGetProductsQuery, useGetCategoriesQuery } = vi.hoisted(() => ({

--- a/frontend/src/pages/purchasing/GoodsReceivedPage.tsx
+++ b/frontend/src/pages/purchasing/GoodsReceivedPage.tsx
@@ -26,7 +26,7 @@ interface GRNSortingState {
   sortOrder: 'asc' | 'desc'
 }
 
-export const GoodsReceivedPage: React.FC = () => {
+const GoodsReceivedPage: React.FC = () => {
   const dispatch = useAppDispatch()
   const [sorting, setSorting] = useState<GRNSortingState>({
     sortBy: 'grnNumber',

--- a/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
@@ -25,7 +25,7 @@ interface PurchaseOrderFilters {
   status: 'draft' | 'received' | null
 }
 
-export const PurchaseOrdersPage: React.FC = () => {
+const PurchaseOrdersPage: React.FC = () => {
   const navigate = useNavigate()
   const dispatch = useAppDispatch()
   const selectedOrder = useAppSelector(selectSelectedPurchaseOrder)

--- a/frontend/src/pages/purchasing/__tests__/GoodsReceivedPage.filterbar.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/GoodsReceivedPage.filterbar.test.tsx
@@ -4,7 +4,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { GoodsReceivedPage } from '../GoodsReceivedPage'
+import GoodsReceivedPage from '../GoodsReceivedPage'
 import purchasingReducer from '@/store/slices/purchasingSlice'
 
 const { useGetGoodsReceivedNotesQuery } = vi.hoisted(() => ({

--- a/frontend/src/pages/purchasing/__tests__/PurchaseOrdersPage.filterbar.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/PurchaseOrdersPage.filterbar.test.tsx
@@ -4,7 +4,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { PurchaseOrdersPage } from '../PurchaseOrdersPage'
+import PurchaseOrdersPage from '../PurchaseOrdersPage'
 import purchasingReducer from '@/store/slices/purchasingSlice'
 
 const { useGetPurchaseOrdersQuery } = vi.hoisted(() => ({

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -30,7 +30,7 @@ interface SalesOrderFilters {
   fulfillmentStatus: 'fulfilled' | 'unfulfilled' | null
 }
 
-export const OrdersPage: React.FC = () => {
+const OrdersPage: React.FC = () => {
   const navigate = useNavigate()
   const dispatch = useAppDispatch()
   const store = useStore()

--- a/frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
+++ b/frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
@@ -4,7 +4,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { OrdersPage } from '../OrdersPage'
+import OrdersPage from '../OrdersPage'
 import salesReducer from '@/store/slices/salesSlice'
 
 const { useGetSalesOrdersQuery } = vi.hoisted(() => ({

--- a/frontend/src/utils/filterBar.url.ts
+++ b/frontend/src/utils/filterBar.url.ts
@@ -1,4 +1,5 @@
 import { PERIOD_KEYS, type PeriodKey } from '@/constants/periods'
+import { JournalEntryStatus } from '@/types'
 import type {
   FilterBarConfig,
   FilterFieldConfig,
@@ -222,7 +223,7 @@ export function parseFilters<TFilters extends object>(
         const VALID_TRANSACTION_STATUS = ['completed', 'pending', 'failed', 'cancelled', 'refunded']
         result[fieldKey] = VALID_TRANSACTION_STATUS.includes(raw) ? raw : (defaultValue ?? null)
       } else if (field.type === 'journal-entry-status') {
-        const VALID_JOURNAL_ENTRY_STATUS = ['draft', 'posted', 'reversed', 'DRAFT', 'POSTED', 'REVERSED']
+        const VALID_JOURNAL_ENTRY_STATUS = ['draft', 'posted', 'reversed', JournalEntryStatus.DRAFT, JournalEntryStatus.POSTED, JournalEntryStatus.REVERSED]
         result[fieldKey] = VALID_JOURNAL_ENTRY_STATUS.includes(raw) ? raw : (defaultValue ?? null)
       } else if (field.type === 'journal-entry-type') {
         const VALID_JOURNAL_ENTRY_TYPE = ['manual', 'sales_order', 'payment', 'settlement', 'goods_received_note', 'vendor_payment', 'stock_adjustment', 'owner_equity_transaction', 'expense', 'opening_balance', 'fund_transfer']


### PR DESCRIPTION
## Summary

- Remove duplicate named+default exports from 5 page components (`JournalEntriesPage`, `ProductsPage`, `GoodsReceivedPage`, `PurchaseOrdersPage`, `OrdersPage`) — keep default export only, update 6 test files to use default imports
- Replace `'DRAFT'`/`'POSTED'`/`'REVERSED'` raw string literals with `JournalEntryStatus` enum members in `AccountActivityPage.tsx` and `filterBar.url.ts`

Note: Knip flagged `JournalEntryStatus.REVERSED` as unused because it was only referenced via raw string literals — this PR fixes the root cause rather than suppressing the warning.

## Test plan

- [x] All 5 affected filterbar/page tests pass (38 tests)
- [x] Accounting integration test passes (12 tests)
- [x] TypeScript type-check clean

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)