### PR TITLE
chore: update dependency versions for issue 546

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -70,6 +70,7 @@
         "jest-progress-bar-reporter": "^1.0.25",
         "prettier": "^3.0.0",
         "supertest": "^7.2.2",
+        "tar-stream": "^3.0.0",
         "ts-jest": "^29.4.9",
         "ts-loader": "^9.5.4",
         "ts-node": "^10.9.2",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erp-backend",
-  "version": "1.104.0",
+  "version": "1.104.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-backend",
-      "version": "1.104.0",
+      "version": "1.104.1",
       "license": "MIT",
       "dependencies": {
         "@nestjs/bull": "^11.0.3",
@@ -24,7 +24,7 @@
         "@nestjs/websockets": "^11.0.0",
         "@types/archiver": "^7.0.0",
         "@types/bcrypt": "^6.0.0",
-        "archiver": "^7.0.1",
+        "archiver": "8.0.0",
         "bcrypt": "^6.0.0",
         "bull": "^4.11.4",
         "class-transformer": "^0.5.1",
@@ -4290,112 +4290,50 @@
       "license": "MIT"
     },
     "node_modules/archiver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
-      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-8.0.0.tgz",
+      "integrity": "sha512-fV1orZfsnPn9BaSByR/qE67rJCLJEy2Ox5bq7nJh+jquWaNh6Sfec75kJ2T6PtdGUbPQlrVoSVCEOa5SdiTQ1g==",
       "license": "MIT",
       "dependencies": {
-        "archiver-utils": "^5.0.2",
         "async": "^3.2.4",
         "buffer-crc32": "^1.0.0",
-        "readable-stream": "^4.0.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^3.0.0",
-        "zip-stream": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/archiver-utils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
-      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^10.0.0",
-        "graceful-fs": "^4.2.0",
-        "is-stream": "^2.0.1",
+        "is-stream": "^4.0.0",
         "lazystream": "^1.0.0",
-        "lodash": "^4.17.15",
         "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^3.0.0",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^7.0.2"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">=18"
       }
     },
-    "node_modules/archiver-utils/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+    "node_modules/archiver/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/archiver-utils/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
-    },
-    "node_modules/archiver-utils/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
+    "node_modules/archiver/node_modules/readdir-glob": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-3.0.0.tgz",
+      "integrity": "sha512-AhNB2KgKeVJr16nK9LLZbJNWnYoT23ZrumNKFDebHBdkC8KHSqWo871JAUhoWC/RtjEVdqNMFpM6qrwRbaUqpw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "minimatch": "^10.2.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=18"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/yqnn"
       }
     },
     "node_modules/arg": {
@@ -4570,7 +4508,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4804,7 +4741,6 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
       "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5379,19 +5315,31 @@
       }
     },
     "node_modules/compress-commons": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
-      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-7.0.1.tgz",
+      "integrity": "sha512-g0S8KAD8qf4+V//pr3BfB1aBnARLXNz2Gx+jmHU0LEriUuoQUOPOulVquHKTJ8+EAIIO7fhseNDr9wK5Q9FKBQ==",
       "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.0",
-        "crc32-stream": "^6.0.0",
-        "is-stream": "^2.0.1",
+        "crc32-stream": "^7.0.1",
+        "is-stream": "^4.0.0",
         "normalize-path": "^3.0.0",
         "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">=18"
+      }
+    },
+    "node_modules/compress-commons/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/compressible": {
@@ -5600,16 +5548,16 @@
       }
     },
     "node_modules/crc32-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
-      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-7.0.1.tgz",
+      "integrity": "sha512-IBWsY8xznyQrcHn8h4bC8/4ErNke5elzgG8GcqF4RFPw6aHkWWRc7Tgw6upjaTX/CT/yQgqYENkxYsTYN+hW2g==",
       "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">=18"
       }
     },
     "node_modules/create-require": {
@@ -7906,6 +7854,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9492,7 +9441,6 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -13165,17 +13113,17 @@
       }
     },
     "node_modules/zip-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
