### PR TITLE
fix(sales/purchasing): navigate to invoice/GRN pages from workspace cards

### DIFF
--- a/frontend/src/pages/purchasing/components/SupplierWorkspaceCard.tsx
+++ b/frontend/src/pages/purchasing/components/SupplierWorkspaceCard.tsx
@@ -189,8 +189,8 @@ const SupplierWorkspaceCard: React.FC<SupplierWorkspaceCardProps> = ({ selectedS
                   <TableRow
                     key={grn.id}
                     hover
-                    sx={{ cursor: grn.purchaseOrder?.id ? 'pointer' : 'default' }}
-                    onClick={() => grn.purchaseOrder?.id && navigate(`/purchasing/orders/${grn.purchaseOrder.id}/edit`)}
+                    sx={{ cursor: 'pointer' }}
+                    onClick={() => navigate(`/purchasing/goods-received?grnId=${grn.id}`)}
                   >
                     <TableCell>
                       <Typography variant="body2" color="primary" sx={{

--- a/frontend/src/pages/purchasing/components/__tests__/SupplierWorkspaceCard.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/SupplierWorkspaceCard.test.tsx
@@ -103,6 +103,25 @@ describe('SupplierWorkspaceCard', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/purchasing/orders?highlight=po-1')
   })
 
+  it('clicking a GRN navigates to goods-received with grnId param', async () => {
+    mockGetSupplierGRNsQuery.mockReturnValue({
+      data: {
+        data: [{ id: 'grn-1', grnNumber: 'GRN-001', receivedDate: '2026-01-15', purchaseOrder: { id: 'po-1', orderNumber: 'PO-001' }, status: 'received' }],
+      },
+      isLoading: false,
+    })
+
+    render(
+      <MemoryRouter>
+        <SupplierWorkspaceCard selectedSupplier={mockSupplier} />
+      </MemoryRouter>,
+    )
+
+    await userEvent.click(screen.getByRole('tab', { name: /grns/i }))
+    await userEvent.click(screen.getByText('GRN-001').closest('tr')!)
+    expect(mockNavigate).toHaveBeenCalledWith('/purchasing/goods-received?grnId=grn-1')
+  })
+
   it('switches to GRNs tab on click', async () => {
     render(
       <MemoryRouter>

--- a/frontend/src/pages/sales/components/CustomerWorkspaceCard.tsx
+++ b/frontend/src/pages/sales/components/CustomerWorkspaceCard.tsx
@@ -215,13 +215,13 @@ const CustomerWorkspaceCard: React.FC<CustomerWorkspaceCardProps> = ({ selectedC
                     <TableRow
                       key={invoice.id}
                       hover
-                      sx={{ cursor: invoice.salesOrderId ? 'pointer' : 'default' }}
-                      onClick={() => invoice.salesOrderId && navigate(`/sales/orders/${invoice.salesOrderId}/edit`)}
+                      sx={{ cursor: 'pointer' }}
+                      onClick={() => navigate('/sales/invoices', { state: { highlightInvoiceId: invoice.id } })}
                     >
                       <TableCell>
                         <Typography
                           variant="body2"
-                          color={invoice.salesOrderId ? 'primary' : 'text.primary'}
+                          color="primary"
                           sx={{
                             fontWeight: 600
                           }}

--- a/frontend/src/pages/sales/components/__tests__/CustomerWorkspaceCard.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/CustomerWorkspaceCard.test.tsx
@@ -106,6 +106,27 @@ describe('CustomerWorkspaceCard', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/sales/orders?highlight=o-1')
   })
 
+  it('clicking an invoice navigates to sales invoices with highlightInvoiceId state', async () => {
+    mockUseGetCustomerOutstandingInvoicesQuery.mockReturnValue({
+      data: {
+        invoices: [
+          { id: 'inv-1', invoiceNumber: 'INV-001', invoiceDate: '2026-01-05', totalAmount: 1000, paidAmount: 0, balanceDue: 1000, salesOrderId: null },
+        ],
+        totalOutstanding: 1000,
+      },
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<CustomerWorkspaceCard selectedCustomer={mockCustomer} />)
+    fireEvent.click(screen.getByRole('tab', { name: /invoices/i }))
+
+    await waitFor(() => expect(screen.getByText('INV-001')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByText('INV-001').closest('tr')!)
+    expect(mockNavigate).toHaveBeenCalledWith('/sales/invoices', { state: { highlightInvoiceId: 'inv-1' } })
+  })
+
   it('shows invoices when Invoices tab clicked', async () => {
     mockUseGetCustomerOutstandingInvoicesQuery.mockReturnValue({
       data: {


### PR DESCRIPTION
## Summary
- Clicking an invoice in the Customer workspace card now navigates to `/sales/invoices` with `highlightInvoiceId` state instead of the order edit page
- Clicking a GRN in the Supplier workspace card now navigates to `/purchasing/goods-received?grnId=` instead of the order edit page
- Both rows are now always clickable (cursor always pointer), since the invoice/GRN id is always present

## Test Plan
- [x] Existing 21 tests pass (12 CustomerWorkspaceCard + 9 SupplierWorkspaceCard)
- [x] New test: clicking an invoice row navigates to `/sales/invoices` with `{ state: { highlightInvoiceId } }`
- [x] New test: clicking a GRN row navigates to `/purchasing/goods-received?grnId=`

Closes #552