### PR TITLE
perf(accounting): fix N+1 query in journal entry list endpoint

### DIFF
--- a/backend/src/modules/accounting/services/journal-entry.service.spec.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.spec.ts
@@ -928,4 +928,72 @@ describe('JournalEntryService', () => {
       await expect(service.reverseEntry('non-existent')).rejects.toThrow(NotFoundException);
     });
   });
+
+  describe('resolveSourceRefNumbersMany', () => {
+    it('batches lookups by sourceType - one find call per type, correct map keys', async () => {
+      const entries = [
+        {
+          id: 'e1',
+          sourceType: 'sales_order',
+          sourceId: 'so-1',
+        },
+        {
+          id: 'e2',
+          sourceType: 'sales_order',
+          sourceId: 'so-2',
+        },
+        {
+          id: 'e3',
+          sourceType: 'payment',
+          sourceId: 'pay-1',
+        },
+      ] as any[];
+
+      mockSalesOrderRepo.find.mockResolvedValue([
+        { id: 'so-1', orderNumber: 'SO-001' },
+        { id: 'so-2', orderNumber: 'SO-002' },
+      ]);
+      mockPaymentRepo.find.mockResolvedValue([
+        { id: 'pay-1', paymentNumber: 'PAY-001' },
+      ]);
+
+      const map = await (service as any).resolveSourceRefNumbersMany(entries);
+
+      expect(mockSalesOrderRepo.find).toHaveBeenCalledTimes(1);
+      expect(mockSalesOrderRepo.find).toHaveBeenCalledWith({
+        where: { id: expect.anything() },
+        select: ['id', 'orderNumber'],
+      });
+      expect(mockPaymentRepo.find).toHaveBeenCalledTimes(1);
+      expect(map.get('sales_order:so-1')).toBe('SO-001');
+      expect(map.get('sales_order:so-2')).toBe('SO-002');
+      expect(map.get('payment:pay-1')).toBe('PAY-001');
+    });
+
+    it('skips entries with null sourceType or sourceId - no repo calls', async () => {
+      const entries = [
+        { id: 'e1', sourceType: null, sourceId: 'so-1' },
+        { id: 'e2', sourceType: 'sales_order', sourceId: null },
+        { id: 'e3', sourceType: undefined, sourceId: undefined },
+      ] as any[];
+
+      const map = await (service as any).resolveSourceRefNumbersMany(entries);
+
+      expect(mockSalesOrderRepo.find).not.toHaveBeenCalled();
+      expect(map.size).toBe(0);
+    });
+
+    it('returns empty Map when a repo throws - does not rethrow', async () => {
+      const entries = [
+        { id: 'e1', sourceType: 'sales_order', sourceId: 'so-1' },
+      ] as any[];
+
+      mockSalesOrderRepo.find.mockRejectedValue(new Error('DB error'));
+
+      const map = await (service as any).resolveSourceRefNumbersMany(entries);
+
+      expect(map).toBeInstanceOf(Map);
+      expect(map.size).toBe(0);
+    });
+  });
 });

--- a/backend/src/modules/accounting/services/journal-entry.service.spec.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.spec.ts
@@ -498,6 +498,37 @@ describe('JournalEntryService', () => {
       );
     });
 
+    it('calls resolveSourceRefNumbersMany once and does not call per-entry findOne on source repos', async () => {
+      const entryWithSource = {
+        ...mockJournalEntry,
+        sourceType: 'sales_order',
+        sourceId: 'so-1',
+        lines: [],
+      };
+
+      const queryBuilder = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[entryWithSource], 1]),
+      };
+      journalEntryRepository.createQueryBuilder.mockReturnValue(queryBuilder as any);
+      mockSalesOrderRepo.find.mockResolvedValue([{ id: 'so-1', orderNumber: 'SO-001' }]);
+
+      const result = await service.findAll({ page: 1, limit: 20 });
+
+      // Batch find was called once, not once per entry
+      expect(mockSalesOrderRepo.find).toHaveBeenCalledTimes(1);
+      // Per-entry findOne was never called
+      expect(mockSalesOrderRepo.findOne).not.toHaveBeenCalled();
+      // The resolved ref number surfaces in the response
+      expect(result.data[0].sourceRefNumber).toBe('SO-001');
+    });
+
     it('does not apply ids filter when ids param is absent', async () => {
       const andWhereMock = jest.fn().mockReturnThis();
       const queryBuilder = {
@@ -994,6 +1025,24 @@ describe('JournalEntryService', () => {
 
       expect(map).toBeInstanceOf(Map);
       expect(map.size).toBe(0);
+    });
+
+    it('preserves partial results when one source type throws and another succeeds', async () => {
+      const entries = [
+        { id: 'e1', sourceType: 'sales_order', sourceId: 'so-1' },
+        { id: 'e2', sourceType: 'payment', sourceId: 'pay-1' },
+      ] as any[];
+
+      mockSalesOrderRepo.find.mockRejectedValue(new Error('DB error'));
+      mockPaymentRepo.find.mockResolvedValue([{ id: 'pay-1', paymentNumber: 'PAY-001' }]);
+
+      const map = await (service as any).resolveSourceRefNumbersMany(entries);
+
+      expect(map).toBeInstanceOf(Map);
+      // payment succeeded even though sales_order failed
+      expect(map.get('payment:pay-1')).toBe('PAY-001');
+      // sales_order entries are absent (not resolved) but did not wipe payment entries
+      expect(map.has('sales_order:so-1')).toBe(false);
     });
   });
 });

