### PR TITLE
feat: standardize AppButton colors by functional role

### DIFF
--- a/frontend/src/components/common/AppButton.tsx
+++ b/frontend/src/components/common/AppButton.tsx
@@ -9,6 +9,7 @@ type AppButtonVariant =
   | 'primary'
   | 'secondary'
   | 'outlined'
+  | 'neutral'
   | 'danger'
   | 'warning'
   | 'success'
@@ -48,7 +49,7 @@ export function AppButton({
 
   if (sortConfig != null) {
     muiVariant = isSortActive ? 'contained' : 'outlined'
-    muiColor = isSortActive ? 'primary' : 'inherit'
+    muiColor = isSortActive ? 'primary' : 'primary'
 
     if (isSortActive) {
       resolvedStartIcon =
@@ -61,6 +62,18 @@ export function AppButton({
       case 'primary':
         muiVariant = 'contained'
         muiColor = 'primary'
+        break
+      case 'secondary':
+        muiVariant = 'outlined'
+        muiColor = 'secondary'
+        break
+      case 'outlined':
+        muiVariant = 'outlined'
+        muiColor = 'primary'
+        break
+      case 'neutral':
+        muiVariant = 'outlined'
+        muiColor = 'inherit'
         break
       case 'danger':
         muiVariant = 'contained'
@@ -82,11 +95,9 @@ export function AppButton({
         muiVariant = 'contained'
         muiColor = 'info'
         break
-      case 'secondary':
-      case 'outlined':
       default:
         muiVariant = 'outlined'
-        muiColor = 'inherit'
+        muiColor = 'primary'
         break
     }
   }

--- a/frontend/src/components/common/AppButton.tsx
+++ b/frontend/src/components/common/AppButton.tsx
@@ -49,7 +49,7 @@ export function AppButton({
 
   if (sortConfig != null) {
     muiVariant = isSortActive ? 'contained' : 'outlined'
-    muiColor = isSortActive ? 'primary' : 'primary'
+    muiColor = 'primary'
 
     if (isSortActive) {
       resolvedStartIcon =

--- a/frontend/src/components/common/AppButton.tsx
+++ b/frontend/src/components/common/AppButton.tsx
@@ -64,7 +64,7 @@ export function AppButton({
         muiColor = 'primary'
         break
       case 'secondary':
-        muiVariant = 'outlined'
+        muiVariant = 'contained'
         muiColor = 'secondary'
         break
       case 'outlined':

--- a/frontend/src/components/common/__tests__/AppButton.test.tsx
+++ b/frontend/src/components/common/__tests__/AppButton.test.tsx
@@ -19,10 +19,10 @@ describe('AppButton - variants', () => {
     expect(btn.className).toMatch(/MuiButton-colorPrimary/)
   })
 
-  it('renders secondary as outlined colorSecondary', () => {
+  it('renders secondary as contained colorSecondary', () => {
     wrap(<AppButton variant="secondary">Cancel</AppButton>)
     const btn = screen.getByRole('button', { name: 'Cancel' })
-    expect(btn.className).toMatch(/MuiButton-outlined/)
+    expect(btn.className).toMatch(/MuiButton-contained/)
     expect(btn.className).toMatch(/MuiButton-colorSecondary/)
   })
 

--- a/frontend/src/components/common/__tests__/AppButton.test.tsx
+++ b/frontend/src/components/common/__tests__/AppButton.test.tsx
@@ -60,6 +60,27 @@ describe('AppButton - variants', () => {
     expect(btn.className).toMatch(/MuiButton-contained/)
     expect(btn.className).toMatch(/MuiButton-colorSuccess/)
   })
+
+  it('renders info as contained colorInfo', () => {
+    wrap(<AppButton variant="info">Info</AppButton>)
+    const btn = screen.getByRole('button', { name: 'Info' })
+    expect(btn.className).toMatch(/MuiButton-contained/)
+    expect(btn.className).toMatch(/MuiButton-colorInfo/)
+  })
+
+  it('renders text as text colorInherit', () => {
+    wrap(<AppButton variant="text">Link</AppButton>)
+    const btn = screen.getByRole('button', { name: 'Link' })
+    expect(btn.className).toMatch(/MuiButton-text/)
+    expect(btn.className).toMatch(/MuiButton-colorInherit/)
+  })
+
+  it('renders with no variant as outlined colorPrimary (default)', () => {
+    wrap(<AppButton>Default</AppButton>)
+    const btn = screen.getByRole('button', { name: 'Default' })
+    expect(btn.className).toMatch(/MuiButton-outlined/)
+    expect(btn.className).toMatch(/MuiButton-colorPrimary/)
+  })
 })
 
 describe('AppButton - size=filter', () => {
@@ -94,10 +115,11 @@ describe('AppButton - sortConfig', () => {
     sortOrder: 'asc' as const,
   }
 
-  it('renders as contained when sort is active', () => {
+  it('renders as contained colorPrimary when sort is active', () => {
     wrap(<AppButton sortConfig={baseSortConfig}>Sort</AppButton>)
     const btn = screen.getByRole('button', { name: /sort/i })
     expect(btn.className).toMatch(/MuiButton-contained/)
+    expect(btn.className).toMatch(/MuiButton-colorPrimary/)
   })
 
   it('renders as outlined colorPrimary when sort is inactive', () => {

--- a/frontend/src/components/common/__tests__/AppButton.test.tsx
+++ b/frontend/src/components/common/__tests__/AppButton.test.tsx
@@ -12,22 +12,32 @@ function wrap(ui: React.ReactElement) {
 }
 
 describe('AppButton - variants', () => {
-  it('renders primary as contained', () => {
+  it('renders primary as contained colorPrimary', () => {
     wrap(<AppButton variant="primary">Save</AppButton>)
     const btn = screen.getByRole('button', { name: 'Save' })
     expect(btn.className).toMatch(/MuiButton-contained/)
+    expect(btn.className).toMatch(/MuiButton-colorPrimary/)
   })
 
-  it('renders outlined as outlined', () => {
-    wrap(<AppButton variant="outlined">Cancel</AppButton>)
+  it('renders secondary as outlined colorSecondary', () => {
+    wrap(<AppButton variant="secondary">Cancel</AppButton>)
     const btn = screen.getByRole('button', { name: 'Cancel' })
     expect(btn.className).toMatch(/MuiButton-outlined/)
+    expect(btn.className).toMatch(/MuiButton-colorSecondary/)
   })
 
-  it('renders secondary as outlined', () => {
-    wrap(<AppButton variant="secondary">View</AppButton>)
+  it('renders outlined as outlined colorPrimary', () => {
+    wrap(<AppButton variant="outlined">View</AppButton>)
     const btn = screen.getByRole('button', { name: 'View' })
     expect(btn.className).toMatch(/MuiButton-outlined/)
+    expect(btn.className).toMatch(/MuiButton-colorPrimary/)
+  })
+
+  it('renders neutral as outlined colorInherit', () => {
+    wrap(<AppButton variant="neutral">Custom</AppButton>)
+    const btn = screen.getByRole('button', { name: 'Custom' })
+    expect(btn.className).toMatch(/MuiButton-outlined/)
+    expect(btn.className).toMatch(/MuiButton-colorInherit/)
   })
 
   it('renders danger as contained colorError', () => {
@@ -90,10 +100,11 @@ describe('AppButton - sortConfig', () => {
     expect(btn.className).toMatch(/MuiButton-contained/)
   })
 
-  it('renders as outlined when sort is inactive', () => {
+  it('renders as outlined colorPrimary when sort is inactive', () => {
     wrap(<AppButton sortConfig={{ ...baseSortConfig, sortBy: 'other' }}>Sort</AppButton>)
     const btn = screen.getByRole('button', { name: /sort/i })
     expect(btn.className).toMatch(/MuiButton-outlined/)
+    expect(btn.className).toMatch(/MuiButton-colorPrimary/)
   })
 
   it('calls onClick when clicked', () => {

--- a/frontend/src/pages/accounting/components/ChartOfAccountContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/ChartOfAccountContextHeader.tsx
@@ -67,7 +67,7 @@ export function ChartOfAccountContextHeader({ selected, onEdit, onDelete }: Prop
         title={`${selected.code} — ${selected.name}`}
         actions={(
           <Stack direction="row" spacing={0.5}>
-            <AppButton size="small" variant="outlined" startIcon={<EditIcon />} onClick={onEdit}>
+            <AppButton size="small" variant="secondary" startIcon={<EditIcon />} onClick={onEdit}>
               Edit
             </AppButton>
             <AppButton size="small" variant="danger" startIcon={<DeleteIcon />} onClick={onDelete}>

--- a/frontend/src/pages/accounting/components/ExpenseContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/ExpenseContextHeader.tsx
@@ -65,7 +65,7 @@ export function ExpenseContextHeader({ selected, onEdit, onPost, onDelete }: Pro
         actions={
           isDraft ? (
             <Stack direction="row" spacing={0.5}>
-              <AppButton size="small" variant="outlined" startIcon={<EditIcon />} onClick={onEdit}>
+              <AppButton size="small" variant="secondary" startIcon={<EditIcon />} onClick={onEdit}>
                 Edit
               </AppButton>
               <AppButton size="small" variant="success" startIcon={<PostIcon />} onClick={onPost}>

--- a/frontend/src/pages/accounting/components/FiscalPeriodContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/FiscalPeriodContextHeader.tsx
@@ -40,7 +40,7 @@ export function FiscalPeriodContextHeader({ selected, onClose, onReopen, onEdit,
                 Reopen
               </AppButton>
             )}
-            <AppButton size="small" variant="outlined" startIcon={<EditIcon />} onClick={onEdit}>
+            <AppButton size="small" variant="secondary" startIcon={<EditIcon />} onClick={onEdit}>
               Edit
             </AppButton>
             <AppButton size="small" variant="danger" startIcon={<DeleteIcon />} onClick={onDelete}>

--- a/frontend/src/pages/accounting/components/OwnerEquityContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/OwnerEquityContextHeader.tsx
@@ -80,7 +80,7 @@ export function OwnerEquityContextHeader({ selected, onEdit, onPost, onDelete, o
           <Stack direction="row" spacing={0.5}>
             {selected.status === 'draft' && (
               <>
-                <AppButton size="small" variant="outlined" startIcon={<EditIcon />} onClick={onEdit}>
+                <AppButton size="small" variant="secondary" startIcon={<EditIcon />} onClick={onEdit}>
                   Edit
                 </AppButton>
                 <AppButton size="small" variant="success" startIcon={<PostIcon />} onClick={onPost}>

--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -360,7 +360,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
                   <Typography variant="h6">Adjustment Items</Typography>
                   <AppButton
-                    variant="outlined"
+                    variant="secondary"
                     startIcon={<AddIcon />}
                     onClick={addItem}
                   >


### PR DESCRIPTION
## Summary

- `secondary` → `contained secondary` (solid pink) for Edit, Print, Cancel, Add Item, Retry — visible on dark theme
- `outlined` → `outlined primary` (blue border) for general/navigation actions like View Deleted
- Inactive sort buttons → `outlined primary` (blue) instead of colorless
- Add `neutral` variant as explicit escape hatch for colorless buttons
- Fix accounting module Edit buttons and inventory Add Item button that were using `outlined` instead of `secondary`, inconsistent with sales/purchasing

## Test Plan

- [x] All 17 AppButton unit tests pass (`npx vitest run src/components/common/__tests__/AppButton.test.tsx`)
- [x] Full frontend test suite passes (154 files, 1000 tests)
- [x] Visually verify Edit/Print/Cancel buttons have solid pink background in dark theme
- [x] Visually verify View Deleted / navigation buttons have blue outlined appearance
- [x] Visually verify active sort = solid blue contained, inactive sort = blue outlined
- [x] Visually verify primary (Save/Submit) buttons unchanged

Closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)