### PR TITLE
chore(deps): bump @mui/x-date-pickers from 9.1.0 to 9.2.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "erp-frontend",
-  "version": "1.108.0",
+  "version": "1.108.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-frontend",
-      "version": "1.108.0",
+      "version": "1.108.1",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@hookform/resolvers": "5.2.2",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
-        "@mui/x-date-pickers": "9.1.0",
+        "@mui/x-date-pickers": "9.2.0",
         "@reduxjs/toolkit": "^2.11.2",
         "@tanstack/react-query": "^5.96.0",
         "@tanstack/react-query-devtools": "^5.96.0",
@@ -1335,13 +1335,13 @@
       }
     },
     "node_modules/@mui/x-date-pickers": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-9.1.0.tgz",
-      "integrity": "sha512-vE2oXP8bAlwppFckOc4HEwbhj5Mz7ZUqKU8kNyDa6v19cYsX3ais+fcuCGMh1xZiO1Q+H97s9xgN3WzzgcfmPw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-9.2.0.tgz",
+      "integrity": "sha512-4GMal3xvHSKs+Ajv1PwbakWas79DDh6KlsSr9sjJhSINaST6dAPsIQblX5mSOmR7c4Du1Aemhqeiwo3L0CwNzQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
-        "@mui/utils": "9.0.0",
+        "@mui/utils": "9.0.1",
         "@mui/x-internals": "^9.1.0",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
@@ -1396,36 +1396,6 @@
           "optional": true
         },
         "moment-jalaali": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/x-date-pickers/node_modules/@mui/utils": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.0.0.tgz",
-      "integrity": "sha512-bQcqyg/gjULUqTuyUjSAFr6LQGLvtkNtDbJerAtoUn9kGZ0hg5QJiN1PLHMLbeFpe3te1831uq7GFl2ITokGdg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@mui/types": "^9.0.0",
-        "@types/prop-types": "^15.7.15",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.2.4"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
@@ -3062,6 +3032,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cross-spawn": {
@@ -6451,15 +6430,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "@hookform/resolvers": "5.2.2",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
-    "@mui/x-date-pickers": "9.1.0",
+    "@mui/x-date-pickers": "9.2.0",
     "@reduxjs/toolkit": "^2.11.2",
     "@tanstack/react-query": "^5.96.0",
     "@tanstack/react-query-devtools": "^5.96.0",


### PR DESCRIPTION
## Summary
- Bumps `@mui/x-date-pickers` from 9.1.0 to 9.2.0 in `frontend/package.json`
- Updates `package-lock.json` accordingly
- TypeScript type-check passes with no regressions

Closes #580