--- a/backend/src/modules/accounting/services/journal-entry.service.spec.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.spec.ts
@@ -50,16 +50,16 @@ describe('JournalEntryService', () => {
   let chartOfAccountsService: jest.Mocked<ChartOfAccountsService>;
   let fiscalPeriodService: jest.Mocked<FiscalPeriodService>;
   let settingsService: jest.Mocked<SettingsService>;
-  let mockSalesOrderRepo: { findOne: jest.Mock };
-  let mockPurchaseOrderRepo: { findOne: jest.Mock };
-  let mockGrnRepo: { findOne: jest.Mock };
-  let mockPaymentRepo: { findOne: jest.Mock };
-  let mockVendorPaymentRepo: { findOne: jest.Mock };
-  let mockExpenseRepo: { findOne: jest.Mock };
-  let mockOwnerEquityTransactionRepo: { findOne: jest.Mock };
-  let mockFundTransferRepo: { findOne: jest.Mock };
-  let mockStockAdjustmentRepo: { findOne: jest.Mock };
-  let mockInvoiceRepo: { findOne: jest.Mock };
+  let mockSalesOrderRepo: { findOne: jest.Mock; find: jest.Mock };
+  let mockPurchaseOrderRepo: { findOne: jest.Mock; find: jest.Mock };
+  let mockGrnRepo: { findOne: jest.Mock; find: jest.Mock };
+  let mockPaymentRepo: { findOne: jest.Mock; find: jest.Mock };
+  let mockVendorPaymentRepo: { findOne: jest.Mock; find: jest.Mock };
+  let mockExpenseRepo: { findOne: jest.Mock; find: jest.Mock };
+  let mockOwnerEquityTransactionRepo: { findOne: jest.Mock; find: jest.Mock };
+  let mockFundTransferRepo: { findOne: jest.Mock; find: jest.Mock };
+  let mockStockAdjustmentRepo: { findOne: jest.Mock; find: jest.Mock };
+  let mockInvoiceRepo: { findOne: jest.Mock; find: jest.Mock };
 
   // Test data
   const mockFiscalPeriod: Partial<FiscalPeriod> = {
@@ -131,16 +131,16 @@ describe('JournalEntryService', () => {
   };
 
   beforeEach(async () => {
-    mockSalesOrderRepo = { findOne: jest.fn() };
-    mockPurchaseOrderRepo = { findOne: jest.fn() };
-    mockGrnRepo = { findOne: jest.fn() };
-    mockPaymentRepo = { findOne: jest.fn() };
-    mockVendorPaymentRepo = { findOne: jest.fn() };
-    mockExpenseRepo = { findOne: jest.fn() };
-    mockOwnerEquityTransactionRepo = { findOne: jest.fn() };
-    mockFundTransferRepo = { findOne: jest.fn() };
-    mockStockAdjustmentRepo = { findOne: jest.fn() };
-    mockInvoiceRepo = { findOne: jest.fn() };
+    mockSalesOrderRepo = { findOne: jest.fn(), find: jest.fn() };
+    mockPurchaseOrderRepo = { findOne: jest.fn(), find: jest.fn() };
+    mockGrnRepo = { findOne: jest.fn(), find: jest.fn() };
+    mockPaymentRepo = { findOne: jest.fn(), find: jest.fn() };
+    mockVendorPaymentRepo = { findOne: jest.fn(), find: jest.fn() };
+    mockExpenseRepo = { findOne: jest.fn(), find: jest.fn() };
+    mockOwnerEquityTransactionRepo = { findOne: jest.fn(), find: jest.fn() };
+    mockFundTransferRepo = { findOne: jest.fn(), find: jest.fn() };
+    mockStockAdjustmentRepo = { findOne: jest.fn(), find: jest.fn() };
+    mockInvoiceRepo = { findOne: jest.fn(), find: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -6,7 +6,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, Between, IsNull } from 'typeorm';
+import { Repository, Between, IsNull, In } from 'typeorm';
 import {
   JournalEntry,
   JournalEntryStatus,
@@ -850,7 +850,135 @@ export class JournalEntryService {
   /**
    * Convert journal entry entity to response DTO
    */
-  // TODO: batch source lookups to avoid N+1 per JE list response
+  private async resolveSourceRefNumbersMany(
+    entries: JournalEntry[],
+  ): Promise<Map<string, string>> {
+    const refMap = new Map<string, string>();
+
+    try {
+      const withSource = entries.filter((entry) => entry.sourceType && entry.sourceId);
+      if (withSource.length === 0) return refMap;
+
+      const grouped = new Map<string, string[]>();
+      for (const entry of withSource) {
+        const ids = grouped.get(entry.sourceType!) ?? [];
+        if (!ids.includes(entry.sourceId!)) ids.push(entry.sourceId!);
+        grouped.set(entry.sourceType!, ids);
+      }
+
+      for (const [sourceType, ids] of grouped.entries()) {
+        switch (sourceType) {
+          case 'sales_order': {
+            const records = await this.salesOrderRepository.find({
+              where: { id: In(ids) },
+              select: ['id', 'orderNumber'],
+            });
+            for (const record of records) {
+              refMap.set(`sales_order:${record.id}`, record.orderNumber);
+            }
+            break;
+          }
+          case 'purchase_order': {
+            const records = await this.purchaseOrderRepository.find({
+              where: { id: In(ids) },
+              select: ['id', 'orderNumber'],
+            });
+            for (const record of records) {
+              refMap.set(`purchase_order:${record.id}`, record.orderNumber);
+            }
+            break;
+          }
+          case 'payment': {
+            const records = await this.paymentRepository.find({
+              where: { id: In(ids) },
+              select: ['id', 'paymentNumber'],
+            });
+            for (const record of records) {
+              refMap.set(`payment:${record.id}`, record.paymentNumber);
+            }
+            break;
+          }
+          case 'goods_received_note': {
+            const records = await this.grnRepository.find({
+              where: { id: In(ids) },
+              select: ['id', 'grnNumber'],
+            });
+            for (const record of records) {
+              refMap.set(`goods_received_note:${record.id}`, record.grnNumber);
+            }
+            break;
+          }
+          case 'vendor_payment': {
+            const records = await this.vendorPaymentRepository.find({
+              where: { id: In(ids) },
+              select: ['id', 'paymentNumber'],
+            });
+            for (const record of records) {
+              refMap.set(`vendor_payment:${record.id}`, record.paymentNumber);
+            }
+            break;
+          }
+          case 'expense': {
+            const records = await this.expenseRepository.find({
+              where: { id: In(ids) },
+              select: ['id', 'referenceNumber'],
+            });
+            for (const record of records) {
+              refMap.set(`expense:${record.id}`, record.referenceNumber);
+            }
+            break;
+          }
+          case 'owner_equity_transaction': {
+            const records = await this.ownerEquityTransactionRepository.find({
+              where: { id: In(ids) },
+              select: ['id', 'referenceNumber'],
+            });
+            for (const record of records) {
+              refMap.set(`owner_equity_transaction:${record.id}`, record.referenceNumber);
+            }
+            break;
+          }
+          case 'fund_transfer': {
+            const records = await this.fundTransferRepository.find({
+              where: { id: In(ids) },
+              select: ['id', 'referenceNumber'],
+            });
+            for (const record of records) {
+              refMap.set(`fund_transfer:${record.id}`, record.referenceNumber);
+            }
+            break;
+          }
+          case 'stock_adjustment': {
+            const records = await this.stockAdjustmentRepository.find({
+              where: { id: In(ids) },
+              select: ['id', 'adjustmentNumber'],
+            });
+            for (const record of records) {
+              refMap.set(`stock_adjustment:${record.id}`, record.adjustmentNumber);
+            }
+            break;
+          }
+          case 'invoice': {
+            const records = await this.invoiceRepository.find({
+              where: { id: In(ids) },
+              select: ['id', 'invoiceNumber'],
+            });
+            for (const record of records) {
+              refMap.set(`invoice:${record.id}`, record.invoiceNumber);
+            }
+            break;
+          }
+          default:
+            break;
+        }
+      }
+    } catch (err) {
+      this.logger.error('resolveSourceRefNumbersMany failed, returning empty map', err);
+    }
+
+    return refMap;
+  }
+
   private async resolveSourceRefNumber(
     sourceType: string | undefined,
     sourceId: string | undefined,

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -847,26 +847,26 @@ export class JournalEntryService {
     }
   }
 
-  /**
-   * Convert journal entry entity to response DTO
-   */
+  /** Batch-resolves source reference numbers for a list of entries — one IN query per sourceType. */
   private async resolveSourceRefNumbersMany(
     entries: JournalEntry[],
   ): Promise<Map<string, string>> {
     const refMap = new Map<string, string>();
 
-    try {
-      const withSource = entries.filter((entry) => entry.sourceType && entry.sourceId);
-      if (withSource.length === 0) return refMap;
+    const withSource = entries.filter((entry) => entry.sourceType && entry.sourceId);
+    if (withSource.length === 0) return refMap;
 
-      const grouped = new Map<string, string[]>();
-      for (const entry of withSource) {
-        const ids = grouped.get(entry.sourceType!) ?? [];
-        if (!ids.includes(entry.sourceId!)) ids.push(entry.sourceId!);
-        grouped.set(entry.sourceType!, ids);
-      }
+    // Group unique sourceIds by sourceType using a Set to avoid O(n²) dedup
+    const grouped = new Map<string, Set<string>>();
+    for (const entry of withSource) {
+      if (!grouped.has(entry.sourceType!)) grouped.set(entry.sourceType!, new Set());
+      grouped.get(entry.sourceType!)!.add(entry.sourceId!);
+    }
 
-      for (const [sourceType, ids] of grouped.entries()) {
+    // Fire one IN query per sourceType; failures are caught per-type so partial results are preserved
+    for (const [sourceType, idSet] of grouped.entries()) {
+      const ids = [...idSet];
+      try {
         switch (sourceType) {
           case 'sales_order': {
             const records = await this.salesOrderRepository.find({
@@ -971,9 +971,9 @@ export class JournalEntryService {
           default:
             break;
         }
+      } catch (err) {
+        this.logger.error(`resolveSourceRefNumbersMany failed for sourceType '${sourceType}', skipping`, err);
       }
-    } catch (err) {
-      this.logger.error('resolveSourceRefNumbersMany failed, returning empty map', err);
     }
 
     return refMap;
@@ -1067,6 +1067,7 @@ export class JournalEntryService {
     }
   }
 
+  /** Convert journal entry entity to response DTO. */
   private async toResponseDto(
     entry: JournalEntry,
     sourceRefMap?: Map<string, string>,
@@ -1104,6 +1105,7 @@ export class JournalEntryService {
       lines: entry.lines
         ? entry.lines.map((line) => this.toLineResponseDto(line))
         : undefined,
+      // map not propagated: reversalOf/reversedBy are not loaded in list queries
       reversalOf: entry.reversalOf
         ? await this.toResponseDto(entry.reversalOf)
         : undefined,

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -1067,8 +1067,13 @@ export class JournalEntryService {
     }
   }
 
-  private async toResponseDto(entry: JournalEntry): Promise<JournalEntryResponseDto> {
-    const sourceRefNumber = await this.resolveSourceRefNumber(entry.sourceType, entry.sourceId);
+  private async toResponseDto(
+    entry: JournalEntry,
+    sourceRefMap?: Map<string, string>,
+  ): Promise<JournalEntryResponseDto> {
+    const sourceRefNumber = sourceRefMap
+      ? sourceRefMap.get(`${entry.sourceType}:${entry.sourceId}`)
+      : await this.resolveSourceRefNumber(entry.sourceType, entry.sourceId);
 
     return {
       id: entry.id,

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -247,8 +247,8 @@ export class JournalEntryService {
     queryBuilder.skip(offset).take(limit);
 
     const [entries, total] = await queryBuilder.getManyAndCount();
-
-    const data = await Promise.all(entries.map((entry) => this.toResponseDto(entry)));
+    const sourceRefMap = await this.resolveSourceRefNumbersMany(entries);
+    const data = await Promise.all(entries.map((entry) => this.toResponseDto(entry, sourceRefMap)));
 
     return {
       data,


### PR DESCRIPTION
## Summary

- Replaces per-entry `resolveSourceRefNumber` calls in `findAll` with a single batch lookup via `resolveSourceRefNumbersMany`
- Groups entries by `sourceType`, fires one `WHERE id IN (...)` query per unique type (at most 10, typically 1–3), returns a `Map<"sourceType:sourceId", refNumber>` for O(1) DTO lookup
- `toResponseDto` accepts an optional map; when absent it falls back to the existing per-entry path so `findOne`, `postEntry`, `reverseEntry`, and all other single-entry callers are unaffected
- Query count goes from O(N) per page to O(unique source types on the page)

## Test Plan

- [x] 51/51 unit tests pass (`journal-entry.service.spec.ts`)
- [x] New `findAll` integration test asserts one batch `find` per source type, zero per-entry `findOne` calls on source repos, and `sourceRefNumber` surfaces correctly in the response
- [x] New partial-results test asserts a failing source type skips without wiping other types' resolved entries
- [x] Full backend suite: 931 tests across 70 suites pass
- [x] `npm run build` and `npm run lint` pass

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)