### PR TITLE
feat: fulfillment-only customer metrics (#544)

### DIFF
--- a/backend/src/database/migrations/1746700000000-FulfillmentOnlyCustomerMetrics.ts
+++ b/backend/src/database/migrations/1746700000000-FulfillmentOnlyCustomerMetrics.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FulfillmentOnlyCustomerMetrics1746700000000 implements MigrationInterface {
+  name = 'FulfillmentOnlyCustomerMetrics1746700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE "customers" c
+      SET
+        "totalOrders" = sub.cnt,
+        "totalSales" = sub.total,
+        "firstPurchaseDate" = sub.first_date,
+        "lastPurchaseDate" = sub.last_date
+      FROM (
+        SELECT
+          "customerId",
+          COUNT(*) AS cnt,
+          COALESCE(SUM("totalAmount"), 0) AS total,
+          MIN("orderDate") AS first_date,
+          MAX("orderDate") AS last_date
+        FROM "sales_orders"
+        WHERE "deletedAt" IS NULL
+          AND "isFulfilled" = true
+        GROUP BY "customerId"
+      ) sub
+      WHERE c.id = sub."customerId"
+    `);
+
+    await queryRunner.query(`
+      UPDATE "customers"
+      SET
+        "totalOrders" = 0,
+        "totalSales" = 0,
+        "firstPurchaseDate" = NULL,
+        "lastPurchaseDate" = NULL
+      WHERE id NOT IN (
+        SELECT DISTINCT "customerId"
+        FROM "sales_orders"
+        WHERE "deletedAt" IS NULL
+          AND "isFulfilled" = true
+      )
+    `);
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    // No-op: recalculated data cannot be meaningfully reversed.
+  }
+}

--- a/backend/src/modules/sales/services/customer.service.spec.ts
+++ b/backend/src/modules/sales/services/customer.service.spec.ts
@@ -326,10 +326,10 @@ describe('CustomerService', () => {
         andWhere: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
         getRawOne: jest.fn().mockResolvedValue({
-          totalOrders: '2',
-          totalSales: '300',
-          firstOrderDate: new Date('2026-01-01'),
-          lastOrderDate: new Date('2026-03-01'),
+          totalorders: '2',
+          totalsales: '300',
+          firstorderdate: new Date('2026-01-01'),
+          lastorderdate: new Date('2026-03-01'),
         }),
       };
       salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
@@ -360,10 +360,10 @@ describe('CustomerService', () => {
         andWhere: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
         getRawOne: jest.fn().mockResolvedValue({
-          totalOrders: '1',
-          totalSales: '100',
-          firstOrderDate: null,
-          lastOrderDate: null,
+          totalorders: '1',
+          totalsales: '100',
+          firstorderdate: null,
+          lastorderdate: null,
         }),
       };
       salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
@@ -393,11 +393,11 @@ describe('CustomerService', () => {
         andWhere: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
         getRawOne: jest.fn().mockResolvedValue({
-          totalOrders: '3',
-          averageOrderValue: '100',
-          totalSales: '300',
-          firstOrderDate: new Date('2026-01-01'),
-          lastOrderDate: new Date('2026-03-01'),
+          totalorders: '3',
+          averageordervalue: '100',
+          totalsales: '300',
+          firstorderdate: new Date('2026-01-01'),
+          lastorderdate: new Date('2026-03-01'),
         }),
       };
       salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);

--- a/backend/src/modules/sales/services/customer.service.spec.ts
+++ b/backend/src/modules/sales/services/customer.service.spec.ts
@@ -344,4 +344,35 @@ describe('CustomerService', () => {
       );
     });
   });
+
+  describe('recalculateAllCustomerTotals', () => {
+    it('uses isFulfilled filter when recalculating', async () => {
+      const customers = [createCustomer('c1'), createCustomer('c2')];
+      customerRepository.find = jest.fn().mockResolvedValue(customers);
+      customerRepository.save = jest.fn().mockResolvedValue({} as Customer);
+
+      const salesOrderRepository: jest.Mocked<Repository<SalesOrder>> = module.get(
+        getRepositoryToken(SalesOrder),
+      );
+
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue({
+          totalOrders: '1',
+          totalSales: '100',
+          firstOrderDate: null,
+          lastOrderDate: null,
+        }),
+      };
+      salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      await service.recalculateAllCustomerTotals();
+
+      expect(qb.andWhere).toHaveBeenCalledWith('order.isFulfilled = :isFulfilled', {
+        isFulfilled: true,
+      });
+    });
+  });
 });

--- a/backend/src/modules/sales/services/customer.service.spec.ts
+++ b/backend/src/modules/sales/services/customer.service.spec.ts
@@ -10,6 +10,7 @@ import { TransactionManager } from '../../../common/utils/transaction.util';
 import { UserRole } from '../../../database/entities/user.entity';
 
 describe('CustomerService', () => {
+  let module: TestingModule;
   let service: CustomerService;
   let customerRepository: jest.Mocked<Repository<Customer>>;
   const adminUser = { role: UserRole.ADMIN } as any;
@@ -39,7 +40,7 @@ describe('CustomerService', () => {
     }) as Customer;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    module = await Test.createTestingModule({
       providers: [
         CustomerService,
         {
@@ -307,6 +308,40 @@ describe('CustomerService', () => {
       } as any);
 
       expect(results).toEqual([]);
+    });
+  });
+
+  describe('updateCustomerMetrics', () => {
+    it('counts only fulfilled non-deleted orders', async () => {
+      const customer = createCustomer('c1', { totalOrders: 5, totalSales: 500 });
+      customerRepository.findOne = jest.fn().mockResolvedValue(customer);
+      customerRepository.save = jest.fn().mockResolvedValue(customer);
+
+      const salesOrderRepository: jest.Mocked<Repository<SalesOrder>> = module.get(
+        getRepositoryToken(SalesOrder),
+      );
+
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue({
+          totalOrders: '2',
+          totalSales: '300',
+          firstOrderDate: new Date('2026-01-01'),
+          lastOrderDate: new Date('2026-03-01'),
+        }),
+      };
+      salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      await service.updateCustomerMetrics('c1');
+
+      expect(qb.andWhere).toHaveBeenCalledWith('order.isFulfilled = :isFulfilled', {
+        isFulfilled: true,
+      });
+      expect(customerRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ totalOrders: 2, totalSales: 300 }),
+      );
     });
   });
 });

--- a/backend/src/modules/sales/services/customer.service.spec.ts
+++ b/backend/src/modules/sales/services/customer.service.spec.ts
@@ -375,4 +375,39 @@ describe('CustomerService', () => {
       });
     });
   });
+
+  describe('getCustomerStatistics', () => {
+    it('filters order stats to fulfilled orders only', async () => {
+      const customer = createCustomer('c1');
+      customerRepository.findOne = jest.fn().mockResolvedValue(customer);
+
+      const salesOrderRepository: jest.Mocked<Repository<SalesOrder>> = module.get(
+        getRepositoryToken(SalesOrder),
+      );
+      const invoiceRepository: jest.Mocked<Repository<Invoice>> = module.get(
+        getRepositoryToken(Invoice),
+      );
+
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue({
+          totalOrders: '3',
+          averageOrderValue: '100',
+          totalSales: '300',
+          firstOrderDate: new Date('2026-01-01'),
+          lastOrderDate: new Date('2026-03-01'),
+        }),
+      };
+      salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+      invoiceRepository.count = jest.fn().mockResolvedValue(0);
+
+      await service.getCustomerStatistics('c1');
+
+      expect(qb.andWhere).toHaveBeenCalledWith('order.isFulfilled = :isFulfilled', {
+        isFulfilled: true,
+      });
+    });
+  });
 });

--- a/backend/src/modules/sales/services/customer.service.ts
+++ b/backend/src/modules/sales/services/customer.service.ts
@@ -494,6 +494,7 @@ export class CustomerService extends BaseCrudService<
       .createQueryBuilder('order')
       .where('order.customerId = :customerId', { customerId })
       .andWhere('order.deletedAt IS NULL')
+      .andWhere('order.isFulfilled = :isFulfilled', { isFulfilled: true })
       .select([
         'COUNT(*) as totalOrders',
         'COALESCE(AVG(order.totalAmount), 0) as averageOrderValue',

--- a/backend/src/modules/sales/services/customer.service.ts
+++ b/backend/src/modules/sales/services/customer.service.ts
@@ -496,11 +496,11 @@ export class CustomerService extends BaseCrudService<
       .andWhere('order.deletedAt IS NULL')
       .andWhere('order.isFulfilled = :isFulfilled', { isFulfilled: true })
       .select([
-        'COUNT(*) as totalOrders',
-        'COALESCE(AVG(order.totalAmount), 0) as averageOrderValue',
-        'COALESCE(SUM(order.totalAmount), 0) as totalSales',
-        'MIN(order.orderDate) as firstOrderDate',
-        'MAX(order.orderDate) as lastOrderDate',
+        'COUNT(*) as totalorders',
+        'COALESCE(AVG(order.totalAmount), 0) as averageordervalue',
+        'COALESCE(SUM(order.totalAmount), 0) as totalsales',
+        'MIN(order.orderDate) as firstorderdate',
+        'MAX(order.orderDate) as lastorderdate',
       ])
       .getRawOne();
 
@@ -525,11 +525,11 @@ export class CustomerService extends BaseCrudService<
         name: customer.name,
       },
       orders: {
-        totalOrders: parseInt(orderStats.totalOrders) || 0,
-        totalSales: parseFloat(orderStats.totalSales) || 0,
-        averageOrderValue: parseFloat(orderStats.averageOrderValue) || 0,
-        firstOrderDate: orderStats.firstOrderDate,
-        lastOrderDate: orderStats.lastOrderDate,
+        totalOrders: parseInt(orderStats.totalorders) || 0,
+        totalSales: parseFloat(orderStats.totalsales) || 0,
+        averageOrderValue: parseFloat(orderStats.averageordervalue) || 0,
+        firstOrderDate: orderStats.firstorderdate,
+        lastOrderDate: orderStats.lastorderdate,
       },
       payments: {
         totalPayments: paymentStats.totalPayments || 0,
@@ -921,17 +921,17 @@ export class CustomerService extends BaseCrudService<
         .andWhere('order.deletedAt IS NULL')
         .andWhere('order.isFulfilled = :isFulfilled', { isFulfilled: true })
         .select([
-          'COUNT(*) as totalOrders',
-          'COALESCE(SUM(order.totalAmount), 0) as totalSales',
-          'MIN(order.orderDate) as firstOrderDate',
-          'MAX(order.orderDate) as lastOrderDate',
+          'COUNT(*) as totalorders',
+          'COALESCE(SUM(order.totalAmount), 0) as totalsales',
+          'MIN(order.orderDate) as firstorderdate',
+          'MAX(order.orderDate) as lastorderdate',
         ])
         .getRawOne();
 
-      const actualTotalOrders = parseInt(orderStats.totalOrders) || 0;
-      const actualTotalSales = parseFloat(orderStats.totalSales) || 0;
-      const firstOrderDate = orderStats.firstOrderDate;
-      const lastOrderDate = orderStats.lastOrderDate;
+      const actualTotalOrders = parseInt(orderStats.totalorders) || 0;
+      const actualTotalSales = parseFloat(orderStats.totalsales) || 0;
+      const firstOrderDate = orderStats.firstorderdate;
+      const lastOrderDate = orderStats.lastorderdate;
 
       // Check if there's a discrepancy
       const hasDiscrepancy =
@@ -976,17 +976,17 @@ export class CustomerService extends BaseCrudService<
       .andWhere('order.deletedAt IS NULL')
       .andWhere('order.isFulfilled = :isFulfilled', { isFulfilled: true })
       .select([
-        'COUNT(*) as totalOrders',
-        'COALESCE(SUM(order.totalAmount), 0) as totalSales',
-        'MIN(order.orderDate) as firstOrderDate',
-        'MAX(order.orderDate) as lastOrderDate',
+        'COUNT(*) as totalorders',
+        'COALESCE(SUM(order.totalAmount), 0) as totalsales',
+        'MIN(order.orderDate) as firstorderdate',
+        'MAX(order.orderDate) as lastorderdate',
       ])
       .getRawOne();
 
-    customer.totalOrders = parseInt(orderStats.totalOrders) || 0;
-    customer.totalSales = parseFloat(orderStats.totalSales) || 0;
-    customer.firstPurchaseDate = orderStats.firstOrderDate;
-    customer.lastPurchaseDate = orderStats.lastOrderDate;
+    customer.totalOrders = parseInt(orderStats.totalorders) || 0;
+    customer.totalSales = parseFloat(orderStats.totalsales) || 0;
+    customer.firstPurchaseDate = orderStats.firstorderdate;
+    customer.lastPurchaseDate = orderStats.lastorderdate;
 
     await this.customerRepository.save(customer);
   }

--- a/backend/src/modules/sales/services/customer.service.ts
+++ b/backend/src/modules/sales/services/customer.service.ts
@@ -975,6 +975,7 @@ export class CustomerService extends BaseCrudService<
       .createQueryBuilder('order')
       .where('order.customerId = :customerId', { customerId })
       .andWhere('order.deletedAt IS NULL')
+      .andWhere('order.isFulfilled = :isFulfilled', { isFulfilled: true })
       .select([
         'COUNT(*) as totalOrders',
         'COALESCE(SUM(order.totalAmount), 0) as totalSales',

--- a/backend/src/modules/sales/services/customer.service.ts
+++ b/backend/src/modules/sales/services/customer.service.ts
@@ -921,6 +921,7 @@ export class CustomerService extends BaseCrudService<
         .createQueryBuilder('order')
         .where('order.customerId = :customerId', { customerId: customer.id })
         .andWhere('order.deletedAt IS NULL')
+        .andWhere('order.isFulfilled = :isFulfilled', { isFulfilled: true })
         .select([
           'COUNT(*) as totalOrders',
           'COALESCE(SUM(order.totalAmount), 0) as totalSales',

--- a/backend/src/modules/sales/services/customer.service.ts
+++ b/backend/src/modules/sales/services/customer.service.ts
@@ -908,11 +908,8 @@ export class CustomerService extends BaseCrudService<
   async recalculateAllCustomerTotals(): Promise<{ updated: number; message: string }> {
     console.log('🔄 Starting recalculation of all customer totals...');
 
-    // Get all customers
-    const customers = await this.customerRepository.find({
-      where: { isActive: true },
-      relations: ['salesOrders']
-    });
+    // Get all customers (including inactive — inactive customers may still have fulfilled orders)
+    const customers = await this.customerRepository.find();
 
     let updatedCount = 0;
 
@@ -967,9 +964,9 @@ export class CustomerService extends BaseCrudService<
    * Update customer metrics for a specific customer based on their sales orders
    */
   async updateCustomerMetrics(customerId: string): Promise<void> {
-    const customer = await this.customerRepository.findOne({ where: { id: customerId } });
+    const customer = await this.customerRepository.findOne({ where: { id: customerId }, withDeleted: true });
     if (!customer) {
-      throw new NotFoundException('Customer not found');
+      throw new NotFoundException(`Customer not found for metric update (customerId: ${customerId}) — possible orphaned order`);
     }
 
     // Calculate actual totals from sales orders

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -760,4 +760,43 @@ describe('SalesOrderService', () => {
       expect(customerService.updateCustomerMetrics).not.toHaveBeenCalled();
     });
   });
+
+  describe('bulkRestore calls updateCustomerMetrics per unique customer', () => {
+    it('calls updateCustomerMetrics for each unique customerId in the batch', async () => {
+      salesOrderRepository.find = jest.fn().mockResolvedValue([
+        { id: 'o1', customerId: 'c1' } as SalesOrder,
+        { id: 'o2', customerId: 'c2' } as SalesOrder,
+        { id: 'o3', customerId: 'c1' } as SalesOrder, // duplicate customer
+      ]);
+      salesOrderLifecycleService.bulkRestore = jest.fn().mockResolvedValue({
+        success: 3, failed: [],
+      });
+      const customerService = module.get(CustomerService);
+
+      await service.bulkRestore(['o1', 'o2', 'o3']);
+
+      expect(customerService.updateCustomerMetrics).toHaveBeenCalledWith('c1');
+      expect(customerService.updateCustomerMetrics).toHaveBeenCalledWith('c2');
+      expect(customerService.updateCustomerMetrics).toHaveBeenCalledTimes(2); // deduplicated
+    });
+  });
+
+  describe('bulkPermanentDelete calls updateCustomerMetrics per unique customer', () => {
+    it('calls updateCustomerMetrics for each unique customerId in the batch', async () => {
+      salesOrderRepository.find = jest.fn().mockResolvedValue([
+        { id: 'o1', customerId: 'c1' } as SalesOrder,
+        { id: 'o2', customerId: 'c2' } as SalesOrder,
+      ]);
+      salesOrderLifecycleService.bulkPermanentDelete = jest.fn().mockResolvedValue({
+        success: 2, failed: [],
+      });
+      const customerService = module.get(CustomerService);
+
+      await service.bulkPermanentDelete(['o1', 'o2']);
+
+      expect(customerService.updateCustomerMetrics).toHaveBeenCalledWith('c1');
+      expect(customerService.updateCustomerMetrics).toHaveBeenCalledWith('c2');
+      expect(customerService.updateCustomerMetrics).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -22,8 +22,10 @@ import { SalesOrderFulfillmentService } from './sales-order-fulfillment.service'
 import { SalesOrderLifecycleService } from './sales-order-lifecycle.service';
 import { SalesOrderPaymentService } from './sales-order-payment.service';
 import { SalesOrderQueryService } from './sales-order-query.service';
+import { CustomerService } from './customer.service';
 
 describe('SalesOrderService', () => {
+  let module: TestingModule;
   let service: SalesOrderService;
   let salesOrderRepository: jest.Mocked<Repository<SalesOrder>>;
   let accountingService: jest.Mocked<AccountingService>;
@@ -33,6 +35,9 @@ describe('SalesOrderService', () => {
   let settingsService: jest.Mocked<SettingsService>;
   let auditLogService: jest.Mocked<AuditLogService>;
   let dataSource: jest.Mocked<DataSource>;
+  let salesOrderFulfillmentService: jest.Mocked<SalesOrderFulfillmentService>;
+  let salesOrderLifecycleService: jest.Mocked<SalesOrderLifecycleService>;
+  let salesOrderQueryService: jest.Mocked<SalesOrderQueryService>;
   const adminUser = { role: UserRole.ADMIN } as any;
 
   const createMockSalesOrder = (): Partial<SalesOrder> => ({
@@ -67,7 +72,7 @@ describe('SalesOrderService', () => {
       transaction: jest.fn(),
     } as any;
 
-    const module: TestingModule = await Test.createTestingModule({
+    module = await Test.createTestingModule({
       providers: [
         SalesOrderService,
         SalesOrderFulfillmentService,
@@ -161,6 +166,10 @@ describe('SalesOrderService', () => {
             reverseSourceEntries: jest.fn(),
           },
         },
+        {
+          provide: CustomerService,
+          useValue: { updateCustomerMetrics: jest.fn().mockResolvedValue(undefined) },
+        },
       ],
     }).compile();
 
@@ -172,6 +181,9 @@ describe('SalesOrderService', () => {
     baseCostCalculator = module.get(BaseCostCalculatorService);
     settingsService = module.get(SettingsService);
     auditLogService = module.get(AuditLogService);
+    salesOrderFulfillmentService = module.get(SalesOrderFulfillmentService);
+    salesOrderLifecycleService = module.get(SalesOrderLifecycleService);
+    salesOrderQueryService = module.get(SalesOrderQueryService);
   });
 
   it('should be defined', () => {
@@ -627,6 +639,17 @@ describe('SalesOrderService', () => {
   });
 
   describe('unfulfillOrder', () => {
+    it('calls updateCustomerMetrics with the order customerId after unfulfillment', async () => {
+      const mockOrder = { id: 'o1', customerId: 'c1' } as SalesOrder;
+      salesOrderFulfillmentService.unfulfillOrder = jest.fn().mockResolvedValue(mockOrder);
+      salesOrderQueryService.findById = jest.fn().mockResolvedValue({ id: 'o1' } as any);
+      const customerService = module.get(CustomerService);
+
+      await service.unfulfillOrder('o1');
+
+      expect(customerService.updateCustomerMetrics).toHaveBeenCalledWith('c1');
+    });
+
     it('should call reverseSourceEntries with sales_order sourceType when unfulfilling', async () => {
       const mockOrder = {
         id: 'so-123',
@@ -669,6 +692,72 @@ describe('SalesOrderService', () => {
       accountingService.reverseSourceEntries.mockRejectedValue(new Error('No open period'));
 
       await expect(service.unfulfillOrder('so-123')).resolves.toBeDefined();
+    });
+  });
+
+  describe('fulfillOrder calls updateCustomerMetrics', () => {
+    it('calls updateCustomerMetrics with the order customerId after fulfillment', async () => {
+      const mockOrder = { id: 'o1', customerId: 'c1' } as SalesOrder;
+      salesOrderFulfillmentService.fulfillOrder = jest.fn().mockResolvedValue(mockOrder);
+      salesOrderQueryService.findById = jest.fn().mockResolvedValue({ id: 'o1' } as any);
+      const customerService = module.get(CustomerService);
+
+      await service.fulfillOrder('o1', 'user1', 'user1');
+
+      expect(customerService.updateCustomerMetrics).toHaveBeenCalledWith('c1');
+    });
+  });
+
+  describe('delete calls updateCustomerMetrics', () => {
+    it('calls updateCustomerMetrics with the order customerId after delete', async () => {
+      salesOrderRepository.findOne.mockResolvedValue({ id: 'o1', customerId: 'c1' } as SalesOrder);
+      salesOrderLifecycleService.delete = jest.fn().mockResolvedValue({
+        deletedOrderNumber: 'SO-000001',
+        previousOrder: null,
+      });
+      const customerService = module.get(CustomerService);
+
+      await service.delete('o1');
+
+      expect(customerService.updateCustomerMetrics).toHaveBeenCalledWith('c1');
+    });
+  });
+
+  describe('restore calls updateCustomerMetrics', () => {
+    it('calls updateCustomerMetrics with the order customerId after restore', async () => {
+      salesOrderLifecycleService.restore = jest.fn().mockResolvedValue({
+        id: 'o1',
+        customerId: 'c1',
+      } as SalesOrder);
+      const customerService = module.get(CustomerService);
+
+      await service.restore('o1');
+
+      expect(customerService.updateCustomerMetrics).toHaveBeenCalledWith('c1');
+    });
+  });
+
+  describe('permanentDelete calls updateCustomerMetrics', () => {
+    it('calls updateCustomerMetrics with the order customerId after permanent delete', async () => {
+      salesOrderRepository.findOne.mockResolvedValue({ id: 'o1', customerId: 'c1' } as SalesOrder);
+      salesOrderLifecycleService.permanentDelete = jest.fn().mockResolvedValue(undefined);
+      const customerService = module.get(CustomerService);
+
+      await service.permanentDelete('o1');
+
+      expect(customerService.updateCustomerMetrics).toHaveBeenCalledWith('c1');
+    });
+  });
+
+  describe('create does NOT call updateCustomerSalesMetrics', () => {
+    it('does not update customer metrics when an order is created', async () => {
+      const customerService = module.get(CustomerService);
+
+      try {
+        await service.create({ customerId: 'nonexistent', items: [], shippingAmount: 0 });
+      } catch {}
+
+      expect(customerService.updateCustomerMetrics).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -602,11 +602,7 @@ export class SalesOrderService extends BaseCrudService<
     );
 
     if (customerId) {
-      try {
-        await this.customerService.updateCustomerMetrics(customerId);
-      } catch (error) {
-        this.logger.error(`Failed to update customer metrics after delete ${id}: ${error.message}`);
-      }
+      await this.triggerMetricUpdate(customerId, `delete ${id}`);
     }
 
     return result;
@@ -694,6 +690,18 @@ export class SalesOrderService extends BaseCrudService<
 
   // Helper methods
 
+  private async triggerMetricUpdate(customerId: string, context: string): Promise<void> {
+    try {
+      await this.customerService.updateCustomerMetrics(customerId);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        this.logger.warn(`Customer not found for metric update after ${context} — possible orphaned order (customerId: ${customerId})`);
+      } else {
+        this.logger.error(`Failed to update customer metrics after ${context} (customerId: ${customerId}): ${error.message}`);
+      }
+    }
+  }
+
   private async validateAndProcessItems(items: any[], customer?: Customer) {
     const processedItems = [];
     let lineNumber = 1;
@@ -770,16 +778,23 @@ export class SalesOrderService extends BaseCrudService<
 
   async restore(id: string, userId?: string, username?: string): Promise<SalesOrderResponseDto> {
     const restoredOrder = await this.salesOrderLifecycleService.restore(id, userId, username);
-    try {
-      await this.customerService.updateCustomerMetrics(restoredOrder.customerId);
-    } catch (error) {
-      this.logger.error(`Failed to update customer metrics after restore ${id}: ${error.message}`);
-    }
+    await this.triggerMetricUpdate(restoredOrder.customerId, `restore ${id}`);
     return restoredOrder;
   }
 
   async bulkRestore(ids: string[], userId?: string, username?: string): Promise<BulkOperationResponse> {
-    return this.salesOrderLifecycleService.bulkRestore(ids, userId, username);
+    const orders = ids.length > 0
+      ? await this.salesOrderRepository.find({ where: ids.map(id => ({ id })), withDeleted: true })
+      : [];
+    const customerIds = [...new Set(orders.map(o => o.customerId).filter(Boolean))];
+
+    const result = await this.salesOrderLifecycleService.bulkRestore(ids, userId, username);
+
+    for (const customerId of customerIds) {
+      await this.triggerMetricUpdate(customerId, `bulkRestore`);
+    }
+
+    return result;
   }
 
   async permanentDelete(id: string, userId?: string, username?: string): Promise<void> {
@@ -792,11 +807,7 @@ export class SalesOrderService extends BaseCrudService<
     await this.salesOrderLifecycleService.permanentDelete(id, userId, username);
 
     if (customerId) {
-      try {
-        await this.customerService.updateCustomerMetrics(customerId);
-      } catch (error) {
-        this.logger.error(`Failed to update customer metrics after permanentDelete ${id}: ${error.message}`);
-      }
+      await this.triggerMetricUpdate(customerId, `permanentDelete ${id}`);
     }
   }
 
@@ -805,7 +816,18 @@ export class SalesOrderService extends BaseCrudService<
     userId?: string,
     username?: string,
   ): Promise<BulkOperationResponse> {
-    return this.salesOrderLifecycleService.bulkPermanentDelete(orderIds, userId, username);
+    const orders = orderIds.length > 0
+      ? await this.salesOrderRepository.find({ where: orderIds.map(id => ({ id })), withDeleted: true })
+      : [];
+    const customerIds = [...new Set(orders.map(o => o.customerId).filter(Boolean))];
+
+    const result = await this.salesOrderLifecycleService.bulkPermanentDelete(orderIds, userId, username);
+
+    for (const customerId of customerIds) {
+      await this.triggerMetricUpdate(customerId, `bulkPermanentDelete`);
+    }
+
+    return result;
   }
 
   async updateAssociatedInvoices(salesOrderId: string): Promise<void> {
@@ -922,21 +944,13 @@ export class SalesOrderService extends BaseCrudService<
       userId,
       username,
     );
-    try {
-      await this.customerService.updateCustomerMetrics(savedOrder.customerId);
-    } catch (error) {
-      this.logger.error(`Failed to update customer metrics after fulfillOrder ${id}: ${error.message}`);
-    }
+    await this.triggerMetricUpdate(savedOrder.customerId, `fulfillOrder ${id}`);
     return this.findById(savedOrder.id);
   }
 
   async unfulfillOrder(id: string): Promise<SalesOrderResponseDto> {
     const savedOrder = await this.salesOrderFulfillmentService.unfulfillOrder(id);
-    try {
-      await this.customerService.updateCustomerMetrics(savedOrder.customerId);
-    } catch (error) {
-      this.logger.error(`Failed to update customer metrics after unfulfillOrder ${id}: ${error.message}`);
-    }
+    await this.triggerMetricUpdate(savedOrder.customerId, `unfulfillOrder ${id}`);
     return this.findById(savedOrder.id);
   }
 

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -33,7 +33,7 @@ import {
   BOOST_TRANSACTION,
   BOOST_EXACT_MATCH,
 } from '../../search/search.constants';
-// import { CustomerService } from './customer.service';
+import { CustomerService } from './customer.service';
 import { InventoryIntegrationService } from './inventory-integration.service';
 import { ValidationUtil, BulkOperationUtil, BulkOperationResponse } from '../../../common/utils/validation.util';
 import { StockMovementService } from '../../../modules/inventory/services/stock-movement.service';
@@ -72,7 +72,7 @@ export class SalesOrderService extends BaseCrudService<
     private readonly userRepository: Repository<User>,
     @InjectRepository(PriceListItem)
     private readonly priceListItemRepository: Repository<PriceListItem>,
-    // private readonly customerService: CustomerService,
+    private readonly customerService: CustomerService,
     private readonly inventoryIntegrationService: InventoryIntegrationService,
     private readonly stockMovementService: StockMovementService,
     private readonly baseCostCalculator: BaseCostCalculatorService,
@@ -271,14 +271,6 @@ export class SalesOrderService extends BaseCrudService<
         salesOrderId: savedOrder.id,
       }))
     );
-
-    // Update customer metrics immediately
-    try {
-      await this.updateCustomerSalesMetrics(customer.id, totalAmount);
-    } catch (error) {
-      console.error('Failed to update customer metrics:', error.message);
-      // Don't fail the order creation if customer metric update fails
-    }
 
     // Automatically generate invoice when order is created
     try {
@@ -599,12 +591,25 @@ export class SalesOrderService extends BaseCrudService<
     userId?: string,
     username?: string,
   ): Promise<{ deletedOrderNumber: string; previousOrder: SalesOrderResponseDto | null }> {
-    return this.salesOrderLifecycleService.delete(
+    const order = await this.salesOrderRepository.findOne({ where: { id } });
+    const customerId = order?.customerId;
+
+    const result = await this.salesOrderLifecycleService.delete(
       id,
       userId,
       username,
       this.findPreviousOrder.bind(this),
     );
+
+    if (customerId) {
+      try {
+        await this.customerService.updateCustomerMetrics(customerId);
+      } catch (error) {
+        this.logger.error(`Failed to update customer metrics after delete ${id}: ${error.message}`);
+      }
+    }
+
+    return result;
   }
 
   async duplicateOrder(id: string, userId: string): Promise<SalesOrderResponseDto> {
@@ -689,19 +694,6 @@ export class SalesOrderService extends BaseCrudService<
 
   // Helper methods
 
-  /**
-   * Update customer sales metrics when an order is created
-   */
-  private async updateCustomerSalesMetrics(customerId: string, orderAmount: number): Promise<void> {
-    const customer = await this.customerRepository.findOne({ where: { id: customerId } });
-    if (customer) {
-      // Use the entity's built-in method to update metrics
-      const isFirstOrder = customer.totalOrders === 0;
-      customer.updateSalesMetrics(orderAmount, isFirstOrder);
-      await this.customerRepository.save(customer);
-    }
-  }
-
   private async validateAndProcessItems(items: any[], customer?: Customer) {
     const processedItems = [];
     let lineNumber = 1;
@@ -777,7 +769,13 @@ export class SalesOrderService extends BaseCrudService<
   }
 
   async restore(id: string, userId?: string, username?: string): Promise<SalesOrderResponseDto> {
-    return this.salesOrderLifecycleService.restore(id, userId, username);
+    const restoredOrder = await this.salesOrderLifecycleService.restore(id, userId, username);
+    try {
+      await this.customerService.updateCustomerMetrics(restoredOrder.customerId);
+    } catch (error) {
+      this.logger.error(`Failed to update customer metrics after restore ${id}: ${error.message}`);
+    }
+    return restoredOrder;
   }
 
   async bulkRestore(ids: string[], userId?: string, username?: string): Promise<BulkOperationResponse> {
@@ -785,7 +783,21 @@ export class SalesOrderService extends BaseCrudService<
   }
 
   async permanentDelete(id: string, userId?: string, username?: string): Promise<void> {
-    return this.salesOrderLifecycleService.permanentDelete(id, userId, username);
+    const order = await this.salesOrderRepository.findOne({
+      where: { id },
+      withDeleted: true,
+    });
+    const customerId = order?.customerId;
+
+    await this.salesOrderLifecycleService.permanentDelete(id, userId, username);
+
+    if (customerId) {
+      try {
+        await this.customerService.updateCustomerMetrics(customerId);
+      } catch (error) {
+        this.logger.error(`Failed to update customer metrics after permanentDelete ${id}: ${error.message}`);
+      }
+    }
   }
 
   async bulkPermanentDelete(
@@ -910,11 +922,21 @@ export class SalesOrderService extends BaseCrudService<
       userId,
       username,
     );
+    try {
+      await this.customerService.updateCustomerMetrics(savedOrder.customerId);
+    } catch (error) {
+      this.logger.error(`Failed to update customer metrics after fulfillOrder ${id}: ${error.message}`);
+    }
     return this.findById(savedOrder.id);
   }
 
   async unfulfillOrder(id: string): Promise<SalesOrderResponseDto> {
     const savedOrder = await this.salesOrderFulfillmentService.unfulfillOrder(id);
+    try {
+      await this.customerService.updateCustomerMetrics(savedOrder.customerId);
+    } catch (error) {
+      this.logger.error(`Failed to update customer metrics after unfulfillOrder ${id}: ${error.message}`);
+    }
     return this.findById(savedOrder.id);
   }
 


### PR DESCRIPTION
## Summary

- Customer Account Summary metrics (Total Orders, Total Sales, First/Last Purchase Dates) now count only fulfilled, non-deleted orders — previously they counted all orders including unfulfilled and deleted ones
- `CustomerService.updateCustomerMetrics()`, `recalculateAllCustomerTotals()`, and `getCustomerStatistics()` all filter to `isFulfilled = true`
- `SalesOrderService` recalculates customer metrics after every lifecycle event: fulfill, unfulfill, soft-delete, restore, permanent delete, bulk restore, bulk permanent delete
- Order creation no longer bumps customer metrics
- Data migration fixes existing records: recalculates from fulfilled orders, zeroes out customers with none
- Root cause fix: TypeORM `getRawOne()` lowercases column aliases — was reading `totalOrders` (undefined) instead of `totalorders`, causing every write to persist 0

## Test Plan

- [x] 913 backend tests passing
- [x] Verified live: Customer B1 went from 9 (wrong) → 0 (migration) → 7 (correct after fulfill triggers fixed)
- [x] Fulfilling an order increments metrics; unfulfilling reverses them
- [x] Creating an order does not change metrics

Closes #544