### PR TITLE
fix: standardize completion and edit button styling across modules

### DIFF
--- a/frontend/src/pages/accounting/components/AccountMappingContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/AccountMappingContextHeader.tsx
@@ -56,7 +56,7 @@ export function AccountMappingContextHeader({ row, onConfigure, onClear }: Props
           <Stack direction="row" spacing={0.5}>
             <AppButton
               size="small"
-              variant="outlined"
+              variant="secondary"
               startIcon={isConfigured ? <EditIcon /> : <SettingsIcon />}
               onClick={onConfigure}
             >

--- a/frontend/src/pages/accounting/components/ExpenseContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/ExpenseContextHeader.tsx
@@ -1,8 +1,8 @@
 import { Paper, Stack, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material'
 import Grid from '@mui/material/Grid'
+import { default as CheckCircleIcon } from '@mui/icons-material/CheckCircle'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as EditIcon } from '@mui/icons-material/Edit'
-import { default as PostIcon } from '@mui/icons-material/PostAdd'
 
 import { AppButton } from '@/components/common/AppButton'
 import { EntityContextHeaderBar } from '@/components/common/EntityContextHeaderBar'
@@ -68,7 +68,7 @@ export function ExpenseContextHeader({ selected, onEdit, onPost, onDelete }: Pro
               <AppButton size="small" variant="secondary" startIcon={<EditIcon />} onClick={onEdit}>
                 Edit
               </AppButton>
-              <AppButton size="small" variant="success" startIcon={<PostIcon />} onClick={onPost}>
+              <AppButton size="small" variant="success" startIcon={<CheckCircleIcon />} onClick={onPost}>
                 Post
               </AppButton>
               <AppButton size="small" variant="danger" startIcon={<DeleteIcon />} onClick={onDelete}>

--- a/frontend/src/pages/accounting/components/OwnerEquityContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/OwnerEquityContextHeader.tsx
@@ -1,8 +1,8 @@
 import { Chip, Paper, Stack, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material'
 import Grid from '@mui/material/Grid'
+import { default as CheckCircleIcon } from '@mui/icons-material/CheckCircle'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as EditIcon } from '@mui/icons-material/Edit'
-import { default as PostIcon } from '@mui/icons-material/PostAdd'
 import { default as UndoIcon } from '@mui/icons-material/Undo'
 
 import { AppButton } from '@/components/common/AppButton'
@@ -83,7 +83,7 @@ export function OwnerEquityContextHeader({ selected, onEdit, onPost, onDelete, o
                 <AppButton size="small" variant="secondary" startIcon={<EditIcon />} onClick={onEdit}>
                   Edit
                 </AppButton>
-                <AppButton size="small" variant="success" startIcon={<PostIcon />} onClick={onPost}>
+                <AppButton size="small" variant="success" startIcon={<CheckCircleIcon />} onClick={onPost}>
                   Post
                 </AppButton>
                 <AppButton size="small" variant="danger" startIcon={<DeleteIcon />} onClick={onDelete}>

--- a/frontend/src/pages/inventory/components/StockAdjustmentContextHeader.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentContextHeader.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { default as CheckCircleIcon } from '@mui/icons-material/CheckCircle'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as EditIcon } from '@mui/icons-material/Edit'
 import {
@@ -198,8 +199,9 @@ const StockAdjustmentContextHeader: React.FC<StockAdjustmentContextHeaderProps> 
                         <Stack direction="row" spacing={1} sx={{ alignItems: 'center', justifyContent: 'center' }}>
                           {selectedAdjustment.status === 'draft' && (
                             <AppButton
-                              variant="primary"
+                              variant="success"
                               size="small"
+                              startIcon={<CheckCircleIcon />}
                               onClick={onComplete}
                               sx={{ minWidth: 110 }}
                             >

--- a/frontend/src/pages/purchasing/components/PurchaseOrderContextHeader.tsx
+++ b/frontend/src/pages/purchasing/components/PurchaseOrderContextHeader.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { default as CheckCircleIcon } from '@mui/icons-material/CheckCircle'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as EditIcon } from '@mui/icons-material/Edit'
 import { default as PrintIcon } from '@mui/icons-material/Print'
@@ -300,6 +301,7 @@ const PurchaseOrderContextHeader: React.FC<PurchaseOrderContextHeaderProps> = ({
                           <AppButton
                             variant="success"
                             size="small"
+                            startIcon={<CheckCircleIcon />}
                             sx={{ minWidth: 110 }}
                             onClick={onReceive}
                             disabled={

--- a/frontend/src/pages/sales/components/OrderContextHeader.tsx
+++ b/frontend/src/pages/sales/components/OrderContextHeader.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { default as CheckCircleIcon } from '@mui/icons-material/CheckCircle'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as EditIcon } from '@mui/icons-material/Edit'
 import { default as PrintIcon } from '@mui/icons-material/Print'
@@ -417,6 +418,7 @@ const OrderContextHeader: React.FC<OrderContextHeaderProps> = ({
                         <AppButton
                           size="small"
                           variant={selectedOrder.isFulfilled ? 'warning' : 'success'}
+                          startIcon={selectedOrder.isFulfilled ? undefined : <CheckCircleIcon />}
                           onClick={selectedOrder.isFulfilled ? onUnfulfillOrder : onFulfillOrder}
                           disabled={isLoading || (!selectedOrder.isFulfilled && !selectedOrder.isPaidInFull)}
                           sx={{ minWidth: 110 }}

--- a/frontend/src/pages/settings/PriceListDetailsPage.tsx
+++ b/frontend/src/pages/settings/PriceListDetailsPage.tsx
@@ -21,7 +21,9 @@ import {
   DialogActions,
   InputAdornment,
 } from '@mui/material'
+import { AppButton } from '@/components/common/AppButton'
 import { default as BackIcon } from '@mui/icons-material/ArrowBack'
+import { default as CheckCircleIcon } from '@mui/icons-material/CheckCircle'
 import { default as EditIcon } from '@mui/icons-material/Edit'
 import { default as SaveIcon } from '@mui/icons-material/Save'
 import { default as RefreshIcon } from '@mui/icons-material/Refresh'
@@ -179,9 +181,9 @@ const PriceListDetailsPage: React.FC = () => {
     return (
       <Box>
         <Alert severity="error">Price list not found</Alert>
-        <Button startIcon={<BackIcon />} onClick={() => navigate('/settings/price-lists')} sx={{ mt: 2 }}>
+        <AppButton variant="secondary" startIcon={<BackIcon />} onClick={() => navigate('/settings/price-lists')} sx={{ mt: 2 }}>
           Back to Price Lists
-        </Button>
+        </AppButton>
       </Box>
     )
   }
@@ -190,9 +192,9 @@ const PriceListDetailsPage: React.FC = () => {
     <>
       {/* Header */}
       <Box sx={{ mb: 3 }}>
-        <Button startIcon={<BackIcon />} onClick={() => navigate('/settings/price-lists')} sx={{ mb: 2 }}>
+        <AppButton variant="secondary" startIcon={<BackIcon />} onClick={() => navigate('/settings/price-lists')} sx={{ mb: 2 }}>
           Back to Price Lists
-        </Button>
+        </AppButton>
 
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 2 }}>
           <Box>
@@ -227,36 +229,36 @@ const PriceListDetailsPage: React.FC = () => {
           </Box>
 
           <Box sx={{ display: 'flex', gap: 1 }}>
-            <Button variant="outlined" startIcon={<RefreshIcon />} onClick={loadData}>
+            <AppButton variant="secondary" startIcon={<RefreshIcon />} onClick={loadData}>
               Refresh
-            </Button>
+            </AppButton>
             {!editMode && (
               <>
-                <Button
-                  variant="outlined"
+                <AppButton
+                  variant="secondary"
                   startIcon={<AdjustIcon />}
                   onClick={() => setAdjustmentDialogOpen(true)}
                 >
                   Adjust Prices
-                </Button>
-                <Button variant="contained" startIcon={<EditIcon />} onClick={() => setEditMode(true)}>
+                </AppButton>
+                <AppButton variant="secondary" startIcon={<EditIcon />} onClick={() => setEditMode(true)}>
                   Edit Prices
-                </Button>
+                </AppButton>
               </>
             )}
             {editMode && (
               <>
-                <Button variant="outlined" onClick={() => { setEditMode(false); setEditedItems(new Map()); }}>
+                <AppButton variant="secondary" onClick={() => { setEditMode(false); setEditedItems(new Map()); }}>
                   Cancel
-                </Button>
-                <Button
-                  variant="contained"
+                </AppButton>
+                <AppButton
+                  variant="success"
                   startIcon={<SaveIcon />}
                   onClick={handleSaveChanges}
                   disabled={editedItems.size === 0}
                 >
                   Save Changes ({editedItems.size})
-                </Button>
+                </AppButton>
               </>
             )}
           </Box>
@@ -569,14 +571,15 @@ const PriceListDetailsPage: React.FC = () => {
           </Stack>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setAdjustmentDialogOpen(false)}>Cancel</Button>
-          <Button
-            variant="contained"
+          <AppButton variant="secondary" onClick={() => setAdjustmentDialogOpen(false)}>Cancel</AppButton>
+          <AppButton
+            variant="success"
+            startIcon={<CheckCircleIcon />}
             onClick={handleApplyAdjustment}
             disabled={!adjustmentPercentage || priceListItemsLoading}
           >
             Apply Adjustment
-          </Button>
+          </AppButton>
         </DialogActions>
       </Dialog>
     </>


### PR DESCRIPTION
## Summary

- Completion/finalization buttons (Fulfill, Receive, Complete, Post) now consistently use `variant="success"` + `CheckCircleIcon` across Sales, Purchasing, Inventory, and Accounting modules
- Edit/Configure buttons in `AccountMappingContextHeader` changed from `variant="outlined"` to `variant="secondary"`
- `PriceListDetailsPage` migrated from raw MUI `Button` to `AppButton` throughout

## Affected Files

- `frontend/src/pages/sales/components/OrderContextHeader.tsx`
- `frontend/src/pages/purchasing/components/PurchaseOrderContextHeader.tsx`
- `frontend/src/pages/inventory/components/StockAdjustmentContextHeader.tsx`
- `frontend/src/pages/accounting/components/ExpenseContextHeader.tsx`
- `frontend/src/pages/accounting/components/OwnerEquityContextHeader.tsx`
- `frontend/src/pages/accounting/components/AccountMappingContextHeader.tsx`
- `frontend/src/pages/settings/PriceListDetailsPage.tsx`

## Test plan

- [x] Sales: Open a sales order — Fulfill button shows green with checkmark icon
- [x] Purchasing: Open a purchase order — Receive button shows green with checkmark icon
- [x] Inventory: Open a stock adjustment in draft — Complete button shows green with checkmark icon
- [x] Accounting > Expenses: Open a draft expense — Post button shows green with checkmark icon
- [x] Accounting > Owner Equity: Open a draft transaction — Post button shows green with checkmark icon
- [x] Accounting > Account Mappings: Configure/Edit buttons use secondary styling
- [x] Settings > Price Lists: Open a price list — all buttons use AppButton styling, Save Changes is green

Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)