### PR TITLE
chore: add root knip.json to fix false positives

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://unpkg.com/knip@5/schema.json",
+  "entry": [
+    "release.config.cjs",
+    "scripts/*.cjs",
+    "scripts/__tests__/*.js"
+  ],
+  "project": [
+    "*.cjs",
+    "scripts/**/*.{cjs,js}"
+  ],
+  "ignore": [],
+  "ignoreDependencies": [
+    "conventional-changelog-angular"
+  ],
+  "ignoreBinaries": [
+    "eslint",
+    "semantic-release"
+  ],
+  "ignoreExportsUsedInFile": true
+}


### PR DESCRIPTION
## Summary
- Creates `knip.json` at repo root so `npx knip` reports zero issues (was 978 false positives)
- Ignores `backend/` and `frontend/` sub-projects, each of which has its own `knip.json`
- Adds `ignoreBinaries` for `eslint` and `semantic-release` (CI-only runtime installs) and `ignoreDependencies` for `conventional-changelog-angular`

## Test Plan
- [x] `npx knip` from repo root exits 0 with no output

Closes #542