### PR TITLE
fix: allow stock adjustments for products with negative stock

### DIFF
--- a/backend/src/modules/inventory/dto/stock-adjustment.dto.ts
+++ b/backend/src/modules/inventory/dto/stock-adjustment.dto.ts
@@ -20,7 +20,7 @@ export class StockAdjustmentItemDto {
   @IsUUID(4)
   productId: string;
 
-  @ApiProperty({ description: 'Quantity before adjustment' })
+  @ApiProperty({ description: 'Stock snapshot at adjustment time; can be negative (e.g. oversell)' })
   @IsNumber({ maxDecimalPlaces: 4 })
   oldQuantity: number;
 

--- a/backend/src/modules/inventory/dto/stock-adjustment.dto.ts
+++ b/backend/src/modules/inventory/dto/stock-adjustment.dto.ts
@@ -22,7 +22,6 @@ export class StockAdjustmentItemDto {
 
   @ApiProperty({ description: 'Quantity before adjustment' })
   @IsNumber({ maxDecimalPlaces: 4 })
-  @Min(0)
   oldQuantity: number;
 
   @ApiProperty({ description: 'Quantity after adjustment' })

--- a/backend/src/modules/inventory/services/stock-adjustment.service.spec.ts
+++ b/backend/src/modules/inventory/services/stock-adjustment.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { validate } from 'class-validator';
 import { getRepositoryToken, getDataSourceToken } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
 import { StockAdjustmentService } from './stock-adjustment.service';
@@ -9,6 +10,7 @@ import { StockMovementService } from './stock-movement.service';
 import { SettingsService } from '../../settings/settings.service';
 import { AuditLogService } from '../../audit-logs/services';
 import { AccountingService } from '../../accounting/services/accounting.service';
+import { StockAdjustmentItemDto } from '../dto/stock-adjustment.dto';
 
 describe('StockAdjustmentService', () => {
   let service: StockAdjustmentService;
@@ -272,5 +274,17 @@ describe('StockAdjustmentService', () => {
       );
       expect(result).toBeDefined();
     });
+  });
+});
+
+describe('StockAdjustmentItemDto', () => {
+  it('allows negative oldQuantity because it is the current stock snapshot', async () => {
+    const dto = new StockAdjustmentItemDto();
+    dto.productId = '123e4567-e89b-42d3-a456-426614174000';
+    dto.oldQuantity = -5;
+    dto.newQuantity = 10;
+    dto.difference = 15;
+
+    await expect(validate(dto)).resolves.toHaveLength(0);
   });
 });

--- a/backend/src/modules/inventory/services/stock-adjustment.service.spec.ts
+++ b/backend/src/modules/inventory/services/stock-adjustment.service.spec.ts
@@ -287,4 +287,16 @@ describe('StockAdjustmentItemDto', () => {
 
     await expect(validate(dto)).resolves.toHaveLength(0);
   });
+
+  it('rejects negative newQuantity because target stock must be non-negative', async () => {
+    const dto = new StockAdjustmentItemDto();
+    dto.productId = '123e4567-e89b-42d3-a456-426614174000';
+    dto.oldQuantity = -5;
+    dto.newQuantity = -1;
+    dto.difference = 4;
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some(e => e.property === 'newQuantity')).toBe(true);
+  });
 });

--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -58,7 +58,7 @@ const schema = yup.object({
     yup.object({
       productId: yup.string().required('Product is required'),
       newQuantity: yup.number().min(0, 'New quantity cannot be negative').required(),
-      oldQuantity: yup.number().min(0).required(),
+      oldQuantity: yup.number().required(),
       difference: yup.number().required(),
     })
   ).min(1, 'At least one item is required'),

--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -518,7 +518,8 @@ const CreateStockAdjustmentPage: React.FC = () => {
                                       htmlInput: {
                                         style: { textAlign: 'center', fontSize: '0.875rem' },
                                         inputMode: 'numeric',
-                                        pattern: '[0-9]*'
+                                        pattern: '[0-9]*',
+                                        'data-testid': `items.${index}.newQuantity`,
                                       }
                                     }}
                                     error={!!errors.items?.[index]?.newQuantity}

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -356,10 +356,7 @@ describe('CreateStockAdjustmentPage submit', { timeout: 60000 }, () => {
       expect(productInput).toHaveValue('Overdrawn Widget')
     })
 
