### PR TITLE
feat: compact FilterBar height to 32px

### DIFF
--- a/frontend/src/components/common/AppButton.tsx
+++ b/frontend/src/components/common/AppButton.tsx
@@ -115,7 +115,7 @@ export function AppButton({
       size={muiSize}
       disabled={disabled || loading}
       startIcon={resolvedStartIcon}
-      sx={size === 'filter' ? { height: 40, ...((sx as object) ?? {}) } : sx}
+      sx={size === 'filter' ? { height: 32, ...((sx as object) ?? {}) } : sx}
       {...rest}
     >
       {children}

--- a/frontend/src/components/filters/FilterCompare.tsx
+++ b/frontend/src/components/filters/FilterCompare.tsx
@@ -22,8 +22,8 @@ export function FilterCompare({ value, onChange, periodValue }: Props) {
       placement="top"
     >
       <span>
-        <FormControl size="small" sx={{ minWidth: 210 }} disabled={compareDisabled}>
-          <InputLabel id={labelId}>Compare</InputLabel>
+        <FormControl size="xs" sx={{ minWidth: 210 }} disabled={compareDisabled}>
+          <InputLabel id={labelId} size="xs">Compare</InputLabel>
           <Select
             id={selectId}
             labelId={labelId}

--- a/frontend/src/components/filters/FilterPeriod.tsx
+++ b/frontend/src/components/filters/FilterPeriod.tsx
@@ -103,9 +103,10 @@ export function FilterPeriod({ value, customFrom, customTo, onChange }: FilterPe
               textField: {
                 size: 'small',
                 sx: {
-                  // DatePicker ignores custom size variants; force xs dimensions explicitly
-                  '& .MuiOutlinedInput-root': { height: 32, boxSizing: 'border-box' },
-                  '& .MuiOutlinedInput-input': { paddingTop: '4.5px', paddingBottom: '4.5px' },
+                  // DatePicker uses MuiPickersOutlinedInput, not MuiOutlinedInput
+                  '& .MuiPickersOutlinedInput-root': { height: 32, boxSizing: 'border-box' },
+                  '& .MuiPickersOutlinedInput-input': { paddingTop: '4.5px', paddingBottom: '4.5px' },
+                  '& .MuiPickersInputBase-sectionsContainer': { paddingTop: '4.5px', paddingBottom: '4.5px' },
                   '& .MuiInputAdornment-root': { height: 32, maxHeight: 32 },
                   '& .MuiInputAdornment-root .MuiIconButton-root': { padding: '4px' },
                   '& .MuiInputLabel-outlined:not(.MuiInputLabel-shrink)': { transform: 'translate(14px, 5px) scale(1)' },
@@ -124,9 +125,10 @@ export function FilterPeriod({ value, customFrom, customTo, onChange }: FilterPe
               textField: {
                 size: 'small',
                 sx: {
-                  // DatePicker ignores custom size variants; force xs dimensions explicitly
-                  '& .MuiOutlinedInput-root': { height: 32, boxSizing: 'border-box' },
-                  '& .MuiOutlinedInput-input': { paddingTop: '4.5px', paddingBottom: '4.5px' },
+                  // DatePicker uses MuiPickersOutlinedInput, not MuiOutlinedInput
+                  '& .MuiPickersOutlinedInput-root': { height: 32, boxSizing: 'border-box' },
+                  '& .MuiPickersOutlinedInput-input': { paddingTop: '4.5px', paddingBottom: '4.5px' },
+                  '& .MuiPickersInputBase-sectionsContainer': { paddingTop: '4.5px', paddingBottom: '4.5px' },
                   '& .MuiInputAdornment-root': { height: 32, maxHeight: 32 },
                   '& .MuiInputAdornment-root .MuiIconButton-root': { padding: '4px' },
                   '& .MuiInputLabel-outlined:not(.MuiInputLabel-shrink)': { transform: 'translate(14px, 5px) scale(1)' },

--- a/frontend/src/components/filters/FilterPeriod.tsx
+++ b/frontend/src/components/filters/FilterPeriod.tsx
@@ -104,8 +104,10 @@ export function FilterPeriod({ value, customFrom, customTo, onChange }: FilterPe
                 size: 'small',
                 sx: {
                   // DatePicker ignores custom size variants; force xs dimensions explicitly
-                  '& .MuiOutlinedInput-root': { height: 32 },
-                  '& .MuiOutlinedInput-input': { paddingTop: '4px', paddingBottom: '4px' },
+                  '& .MuiOutlinedInput-root': { height: 32, boxSizing: 'border-box' },
+                  '& .MuiOutlinedInput-input': { paddingTop: '4.5px', paddingBottom: '4.5px' },
+                  '& .MuiInputAdornment-root': { height: 32, maxHeight: 32 },
+                  '& .MuiInputAdornment-root .MuiIconButton-root': { padding: '4px' },
                   '& .MuiInputLabel-outlined:not(.MuiInputLabel-shrink)': { transform: 'translate(14px, 5px) scale(1)' },
                 },
               },
@@ -123,8 +125,10 @@ export function FilterPeriod({ value, customFrom, customTo, onChange }: FilterPe
                 size: 'small',
                 sx: {
                   // DatePicker ignores custom size variants; force xs dimensions explicitly
-                  '& .MuiOutlinedInput-root': { height: 32 },
-                  '& .MuiOutlinedInput-input': { paddingTop: '4px', paddingBottom: '4px' },
+                  '& .MuiOutlinedInput-root': { height: 32, boxSizing: 'border-box' },
+                  '& .MuiOutlinedInput-input': { paddingTop: '4.5px', paddingBottom: '4.5px' },
+                  '& .MuiInputAdornment-root': { height: 32, maxHeight: 32 },
+                  '& .MuiInputAdornment-root .MuiIconButton-root': { padding: '4px' },
                   '& .MuiInputLabel-outlined:not(.MuiInputLabel-shrink)': { transform: 'translate(14px, 5px) scale(1)' },
                 },
               },

--- a/frontend/src/components/filters/FilterPeriod.tsx
+++ b/frontend/src/components/filters/FilterPeriod.tsx
@@ -101,7 +101,7 @@ export function FilterPeriod({ value, customFrom, customTo, onChange }: FilterPe
             }}
             slotProps={{
               textField: {
-                size: 'xs' as any,
+                size: 'xs' as any, // DatePicker slots don't pick up module augmentation; sx below is the fallback
                 sx: {
                   '& .MuiOutlinedInput-input': { paddingTop: '4px', paddingBottom: '4px' },
                 },
@@ -117,7 +117,7 @@ export function FilterPeriod({ value, customFrom, customTo, onChange }: FilterPe
             }}
             slotProps={{
               textField: {
-                size: 'xs' as any,
+                size: 'xs' as any, // DatePicker slots don't pick up module augmentation; sx below is the fallback
                 sx: {
                   '& .MuiOutlinedInput-input': { paddingTop: '4px', paddingBottom: '4px' },
                 },

--- a/frontend/src/components/filters/FilterPeriod.tsx
+++ b/frontend/src/components/filters/FilterPeriod.tsx
@@ -67,8 +67,8 @@ export function FilterPeriod({ value, customFrom, customTo, onChange }: FilterPe
         alignItems: "center",
         flexWrap: "wrap"
       }}>
-      <FormControl size="small" sx={{ minWidth: 150 }}>
-        <InputLabel id={labelId} shrink={value !== null}>Period</InputLabel>
+      <FormControl size="xs" sx={{ minWidth: 150 }}>
+        <InputLabel id={labelId} size="xs" shrink={value !== null}>Period</InputLabel>
         <Select
           labelId={labelId}
           id={selectId}
@@ -99,7 +99,14 @@ export function FilterPeriod({ value, customFrom, customTo, onChange }: FilterPe
             onChange={(date) => {
               handleFromChange(date ? format(date, 'yyyy-MM-dd') : null)
             }}
-            slotProps={{ textField: { size: 'small' } }}
+            slotProps={{
+              textField: {
+                size: 'xs' as any,
+                sx: {
+                  '& .MuiOutlinedInput-input': { paddingTop: '4px', paddingBottom: '4px' },
+                },
+              },
+            }}
           />
           <DatePicker
             label="To"
@@ -108,7 +115,14 @@ export function FilterPeriod({ value, customFrom, customTo, onChange }: FilterPe
             onChange={(date) => {
               handleToChange(date ? format(date, 'yyyy-MM-dd') : null)
             }}
-            slotProps={{ textField: { size: 'small' } }}
+            slotProps={{
+              textField: {
+                size: 'xs' as any,
+                sx: {
+                  '& .MuiOutlinedInput-input': { paddingTop: '4px', paddingBottom: '4px' },
+                },
+              },
+            }}
           />
         </>
       )}

--- a/frontend/src/components/filters/FilterPeriod.tsx
+++ b/frontend/src/components/filters/FilterPeriod.tsx
@@ -101,9 +101,12 @@ export function FilterPeriod({ value, customFrom, customTo, onChange }: FilterPe
             }}
             slotProps={{
               textField: {
-                size: 'xs' as any, // DatePicker slots don't pick up module augmentation; sx below is the fallback
+                size: 'small',
                 sx: {
+                  // DatePicker ignores custom size variants; force xs dimensions explicitly
+                  '& .MuiOutlinedInput-root': { height: 32 },
                   '& .MuiOutlinedInput-input': { paddingTop: '4px', paddingBottom: '4px' },
+                  '& .MuiInputLabel-outlined:not(.MuiInputLabel-shrink)': { transform: 'translate(14px, 5px) scale(1)' },
                 },
               },
             }}
@@ -117,9 +120,12 @@ export function FilterPeriod({ value, customFrom, customTo, onChange }: FilterPe
             }}
             slotProps={{
               textField: {
-                size: 'xs' as any, // DatePicker slots don't pick up module augmentation; sx below is the fallback
+                size: 'small',
                 sx: {
+                  // DatePicker ignores custom size variants; force xs dimensions explicitly
+                  '& .MuiOutlinedInput-root': { height: 32 },
                   '& .MuiOutlinedInput-input': { paddingTop: '4px', paddingBottom: '4px' },
+                  '& .MuiInputLabel-outlined:not(.MuiInputLabel-shrink)': { transform: 'translate(14px, 5px) scale(1)' },
                 },
               },
             }}

--- a/frontend/src/components/filters/FilterSearch.tsx
+++ b/frontend/src/components/filters/FilterSearch.tsx
@@ -14,7 +14,7 @@ export function FilterSearch({ value, placeholder = 'Search...', onChange, onCom
   return (
     <TextField
       inputRef={inputRef}
-      size="small"
+      size="xs"
       value={value}
       placeholder={placeholder}
       onChange={(event) => onChange(event.target.value)}

--- a/frontend/src/components/filters/FilterSelect.tsx
+++ b/frontend/src/components/filters/FilterSelect.tsx
@@ -22,13 +22,13 @@ export function FilterSelect({ field, label, value, options, onChange, emptyLabe
   const labelId = `filter-${field}-label`
 
   return (
-    <FormControl size="small" sx={{ minWidth: minWidth ?? 160 }}>
-      <InputLabel id={labelId} shrink>{label}</InputLabel>
+    <FormControl size="xs" sx={{ minWidth: minWidth ?? 160 }}>
+      <InputLabel id={labelId} size="xs" shrink>{label}</InputLabel>
       <Select
         labelId={labelId}
         value={value ?? ''}
         displayEmpty
-        input={<OutlinedInput label={label} notched />}
+        input={<OutlinedInput size="xs" label={label} notched />}
         onChange={(event) => onChange(event.target.value === '' ? null : event.target.value)}
       >
         <MenuItem value="">{emptyLabel ?? 'All'}</MenuItem>

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -330,8 +330,9 @@ const baseThemeOptions: ThemeOptions = {
     MuiInputLabel: {
       styleOverrides: {
         root: {
-          '&.MuiInputLabel-sizeXs:not(.MuiInputLabel-shrink)': {
-            top: '-4px',
+          // outlined unshrunk: MUI default is translate(14px,9px); 32px field center is 4px higher
+          '&.MuiInputLabel-outlined.MuiInputLabel-sizeXs:not(.MuiInputLabel-shrink)': {
+            transform: 'translate(14px, 5px) scale(1)',
           },
         },
       },

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -317,9 +317,12 @@ const baseThemeOptions: ThemeOptions = {
     MuiOutlinedInput: {
       styleOverrides: {
         root: {
-          '&.MuiInputBase-sizeXs .MuiOutlinedInput-input': {
-            paddingTop: '4px',
-            paddingBottom: '4px',
+          '&.MuiInputBase-sizeXs': {
+            height: 32,
+            '& .MuiOutlinedInput-input': {
+              paddingTop: '4px',
+              paddingBottom: '4px',
+            },
           },
         },
       },
@@ -402,9 +405,12 @@ const darkTheme = createTheme({
     MuiOutlinedInput: {
       styleOverrides: {
         root: {
-          '&.MuiInputBase-sizeXs .MuiOutlinedInput-input': {
-            paddingTop: '4px',
-            paddingBottom: '4px',
+          '&.MuiInputBase-sizeXs': {
+            height: 32,
+            '& .MuiOutlinedInput-input': {
+              paddingTop: '4px',
+              paddingBottom: '4px',
+            },
           },
           '& .MuiOutlinedInput-notchedOutline': {
             borderColor: alpha('#ffffff', 0.23) + ' !important',

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -330,11 +330,8 @@ const baseThemeOptions: ThemeOptions = {
     MuiInputLabel: {
       styleOverrides: {
         root: {
-          '&.MuiInputLabel-sizeXs': {
+          '&.MuiInputLabel-sizeXs:not(.MuiInputLabel-shrink)': {
             top: '-4px',
-            '&.MuiInputLabel-shrink': {
-              top: 0,
-            },
           },
         },
       },

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -402,6 +402,10 @@ const darkTheme = createTheme({
     MuiOutlinedInput: {
       styleOverrides: {
         root: {
+          '&.MuiInputBase-sizeXs .MuiOutlinedInput-input': {
+            paddingTop: '4px',
+            paddingBottom: '4px',
+          },
           '& .MuiOutlinedInput-notchedOutline': {
             borderColor: alpha('#ffffff', 0.23) + ' !important',
           },

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -24,6 +24,36 @@ declare module '@mui/material/Typography' {
   }
 }
 
+declare module '@mui/material/OutlinedInput' {
+  interface OutlinedInputPropsSizeOverrides {
+    xs: true
+  }
+}
+
+declare module '@mui/material/InputBase' {
+  interface InputBasePropsSizeOverrides {
+    xs: true
+  }
+}
+
+declare module '@mui/material/FormControl' {
+  interface FormControlPropsSizeOverrides {
+    xs: true
+  }
+}
+
+declare module '@mui/material/TextField' {
+  interface TextFieldPropsSizeOverrides {
+    xs: true
+  }
+}
+
+declare module '@mui/material/InputLabel' {
+  interface InputLabelPropsSizeOverrides {
+    xs: true
+  }
+}
+
 // Color palette
 const colors = {
   primary: {
@@ -281,6 +311,28 @@ const baseThemeOptions: ThemeOptions = {
       styleOverrides: {
         root: {
           fontFamily: 'inherit',
+        },
+      },
+    },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: {
+          '&.MuiInputBase-sizeXs .MuiOutlinedInput-input': {
+            paddingTop: '4px',
+            paddingBottom: '4px',
+          },
+        },
+      },
+    },
+    MuiInputLabel: {
+      styleOverrides: {
+        root: {
+          '&.MuiInputLabel-sizeXs': {
+            top: '-4px',
+            '&.MuiInputLabel-shrink': {
+              top: 0,
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
## Summary
- Adds a scoped MUI `"xs"` size variant (via theme style overrides + TypeScript module augmentation) so only filter primitives are affected — global `size="small"` usage in forms, dialogs, and reports is untouched
- Updates `FilterSelect`, `FilterSearch`, `FilterPeriod`, and `FilterCompare` to use the new `"xs"` size, reducing height from ~40px to 32px
- Reduces `AppButton` `size="filter"` height from 40 → 32px to match
- All ~25 specific filter wrappers (FilterStatus, FilterCustomer, etc.) inherit the change through `FilterSelect` automatically
- DatePicker custom range inputs in `FilterPeriod` use explicit `sx` overrides targeting `MuiPickersOutlinedInput` classes (DatePicker has its own internal component, not `MuiOutlinedInput`)

## Test Plan
- [x] `npm run type-check` passes
- [x] `npx vitest run src/components/filters/` passes (14 files, 67 tests)
- [x] FilterBar on Inventory, Sales, and Purchasing pages shows ~32px height
- [x] Floating labels correctly positioned (centered when unshrunk, floated when shrunk)
- [x] Custom date range DatePicker inputs match 32px height
- [x] Reset and Sort buttons align with filter height
- [x] No regressions in forms/dialogs that use `size="small"`

Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)