### PR TITLE
fix: show validation errors when Create Adjustment is clicked with empty product

### DIFF
--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -300,7 +300,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
             { key: 'quantity', label: 'Quantity' },
             { key: 'notes', label: 'Notes' },
           ]}
-          onSubmit={handleSubmit(onSubmit)}
+          onSubmit={handleSubmit(onSubmit, () => showError('Please fix the form errors before submitting.'))}
           onCancel={() => navigate('/inventory/stock-adjustments')}
           isSubmitting={loading}
           hideDefaultActions
@@ -455,6 +455,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
                                       placeholder="Search by name or barcode..."
                                       variant="outlined"
                                       error={!!errors.items?.[index]?.productId}
+                                      helperText={errors.items?.[index]?.productId?.message}
                                       sx={{
                                         '& .MuiInputBase-input': {
                                           textAlign: 'left !important',

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -8,13 +8,15 @@ import CreateStockAdjustmentPage from '../CreateStockAdjustmentPage'
 
 const replacementSearchTerm = 'B'
 
-const { mockGet, mockNavigate, mockParams, mockFetchAdjustment, mockCreateAdjustment, mockUpdateAdjustment } = vi.hoisted(() => ({
+const { mockGet, mockNavigate, mockParams, mockFetchAdjustment, mockCreateAdjustment, mockUpdateAdjustment, mockShowError, mockShowSuccess } = vi.hoisted(() => ({
   mockGet: vi.fn(),
   mockNavigate: vi.fn(),
   mockParams: vi.fn(() => ({})),
   mockFetchAdjustment: vi.fn(),
   mockCreateAdjustment: vi.fn(),
   mockUpdateAdjustment: vi.fn(),
+  mockShowError: vi.fn(),
+  mockShowSuccess: vi.fn(),
 }))
 
 vi.mock('react-router-dom', async () => {
@@ -29,8 +31,8 @@ vi.mock('react-router-dom', async () => {
 
 vi.mock('@/hooks/useNotification', () => ({
   useNotification: () => ({
-    showSuccess: vi.fn(),
-    showError: vi.fn(),
+    showSuccess: mockShowSuccess,
+    showError: mockShowError,
   }),
 }))
 
@@ -378,6 +380,38 @@ describe('CreateStockAdjustmentPage submit', { timeout: 60000 }, () => {
           }),
         })
       )
+    })
+  })
+
+  it('calls showError when form is submitted with no product selected', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <BrowserRouter>
+        <CreateStockAdjustmentPage />
+      </BrowserRouter>
+    )
+
+    await user.click(screen.getByRole('button', { name: /create adjustment/i }))
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledWith(expect.stringMatching(/fix.*error|error.*fix/i))
+    })
+  })
+
+  it('shows helper text under the product field when submitted with no product selected', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <BrowserRouter>
+        <CreateStockAdjustmentPage />
+      </BrowserRouter>
+    )
+
+    await user.click(screen.getByRole('button', { name: /create adjustment/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Product is required')).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## Summary

- Adds `helperText` to the product `Autocomplete` field so "Product is required" appears inline under the field on failed submission
- Wires an `onError` callback to `handleSubmit` so the existing `showError` notification fires ("Please fix the form errors before submitting.") instead of silently blocking submission
- Refactors `useNotification` mock in tests to use hoisted named mocks, enabling assertions on `showError` calls

## Test plan

- [x] Click "Create Adjustment" with no product selected — toast notification appears and "Product is required" shows under the product field
- [x] Fill in a valid product and quantity with a difference — form submits normally
- [x] All existing tests pass (`npx vitest run src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx`)

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)