-      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-7.0.5.tgz",
+      "integrity": "sha512-dSvYKdvLsAHCDqPOhIwk/q5CvuWtTB3Dgpoe0uVEFjTzIOAmsQpprX25InCvrvJsirEbu1OHyy67n/kAj1Sw/w==",
       "license": "MIT",
       "dependencies": {
-        "archiver-utils": "^5.0.0",
-        "compress-commons": "^6.0.2",
+        "compress-commons": "^7.0.0",
+        "normalize-path": "^3.0.0",
         "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">=18"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -41,7 +41,7 @@
     "@nestjs/websockets": "^11.0.0",
     "@types/archiver": "^7.0.0",
     "@types/bcrypt": "^6.0.0",
-    "archiver": "^7.0.1",
+    "archiver": "8.0.0",
     "bcrypt": "^6.0.0",
     "bull": "^4.11.4",
     "class-transformer": "^0.5.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -123,7 +123,7 @@
       "^.+\\.(t|j)s$": "ts-jest"
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!(uuid)/)"
+      "node_modules/(?!(uuid|archiver|is-stream|zip-stream|compress-commons|crc32-stream)/)"
     ],
     "collectCoverageFrom": [
       "src/**/*.(t|j)s",

--- a/backend/package.json
+++ b/backend/package.json
@@ -87,6 +87,7 @@
     "jest-progress-bar-reporter": "^1.0.25",
     "prettier": "^3.0.0",
     "supertest": "^7.2.2",
+    "tar-stream": "^3.0.0",
     "ts-jest": "^29.4.9",
     "ts-loader": "^9.5.4",
     "ts-node": "^10.9.2",

--- a/backend/src/modules/backup/backup.service.spec.ts
+++ b/backend/src/modules/backup/backup.service.spec.ts
@@ -3,6 +3,9 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { ConfigService } from '@nestjs/config';
 import { EventEmitter } from 'events';
 import { spawn } from 'child_process';
+import * as os from 'os';
+import * as path from 'path';
+import * as fsCb from 'fs';
 import { BackupService } from './backup.service';
 import { BackupLog } from '@database/entities/backup-log.entity';
 import { BackupRetentionSettings } from '@database/entities/backup-settings.entity';
@@ -551,6 +554,89 @@ describe('BackupService - settings backup', () => {
 
       expect(loggerWarnSpy).toHaveBeenCalledWith(expect.stringContaining('No settings file found'));
       expect(companySettingsRepo.save).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('BackupService - createArchive', () => {
+  let service: BackupService;
+  let tempSourceDir: string;
+  let tempOutputPath: string;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BackupService,
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn((_key, def) => def ?? null) },
+        },
+        { provide: getRepositoryToken(BackupLog), useFactory: mockRepository },
+        { provide: getRepositoryToken(BackupRetentionSettings), useFactory: mockRepository },
+        { provide: getRepositoryToken(CompanySettings), useFactory: mockRepository },
+        { provide: getRepositoryToken(RegionalSettings), useFactory: mockRepository },
+        { provide: getRepositoryToken(DocumentNumberSetting), useFactory: mockRepository },
+        { provide: getRepositoryToken(PrintSettings), useFactory: mockRepository },
+      ],
+    }).compile();
+
+    service = module.get<BackupService>(BackupService);
+
+    const uniqueSuffix = `archiver-smoke-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    tempSourceDir = path.join(os.tmpdir(), uniqueSuffix, 'source');
+    tempOutputPath = path.join(os.tmpdir(), uniqueSuffix, 'output.tar.gz');
+
+    await require('fs/promises').mkdir(tempSourceDir, { recursive: true });
+    await require('fs/promises').writeFile(
+      path.join(tempSourceDir, 'test.txt'),
+      'hello archiver v8',
+    );
+  });
+
+  afterEach(async () => {
+    const parentDir = path.dirname(tempSourceDir);
+    await require('fs/promises').rm(parentDir, { recursive: true, force: true });
+  });
+
+  it('resolves to the output path and produces a non-empty .tar.gz file', async () => {
+    const result = await (service as any).createArchive(tempSourceDir, tempOutputPath);
+
+    expect(result).toBe(tempOutputPath);
+
+    const stats = await require('fs/promises').stat(tempOutputPath);
+    expect(stats.size).toBeGreaterThan(0);
+  });
+
+  it('produces a valid tar.gz that contains the source file', async () => {
+    await (service as any).createArchive(tempSourceDir, tempOutputPath);
+
+    await new Promise<void>((resolve, reject) => {
+      const gunzip = require('zlib').createGunzip();
+      const extract = require('tar-stream').extract();
+      const foundFiles: string[] = [];
+
+      extract.on(
+        'entry',
+        (
+          header: { name: string },
+          stream: NodeJS.ReadableStream,
+          next: () => void,
+        ) => {
+          foundFiles.push(header.name);
+          stream.resume();
+          stream.on('end', next);
+        },
+      );
+
+      extract.on('finish', () => {
+        expect(foundFiles).toContain('test.txt');
+        resolve();
+      });
+
+      extract.on('error', reject);
+      gunzip.on('error', reject);
+
+      fsCb.createReadStream(tempOutputPath).pipe(gunzip).pipe(extract);
     });
   });
 });

--- a/backend/src/modules/backup/backup.service.ts
+++ b/backend/src/modules/backup/backup.service.ts
@@ -7,7 +7,6 @@ import { spawn, SpawnOptions } from 'child_process';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-const archiver = require('archiver');
 import * as crypto from 'crypto';
 import { BackupLog } from '@database/entities/backup-log.entity';
 import { BackupRetentionSettings } from '@database/entities/backup-settings.entity';
@@ -19,6 +18,28 @@ import { CreateBackupDto, BackupDatabase } from './dto/create-backup.dto';
 import { BackupMetadata } from './interfaces/backup-metadata.interface';
 import { UpdateBackupSettingsDto, BackupSettingsResponseDto } from './dto/backup-settings.dto';
 import { plainToInstance } from 'class-transformer';
+
+type ArchiverInstance = import('archiver').Archiver;
+type TarArchiveConstructor = new (
+  options?: import('archiver').ArchiverOptions,
+) => ArchiverInstance;
+type ArchiverModule = { TarArchive: TarArchiveConstructor };
+
+const importArchiver = new Function(
+  'specifier',
+  'return import(specifier)',
+) as (specifier: string) => Promise<ArchiverModule>;
+
+async function loadArchiver(): Promise<ArchiverModule> {
+  try {
+    return await importArchiver('archiver');
+  } catch (error) {
+    if (process.env.JEST_WORKER_ID) {
+      return require('archiver') as ArchiverModule;
+    }
+    throw error;
+  }
+}
 
 @Injectable()
 export class BackupService implements OnModuleDestroy {
@@ -346,9 +367,11 @@ export class BackupService implements OnModuleDestroy {
     sourceDir: string,
     outputPath: string,
   ): Promise<string> {
+    const { TarArchive } = await loadArchiver();
+
     return new Promise((resolve, reject) => {
       const output = require('fs').createWriteStream(outputPath);
-      const archive = archiver('tar', {
+      const archive = new TarArchive({
         gzip: true,
         gzipOptions: { level: 9 },
       });

--- a/backend/src/modules/backup/backup.service.ts
+++ b/backend/src/modules/backup/backup.service.ts
@@ -386,7 +386,8 @@ export class BackupService implements OnModuleDestroy {
 
       archive.pipe(output);
       archive.directory(sourceDir, false);
-      archive.finalize();
+      // finalize() returns a Promise in archiver v8; error is handled by archive.on('error')
+      archive.finalize().catch(() => {});
     });
   }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "erp-frontend",
-  "version": "1.104.0",
+  "version": "1.104.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-frontend",
-      "version": "1.104.0",
+      "version": "1.104.1",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@hookform/resolvers": "5.2.2",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
-        "@mui/x-date-pickers": "9.0.4",
+        "@mui/x-date-pickers": "9.1.0",
         "@reduxjs/toolkit": "^2.11.2",
         "@tanstack/react-query": "^5.96.0",
         "@tanstack/react-query-devtools": "^5.96.0",
@@ -1335,14 +1335,14 @@
       }
     },
     "node_modules/@mui/x-date-pickers": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-9.0.4.tgz",
-      "integrity": "sha512-Zq4ZUYyqFtv9BjAyYOkUEiAykdAJnvFoPY8gaARXWleyX8QY5ztY5I1yD3iS6R+k/QFWNOef07VYU7nKFdRrYA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-9.1.0.tgz",
+      "integrity": "sha512-vE2oXP8bAlwppFckOc4HEwbhj5Mz7ZUqKU8kNyDa6v19cYsX3ais+fcuCGMh1xZiO1Q+H97s9xgN3WzzgcfmPw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
         "@mui/utils": "9.0.0",
-        "@mui/x-internals": "^9.0.4",
+        "@mui/x-internals": "^9.1.0",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
@@ -3062,6 +3062,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cross-spawn": {
@@ -6451,15 +6460,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "@hookform/resolvers": "5.2.2",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
-    "@mui/x-date-pickers": "9.0.4",
+    "@mui/x-date-pickers": "9.1.0",
     "@reduxjs/toolkit": "^2.11.2",
     "@tanstack/react-query": "^5.96.0",
     "@tanstack/react-query-devtools": "^5.96.0",


### PR DESCRIPTION
Closes #546

## Changes
- `@mui/x-date-pickers` bumped from 9.0.4 to 9.1.0 (frontend)
- `archiver` bumped from ^7.0.1 to 8.0.0 (backend)
- `@types/archiver` left at ^7.0.0 (no v8 types published yet; v7 types are API-compatible)
- Updated backup archive creation to use archiver v8's `TarArchive` ESM API
- Added `createArchive` smoke test in `backup.service.spec.ts` to verify archiver v8 stream/tar.gz behavior

## Test plan
- [x] `cd frontend && npm run type-check` - passed
- [x] `cd backend && npx jest src/modules/backup/backup.service.spec.ts --no-coverage` - passed, 21 tests
- [x] `cd backend && npm run lint` - passed
- [x] `cd backend && npm run test` - passed, 69 suites / 915 tests