-    // Set newQuantity to 10 (different from oldQuantity -5, so difference != 0)
-    const newQtyInput = screen.getAllByRole('textbox').find(
-      (element) => element !== productInput && (element as HTMLInputElement).value === '-5'
-    ) as HTMLInputElement
+    const newQtyInput = screen.getByTestId('items.0.newQuantity') as HTMLInputElement
 
     await user.clear(newQtyInput)
     await user.type(newQtyInput, '10')

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -330,6 +330,52 @@ describe('CreateStockAdjustmentPage submit', { timeout: 60000 }, () => {
     })
   })
 
+  it('submits successfully when the selected product has negative stock', async () => {
+    const user = userEvent.setup()
+
+    mockGet.mockImplementation(async (url: string) => {
+      if (url.includes('/inventory/products/')) {
+        return { data: { id: 'product-neg', name: 'Overdrawn Widget', stockQuantity: -5 } }
+      }
+      return { data: [{ id: 'product-neg', name: 'Overdrawn Widget', stockQuantity: -5 }] }
+    })
+
+    render(
+      <BrowserRouter>
+        <CreateStockAdjustmentPage />
+      </BrowserRouter>
+    )
+
+    const productInput = screen.getByPlaceholderText('Search by name or barcode...')
+    await user.click(productInput)
+
+    const listbox = await screen.findByRole('listbox')
+    await user.click(within(listbox).getByText('Overdrawn Widget'))
+
+    await waitFor(() => {
+      expect(productInput).toHaveValue('Overdrawn Widget')
+    })
+
+    // Set newQuantity to 10 (different from oldQuantity -5, so difference != 0)
+    const newQtyInput = screen.getAllByRole('textbox').find(
+      (element) => element !== productInput && (element as HTMLInputElement).value === '-5'
+    ) as HTMLInputElement
+
+    await user.clear(newQtyInput)
+    await user.type(newQtyInput, '10')
+    await user.click(screen.getByRole('button', { name: /create adjustment/i }))
+
+    await waitFor(() => {
+      expect(mockCreateAdjustment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          items: expect.arrayContaining([
+            expect.objectContaining({ productId: 'product-neg', oldQuantity: -5, newQuantity: 10 }),
+          ]),
+        })
+      )
+    })
+  })
+
   it('calls updateStockAdjustment mutation on submit in edit mode', async () => {
     const user = userEvent.setup()
     mockParams.mockReturnValue({ adjustmentNumber: 'SA-001' })


### PR DESCRIPTION
## Summary

- Removes `@Min(0)` constraint from `oldQuantity` in the backend DTO — it is a read-only snapshot of current stock, not user input, so blocking on a negative value is incorrect
- Removes `.min(0)` from `oldQuantity` in the frontend yup schema to match
- Adds `data-testid` to the `newQuantity` TextField so tests select it unambiguously
- Adds backend test asserting `newQuantity: -1` still fails validation (locks in the asymmetry between the two fields)

## Root Cause

Products can go negative (e.g. overselling). When a user tried to select such a product in the Stock Adjustment form, both the frontend yup schema and backend DTO rejected `oldQuantity < 0`, triggering the generic "Please fix the form errors before submitting" toast with no actionable field-level error — leaving the user stuck with no way to correct the form.

## Test Plan

- [x] Backend: `cd backend && npx jest src/modules/inventory/services/stock-adjustment.service.spec.ts --no-coverage` — 6 tests pass
- [x] Frontend: `cd frontend && npx vitest run src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx` — 11 tests pass
- [x] Manually select a product with negative stock on the Stock Adjustment creation page and verify the form submits without error

Closes #564