### PR TITLE
fix: sort product dropdown options alphabetically (A-Z)

### DIFF
--- a/frontend/src/hooks/useProductSearch.test.ts
+++ b/frontend/src/hooks/useProductSearch.test.ts
@@ -37,7 +37,7 @@ describe('useProductSearch', () => {
 
     expect(result.current.products).toEqual([makeProduct('1', 'Alpha')])
     expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-      params: { isActive: true },
+      params: { isActive: true, sortBy: 'name', sortOrder: 'ASC' },
     })
   })
 
@@ -48,7 +48,7 @@ describe('useProductSearch', () => {
     await act(() => result.current.loadProducts('apple'))
 
     expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-      params: { isActive: true, search: 'apple' },
+      params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: 'apple' },
     })
   })
 

--- a/frontend/src/hooks/useProductSearch.ts
+++ b/frontend/src/hooks/useProductSearch.ts
@@ -31,6 +31,8 @@ export function useProductSearch() {
     const requestId = ++latestRequestRef.current
 
     try {
+      // sortBy/sortOrder are explicit rather than relying on backend defaults
+      // so this keeps working if the backend default ever changes.
       const params: Record<string, string | boolean> = {
         isActive: true,
         sortBy: 'name',

--- a/frontend/src/hooks/useProductSearch.ts
+++ b/frontend/src/hooks/useProductSearch.ts
@@ -31,7 +31,11 @@ export function useProductSearch() {
     const requestId = ++latestRequestRef.current
 
     try {
-      const params: Record<string, string | boolean> = { isActive: true }
+      const params: Record<string, string | boolean> = {
+        isActive: true,
+        sortBy: 'name',
+        sortOrder: 'ASC',
+      }
       const trimmedSearchTerm = searchTerm.trim()
 
       if (trimmedSearchTerm.length >= 1) {

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -115,7 +115,7 @@ describe('CreateStockAdjustmentPage product search', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, search: replacementSearchTerm },
+        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 
@@ -151,7 +151,7 @@ describe('CreateStockAdjustmentPage product search', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, search: replacementSearchTerm },
+        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 
@@ -252,7 +252,7 @@ describe('CreateStockAdjustmentPage product search', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, search: replacementSearchTerm },
+        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 

--- a/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
@@ -152,7 +152,7 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, search: replacementSearchTerm },
+        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 
@@ -189,7 +189,7 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, search: replacementSearchTerm },
+        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 
@@ -246,7 +246,7 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, search: replacementSearchTerm },
+        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 
@@ -277,7 +277,7 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true },
+        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC' },
       })
     })
 
@@ -286,7 +286,7 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, search: replacementSearchTerm },
+        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -116,7 +116,7 @@ describe('CreateSalesOrderPage product search', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, search: replacementSearchTerm },
+        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 
@@ -152,7 +152,7 @@ describe('CreateSalesOrderPage product search', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, search: replacementSearchTerm },
+        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 
@@ -206,7 +206,7 @@ describe('CreateSalesOrderPage product search', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, search: replacementSearchTerm },
+        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 


### PR DESCRIPTION
## Summary

- Adds `sortBy: 'name'` and `sortOrder: 'ASC'` to `useProductSearch` hook's API params
- Fixes product dropdowns in Sales Order, Purchase Order, and Stock Adjustment pages — products now appear A-Z
- No backend changes needed; the backend already honours these params and uses `UPPER(name)` for case-insensitive ordering

## Test Plan

- [x] `useProductSearch` unit tests updated and passing (7/7)
- [x] Sales Order page tests passing (5/5)
- [x] Purchase Order page tests passing (7/7)
- [x] Stock Adjustment + hook tests passing (15/15)
- [x] `npm run lint` passed
- [x] `npm run type-check` passed
- [ ] Manual: open Create Sales Order, click Product dropdown — verify products sorted A-Z
- [ ] Manual: repeat for Purchase Order and Stock Adjustment pages

Closes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)