### PR TITLE
feat: LockStatusIcon in context headers + WorkspaceCardSectionHeader normalization (#576)

### DIFF
--- a/frontend/src/components/common/LockStatusIcon.test.tsx
+++ b/frontend/src/components/common/LockStatusIcon.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import { LockStatusIcon } from './LockStatusIcon'
+
+describe('LockStatusIcon', () => {
+  it('renders a lock icon when locked', () => {
+    render(<LockStatusIcon isLocked={true} tooltipText="unpay before editing" />)
+    expect(screen.getByTestId('LockIcon')).toBeInTheDocument()
+    expect(screen.queryByTestId('LockOpenIcon')).not.toBeInTheDocument()
+  })
+
+  it('renders an unlock icon when unlocked', () => {
+    render(<LockStatusIcon isLocked={false} tooltipText="unlocked — editable" />)
+    expect(screen.getByTestId('LockOpenIcon')).toBeInTheDocument()
+    expect(screen.queryByTestId('LockIcon')).not.toBeInTheDocument()
+  })
+
+  it('shows tooltip text on hover when locked', async () => {
+    render(<LockStatusIcon isLocked={true} tooltipText="unpay before editing" />)
+    await userEvent.hover(screen.getByTestId('LockIcon'))
+    expect(await screen.findByText('unpay before editing')).toBeInTheDocument()
+  })
+
+  it('shows tooltip text on hover when unlocked', async () => {
+    render(<LockStatusIcon isLocked={false} tooltipText="unlocked — editable" />)
+    await userEvent.hover(screen.getByTestId('LockOpenIcon'))
+    expect(await screen.findByText('unlocked — editable')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/common/LockStatusIcon.tsx
+++ b/frontend/src/components/common/LockStatusIcon.tsx
@@ -1,0 +1,24 @@
+import { default as LockIcon } from '@mui/icons-material/Lock'
+import { default as LockOpenIcon } from '@mui/icons-material/LockOpen'
+import { Tooltip } from '@mui/material'
+
+interface LockStatusIconProps {
+  isLocked: boolean
+  tooltipText: string
+}
+
+export function LockStatusIcon({ isLocked, tooltipText }: LockStatusIconProps) {
+  if (isLocked) {
+    return (
+      <Tooltip title={tooltipText}>
+        <LockIcon sx={{ fontSize: '1rem', color: 'warning.main', cursor: 'default' }} />
+      </Tooltip>
+    )
+  }
+
+  return (
+    <Tooltip title={tooltipText}>
+      <LockOpenIcon sx={{ fontSize: '1rem', color: 'text.disabled', opacity: 0.5, cursor: 'default' }} />
+    </Tooltip>
+  )
+}

--- a/frontend/src/components/common/WorkspaceCardSectionHeader.test.tsx
+++ b/frontend/src/components/common/WorkspaceCardSectionHeader.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { WorkspaceCardSectionHeader } from './WorkspaceCardSectionHeader'
+
+describe('WorkspaceCardSectionHeader', () => {
+  it('renders the title', () => {
+    render(<WorkspaceCardSectionHeader title="PO Items" />)
+    expect(screen.getByText('PO Items')).toBeInTheDocument()
+  })
+
+  it('renders the action slot when provided', () => {
+    render(<WorkspaceCardSectionHeader title="PO Items" action={<button>Action</button>} />)
+    expect(screen.getByRole('button', { name: 'Action' })).toBeInTheDocument()
+  })
+
+  it('renders no action slot when not provided', () => {
+    render(<WorkspaceCardSectionHeader title="PO Items" />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/common/WorkspaceCardSectionHeader.tsx
+++ b/frontend/src/components/common/WorkspaceCardSectionHeader.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react'
+import { Box, Typography } from '@mui/material'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+
+interface WorkspaceCardSectionHeaderProps {
+  title: string
+  action?: ReactNode
+}
+
+export function WorkspaceCardSectionHeader({ title, action }: WorkspaceCardSectionHeaderProps) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        p: TABLE_STYLES.cell.padding.px,
+        borderBottom: TABLE_STYLES.cell.border,
+      }}
+    >
+      <Typography
+        variant="tableHeader"
+        sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
+      >
+        {title}
+      </Typography>
+      {action}
+    </Box>
+  )
+}

--- a/frontend/src/pages/accounting/components/AccountMappingWorkspaceCard.tsx
+++ b/frontend/src/pages/accounting/components/AccountMappingWorkspaceCard.tsx
@@ -1,5 +1,6 @@
-import { Box, Paper, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
+import { Paper, Table, TableBody, TableCell, TableRow } from '@mui/material'
 
+import { WorkspaceCardSectionHeader } from '@/components/common/WorkspaceCardSectionHeader'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { AccountMapping } from '@/types/accountMapping'
 
@@ -10,9 +11,7 @@ export function AccountMappingWorkspaceCard({ mapping }: Props) {
   if (!mapping) return <Paper sx={{ flex: 1 }} />
   return (
     <Paper sx={{ flex: 1 }}>
-      <Box sx={{ px: 2, py: 1, borderBottom: TABLE_STYLES.cell.border }}>
-        <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>Details</Typography>
-      </Box>
+      <WorkspaceCardSectionHeader title="Details" />
       <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': cellSx }}>
         <TableBody>
           <TableRow><TableCell sx={{ ...cellSx, color: 'text.secondary', width: '35%' }}>Mapped Account</TableCell><TableCell>{mapping.account?.code} - {mapping.account?.name}</TableCell></TableRow>

--- a/frontend/src/pages/accounting/components/BankReconciliationWorkspaceCard.tsx
+++ b/frontend/src/pages/accounting/components/BankReconciliationWorkspaceCard.tsx
@@ -1,6 +1,7 @@
 import { Alert, Box, Checkbox, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from '@mui/material'
 import { format } from 'date-fns'
 
+import { WorkspaceCardSectionHeader } from '@/components/common/WorkspaceCardSectionHeader'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { BankReconciliation, BankReconciliationStatus, ReconciledTransaction } from '@/types'
 import { formatCurrency } from '@/utils/formatters'
@@ -24,39 +25,7 @@ export function BankReconciliationWorkspaceCard({ selected, onToggleCleared }: P
 
   return (
     <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <TableContainer>
-        <Table
-          size={TABLE_STYLES.size}
-          sx={{
-            tableLayout: 'fixed',
-            '& .MuiTableCell-root': {
-              border: 'none',
-              py: TABLE_STYLES.cell.padding.py,
-              px: TABLE_STYLES.cell.padding.px,
-            },
-          }}
-        >
-          <TableBody>
-            <TableRow>
-              <TableCell
-                colSpan={4}
-                sx={{
-                  pb: TABLE_STYLES.cell.padding.py * 0.67,
-                  py: TABLE_STYLES.cell.padding.py * 0.67,
-                  borderTop: TABLE_STYLES.cell.border,
-                }}
-              >
-                <Typography
-                  variant="tableHeader"
-                  sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
-                >
-                  Transactions
-                </Typography>
-              </TableCell>
-            </TableRow>
-          </TableBody>
-        </Table>
-      </TableContainer>
+      <WorkspaceCardSectionHeader title="Transactions" />
 
       <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', p: TABLE_STYLES.cell.padding.px }}>
         {isCompleted && (

--- a/frontend/src/pages/accounting/components/ChartOfAccountWorkspaceCard.tsx
+++ b/frontend/src/pages/accounting/components/ChartOfAccountWorkspaceCard.tsx
@@ -10,6 +10,7 @@ import {
   Typography,
 } from '@mui/material'
 
+import { WorkspaceCardSectionHeader } from '@/components/common/WorkspaceCardSectionHeader'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { useGetChartOfAccountRecentActivityQuery } from '@/store/api/accountingApi'
 import type { ChartOfAccount } from '@/types'
@@ -19,12 +20,6 @@ import { ACCOUNT_TYPE_COLORS } from '../utils/accountTypeColors'
 
 interface Props {
   selected: ChartOfAccount | null
-}
-
-const headerSx = {
-  px: TABLE_STYLES.cell.padding.px,
-  py: 1,
-  borderBottom: TABLE_STYLES.cell.border,
 }
 
 const thSx = {
@@ -145,14 +140,7 @@ export function ChartOfAccountWorkspaceCard({ selected }: Props) {
 
   return (
     <Paper sx={{ flex: 1 }}>
-      <Box sx={headerSx}>
-        <Typography
-          variant="tableHeader"
-          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
-        >
-          {sectionTitle}
-        </Typography>
-      </Box>
+      <WorkspaceCardSectionHeader title={sectionTitle} />
       {isHeader ? (
         <SubAccountsTable accounts={selected.children ?? []} />
       ) : (

--- a/frontend/src/pages/accounting/components/ExpenseWorkspaceCard.tsx
+++ b/frontend/src/pages/accounting/components/ExpenseWorkspaceCard.tsx
@@ -1,5 +1,6 @@
-import { Box, Paper, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
+import { Paper, Table, TableBody, TableCell, TableRow } from '@mui/material'
 
+import { WorkspaceCardSectionHeader } from '@/components/common/WorkspaceCardSectionHeader'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ExpenseRecord } from '@/types'
 
@@ -14,11 +15,7 @@ export function ExpenseWorkspaceCard({ selected }: Props) {
 
   return (
     <Paper sx={{ flex: 1 }}>
-      <Box sx={{ px: 2, py: 1, borderBottom: TABLE_STYLES.cell.border }}>
-        <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
-          Details
-        </Typography>
-      </Box>
+      <WorkspaceCardSectionHeader title="Details" />
       <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': cellSx }}>
         <TableBody>
           <TableRow>

--- a/frontend/src/pages/accounting/components/FiscalPeriodWorkspaceCard.tsx
+++ b/frontend/src/pages/accounting/components/FiscalPeriodWorkspaceCard.tsx
@@ -1,6 +1,7 @@
-import { Box, Paper, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
+import { Paper, Table, TableBody, TableCell, TableRow } from '@mui/material'
 import { format } from 'date-fns'
 
+import { WorkspaceCardSectionHeader } from '@/components/common/WorkspaceCardSectionHeader'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { FiscalPeriod } from '@/types'
 
@@ -11,9 +12,7 @@ export function FiscalPeriodWorkspaceCard({ selected }: Props) {
   if (!selected) return <Paper sx={{ flex: 1 }} />
   return (
     <Paper sx={{ flex: 1 }}>
-      <Box sx={{ px: 2, py: 1, borderBottom: TABLE_STYLES.cell.border }}>
-        <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>Details</Typography>
-      </Box>
+      <WorkspaceCardSectionHeader title="Details" />
       <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': cellSx }}>
         <TableBody>
           <TableRow><TableCell sx={{ ...cellSx, color: 'text.secondary', width: '35%' }}>Start Date</TableCell><TableCell>{format(new Date(selected.startDate), 'yyyy-MM-dd')}</TableCell></TableRow>

--- a/frontend/src/pages/accounting/components/FundTransferWorkspaceCard.tsx
+++ b/frontend/src/pages/accounting/components/FundTransferWorkspaceCard.tsx
@@ -1,5 +1,6 @@
 import { Box, Divider, Paper, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material'
 
+import { WorkspaceCardSectionHeader } from '@/components/common/WorkspaceCardSectionHeader'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { FundTransfer } from '@/types'
 import { formatCurrency } from '@/utils/formatters'
@@ -18,11 +19,7 @@ export function FundTransferWorkspaceCard({ selected }: Props) {
 
   return (
     <Paper sx={{ flex: 1 }}>
-      <Box sx={{ px: 2, py: 1, borderBottom: TABLE_STYLES.cell.border }}>
-        <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
-          Ledger Preview
-        </Typography>
-      </Box>
+      <WorkspaceCardSectionHeader title="Ledger Preview" />
 
       {!selected.journalEntry ? (
         <Box sx={{ px: 2, py: 2 }}>

--- a/frontend/src/pages/accounting/components/JournalEntryWorkspaceCard.tsx
+++ b/frontend/src/pages/accounting/components/JournalEntryWorkspaceCard.tsx
@@ -1,5 +1,6 @@
 import { Alert, Box, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from '@mui/material'
 
+import { WorkspaceCardSectionHeader } from '@/components/common/WorkspaceCardSectionHeader'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { JournalEntry } from '@/types'
 import { formatCurrency } from '@/utils/formatters'
@@ -16,19 +17,7 @@ export function JournalEntryWorkspaceCard({ selectedEntry }: Props) {
 
   return (
     <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <TableContainer>
-        <Table size={TABLE_STYLES.size} sx={{ tableLayout: 'fixed', '& .MuiTableCell-root': { border: 'none', py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px } }}>
-          <TableBody>
-            <TableRow>
-              <TableCell colSpan={4} sx={{ pb: TABLE_STYLES.cell.padding.py * 0.67, py: TABLE_STYLES.cell.padding.py * 0.67, borderTop: TABLE_STYLES.cell.border }}>
-                <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
-                  Ledger Lines
-                </Typography>
-              </TableCell>
-            </TableRow>
-          </TableBody>
-        </Table>
-      </TableContainer>
+      <WorkspaceCardSectionHeader title="Ledger Lines" />
 
       <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', p: TABLE_STYLES.cell.padding.px }}>
         {!isBalanced && (

--- a/frontend/src/pages/accounting/components/OwnerEquityWorkspaceCard.tsx
+++ b/frontend/src/pages/accounting/components/OwnerEquityWorkspaceCard.tsx
@@ -1,5 +1,6 @@
-import { Box, Paper, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
+import { Paper, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
 
+import { WorkspaceCardSectionHeader } from '@/components/common/WorkspaceCardSectionHeader'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { OwnerEquityTransaction } from '@/types'
 import { formatDate } from '@/utils/formatters'
@@ -19,11 +20,7 @@ export function OwnerEquityWorkspaceCard({ selected }: Props) {
   if (!selected) return <Paper sx={{ flex: 1 }} />
   return (
     <Paper sx={{ flex: 1 }}>
-      <Box sx={{ px: 2, py: 1, borderBottom: TABLE_STYLES.cell.border }}>
-        <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
-          Details
-        </Typography>
-      </Box>
+      <WorkspaceCardSectionHeader title="Details" />
       <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': cellSx }}>
         <TableBody>
           <TableRow>

--- a/frontend/src/pages/accounting/components/SettlementWorkspaceCard.tsx
+++ b/frontend/src/pages/accounting/components/SettlementWorkspaceCard.tsx
@@ -1,5 +1,6 @@
-import { Box, Paper, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
+import { Paper, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
 
+import { WorkspaceCardSectionHeader } from '@/components/common/WorkspaceCardSectionHeader'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { Settlement } from '@/types'
 
@@ -17,9 +18,7 @@ export function SettlementWorkspaceCard({ selected }: Props) {
   if (!selected) return <Paper sx={{ flex: 1 }} />
   return (
     <Paper sx={{ flex: 1 }}>
-      <Box sx={{ px: 2, py: 1, borderBottom: TABLE_STYLES.cell.border }}>
-        <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>Details</Typography>
-      </Box>
+      <WorkspaceCardSectionHeader title="Details" />
       <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': cellSx }}>
         <TableBody>
           <TableRow>

--- a/frontend/src/pages/inventory/components/CategoryWorkspaceCard.tsx
+++ b/frontend/src/pages/inventory/components/CategoryWorkspaceCard.tsx
@@ -14,6 +14,7 @@ import {
   Typography,
 } from '@mui/material'
 
+import { WorkspaceCardSectionHeader } from '@/components/common/WorkspaceCardSectionHeader'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { useGetCategoryProductsQuery } from '@/store/api/inventoryApi'
 import { useGetRegionalSettingsQuery } from '@/store/api/settingsApi'
@@ -41,14 +42,7 @@ const CategoryWorkspaceCard: React.FC<CategoryWorkspaceCardProps> = ({ selectedC
 
   return (
     <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
-        <Typography
-          variant="tableHeader"
-          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
-        >
-          Category Products
-        </Typography>
-      </Box>
+      <WorkspaceCardSectionHeader title="Category Products" />
 
       <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', p: TABLE_STYLES.cell.padding.px }}>
         <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>

--- a/frontend/src/pages/inventory/components/StockAdjustmentWorkspaceCard.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentWorkspaceCard.tsx
@@ -12,6 +12,7 @@ import {
   Typography,
 } from '@mui/material'
 
+import { WorkspaceCardSectionHeader } from '@/components/common/WorkspaceCardSectionHeader'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { StockAdjustment } from '@/types'
 
@@ -28,14 +29,7 @@ const StockAdjustmentWorkspaceCard: React.FC<StockAdjustmentWorkspaceCardProps> 
 
   return (
     <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
-        <Typography
-          variant="tableHeader"
-          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
-        >
-          SA Items
-        </Typography>
-      </Box>
+      <WorkspaceCardSectionHeader title="SA Items" />
 
       <Box
         sx={{

--- a/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
@@ -175,11 +175,11 @@ const PurchaseOrdersPage: React.FC = () => {
           onReturn={workspace.handleReturn}
           onReceive={workspace.handleReceive}
           isLocked={
-            !!(selectedOrder?.goodsReceivedNotes?.some((grn: any) => grn.status === 'received')) ||
+            !!(selectedOrder?.goodsReceivedNotes?.some((grn) => grn.status === 'received')) ||
             Number(selectedOrder?.paidAmount || 0) > 0
           }
           lockTooltip={(() => {
-            const hasReceivedGoods = !!(selectedOrder?.goodsReceivedNotes?.some((grn: any) => grn.status === 'received'))
+            const hasReceivedGoods = !!(selectedOrder?.goodsReceivedNotes?.some((grn) => grn.status === 'received'))
             const hasPayments = Number(selectedOrder?.paidAmount || 0) > 0
             if (hasReceivedGoods && hasPayments) return 'return goods and unpay before editing'
             if (hasReceivedGoods) return 'return goods before editing'

--- a/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
@@ -174,6 +174,18 @@ const PurchaseOrdersPage: React.FC = () => {
           onOpenPaymentDialog={workspace.handleOpenPaymentDialog}
           onReturn={workspace.handleReturn}
           onReceive={workspace.handleReceive}
+          isLocked={
+            !!(selectedOrder?.goodsReceivedNotes?.some((grn: any) => grn.status === 'received')) ||
+            Number(selectedOrder?.paidAmount || 0) > 0
+          }
+          lockTooltip={(() => {
+            const hasReceivedGoods = !!(selectedOrder?.goodsReceivedNotes?.some((grn: any) => grn.status === 'received'))
+            const hasPayments = Number(selectedOrder?.paidAmount || 0) > 0
+            if (hasReceivedGoods && hasPayments) return 'return goods and unpay before editing'
+            if (hasReceivedGoods) return 'return goods before editing'
+            if (hasPayments) return 'unpay before editing'
+            return 'unlocked — editable'
+          })()}
         />
       )}
       workspaceSlot={<PurchaseOrderWorkspaceCard selectedOrder={selectedOrder} />}

--- a/frontend/src/pages/purchasing/components/GRNWorkspaceCard.tsx
+++ b/frontend/src/pages/purchasing/components/GRNWorkspaceCard.tsx
@@ -12,6 +12,7 @@ import {
   Typography,
 } from '@mui/material'
 
+import { WorkspaceCardSectionHeader } from '@/components/common/WorkspaceCardSectionHeader'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { GoodsReceivedNote } from '@/types'
 
@@ -26,14 +27,7 @@ const GRNWorkspaceCard: React.FC<GRNWorkspaceCardProps> = ({ selectedGRN }) => {
 
   return (
     <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
-        <Typography
-          variant="tableHeader"
-          sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
-        >
-          GRN Items
-        </Typography>
-      </Box>
+      <WorkspaceCardSectionHeader title="GRN Items" />
 
       <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', p: TABLE_STYLES.cell.padding.px }}>
         {selectedGRN.items && selectedGRN.items.length > 0 ? (

--- a/frontend/src/pages/purchasing/components/PurchaseOrderContextHeader.tsx
+++ b/frontend/src/pages/purchasing/components/PurchaseOrderContextHeader.tsx
@@ -19,6 +19,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { AppButton } from '@/components/common/AppButton'
 import { EntityContextHeaderBar } from '@/components/common/EntityContextHeaderBar'
+import { LockStatusIcon } from '@/components/common/LockStatusIcon'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { JournalEntryRef } from '@/hooks/useJournalEntryRef'
 import type { PurchaseOrder } from '@/types'
@@ -39,6 +40,8 @@ interface PurchaseOrderContextHeaderProps {
   onOpenPaymentDialog: (order: PurchaseOrder) => void
   onReturn: () => void
   onReceive: () => void
+  isLocked: boolean
+  lockTooltip: string
 }
 
 const detailTableSx = {
@@ -88,6 +91,8 @@ const PurchaseOrderContextHeader: React.FC<PurchaseOrderContextHeaderProps> = ({
   onOpenPaymentDialog,
   onReturn,
   onReceive,
+  isLocked,
+  lockTooltip,
 }) => {
   const navigate = useNavigate()
   if (!selectedOrder) {
@@ -115,6 +120,7 @@ const PurchaseOrderContextHeader: React.FC<PurchaseOrderContextHeaderProps> = ({
         title={`Purchase Order Details - ${selectedOrder.orderNumber}`}
         actions={(
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <LockStatusIcon isLocked={isLocked} tooltipText={lockTooltip} />
             <AppButton
               size="small"
               variant="secondary"

--- a/frontend/src/pages/purchasing/components/PurchaseOrderWorkspaceCard.tsx
+++ b/frontend/src/pages/purchasing/components/PurchaseOrderWorkspaceCard.tsx
@@ -12,6 +12,7 @@ import {
   Typography,
 } from '@mui/material'
 
+import { WorkspaceCardSectionHeader } from '@/components/common/WorkspaceCardSectionHeader'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { PurchaseOrder } from '@/types'
 import { formatCurrency } from '@/utils/formatters'
@@ -25,31 +26,12 @@ const PurchaseOrderWorkspaceCard: React.FC<PurchaseOrderWorkspaceCardProps> = ({
     return <Paper sx={{ flex: 1 }} />
   }
 
-  const hasReceivedGoods = selectedOrder.goodsReceivedNotes?.some((grn) => grn.status === 'received')
-  const hasPayments = Number(selectedOrder.paidAmount || 0) > 0
-  const isLocked = hasReceivedGoods || hasPayments
-  const lockReason = hasReceivedGoods && hasPayments
-    ? 'return goods and unpay'
-    : hasReceivedGoods
-      ? 'return goods'
-      : 'unpay'
-
   return (
     <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
-        <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
-          PO Items
-        </Typography>
-      </Box>
+      <WorkspaceCardSectionHeader title="PO Items" />
 
       <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', p: TABLE_STYLES.cell.padding.px }}>
         <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-          {isLocked && (
-            <Alert severity="warning" sx={{ mb: 1, fontSize: '0.8rem', py: 0.5 }}>
-              Items are locked - {lockReason} before editing
-            </Alert>
-          )}
-
           {selectedOrder.items && selectedOrder.items.length > 0 ? (
             <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
               <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': { borderBottom: TABLE_STYLES.cell.border, py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px } }}>

--- a/frontend/src/pages/purchasing/components/VendorPaymentWorkspaceCard.tsx
+++ b/frontend/src/pages/purchasing/components/VendorPaymentWorkspaceCard.tsx
@@ -30,7 +30,7 @@ const VendorPaymentWorkspaceCard: React.FC<VendorPaymentWorkspaceCardProps> = ({
 
   return (
     <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <WorkspaceCardSectionHeader title="PO Items" />
+      <WorkspaceCardSectionHeader title="Purchased Items" />
 
       <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', p: TABLE_STYLES.cell.padding.px }}>
         {items.length > 0 ? (

--- a/frontend/src/pages/purchasing/components/VendorPaymentWorkspaceCard.tsx
+++ b/frontend/src/pages/purchasing/components/VendorPaymentWorkspaceCard.tsx
@@ -12,6 +12,7 @@ import {
   Typography,
 } from '@mui/material'
 
+import { WorkspaceCardSectionHeader } from '@/components/common/WorkspaceCardSectionHeader'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { VendorPayment } from '@/types'
 import { formatCurrency, formatWholeQuantity } from '@/utils/formatters'
@@ -29,39 +30,7 @@ const VendorPaymentWorkspaceCard: React.FC<VendorPaymentWorkspaceCardProps> = ({
 
   return (
     <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <TableContainer>
-        <Table
-          size={TABLE_STYLES.size}
-          sx={{
-            tableLayout: 'fixed',
-            '& .MuiTableCell-root': {
-              border: 'none',
-              py: TABLE_STYLES.cell.padding.py,
-              px: TABLE_STYLES.cell.padding.px,
-            },
-          }}
-        >
-          <TableBody>
-            <TableRow>
-              <TableCell
-                colSpan={4}
-                sx={{
-                  pb: TABLE_STYLES.cell.padding.py * 0.67,
-                  py: TABLE_STYLES.cell.padding.py * 0.67,
-                  borderTop: TABLE_STYLES.cell.border,
-                }}
-              >
-                <Typography
-                  variant="tableHeader"
-                  sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
-                >
-                  PO Items
-                </Typography>
-              </TableCell>
-            </TableRow>
-          </TableBody>
-        </Table>
-      </TableContainer>
+      <WorkspaceCardSectionHeader title="PO Items" />
 
       <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', p: TABLE_STYLES.cell.padding.px }}>
         {items.length > 0 ? (

--- a/frontend/src/pages/purchasing/components/__tests__/PurchaseOrderContextHeader.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/PurchaseOrderContextHeader.test.tsx
@@ -35,6 +35,8 @@ const defaultProps = {
   onOpenPaymentDialog: vi.fn(),
   onReturn: vi.fn(),
   onReceive: vi.fn(),
+  isLocked: false,
+  lockTooltip: 'unlocked — editable',
 }
 
 describe('PurchaseOrderContextHeader', () => {
@@ -81,5 +83,17 @@ describe('PurchaseOrderContextHeader', () => {
     }
     render(<MemoryRouter><PurchaseOrderContextHeader {...defaultProps} selectedOrder={receivedOrder} /></MemoryRouter>)
     expect(screen.getByText('Return')).toBeInTheDocument()
+  })
+
+  it('renders lock icon when isLocked is true', () => {
+    render(<MemoryRouter><PurchaseOrderContextHeader {...defaultProps} isLocked={true} lockTooltip="unpay before editing" /></MemoryRouter>)
+    expect(screen.getByTestId('LockIcon')).toBeInTheDocument()
+    expect(screen.queryByTestId('LockOpenIcon')).not.toBeInTheDocument()
+  })
+
+  it('renders unlock icon when isLocked is false', () => {
+    render(<MemoryRouter><PurchaseOrderContextHeader {...defaultProps} isLocked={false} lockTooltip="unlocked — editable" /></MemoryRouter>)
+    expect(screen.getByTestId('LockOpenIcon')).toBeInTheDocument()
+    expect(screen.queryByTestId('LockIcon')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/purchasing/components/__tests__/PurchaseOrderWorkspaceCard.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/PurchaseOrderWorkspaceCard.test.tsx
@@ -15,54 +15,22 @@ const baseOrder = {
 } as any
 
 describe('PurchaseOrderWorkspaceCard', () => {
-  it('shows a lock banner when the purchase order is paid', () => {
-    render(
-      <PurchaseOrderWorkspaceCard
-        selectedOrder={{ ...baseOrder, paidAmount: 10 }}
-      />,
-    )
-
-    expect(screen.getByText(/Items are locked/i)).toBeInTheDocument()
-    expect(screen.getByText(/unpay before editing/i)).toBeInTheDocument()
+  it('renders the PO Items section header', () => {
+    render(<PurchaseOrderWorkspaceCard selectedOrder={{ ...baseOrder, paidAmount: 0, goodsReceivedNotes: [] }} />)
+    expect(screen.getByText('PO Items')).toBeInTheDocument()
   })
 
-  it('shows a lock banner when goods have been received', () => {
-    render(
-      <PurchaseOrderWorkspaceCard
-        selectedOrder={{
-          ...baseOrder,
-          paidAmount: 0,
-          goodsReceivedNotes: [{ id: 'grn-1', status: 'received' }],
-        }}
-      />,
-    )
-
-    expect(screen.getByText(/Items are locked/i)).toBeInTheDocument()
-    expect(screen.getByText(/return goods before editing/i)).toBeInTheDocument()
+  it('shows no lock alert when locked', () => {
+    render(<PurchaseOrderWorkspaceCard selectedOrder={{ ...baseOrder, paidAmount: 10 }} />)
+    expect(screen.queryByText(/Items are locked/i)).not.toBeInTheDocument()
   })
 
-  it('shows a combined lock banner when both paid and received', () => {
+  it('shows no lock alert when goods received', () => {
     render(
       <PurchaseOrderWorkspaceCard
-        selectedOrder={{
-          ...baseOrder,
-          paidAmount: 10,
-          goodsReceivedNotes: [{ id: 'grn-1', status: 'received' }],
-        }}
+        selectedOrder={{ ...baseOrder, paidAmount: 0, goodsReceivedNotes: [{ id: 'grn-1', status: 'received' }] }}
       />,
     )
-
-    expect(screen.getByText(/Items are locked/i)).toBeInTheDocument()
-    expect(screen.getByText(/return goods and unpay before editing/i)).toBeInTheDocument()
-  })
-
-  it('shows no lock banner when neither paid nor received', () => {
-    render(
-      <PurchaseOrderWorkspaceCard
-        selectedOrder={{ ...baseOrder, paidAmount: 0, goodsReceivedNotes: [] }}
-      />,
-    )
-
     expect(screen.queryByText(/Items are locked/i)).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -172,6 +172,17 @@ const OrdersPage: React.FC = () => {
           onOpenPaymentDialog={workspace.openPaymentDialog}
           onFulfillOrder={workspace.handleFulfillOrder}
           onUnfulfillOrder={workspace.handleUnfulfillOrder}
+          isLocked={
+            Number(selectedOrder?.paidAmount || 0) > 0 || Boolean(selectedOrder?.isFulfilled)
+          }
+          lockTooltip={(() => {
+            const hasPayments = Number(selectedOrder?.paidAmount || 0) > 0
+            const isFulfilled = Boolean(selectedOrder?.isFulfilled)
+            if (hasPayments && isFulfilled) return 'unpay and unfulfill before editing'
+            if (hasPayments) return 'unpay before editing'
+            if (isFulfilled) return 'unfulfill before editing'
+            return 'unlocked — editable'
+          })()}
         />
       )}
       workspaceSlot={<OrderWorkspaceCard selectedOrder={selectedOrder} />}

--- a/frontend/src/pages/sales/components/InvoiceWorkspaceCard.tsx
+++ b/frontend/src/pages/sales/components/InvoiceWorkspaceCard.tsx
@@ -14,6 +14,7 @@ import {
 
 import type { InvoiceListItem } from '../hooks/useInvoicesWorkspace'
 
+import { WorkspaceCardSectionHeader } from '@/components/common/WorkspaceCardSectionHeader'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { InvoiceItem } from '@/types'
 import { formatCurrency } from '@/utils/formatters'
@@ -29,32 +30,7 @@ const InvoiceWorkspaceCard: React.FC<InvoiceWorkspaceCardProps> = ({ selectedInv
 
   return (
     <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <TableContainer>
-        <Table
-          size={TABLE_STYLES.size}
-          sx={{
-            tableLayout: 'fixed',
-            '& .MuiTableCell-root': {
-              border: 'none',
-              py: TABLE_STYLES.cell.padding.py,
-              px: TABLE_STYLES.cell.padding.px,
-            },
-          }}
-        >
-          <TableBody>
-            <TableRow>
-              <TableCell colSpan={5} sx={{ pb: TABLE_STYLES.cell.padding.py * 0.67, py: TABLE_STYLES.cell.padding.py * 0.67, borderTop: TABLE_STYLES.cell.border }}>
-                <Typography
-                  variant="tableHeader"
-                  sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
-                >
-                  Invoice Items
-                </Typography>
-              </TableCell>
-            </TableRow>
-          </TableBody>
-        </Table>
-      </TableContainer>
+      <WorkspaceCardSectionHeader title="Invoice Items" />
 
       <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', p: TABLE_STYLES.cell.padding.px }}>
         <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>

--- a/frontend/src/pages/sales/components/OrderContextHeader.tsx
+++ b/frontend/src/pages/sales/components/OrderContextHeader.tsx
@@ -19,6 +19,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { AppButton } from '@/components/common/AppButton'
 import { EntityContextHeaderBar } from '@/components/common/EntityContextHeaderBar'
+import { LockStatusIcon } from '@/components/common/LockStatusIcon'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { JournalEntryRef } from '@/hooks/useJournalEntryRef'
 import type { SalesOrder } from '@/types'
@@ -40,6 +41,8 @@ interface OrderContextHeaderProps {
   onOpenPaymentDialog: () => void
   onFulfillOrder: () => void
   onUnfulfillOrder: () => void
+  isLocked: boolean
+  lockTooltip: string
 }
 
 const detailTableSx = {
@@ -90,6 +93,8 @@ const OrderContextHeader: React.FC<OrderContextHeaderProps> = ({
   onOpenPaymentDialog,
   onFulfillOrder,
   onUnfulfillOrder,
+  isLocked,
+  lockTooltip,
 }) => {
   const navigate = useNavigate()
   if (!selectedOrder) {
@@ -135,6 +140,7 @@ const OrderContextHeader: React.FC<OrderContextHeaderProps> = ({
         title={`Order Details - ${selectedOrder.orderNumber}`}
         actions={(
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <LockStatusIcon isLocked={isLocked} tooltipText={lockTooltip} />
             <AppButton
               size="small"
               variant="secondary"

--- a/frontend/src/pages/sales/components/OrderWorkspaceCard.tsx
+++ b/frontend/src/pages/sales/components/OrderWorkspaceCard.tsx
@@ -12,6 +12,7 @@ import {
   Typography,
 } from '@mui/material'
 
+import { WorkspaceCardSectionHeader } from '@/components/common/WorkspaceCardSectionHeader'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { SalesOrder } from '@/types'
 import { formatCurrency } from '@/utils/formatters'
@@ -25,38 +26,12 @@ const OrderWorkspaceCard: React.FC<OrderWorkspaceCardProps> = ({ selectedOrder }
     return <Paper sx={{ flex: 1 }} />
   }
 
-  const hasPayments = Number(selectedOrder.paidAmount || 0) > 0
-  const isLocked = hasPayments || Boolean(selectedOrder.isFulfilled)
-  const lockReason = hasPayments && selectedOrder.isFulfilled
-    ? 'unpay and unfulfill'
-    : hasPayments
-      ? 'unpay'
-      : 'unfulfill'
-
   return (
     <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <TableContainer>
-        <Table size={TABLE_STYLES.size} sx={{ tableLayout: 'fixed', '& .MuiTableCell-root': { border: 'none', py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px } }}>
-          <TableBody>
-            <TableRow>
-              <TableCell colSpan={3} sx={{ pb: TABLE_STYLES.cell.padding.py * 0.67, py: TABLE_STYLES.cell.padding.py * 0.67, borderTop: TABLE_STYLES.cell.border }}>
-                <Typography variant="tableHeader" sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
-                  SO Items
-                </Typography>
-              </TableCell>
-            </TableRow>
-          </TableBody>
-        </Table>
-      </TableContainer>
+      <WorkspaceCardSectionHeader title="SO Items" />
 
       <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', p: TABLE_STYLES.cell.padding.px }}>
         <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-          {isLocked && (
-            <Alert severity="warning" sx={{ mb: 1, fontSize: '0.8rem', py: 0.5 }}>
-              Items are locked - {lockReason} before editing
-            </Alert>
-          )}
-
           {selectedOrder.items && selectedOrder.items.length > 0 ? (
             <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
               <Table size={TABLE_STYLES.size} sx={{ '& .MuiTableCell-root': { borderBottom: TABLE_STYLES.cell.border, py: TABLE_STYLES.cell.padding.py, px: TABLE_STYLES.cell.padding.px } }}>

--- a/frontend/src/pages/sales/components/PaymentWorkspaceCard.tsx
+++ b/frontend/src/pages/sales/components/PaymentWorkspaceCard.tsx
@@ -14,6 +14,7 @@ import {
 
 import type { PaymentListItem } from '../hooks/usePaymentsWorkspace'
 
+import { WorkspaceCardSectionHeader } from '@/components/common/WorkspaceCardSectionHeader'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { formatCurrency, formatWholeQuantity } from '@/utils/formatters'
 
@@ -30,39 +31,7 @@ const PaymentWorkspaceCard: React.FC<PaymentWorkspaceCardProps> = ({ selectedPay
 
   return (
     <Paper sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-      <TableContainer>
-        <Table
-          size={TABLE_STYLES.size}
-          sx={{
-            tableLayout: 'fixed',
-            '& .MuiTableCell-root': {
-              border: 'none',
-              py: TABLE_STYLES.cell.padding.py,
-              px: TABLE_STYLES.cell.padding.px,
-            },
-          }}
-        >
-          <TableBody>
-            <TableRow>
-              <TableCell
-                colSpan={5}
-                sx={{
-                  pb: TABLE_STYLES.cell.padding.py * 0.67,
-                  py: TABLE_STYLES.cell.padding.py * 0.67,
-                  borderTop: TABLE_STYLES.cell.border,
-                }}
-              >
-                <Typography
-                  variant="tableHeader"
-                  sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}
-                >
-                  Payment Items
-                </Typography>
-              </TableCell>
-            </TableRow>
-          </TableBody>
-        </Table>
-      </TableContainer>
+      <WorkspaceCardSectionHeader title="Payment Items" />
 
       <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', p: TABLE_STYLES.cell.padding.px }}>
         <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>

--- a/frontend/src/pages/sales/components/__tests__/OrderContextHeader.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/OrderContextHeader.test.tsx
@@ -17,34 +17,46 @@ const baseOrder = {
   isFulfilled: false,
 } as any
 
+const defaultProps = {
+  selectedOrder: baseOrder,
+  isLoading: false,
+  journalEntryRefs: [],
+  journalEntryRefsLoading: false,
+  onEditOrder: vi.fn(),
+  onDeleteOrder: vi.fn(),
+  onPrintOrder: vi.fn(),
+  onNavigateToInvoice: vi.fn(),
+  onNavigateToPayment: vi.fn(),
+  onNavigateToJournalEntries: vi.fn(),
+  onRefundOrder: vi.fn(),
+  onUnpayOrder: vi.fn(),
+  onOpenPaymentDialog: vi.fn(),
+  onFulfillOrder: vi.fn(),
+  onUnfulfillOrder: vi.fn(),
+  isLocked: false,
+  lockTooltip: 'unlocked — editable',
+}
+
 describe('OrderContextHeader', () => {
   it('renders labeled action buttons in the header and payment section', () => {
-    render(
-      <MemoryRouter>
-      <OrderContextHeader
-        selectedOrder={baseOrder}
-        isLoading={false}
-        journalEntryRef={null}
-        journalEntryRefLoading={false}
-        onEditOrder={vi.fn()}
-        onDeleteOrder={vi.fn()}
-        onPrintOrder={vi.fn()}
-        onNavigateToInvoice={vi.fn()}
-        onNavigateToPayment={vi.fn()}
-        onNavigateToJournalEntry={vi.fn()}
-        onRefundOrder={vi.fn()}
-        onUnpayOrder={vi.fn()}
-        onOpenPaymentDialog={vi.fn()}
-        onFulfillOrder={vi.fn()}
-        onUnfulfillOrder={vi.fn()}
-      />
-      </MemoryRouter>,
-    )
+    render(<MemoryRouter><OrderContextHeader {...defaultProps} /></MemoryRouter>)
 
     expect(screen.getByText('Edit')).toBeInTheDocument()
     expect(screen.getByText('Delete')).toBeInTheDocument()
     expect(screen.getByText('Print')).toBeInTheDocument()
     expect(screen.getByText('Pay')).toBeInTheDocument()
     expect(screen.getByText('Fulfill')).toBeInTheDocument()
+  })
+
+  it('renders lock icon when isLocked is true', () => {
+    render(<MemoryRouter><OrderContextHeader {...defaultProps} isLocked={true} lockTooltip="unpay before editing" /></MemoryRouter>)
+    expect(screen.getByTestId('LockIcon')).toBeInTheDocument()
+    expect(screen.queryByTestId('LockOpenIcon')).not.toBeInTheDocument()
+  })
+
+  it('renders unlock icon when isLocked is false', () => {
+    render(<MemoryRouter><OrderContextHeader {...defaultProps} isLocked={false} lockTooltip="unlocked — editable" /></MemoryRouter>)
+    expect(screen.getByTestId('LockOpenIcon')).toBeInTheDocument()
+    expect(screen.queryByTestId('LockIcon')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/sales/components/__tests__/OrderWorkspaceCard.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/OrderWorkspaceCard.test.tsx
@@ -15,14 +15,13 @@ const baseOrder = {
 } as any
 
 describe('OrderWorkspaceCard', () => {
-  it('shows a lock banner when the sales order is fulfilled', () => {
-    render(
-      <OrderWorkspaceCard
-        selectedOrder={{ ...baseOrder, isFulfilled: true }}
-      />,
-    )
+  it('renders the SO Items section header', () => {
+    render(<OrderWorkspaceCard selectedOrder={{ ...baseOrder, isFulfilled: false, paidAmount: 0 }} />)
+    expect(screen.getByText('SO Items')).toBeInTheDocument()
+  })
 
-    expect(screen.getByText(/Items are locked/i)).toBeInTheDocument()
-    expect(screen.getByText(/unfulfill before editing/i)).toBeInTheDocument()
+  it('shows no lock alert when fulfilled', () => {
+    render(<OrderWorkspaceCard selectedOrder={{ ...baseOrder, isFulfilled: true }} />)
+    expect(screen.queryByText(/Items are locked/i)).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- Adds `LockStatusIcon` component (locked/unlocked MUI icon with tooltip) to the PO and SO context header actions bar, replacing the Alert banners in the workspace cards
- Extracts `WorkspaceCardSectionHeader` shared component and applies it to all 20 applicable workspace cards, normalizing 6 cards that previously used an unnecessary Table wrapper for the section title
- Lock state logic moves from workspace cards to page level and is passed as props to context headers

## Closes
Closes #576

## Test plan
- [x] PO page: locked order shows lock icon with correct tooltip before Edit button; unlocked shows subtle unlock icon
- [x] SO page: same for locked/unlocked states
- [x] Workspace cards show section titles consistently (no Alert banners)
- [x] All 6 previously-inconsistent workspace card headers now match the standard pattern
- [x] `npx vitest run src/components/common/LockStatusIcon.test.tsx src/components/common/WorkspaceCardSectionHeader.test.tsx src/pages/purchasing/components/__tests__/PurchaseOrderWorkspaceCard.test.tsx src/pages/sales/components/__tests__/OrderWorkspaceCard.test.tsx` passes
- [x] `npm run lint` passes
- [x] `npm run type-check` passes
- [x] `npm run test` passes

Generated with Codex