### PR TITLE
fix(sales/purchasing): document links and entity navigation (issue #550)

### DIFF
--- a/frontend/src/pages/purchasing/components/GRNContextHeader.tsx
+++ b/frontend/src/pages/purchasing/components/GRNContextHeader.tsx
@@ -43,6 +43,17 @@ const detailTableSx = {
 const labelCellSx = { fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }
 const valueCellSx = { fontSize: '0.8rem' }
 
+const linkButtonSx = {
+  fontSize: '0.8rem',
+  color: 'primary.main',
+  cursor: 'pointer',
+  textDecoration: 'none',
+  border: 'none',
+  background: 'none',
+  padding: 0,
+  '&:hover': { color: 'primary.dark' },
+}
+
 const GRNContextHeader: React.FC<GRNContextHeaderProps> = ({
   selectedGRN,
   journalEntryRefs,
@@ -185,7 +196,17 @@ const GRNContextHeader: React.FC<GRNContextHeaderProps> = ({
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
                     <TableCell sx={labelCellSx}>Supplier</TableCell>
-                    <TableCell sx={valueCellSx}>{selectedGRN.supplier?.companyName || '—'}</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {selectedGRN.supplier?.id ? (
+                        <Typography
+                          component="button"
+                          onClick={() => navigate(`/purchasing/suppliers?highlight=${selectedGRN.supplier!.id}`)}
+                          sx={linkButtonSx}
+                        >
+                          {selectedGRN.supplier.companyName}
+                        </Typography>
+                      ) : '—'}
+                    </TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell sx={labelCellSx}>Purchase Order</TableCell>

--- a/frontend/src/pages/purchasing/components/PurchaseOrderContextHeader.tsx
+++ b/frontend/src/pages/purchasing/components/PurchaseOrderContextHeader.tsx
@@ -14,6 +14,7 @@ import {
   Typography,
 } from '@mui/material'
 import Grid from '@mui/material/Grid'
+import { useNavigate } from 'react-router-dom'
 
 import { AppButton } from '@/components/common/AppButton'
 import { EntityContextHeaderBar } from '@/components/common/EntityContextHeaderBar'
@@ -60,6 +61,17 @@ const valueCellSx = {
   fontSize: '0.8rem',
 }
 
+const linkButtonSx = {
+  fontSize: '0.8rem',
+  color: 'primary.main',
+  cursor: 'pointer',
+  textDecoration: 'none',
+  border: 'none',
+  background: 'none',
+  padding: 0,
+  '&:hover': { color: 'primary.dark' },
+}
+
 const PurchaseOrderContextHeader: React.FC<PurchaseOrderContextHeaderProps> = ({
   selectedOrder,
   isLoading,
@@ -76,6 +88,7 @@ const PurchaseOrderContextHeader: React.FC<PurchaseOrderContextHeaderProps> = ({
   onReturn,
   onReceive,
 }) => {
+  const navigate = useNavigate()
   if (!selectedOrder) {
     return (
       <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
@@ -149,7 +162,19 @@ const PurchaseOrderContextHeader: React.FC<PurchaseOrderContextHeaderProps> = ({
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
                     <TableCell sx={labelCellSx}>Supplier</TableCell>
-                    <TableCell sx={valueCellSx}>{selectedOrder.supplier?.companyName || 'N/A'}</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {selectedOrder.supplier?.id ? (
+                        <Typography
+                          component="button"
+                          onClick={() => navigate(`/purchasing/suppliers?highlight=${selectedOrder.supplier!.id}`)}
+                          sx={linkButtonSx}
+                        >
+                          {selectedOrder.supplier.companyName}
+                        </Typography>
+                      ) : (
+                        'N/A'
+                      )}
+                    </TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell sx={labelCellSx}>PO Date</TableCell>

--- a/frontend/src/pages/purchasing/components/SupplierWorkspaceCard.tsx
+++ b/frontend/src/pages/purchasing/components/SupplierWorkspaceCard.tsx
@@ -254,7 +254,7 @@ const SupplierWorkspaceCard: React.FC<SupplierWorkspaceCardProps> = ({ selectedS
                     onClick={() => navigate(`/purchasing/vendor-payments?vpId=${payment.id}`)}
                   >
                     <TableCell>
-                      <Typography variant="body2" sx={{
+                      <Typography variant="body2" color="primary" sx={{
                         fontWeight: 600
                       }}>
                         {payment.paymentNumber}

--- a/frontend/src/pages/purchasing/components/VendorPaymentContextHeader.tsx
+++ b/frontend/src/pages/purchasing/components/VendorPaymentContextHeader.tsx
@@ -43,6 +43,17 @@ const detailTableSx = {
 const labelCellSx = { fontWeight: 600, color: 'text.secondary', fontSize: '0.8rem' }
 const valueCellSx = { fontSize: '0.8rem' }
 
+const linkButtonSx = {
+  fontSize: '0.8rem',
+  color: 'primary.main',
+  cursor: 'pointer',
+  textDecoration: 'none',
+  border: 'none',
+  background: 'none',
+  padding: 0,
+  '&:hover': { color: 'primary.dark' },
+}
+
 const VendorPaymentContextHeader: React.FC<VendorPaymentContextHeaderProps> = ({
   selectedPayment,
   journalEntryRefs,
@@ -185,7 +196,17 @@ const VendorPaymentContextHeader: React.FC<VendorPaymentContextHeaderProps> = ({
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
                     <TableCell sx={labelCellSx}>Supplier</TableCell>
-                    <TableCell sx={valueCellSx}>{selectedPayment.supplier?.companyName || '—'}</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {selectedPayment.supplier?.id ? (
+                        <Typography
+                          component="button"
+                          onClick={() => navigate(`/purchasing/suppliers?highlight=${selectedPayment.supplier!.id}`)}
+                          sx={linkButtonSx}
+                        >
+                          {selectedPayment.supplier.companyName}
+                        </Typography>
+                      ) : '—'}
+                    </TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell sx={labelCellSx}>Purchase Order</TableCell>

--- a/frontend/src/pages/purchasing/components/__tests__/PurchaseOrderContextHeader.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/PurchaseOrderContextHeader.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 
 import PurchaseOrderContextHeader from '../PurchaseOrderContextHeader'
 
@@ -38,24 +39,24 @@ const defaultProps = {
 
 describe('PurchaseOrderContextHeader', () => {
   it('shows empty state when no order selected', () => {
-    render(<PurchaseOrderContextHeader {...defaultProps} selectedOrder={null} />)
+    render(<MemoryRouter><PurchaseOrderContextHeader {...defaultProps} selectedOrder={null} /></MemoryRouter>)
     expect(screen.getByText('Select a purchase order to view details')).toBeInTheDocument()
   })
 
   it('renders order number in header', () => {
-    render(<PurchaseOrderContextHeader {...defaultProps} />)
+    render(<MemoryRouter><PurchaseOrderContextHeader {...defaultProps} /></MemoryRouter>)
     expect(screen.getByText(/Purchase Order Details - PO-1001/i)).toBeInTheDocument()
   })
 
   it('renders header action buttons', () => {
-    render(<PurchaseOrderContextHeader {...defaultProps} />)
+    render(<MemoryRouter><PurchaseOrderContextHeader {...defaultProps} /></MemoryRouter>)
     expect(screen.getByTitle('Edit Order')).toBeInTheDocument()
     expect(screen.getByTitle('Delete Order')).toBeInTheDocument()
     expect(screen.getByTitle('Print Purchase Order')).toBeInTheDocument()
   })
 
   it('shows Pay button when order has no payment', () => {
-    render(<PurchaseOrderContextHeader {...defaultProps} />)
+    render(<MemoryRouter><PurchaseOrderContextHeader {...defaultProps} /></MemoryRouter>)
     expect(screen.getByText('Pay')).toBeInTheDocument()
   })
 
@@ -64,12 +65,12 @@ describe('PurchaseOrderContextHeader', () => {
       ...baseOrder,
       vendorPayments: [{ id: 'vp-1', paymentNumber: 'VP-001', amount: 100 }],
     }
-    render(<PurchaseOrderContextHeader {...defaultProps} selectedOrder={orderWithPayment} />)
+    render(<MemoryRouter><PurchaseOrderContextHeader {...defaultProps} selectedOrder={orderWithPayment} /></MemoryRouter>)
     expect(screen.getByText('Unpay')).toBeInTheDocument()
   })
 
   it('shows Receive button when order is not yet received', () => {
-    render(<PurchaseOrderContextHeader {...defaultProps} />)
+    render(<MemoryRouter><PurchaseOrderContextHeader {...defaultProps} /></MemoryRouter>)
     expect(screen.getByText('Receive')).toBeInTheDocument()
   })
 
@@ -78,7 +79,7 @@ describe('PurchaseOrderContextHeader', () => {
       ...baseOrder,
       goodsReceivedNotes: [{ id: 'grn-1', grnNumber: 'GRN-001', status: 'received' }],
     }
-    render(<PurchaseOrderContextHeader {...defaultProps} selectedOrder={receivedOrder} />)
+    render(<MemoryRouter><PurchaseOrderContextHeader {...defaultProps} selectedOrder={receivedOrder} /></MemoryRouter>)
     expect(screen.getByText('Return')).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/sales/components/CustomerWorkspaceCard.tsx
+++ b/frontend/src/pages/sales/components/CustomerWorkspaceCard.tsx
@@ -291,7 +291,7 @@ const CustomerWorkspaceCard: React.FC<CustomerWorkspaceCardProps> = ({ selectedC
                     onClick={() => navigate('/sales/payments', { state: { highlightPaymentId: payment.id } })}
                   >
                     <TableCell>
-                      <Typography variant="body2" sx={{
+                      <Typography variant="body2" color="primary" sx={{
                         fontWeight: 600
                       }}>
                         {payment.paymentNumber}

--- a/frontend/src/pages/sales/components/InvoiceContextHeader.tsx
+++ b/frontend/src/pages/sales/components/InvoiceContextHeader.tsx
@@ -13,6 +13,8 @@ import {
 } from '@mui/material'
 import Grid from '@mui/material/Grid'
 
+import { useNavigate } from 'react-router-dom'
+
 import type { InvoiceListItem } from '../hooks/useInvoicesWorkspace'
 
 import { AppButton } from '@/components/common/AppButton'
@@ -73,6 +75,7 @@ const InvoiceContextHeader: React.FC<InvoiceContextHeaderProps> = ({
   onNavigateToPayment,
   onNavigateToJournalEntries,
 }) => {
+  const navigate = useNavigate()
   if (!selectedInvoice) {
     return (
       <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
@@ -135,7 +138,17 @@ const InvoiceContextHeader: React.FC<InvoiceContextHeaderProps> = ({
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
                     <TableCell sx={labelCellSx}>Customer</TableCell>
                     <TableCell sx={valueCellSx}>
-                      {selectedInvoice.customer?.name || selectedInvoice.customerName}
+                      {selectedInvoice.customer?.id ? (
+                        <Typography
+                          component="button"
+                          onClick={() => navigate(`/sales/customers?highlight=${selectedInvoice.customer!.id}`)}
+                          sx={linkButtonSx}
+                        >
+                          {selectedInvoice.customer.name}
+                        </Typography>
+                      ) : (
+                        selectedInvoice.customer?.name || selectedInvoice.customerName
+                      )}
                     </TableCell>
                   </TableRow>
                   <TableRow>

--- a/frontend/src/pages/sales/components/OrderContextHeader.tsx
+++ b/frontend/src/pages/sales/components/OrderContextHeader.tsx
@@ -14,6 +14,7 @@ import {
   Typography,
 } from '@mui/material'
 import Grid from '@mui/material/Grid'
+import { useNavigate } from 'react-router-dom'
 
 import { AppButton } from '@/components/common/AppButton'
 import { EntityContextHeaderBar } from '@/components/common/EntityContextHeaderBar'
@@ -61,6 +62,17 @@ const valueCellSx = {
   fontSize: '0.8rem',
 }
 
+const linkButtonSx = {
+  fontSize: '0.8rem',
+  color: 'primary.main',
+  cursor: 'pointer',
+  textDecoration: 'none',
+  border: 'none',
+  background: 'none',
+  padding: 0,
+  '&:hover': { color: 'primary.dark' },
+}
+
 const OrderContextHeader: React.FC<OrderContextHeaderProps> = ({
   selectedOrder,
   isLoading,
@@ -78,6 +90,7 @@ const OrderContextHeader: React.FC<OrderContextHeaderProps> = ({
   onFulfillOrder,
   onUnfulfillOrder,
 }) => {
+  const navigate = useNavigate()
   if (!selectedOrder) {
     return (
       <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
@@ -180,7 +193,17 @@ const OrderContextHeader: React.FC<OrderContextHeaderProps> = ({
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
                     <TableCell sx={labelCellSx}>Customer Name</TableCell>
                     <TableCell sx={valueCellSx}>
-                      {selectedOrder.customer?.name || 'Unknown Customer'}
+                      {selectedOrder.customer?.id ? (
+                        <Typography
+                          component="button"
+                          onClick={() => navigate(`/sales/customers?highlight=${selectedOrder.customer!.id}`)}
+                          sx={linkButtonSx}
+                        >
+                          {selectedOrder.customer.name}
+                        </Typography>
+                      ) : (
+                        selectedOrder.customer?.name || 'Unknown Customer'
+                      )}
                     </TableCell>
                   </TableRow>
                   <TableRow>

--- a/frontend/src/pages/sales/components/PaymentContextHeader.tsx
+++ b/frontend/src/pages/sales/components/PaymentContextHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { default as PrintIcon } from '@mui/icons-material/Print'
+import { useNavigate } from 'react-router-dom'
 import {
   Box,
   Paper,
@@ -71,6 +72,7 @@ const PaymentContextHeader: React.FC<PaymentContextHeaderProps> = ({
   onInvoiceClick,
   onNavigateToJournalEntry,
 }) => {
+  const navigate = useNavigate()
   if (!selectedPayment) {
     return (
       <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
@@ -127,7 +129,19 @@ const PaymentContextHeader: React.FC<PaymentContextHeaderProps> = ({
                   </TableRow>
                   <TableRow sx={{ backgroundColor: 'grey.50' }}>
                     <TableCell sx={labelCellSx}>Customer</TableCell>
-                    <TableCell sx={valueCellSx}>{selectedPayment.customerName}</TableCell>
+                    <TableCell sx={valueCellSx}>
+                      {selectedPayment.customer?.id ? (
+                        <Typography
+                          component="button"
+                          onClick={() => navigate(`/sales/customers?highlight=${selectedPayment.customer!.id}`)}
+                          sx={linkButtonSx}
+                        >
+                          {selectedPayment.customer.name}
+                        </Typography>
+                      ) : (
+                        selectedPayment.customerName
+                      )}
+                    </TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell sx={labelCellSx}>Amount</TableCell>

--- a/frontend/src/pages/sales/components/__tests__/InvoiceContextHeader.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/InvoiceContextHeader.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 
 import InvoiceContextHeader from '../InvoiceContextHeader'
 
@@ -20,15 +21,17 @@ const baseInvoice = {
 describe('InvoiceContextHeader', () => {
   it('renders a labeled print action button', () => {
     render(
-      <InvoiceContextHeader
-        selectedInvoice={baseInvoice}
-        journalEntryRefs={[]}
-        journalEntryRefsLoading={false}
-        onPrint={vi.fn()}
-        onNavigateToSalesOrder={vi.fn()}
-        onNavigateToPayment={vi.fn()}
-        onNavigateToJournalEntries={vi.fn()}
-      />,
+      <MemoryRouter>
+        <InvoiceContextHeader
+          selectedInvoice={baseInvoice}
+          journalEntryRefs={[]}
+          journalEntryRefsLoading={false}
+          onPrint={vi.fn()}
+          onNavigateToSalesOrder={vi.fn()}
+          onNavigateToPayment={vi.fn()}
+          onNavigateToJournalEntries={vi.fn()}
+        />
+      </MemoryRouter>,
     )
 
     expect(screen.getByText('Print')).toBeInTheDocument()

--- a/frontend/src/pages/sales/components/__tests__/OrderContextHeader.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/OrderContextHeader.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 
 import OrderContextHeader from '../OrderContextHeader'
 
@@ -19,6 +20,7 @@ const baseOrder = {
 describe('OrderContextHeader', () => {
   it('renders labeled action buttons in the header and payment section', () => {
     render(
+      <MemoryRouter>
       <OrderContextHeader
         selectedOrder={baseOrder}
         isLoading={false}
@@ -35,7 +37,8 @@ describe('OrderContextHeader', () => {
         onOpenPaymentDialog={vi.fn()}
         onFulfillOrder={vi.fn()}
         onUnfulfillOrder={vi.fn()}
-      />,
+      />
+      </MemoryRouter>,
     )
 
     expect(screen.getByText('Edit')).toBeInTheDocument()

--- a/frontend/src/pages/sales/components/__tests__/PaymentContextHeader.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/PaymentContextHeader.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 
 import PaymentContextHeader from '../PaymentContextHeader'
 
@@ -17,15 +18,17 @@ const basePayment = {
 describe('PaymentContextHeader', () => {
   it('renders a labeled print action button', () => {
     render(
-      <PaymentContextHeader
-        selectedPayment={basePayment}
-        journalEntryRefs={[]}
-        journalEntryRefsLoading={false}
-        onPrint={vi.fn()}
-        onOrderClick={vi.fn()}
-        onInvoiceClick={vi.fn()}
-        onNavigateToJournalEntry={vi.fn()}
-      />,
+      <MemoryRouter>
+        <PaymentContextHeader
+          selectedPayment={basePayment}
+          journalEntryRefs={[]}
+          journalEntryRefsLoading={false}
+          onPrint={vi.fn()}
+          onOrderClick={vi.fn()}
+          onInvoiceClick={vi.fn()}
+          onNavigateToJournalEntry={vi.fn()}
+        />
+      </MemoryRouter>,
     )
 
     expect(screen.getByText('Print')).toBeInTheDocument()


### PR DESCRIPTION
## Summary

- **Payment # color**: Made Payment # links `primary` color in `CustomerWorkspaceCard` and `SupplierWorkspaceCard` to match the GRN/Invoice link styling
- **Clickable customer name**: Added navigation link on Customer name in Sales Order Details, Invoice Details, and Customer Payment Details → navigates to `/sales/customers?highlight=<id>`
- **Clickable supplier name**: Added navigation link on Supplier name in Purchase Order Details, GRN Details, and Vendor Payment Details → navigates to `/purchasing/suppliers?highlight=<id>`

All links use `useNavigate` directly in the context header components (consistent with how GRNContextHeader and VendorPaymentContextHeader already handle PO navigation). No new callback props added to parent hooks.

Closes #550

## Test plan

- [x] Open Sales > Customers, select a customer → Orders tab: Invoice # links are primary color; Payments tab: Payment # links are now primary color
- [x] Open Sales > Orders, select an order → click Customer Name → lands on Customers page with that customer highlighted
- [x] Open Sales > Invoices, select an invoice → click Customer → lands on Customers page with that customer highlighted
- [x] Open Sales > Payments, select a payment → click Customer → lands on Customers page with that customer highlighted
- [x] Open Purchasing > Suppliers, select a supplier → GRNs tab: GRN # links primary color; Payments tab: Payment # links are now primary color
- [x] Open Purchasing > Purchase Orders, select a PO → click Supplier → lands on Suppliers page with that supplier highlighted
- [x] Open Purchasing > Goods Received, select a GRN → click Supplier → lands on Suppliers page with that supplier highlighted
- [x] Open Purchasing > Vendor Payments, select a payment → click Supplier → lands on Suppliers page with that supplier highlighted
- [x] Edge case: entities without a linked customer/supplier ID fall back to plain text (no broken links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)