### PR TITLE
fix: fix workspace card navigation and tab height (#548)

### DIFF
--- a/frontend/src/pages/purchasing/components/SupplierWorkspaceCard.tsx
+++ b/frontend/src/pages/purchasing/components/SupplierWorkspaceCard.tsx
@@ -89,10 +89,10 @@ const SupplierWorkspaceCard: React.FC<SupplierWorkspaceCardProps> = ({ selectedS
   return (
     <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-        <Tabs value={tabValue} onChange={(_, value) => setTabValue(value)}>
-          <Tab icon={<OrdersIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="Purchase Orders" />
-          <Tab icon={<GRNIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="GRNs" />
-          <Tab icon={<PaymentIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="Payments" />
+        <Tabs value={tabValue} onChange={(_, value) => setTabValue(value)} sx={{ minHeight: 36 }}>
+          <Tab icon={<OrdersIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="Purchase Orders" sx={{ minHeight: 36 }} />
+          <Tab icon={<GRNIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="GRNs" sx={{ minHeight: 36 }} />
+          <Tab icon={<PaymentIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="Payments" sx={{ minHeight: 36 }} />
         </Tabs>
       </Box>
       <TabPanel value={tabValue} index={0}>
@@ -126,7 +126,7 @@ const SupplierWorkspaceCard: React.FC<SupplierWorkspaceCardProps> = ({ selectedS
                     key={po.id}
                     hover
                     sx={{ cursor: 'pointer' }}
-                    onClick={() => navigate(`/purchasing/orders/${po.id}/edit`)}
+                    onClick={() => navigate(`/purchasing/orders?highlight=${po.id}`)}
                   >
                     <TableCell>
                       <Typography variant="body2" color="primary" sx={{
@@ -235,7 +235,12 @@ const SupplierWorkspaceCard: React.FC<SupplierWorkspaceCardProps> = ({ selectedS
               </TableHead>
               <TableBody>
                 {payments.map((payment) => (
-                  <TableRow key={payment.id}>
+                  <TableRow
+                    key={payment.id}
+                    hover
+                    sx={{ cursor: 'pointer' }}
+                    onClick={() => navigate(`/purchasing/vendor-payments?vpId=${payment.id}`)}
+                  >
                     <TableCell>
                       <Typography variant="body2" sx={{
                         fontWeight: 600

--- a/frontend/src/pages/purchasing/components/SupplierWorkspaceCard.tsx
+++ b/frontend/src/pages/purchasing/components/SupplierWorkspaceCard.tsx
@@ -68,13 +68,13 @@ const SupplierWorkspaceCard: React.FC<SupplierWorkspaceCardProps> = ({ selectedS
     setTabValue(0)
   }, [supplierId])
 
-  const { data: posData, isLoading: posLoading } = useGetSupplierPurchaseOrdersQuery(supplierId, {
+  const { data: posData, isLoading: posLoading, isError: posError } = useGetSupplierPurchaseOrdersQuery(supplierId, {
     skip: !supplierId || tabValue !== 0,
   })
-  const { data: grnsData, isLoading: grnsLoading } = useGetSupplierGRNsQuery(supplierId, {
+  const { data: grnsData, isLoading: grnsLoading, isError: grnsError } = useGetSupplierGRNsQuery(supplierId, {
     skip: !supplierId || tabValue !== 1,
   })
-  const { data: paymentsData, isLoading: paymentsLoading } = useGetSupplierPaymentsQuery(supplierId, {
+  const { data: paymentsData, isLoading: paymentsLoading, isError: paymentsError } = useGetSupplierPaymentsQuery(supplierId, {
     skip: !supplierId || tabValue !== 2,
   })
 
@@ -100,6 +100,10 @@ const SupplierWorkspaceCard: React.FC<SupplierWorkspaceCardProps> = ({ selectedS
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
             <CircularProgress />
           </Box>
+        ) : posError ? (
+          <Typography sx={{ color: 'error.main', py: 4, textAlign: 'center' }}>
+            Failed to load purchase orders.
+          </Typography>
         ) : purchaseOrders.length === 0 ? (
           <Typography
             sx={{
@@ -156,6 +160,10 @@ const SupplierWorkspaceCard: React.FC<SupplierWorkspaceCardProps> = ({ selectedS
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
             <CircularProgress />
           </Box>
+        ) : grnsError ? (
+          <Typography sx={{ color: 'error.main', py: 4, textAlign: 'center' }}>
+            Failed to load GRNs.
+          </Typography>
         ) : grns.length === 0 ? (
           <Typography
             sx={{
@@ -213,6 +221,10 @@ const SupplierWorkspaceCard: React.FC<SupplierWorkspaceCardProps> = ({ selectedS
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
             <CircularProgress />
           </Box>
+        ) : paymentsError ? (
+          <Typography sx={{ color: 'error.main', py: 4, textAlign: 'center' }}>
+            Failed to load payments.
+          </Typography>
         ) : payments.length === 0 ? (
           <Typography
             sx={{

--- a/frontend/src/pages/purchasing/components/__tests__/SupplierWorkspaceCard.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/SupplierWorkspaceCard.test.tsx
@@ -143,4 +143,24 @@ describe('SupplierWorkspaceCard', () => {
     await userEvent.click(screen.getByText('VP-001').closest('tr')!)
     expect(mockNavigate).toHaveBeenCalledWith('/purchasing/vendor-payments?vpId=vp-1')
   })
+
+  it('shows error state for each tab on fetch failure', async () => {
+    mockGetSupplierPurchaseOrdersQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true })
+    mockGetSupplierGRNsQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true })
+    mockGetSupplierPaymentsQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true })
+
+    render(
+      <MemoryRouter>
+        <SupplierWorkspaceCard selectedSupplier={mockSupplier} />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('Failed to load purchase orders.')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('tab', { name: /grns/i }))
+    expect(screen.getByText('Failed to load GRNs.')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('tab', { name: /payments/i }))
+    expect(screen.getByText('Failed to load payments.')).toBeInTheDocument()
+  })
 })

--- a/frontend/src/pages/purchasing/components/__tests__/SupplierWorkspaceCard.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/SupplierWorkspaceCard.test.tsx
@@ -2,17 +2,30 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 import type { Supplier } from '@/types'
 import { SupplierType } from '@/types'
 import SupplierWorkspaceCard from '../SupplierWorkspaceCard'
 
+const mockGetSupplierPurchaseOrdersQuery = vi.hoisted(() => vi.fn())
+const mockGetSupplierGRNsQuery = vi.hoisted(() => vi.fn())
+const mockGetSupplierPaymentsQuery = vi.hoisted(() => vi.fn())
+const mockNavigate = vi.hoisted(() => vi.fn())
+
 vi.mock('@/store/api/purchasingApi', () => ({
-  useGetSupplierPurchaseOrdersQuery: vi.fn(() => ({ data: undefined, isLoading: false })),
-  useGetSupplierGRNsQuery: vi.fn(() => ({ data: undefined, isLoading: false })),
-  useGetSupplierPaymentsQuery: vi.fn(() => ({ data: undefined, isLoading: false })),
+  useGetSupplierPurchaseOrdersQuery: mockGetSupplierPurchaseOrdersQuery,
+  useGetSupplierGRNsQuery: mockGetSupplierGRNsQuery,
+  useGetSupplierPaymentsQuery: mockGetSupplierPaymentsQuery,
 }))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
 
 const mockSupplier: Supplier = {
   id: 'sup-1',
@@ -26,6 +39,17 @@ const mockSupplier: Supplier = {
 }
 
 describe('SupplierWorkspaceCard', () => {
+  beforeEach(() => {
+    mockGetSupplierPurchaseOrdersQuery.mockReset()
+    mockGetSupplierGRNsQuery.mockReset()
+    mockGetSupplierPaymentsQuery.mockReset()
+    mockNavigate.mockReset()
+
+    mockGetSupplierPurchaseOrdersQuery.mockReturnValue({ data: undefined, isLoading: false })
+    mockGetSupplierGRNsQuery.mockReturnValue({ data: undefined, isLoading: false })
+    mockGetSupplierPaymentsQuery.mockReturnValue({ data: undefined, isLoading: false })
+  })
+
   it('renders empty Paper when no supplier selected', () => {
     const { container } = render(
       <MemoryRouter>
@@ -50,6 +74,8 @@ describe('SupplierWorkspaceCard', () => {
   })
 
   it('shows empty state when no purchase orders', () => {
+    mockGetSupplierPurchaseOrdersQuery.mockReturnValue({ data: { data: [] }, isLoading: false })
+
     render(
       <MemoryRouter>
         <SupplierWorkspaceCard selectedSupplier={mockSupplier} />
@@ -57,6 +83,24 @@ describe('SupplierWorkspaceCard', () => {
     )
 
     expect(screen.getByText(/no purchase orders found/i)).toBeInTheDocument()
+  })
+
+  it('clicking a purchase order navigates to purchasing orders list with highlight param', async () => {
+    mockGetSupplierPurchaseOrdersQuery.mockReturnValue({
+      data: {
+        data: [{ id: 'po-1', orderNumber: 'PO-001', orderDate: '2026-01-10', receivedDate: null, paidAmount: 0, total: 2000 }],
+      },
+      isLoading: false,
+    })
+
+    render(
+      <MemoryRouter>
+        <SupplierWorkspaceCard selectedSupplier={mockSupplier} />
+      </MemoryRouter>,
+    )
+
+    await userEvent.click(screen.getByText('PO-001').closest('tr')!)
+    expect(mockNavigate).toHaveBeenCalledWith('/purchasing/orders?highlight=po-1')
   })
 
   it('switches to GRNs tab on click', async () => {
@@ -79,5 +123,24 @@ describe('SupplierWorkspaceCard', () => {
 
     await userEvent.click(screen.getByRole('tab', { name: /payments/i }))
     expect(screen.getByText(/no payments found/i)).toBeInTheDocument()
+  })
+
+  it('clicking a payment navigates to vendor payments with vpId param', async () => {
+    mockGetSupplierPaymentsQuery.mockReturnValue({
+      data: {
+        data: [{ id: 'vp-1', paymentNumber: 'VP-001', paymentDate: '2026-01-20', status: 'completed', amount: 500 }],
+      },
+      isLoading: false,
+    })
+
+    render(
+      <MemoryRouter>
+        <SupplierWorkspaceCard selectedSupplier={mockSupplier} />
+      </MemoryRouter>,
+    )
+
+    await userEvent.click(screen.getByRole('tab', { name: /payments/i }))
+    await userEvent.click(screen.getByText('VP-001').closest('tr')!)
+    expect(mockNavigate).toHaveBeenCalledWith('/purchasing/vendor-payments?vpId=vp-1')
   })
 })

--- a/frontend/src/pages/sales/components/CustomerWorkspaceCard.tsx
+++ b/frontend/src/pages/sales/components/CustomerWorkspaceCard.tsx
@@ -90,10 +90,10 @@ const CustomerWorkspaceCard: React.FC<CustomerWorkspaceCardProps> = ({ selectedC
   return (
     <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-        <Tabs value={tabValue} onChange={(_, value) => setTabValue(value)}>
-          <Tab icon={<OrdersIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="Orders" />
-          <Tab icon={<InvoiceIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="Invoices" />
-          <Tab icon={<PaymentIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="Payments" />
+        <Tabs value={tabValue} onChange={(_, value) => setTabValue(value)} sx={{ minHeight: 36 }}>
+          <Tab icon={<OrdersIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="Orders" sx={{ minHeight: 36 }} />
+          <Tab icon={<InvoiceIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="Invoices" sx={{ minHeight: 36 }} />
+          <Tab icon={<PaymentIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="Payments" sx={{ minHeight: 36 }} />
         </Tabs>
       </Box>
       <TabPanel value={tabValue} index={0}>
@@ -136,7 +136,7 @@ const CustomerWorkspaceCard: React.FC<CustomerWorkspaceCardProps> = ({ selectedC
                     key={order.id}
                     hover
                     sx={{ cursor: 'pointer' }}
-                    onClick={() => navigate(`/sales/orders/${order.id}/edit`)}
+                    onClick={() => navigate(`/sales/orders?highlight=${order.id}`)}
                   >
                     <TableCell>
                       <Typography variant="body2" color="primary" sx={{
@@ -284,7 +284,12 @@ const CustomerWorkspaceCard: React.FC<CustomerWorkspaceCardProps> = ({ selectedC
               </TableHead>
               <TableBody>
                 {payments.map((payment) => (
-                  <TableRow key={payment.id}>
+                  <TableRow
+                    key={payment.id}
+                    hover
+                    sx={{ cursor: 'pointer' }}
+                    onClick={() => navigate('/sales/payments', { state: { highlightPaymentId: payment.id } })}
+                  >
                     <TableCell>
                       <Typography variant="body2" sx={{
                         fontWeight: 600

--- a/frontend/src/pages/sales/components/__tests__/CustomerWorkspaceCard.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/CustomerWorkspaceCard.test.tsx
@@ -190,11 +190,4 @@ describe('CustomerWorkspaceCard', () => {
     await waitFor(() => expect(screen.getByText('Failed to load payments.')).toBeInTheDocument())
   })
 
-  it('tabs have compact minHeight of 36', () => {
-    render(<CustomerWorkspaceCard selectedCustomer={mockCustomer} />)
-    const tabsContainer = screen.getByRole('tablist').closest('.MuiTabs-root')
-    expect(tabsContainer).toBeInTheDocument()
-    // Visual check - minHeight is applied via sx and rendered inline or in class
-    // The structural test above (tabs render, are clickable) is the functional guard
-  })
 })

--- a/frontend/src/pages/sales/components/__tests__/CustomerWorkspaceCard.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/CustomerWorkspaceCard.test.tsx
@@ -7,6 +7,7 @@ import { CustomerType } from '@/types'
 const mockUseGetCustomerSalesHistoryQuery = vi.hoisted(() => vi.fn())
 const mockUseGetCustomerOutstandingInvoicesQuery = vi.hoisted(() => vi.fn())
 const mockUseGetCustomerPaymentsQuery = vi.hoisted(() => vi.fn())
+const mockNavigate = vi.hoisted(() => vi.fn())
 
 vi.mock('@/store/api/salesApi', () => ({
   useGetCustomerSalesHistoryQuery: mockUseGetCustomerSalesHistoryQuery,
@@ -18,7 +19,7 @@ vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-router-dom')>()
   return {
     ...actual,
-    useNavigate: () => vi.fn(),
+    useNavigate: () => mockNavigate,
   }
 })
 
@@ -39,6 +40,7 @@ describe('CustomerWorkspaceCard', () => {
     mockUseGetCustomerSalesHistoryQuery.mockReset()
     mockUseGetCustomerOutstandingInvoicesQuery.mockReset()
     mockUseGetCustomerPaymentsQuery.mockReset()
+    mockNavigate.mockReset()
 
     mockUseGetCustomerSalesHistoryQuery.mockReturnValue({ data: undefined, isLoading: false, isError: false })
     mockUseGetCustomerOutstandingInvoicesQuery.mockReturnValue({ data: undefined, isLoading: false, isError: false })
@@ -87,6 +89,21 @@ describe('CustomerWorkspaceCard', () => {
     render(<CustomerWorkspaceCard selectedCustomer={mockCustomer} />)
 
     expect(screen.getByText('SO-001')).toBeInTheDocument()
+  })
+
+  it('clicking an order navigates to sales orders list with highlight param', () => {
+    mockUseGetCustomerSalesHistoryQuery.mockReturnValue({
+      data: {
+        orders: [{ id: 'o-1', orderNumber: 'SO-001', orderDate: '2026-01-10', isFulfilled: false, isPaid: false, totalAmount: 500, itemsCount: 2 }],
+      },
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<CustomerWorkspaceCard selectedCustomer={mockCustomer} />)
+
+    fireEvent.click(screen.getByText('SO-001').closest('tr')!)
+    expect(mockNavigate).toHaveBeenCalledWith('/sales/orders?highlight=o-1')
   })
 
   it('shows invoices when Invoices tab clicked', async () => {
@@ -140,6 +157,23 @@ describe('CustomerWorkspaceCard', () => {
     expect(screen.getByText('completed')).toBeInTheDocument()
   })
 
+  it('clicking a payment navigates to sales payments with highlightPaymentId state', async () => {
+    mockUseGetCustomerPaymentsQuery.mockReturnValue({
+      data: [{ id: 'pay-1', paymentNumber: 'PAY-001', paymentDate: '2026-01-15', status: 'completed', amount: 1500 }],
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<CustomerWorkspaceCard selectedCustomer={mockCustomer} />)
+
+    fireEvent.click(screen.getByRole('tab', { name: /payments/i }))
+
+    await waitFor(() => expect(screen.getByText('PAY-001')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByText('PAY-001').closest('tr')!)
+    expect(mockNavigate).toHaveBeenCalledWith('/sales/payments', { state: { highlightPaymentId: 'pay-1' } })
+  })
+
   it('shows error state for each tab on fetch failure', async () => {
     mockUseGetCustomerSalesHistoryQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true })
     mockUseGetCustomerOutstandingInvoicesQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true })
@@ -154,5 +188,13 @@ describe('CustomerWorkspaceCard', () => {
 
     fireEvent.click(screen.getByRole('tab', { name: /payments/i }))
     await waitFor(() => expect(screen.getByText('Failed to load payments.')).toBeInTheDocument())
+  })
+
+  it('tabs have compact minHeight of 36', () => {
+    render(<CustomerWorkspaceCard selectedCustomer={mockCustomer} />)
+    const tabsContainer = screen.getByRole('tablist').closest('.MuiTabs-root')
+    expect(tabsContainer).toBeInTheDocument()
+    // Visual check - minHeight is applied via sx and rendered inline or in class
+    // The structural test above (tabs render, are clickable) is the functional guard
   })
 })


### PR DESCRIPTION
## Summary

- Order rows in Customer/Supplier workspace cards now navigate to the list page with `?highlight={id}` instead of opening the edit page directly
- Payment rows in both cards are now clickable and navigate to their respective payments list with the correct highlight param/state
- Tab height reduced from MUI default 48px to 36px via `sx={{ minHeight: 36 }}` on `<Tabs>` and `<Tab>`

## Test plan

- [x] `cd frontend && npx vitest run src/pages/sales/components/__tests__/CustomerWorkspaceCard.test.tsx` - PASS, 12 tests
- [x] `cd frontend && npx vitest run src/pages/purchasing/components/__tests__/SupplierWorkspaceCard.test.tsx` - PASS, 7 tests
- [x] `cd frontend && npm run lint` - PASS
- [x] `cd frontend && npm run type-check` - PASS
- [x] `cd frontend && npm run test` - DID NOT COMPLETE; command hung after Vitest startup output for several minutes and was stopped, with no failure output emitted

Closes #548