### PR TITLE
fix: remove journal entry book icon from EntityContextHeaderBar

### DIFF
--- a/frontend/src/components/common/EntityContextHeaderBar.tsx
+++ b/frontend/src/components/common/EntityContextHeaderBar.tsx
@@ -1,47 +1,19 @@
 import type { ReactNode } from 'react'
-import MenuBookIcon from '@mui/icons-material/MenuBook'
-import { Box, CircularProgress, IconButton, Tooltip, Typography } from '@mui/material'
+import { Box, Typography } from '@mui/material'
 
 import { TABLE_STYLES } from '@/constants/tableStyles'
-
-import type { JournalEntryRef } from '@/hooks/useJournalEntryRef'
 
 interface EntityContextHeaderBarProps {
   title: string
   statusChip?: ReactNode
   actions?: ReactNode
-  journalEntryRef?: JournalEntryRef | null
-  journalEntryRefs?: JournalEntryRef[]
-  /** Loading state for either the single-ref or multi-ref path */
-  journalEntryRefLoading?: boolean
-  journalEntryRefsLoading?: boolean
-  onNavigateToJournalEntry?: () => void
 }
 
 export function EntityContextHeaderBar({
   title,
   statusChip,
   actions,
-  journalEntryRef,
-  journalEntryRefs,
-  journalEntryRefLoading,
-  journalEntryRefsLoading,
-  onNavigateToJournalEntry,
 }: EntityContextHeaderBarProps) {
-  const isLoading = journalEntryRefsLoading ?? journalEntryRefLoading ?? false
-
-  const activeRefs = journalEntryRefs && journalEntryRefs.length > 0
-    ? journalEntryRefs
-    : journalEntryRef
-      ? [journalEntryRef]
-      : []
-
-  const tooltipTitle = activeRefs.length > 1
-    ? `Journal Entries: ${activeRefs.map((r) => r.referenceNumber).join(', ')}`
-    : activeRefs.length === 1
-      ? `Journal Entry: ${activeRefs[0].referenceNumber}`
-      : ''
-
   return (
     <Box
       sx={{
@@ -68,16 +40,6 @@ export function EntityContextHeaderBar({
       </Box>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
         {actions}
-        {isLoading && activeRefs.length === 0 && (
-          <CircularProgress size={16} sx={{ mx: 0.5 }} />
-        )}
-        {activeRefs.length > 0 && (
-          <Tooltip title={tooltipTitle}>
-            <IconButton size="small" onClick={onNavigateToJournalEntry}>
-              <MenuBookIcon fontSize="small" />
-            </IconButton>
-          </Tooltip>
-        )}
       </Box>
     </Box>
   )

--- a/frontend/src/components/common/EntityContextHeaderBar.tsx
+++ b/frontend/src/components/common/EntityContextHeaderBar.tsx
@@ -38,9 +38,11 @@ export function EntityContextHeaderBar({
         </Typography>
         {statusChip}
       </Box>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-        {actions}
-      </Box>
+      {actions && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          {actions}
+        </Box>
+      )}
     </Box>
   )
 }

--- a/frontend/src/pages/inventory/components/StockAdjustmentContextHeader.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentContextHeader.tsx
@@ -109,9 +109,6 @@ const StockAdjustmentContextHeader: React.FC<StockAdjustmentContextHeaderProps> 
             </AppButton>
           </Box>
         )}
-        journalEntryRef={journalEntryRef}
-        journalEntryRefLoading={journalEntryRefLoading}
-        onNavigateToJournalEntry={onNavigateToJournalEntry}
       />
 
       <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>

--- a/frontend/src/pages/purchasing/components/GRNContextHeader.tsx
+++ b/frontend/src/pages/purchasing/components/GRNContextHeader.tsx
@@ -95,9 +95,6 @@ const GRNContextHeader: React.FC<GRNContextHeaderProps> = ({
             Print
           </AppButton>
         }
-        journalEntryRefs={journalEntryRefs}
-        journalEntryRefLoading={journalEntryRefLoading}
-        onNavigateToJournalEntry={onNavigateToJournalEntry}
       />
 
       <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>

--- a/frontend/src/pages/purchasing/components/PurchaseOrderContextHeader.tsx
+++ b/frontend/src/pages/purchasing/components/PurchaseOrderContextHeader.tsx
@@ -144,9 +144,6 @@ const PurchaseOrderContextHeader: React.FC<PurchaseOrderContextHeaderProps> = ({
             </AppButton>
           </Box>
         )}
-        journalEntryRefs={journalEntryRefs}
-        journalEntryRefLoading={journalEntryRefLoading}
-        onNavigateToJournalEntry={onNavigateToJournalEntry}
       />
       <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
         <Grid container spacing={3}>

--- a/frontend/src/pages/purchasing/components/VendorPaymentContextHeader.tsx
+++ b/frontend/src/pages/purchasing/components/VendorPaymentContextHeader.tsx
@@ -95,9 +95,6 @@ const VendorPaymentContextHeader: React.FC<VendorPaymentContextHeaderProps> = ({
             Print
           </AppButton>
         }
-        journalEntryRefs={journalEntryRefs}
-        journalEntryRefLoading={journalEntryRefLoading}
-        onNavigateToJournalEntry={onNavigateToJournalEntry}
       />
 
       <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>

--- a/frontend/src/pages/sales/components/InvoiceContextHeader.tsx
+++ b/frontend/src/pages/sales/components/InvoiceContextHeader.tsx
@@ -107,9 +107,6 @@ const InvoiceContextHeader: React.FC<InvoiceContextHeaderProps> = ({
             Print
           </AppButton>
         }
-        journalEntryRefs={journalEntryRefs}
-        journalEntryRefsLoading={journalEntryRefsLoading}
-        onNavigateToJournalEntry={onNavigateToJournalEntries}
       />
 
       <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>

--- a/frontend/src/pages/sales/components/OrderContextHeader.tsx
+++ b/frontend/src/pages/sales/components/OrderContextHeader.tsx
@@ -164,9 +164,6 @@ const OrderContextHeader: React.FC<OrderContextHeaderProps> = ({
             </AppButton>
           </Box>
         )}
-        journalEntryRefs={journalEntryRefs}
-        journalEntryRefsLoading={journalEntryRefsLoading}
-        onNavigateToJournalEntry={onNavigateToJournalEntries}
       />
       <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>
         <Grid container spacing={3}>

--- a/frontend/src/pages/sales/components/PaymentContextHeader.tsx
+++ b/frontend/src/pages/sales/components/PaymentContextHeader.tsx
@@ -99,9 +99,6 @@ const PaymentContextHeader: React.FC<PaymentContextHeaderProps> = ({
             Print
           </AppButton>
         }
-        journalEntryRefs={journalEntryRefs}
-        journalEntryRefsLoading={journalEntryRefsLoading}
-        onNavigateToJournalEntry={onNavigateToJournalEntry}
       />
 
       <Box sx={{ p: TABLE_STYLES.cell.padding.px }}>


### PR DESCRIPTION
## Summary

- Removed `MenuBookIcon`, loading spinner, tooltip, and all five journal-entry props (`journalEntryRef`, `journalEntryRefs`, `journalEntryRefLoading`, `journalEntryRefsLoading`, `onNavigateToJournalEntry`) from `EntityContextHeaderBar`
- Updated all 7 callers (sales, purchasing, inventory headers) to stop passing the removed props
- Conditionally renders the `actions` Box only when actions are present, avoiding an empty DOM node

## What was NOT changed

- Textual "Journal Entry No" links in detail tables — fully intact
- `useJournalEntryRef` / `useJournalEntryRefs` hooks — still used by detail-table links

## Test Plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] All 8 affected test files pass (33 tests)
- [ ] Manually verify book icon is gone from Sales Orders, Purchase Orders, GRN, Vendor Payment, Stock Adjustment headers
- [ ] Manually verify "Journal Entry No" textual links still navigate correctly

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)