### PR TITLE
fix: extend auto-logout idle timeout to 12h with 5min warning

### DIFF
--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -346,8 +346,8 @@ export class AuthService {
     });
 
     // Generate refresh token (long-lived)
-    // If "Remember me" is checked: 7 days, otherwise: 1 day
-    const refreshTokenExpiry = rememberMe ? '7d' : '1d';
+    // If "Remember me" is checked: 7 days, otherwise: 2 days (covers 12h idle + buffer)
+    const refreshTokenExpiry = rememberMe ? '7d' : '2d';
     const refreshToken = this.jwtService.sign(payload, {
       expiresIn: this.configService.get('JWT_REFRESH_TOKEN_EXPIRY', refreshTokenExpiry),
     });

--- a/frontend/src/RootLayout.tsx
+++ b/frontend/src/RootLayout.tsx
@@ -7,6 +7,9 @@ import { clearAuth, logout as logoutAction, selectIsAuthenticated, selectRemembe
 import { useIdleTimer } from './hooks/useIdleTimer'
 import IdleWarningDialog from './components/auth/IdleWarningDialog'
 
+const IDLE_TIMEOUT = 12 * 60 * 60 * 1000
+const WARNING_TIME = 5 * 60 * 1000
+
 const PageLoader = () => (
   <Box sx={{ width: '100%', position: 'fixed', top: 0, zIndex: 9999 }}>
     <LinearProgress />
@@ -23,9 +26,6 @@ export default function RootLayout() {
   const [showIdleWarning, setShowIdleWarning] = useState(false)
 
   useRegionalSettings(isAuthenticated)
-
-  const IDLE_TIMEOUT = 12 * 60 * 60 * 1000
-  const WARNING_TIME = 5 * 60 * 1000
 
   const handleAutoLogout = useCallback(async () => {
     setShowIdleWarning(false)

--- a/frontend/src/RootLayout.tsx
+++ b/frontend/src/RootLayout.tsx
@@ -24,8 +24,8 @@ export default function RootLayout() {
 
   useRegionalSettings(isAuthenticated)
 
-  const IDLE_TIMEOUT = 30 * 60 * 1000
-  const WARNING_TIME = 2 * 60 * 1000
+  const IDLE_TIMEOUT = 12 * 60 * 60 * 1000
+  const WARNING_TIME = 5 * 60 * 1000
 
   const handleAutoLogout = useCallback(async () => {
     setShowIdleWarning(false)

--- a/frontend/src/components/auth/IdleWarningDialog.tsx
+++ b/frontend/src/components/auth/IdleWarningDialog.tsx
@@ -38,7 +38,7 @@ interface IdleWarningDialogProps {
 const IdleWarningDialog: React.FC<IdleWarningDialogProps> = ({
   open,
   remainingSeconds,
-  totalWarningSeconds = 120, // Default 2 minutes
+  totalWarningSeconds = 300, // Default 5 minutes
   onStayLoggedIn,
   onLogout,
 }) => {

--- a/frontend/src/hooks/__tests__/useIdleTimer.test.ts
+++ b/frontend/src/hooks/__tests__/useIdleTimer.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useIdleTimer } from '../useIdleTimer'
+
+describe('useIdleTimer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  const TIMEOUT = 12 * 60 * 60 * 1000 // 12 hours
+  const WARNING = 5 * 60 * 1000 // 5 minutes
+  const IDLE_DELAY = TIMEOUT - WARNING
+
+  it('calls onIdle after timeout - warningTime ms of inactivity', () => {
+    const onIdle = vi.fn()
+    renderHook(() => useIdleTimer({ timeout: TIMEOUT, warningTime: WARNING, onIdle, enabled: true }))
+
+    act(() => { vi.advanceTimersByTime(IDLE_DELAY - 1) })
+    expect(onIdle).not.toHaveBeenCalled()
+
+    act(() => { vi.advanceTimersByTime(1) })
+    expect(onIdle).toHaveBeenCalledOnce()
+  })
+
+  it('calls onTimeout after full timeout ms of inactivity', () => {
+    const onTimeout = vi.fn()
+    renderHook(() => useIdleTimer({ timeout: TIMEOUT, warningTime: WARNING, onTimeout, enabled: true }))
+
+    act(() => { vi.advanceTimersByTime(TIMEOUT) })
+    expect(onTimeout).toHaveBeenCalledOnce()
+  })
+
+  it('calls onActive and resets timer when activity occurs during warning', () => {
+    const onIdle = vi.fn()
+    const onActive = vi.fn()
+    const { result } = renderHook(() =>
+      useIdleTimer({ timeout: TIMEOUT, warningTime: WARNING, onIdle, onActive, enabled: true })
+    )
+
+    // Trigger idle state
+    act(() => { vi.advanceTimersByTime(IDLE_DELAY) })
+    expect(onIdle).toHaveBeenCalledOnce()
+
+    // Simulate user activity
+    act(() => { result.current.reset() })
+    expect(onActive).toHaveBeenCalledOnce()
+    expect(result.current.remainingTime).toBe(0)
+  })
+
+  it('does not fire when disabled', () => {
+    const onIdle = vi.fn()
+    const onTimeout = vi.fn()
+    renderHook(() =>
+      useIdleTimer({ timeout: TIMEOUT, warningTime: WARNING, onIdle, onTimeout, enabled: false })
+    )
+
+    act(() => { vi.advanceTimersByTime(TIMEOUT + 1000) })
+    expect(onIdle).not.toHaveBeenCalled()
+    expect(onTimeout).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/hooks/useIdleTimer.ts
+++ b/frontend/src/hooks/useIdleTimer.ts
@@ -9,7 +9,7 @@ interface UseIdleTimerOptions {
 
   /**
    * Warning time in milliseconds before logout
-   * @default 120000 (2 minutes)
+   * @default 300000 (5 minutes)
    */
   warningTime?: number
 
@@ -64,8 +64,8 @@ interface UseIdleTimerReturn {
  * @example
  * ```tsx
  * const { isIdle, remainingTime, reset } = useIdleTimer({
- *   timeout: 60 * 60 * 1000, // 60 minutes
- *   warningTime: 2 * 60 * 1000, // 2 minutes warning
+ *   timeout: 12 * 60 * 60 * 1000, // 12 hours
+ *   warningTime: 5 * 60 * 1000, // 5 minutes warning
  *   onTimeout: () => logout(),
  * })
  * ```
@@ -73,7 +73,7 @@ interface UseIdleTimerReturn {
 export function useIdleTimer(options: UseIdleTimerOptions = {}): UseIdleTimerReturn {
   const {
     timeout = 60 * 60 * 1000, // 60 minutes default
-    warningTime = 2 * 60 * 1000, // 2 minutes warning default
+    warningTime = 5 * 60 * 1000, // 5 minutes warning default
     onIdle,
     onTimeout,
     onActive,


### PR DESCRIPTION
## Summary

- Extends idle timeout from 30 minutes to 12 hours (industry standard for internal ERP tools)
- Extends warning dialog from 2 minutes to 5 minutes
- Bumps non-rememberMe JWT refresh token expiry from 1d to 2d for session headroom
- Fixes stale `IdleWarningDialog` default prop (`totalWarningSeconds: 120 → 300`)
- Moves `IDLE_TIMEOUT`/`WARNING_TIME` to module scope in `RootLayout`
- Updates `useIdleTimer` JSDoc defaults to reflect new values
- Adds `useIdleTimer` test suite (4 tests: idle fires, timeout fires, active resets, disabled)

Closes #572

## Test Plan

- [ ] Log in without "Remember Me" — verify session stays active after 12h of activity (token refresh interceptor handles silent renewal)
- [ ] Sit idle — verify warning dialog appears at ~11h 55m with 5-minute countdown
- [ ] Click "Stay Logged In" in dialog — verify session continues
- [ ] Let warning dialog expire — verify auto-logout and redirect to `/login`
- [ ] Log in with "Remember Me" — verify idle timer is disabled (no auto-logout)
- [ ] All 41 auth/hooks tests pass: `npx vitest run src/pages/auth src/components/auth src/store/slices/__tests__/authSlice.test.ts src/hooks/__tests__/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)