### PR TITLE
feat(fund-transfers): add source and destination account filters

### DIFF
--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -7,6 +7,7 @@ import { FilterBankReconciliationStatus } from './FilterBankReconciliationStatus
 import { FilterCompare } from './FilterCompare'
 import { FilterCustomer } from './FilterCustomer'
 import { FilterCustomerType } from './FilterCustomerType'
+import { FilterDestinationAccount } from './FilterDestinationAccount'
 import { FilterFiscalPeriodStatus } from './FilterFiscalPeriodStatus'
 import { FilterFundTransferStatus } from './FilterFundTransferStatus'
 import { FilterJournalEntryStatus } from './FilterJournalEntryStatus'
@@ -21,6 +22,7 @@ import { FilterPurchasingStatus } from './FilterPurchasingStatus'
 import { FilterRole } from './FilterRole'
 import { FilterSearch } from './FilterSearch'
 import { FilterSettlementStatus } from './FilterSettlementStatus'
+import { FilterSourceAccount } from './FilterSourceAccount'
 import { FilterStatus } from './FilterStatus'
 import { FilterStockAdjustmentStatus } from './FilterStockAdjustmentStatus'
 import { FilterStockStatus } from './FilterStockStatus'
@@ -366,6 +368,28 @@ function renderQuickField<TFilters extends object>(
   if (field.type === 'account-type') {
     return (
       <FilterAccountType
+        key={fieldKey}
+        field={fieldKey}
+        value={(value as string | null) ?? null}
+        onChange={onChange}
+      />
+    )
+  }
+
+  if (field.type === 'fund-transfer-source-account') {
+    return (
+      <FilterSourceAccount
+        key={fieldKey}
+        field={fieldKey}
+        value={(value as string | null) ?? null}
+        onChange={onChange}
+      />
+    )
+  }
+
+  if (field.type === 'fund-transfer-destination-account') {
+    return (
+      <FilterDestinationAccount
         key={fieldKey}
         field={fieldKey}
         value={(value as string | null) ?? null}

--- a/frontend/src/components/filters/FilterDestinationAccount.tsx
+++ b/frontend/src/components/filters/FilterDestinationAccount.tsx
@@ -1,0 +1,26 @@
+import { useGetChartOfAccountsQuery } from '@/store/api/accountingApi'
+
+import { FilterSelect } from './FilterSelect'
+
+interface Props {
+  field: string
+  value: string | null
+  onChange: (value: string | null) => void
+}
+
+export function FilterDestinationAccount({ field, value, onChange }: Props) {
+  const { data } = useGetChartOfAccountsQuery({ isCashEquivalent: true, limit: 200 })
+  const options = ((data?.data ?? []) as { id: string; code: string; name: string; isActive: boolean }[])
+    .filter((account) => account.isActive)
+    .map((account) => ({ value: account.id, label: `${account.code} - ${account.name}` }))
+
+  return (
+    <FilterSelect
+      field={field}
+      label="Destination Account"
+      value={value}
+      options={options}
+      onChange={onChange}
+    />
+  )
+}

--- a/frontend/src/components/filters/FilterFundTransferStatus.tsx
+++ b/frontend/src/components/filters/FilterFundTransferStatus.tsx
@@ -1,9 +1,8 @@
 import { FilterSelect } from './FilterSelect'
 
 const OPTIONS = [
-  { value: 'pending', label: 'Pending' },
-  { value: 'completed', label: 'Completed' },
-  { value: 'cancelled', label: 'Cancelled' },
+  { value: 'ACTIVE', label: 'Active' },
+  { value: 'CANCELLED', label: 'Cancelled' },
 ]
 
 interface Props {

--- a/frontend/src/components/filters/FilterSourceAccount.tsx
+++ b/frontend/src/components/filters/FilterSourceAccount.tsx
@@ -1,0 +1,26 @@
+import { useGetChartOfAccountsQuery } from '@/store/api/accountingApi'
+
+import { FilterSelect } from './FilterSelect'
+
+interface Props {
+  field: string
+  value: string | null
+  onChange: (value: string | null) => void
+}
+
+export function FilterSourceAccount({ field, value, onChange }: Props) {
+  const { data } = useGetChartOfAccountsQuery({ isCashEquivalent: true, limit: 200 })
+  const options = ((data?.data ?? []) as { id: string; code: string; name: string; isActive: boolean }[])
+    .filter((account) => account.isActive)
+    .map((account) => ({ value: account.id, label: `${account.code} - ${account.name}` }))
+
+  return (
+    <FilterSelect
+      field={field}
+      label="Source Account"
+      value={value}
+      options={options}
+      onChange={onChange}
+    />
+  )
+}

--- a/frontend/src/pages/accounting/FundTransfersPage.tsx
+++ b/frontend/src/pages/accounting/FundTransfersPage.tsx
@@ -30,6 +30,8 @@ interface FTFilters {
   search: string
   status: string | null
   period: PeriodValue
+  sourceAccountId: string | null
+  destinationAccountId: string | null
 }
 
 const filterConfig: FilterBarConfig<FTFilters> = {
@@ -37,8 +39,10 @@ const filterConfig: FilterBarConfig<FTFilters> = {
   fields: [
     { field: 'period', label: 'Period', type: 'period' },
     { field: 'status', label: 'Status', type: 'fund-transfer-status' },
+    { field: 'sourceAccountId', label: 'Source Account', type: 'fund-transfer-source-account' },
+    { field: 'destinationAccountId', label: 'Destination Account', type: 'fund-transfer-destination-account' },
   ],
-  defaults: { search: '', status: null, period: { key: null, from: null, to: null } },
+  defaults: { search: '', status: null, period: { key: null, from: null, to: null }, sourceAccountId: null, destinationAccountId: null },
 }
 
 const defaultForm: FormState = { sourceAccountId: '', destinationAccountId: '', amount: '', transferDate: getCurrentDate(), description: '' }
@@ -64,7 +68,9 @@ const FundTransfersPage: React.FC = () => {
     startDate: dateRange.fromDate,
     endDate: dateRange.toDate,
     status: appliedFilters.status || undefined,
-  }), [appliedFilters.status, dateRange])
+    sourceAccountId: appliedFilters.sourceAccountId || undefined,
+    destinationAccountId: appliedFilters.destinationAccountId || undefined,
+  }), [appliedFilters.status, appliedFilters.sourceAccountId, appliedFilters.destinationAccountId, dateRange])
 
   const { data, isLoading, refetch } = useGetFundTransfersQuery(filters)
   const { data: accountsResponse } = useGetChartOfAccountsQuery({ isCashEquivalent: true, limit: 200 })

--- a/frontend/src/pages/accounting/__tests__/FundTransfersPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/FundTransfersPage.test.tsx
@@ -121,4 +121,14 @@ describe('FundTransfersPage', () => {
       expect(selectSelectedFundTransfer(store.getState())?.id).toBe('trf-1')
     })
   })
+
+  it('renders Source Account filter dropdown', () => {
+    renderPage()
+    expect(screen.getByRole('combobox', { name: /source account/i })).toBeInTheDocument()
+  })
+
+  it('renders Destination Account filter dropdown', () => {
+    renderPage()
+    expect(screen.getByRole('combobox', { name: /destination account/i })).toBeInTheDocument()
+  })
 })

--- a/frontend/src/types/filterBar.types.ts
+++ b/frontend/src/types/filterBar.types.ts
@@ -37,6 +37,8 @@ export type FilterFieldType =
   | 'settlement-status'
   | 'fund-transfer-status'
   | 'account-type'
+  | 'fund-transfer-source-account'
+  | 'fund-transfer-destination-account'
 
 interface BaseFilterFieldConfig<TFilters, K extends keyof TFilters> {
   field: K
@@ -187,6 +189,16 @@ export interface AccountTypeFilterFieldConfig<TFilters, K extends keyof TFilters
   type: 'account-type'
 }
 
+export interface FundTransferSourceAccountFilterFieldConfig<TFilters, K extends keyof TFilters>
+  extends BaseFilterFieldConfig<TFilters, K> {
+  type: 'fund-transfer-source-account'
+}
+
+export interface FundTransferDestinationAccountFilterFieldConfig<TFilters, K extends keyof TFilters>
+  extends BaseFilterFieldConfig<TFilters, K> {
+  type: 'fund-transfer-destination-account'
+}
+
 export type FilterFieldConfig<TFilters> =
   | StatusFilterFieldConfig<TFilters, keyof TFilters>
   | UserStatusFilterFieldConfig<TFilters, keyof TFilters>
@@ -216,6 +228,8 @@ export type FilterFieldConfig<TFilters> =
   | SettlementStatusFilterFieldConfig<TFilters, keyof TFilters>
   | FundTransferStatusFilterFieldConfig<TFilters, keyof TFilters>
   | AccountTypeFilterFieldConfig<TFilters, keyof TFilters>
+  | FundTransferSourceAccountFilterFieldConfig<TFilters, keyof TFilters>
+  | FundTransferDestinationAccountFilterFieldConfig<TFilters, keyof TFilters>
 
 export interface FilterBarConfig<TFilters> {
   search?: {

--- a/frontend/src/utils/filterBar.url.ts
+++ b/frontend/src/utils/filterBar.url.ts
@@ -240,9 +240,12 @@ export function parseFilters<TFilters extends object>(
       } else if (field.type === 'bank-reconciliation-status') {
         const VALID_BANK_RECONCILIATION_STATUS = ['in_progress', 'completed']
         result[fieldKey] = VALID_BANK_RECONCILIATION_STATUS.includes(raw) ? raw : (defaultValue ?? null)
-      } else if (field.type === 'settlement-status' || field.type === 'fund-transfer-status') {
-        const VALID_COMPLETION_STATUS = ['pending', 'completed', 'cancelled']
-        result[fieldKey] = VALID_COMPLETION_STATUS.includes(raw) ? raw : (defaultValue ?? null)
+      } else if (field.type === 'settlement-status') {
+        const VALID_SETTLEMENT_STATUS = ['pending', 'completed', 'cancelled']
+        result[fieldKey] = VALID_SETTLEMENT_STATUS.includes(raw) ? raw : (defaultValue ?? null)
+      } else if (field.type === 'fund-transfer-status') {
+        const VALID_FUND_TRANSFER_STATUS = ['ACTIVE', 'CANCELLED']
+        result[fieldKey] = VALID_FUND_TRANSFER_STATUS.includes(raw) ? raw : (defaultValue ?? null)
       } else if (field.type === 'account-type') {
         const VALID_ACCOUNT_TYPE = ['ASSET', 'LIABILITY', 'EQUITY', 'REVENUE', 'EXPENSE']
         result[fieldKey] = VALID_ACCOUNT_TYPE.includes(raw) ? raw : (defaultValue ?? null)

--- a/frontend/src/utils/filterBar.url.ts
+++ b/frontend/src/utils/filterBar.url.ts
@@ -91,7 +91,9 @@ export function serializeFilters<TFilters extends object>(
       field.type === 'bank-reconciliation-status' ||
       field.type === 'settlement-status' ||
       field.type === 'fund-transfer-status' ||
-      field.type === 'account-type'
+      field.type === 'account-type' ||
+      field.type === 'fund-transfer-source-account' ||
+      field.type === 'fund-transfer-destination-account'
 
     if (isSingleValueField) {
       if (value !== null && value !== undefined && value !== defaultValue) {
@@ -177,7 +179,9 @@ export function parseFilters<TFilters extends object>(
       field.type === 'bank-reconciliation-status' ||
       field.type === 'settlement-status' ||
       field.type === 'fund-transfer-status' ||
-      field.type === 'account-type'
+      field.type === 'account-type' ||
+      field.type === 'fund-transfer-source-account' ||
+      field.type === 'fund-transfer-destination-account'
 
     if (isSingleValueField) {
       const raw = searchParams.get(key)
@@ -246,6 +250,9 @@ export function parseFilters<TFilters extends object>(
       } else if (field.type === 'fund-transfer-status') {
         const VALID_FUND_TRANSFER_STATUS = ['ACTIVE', 'CANCELLED']
         result[fieldKey] = VALID_FUND_TRANSFER_STATUS.includes(raw) ? raw : (defaultValue ?? null)
+      } else if (field.type === 'fund-transfer-source-account' || field.type === 'fund-transfer-destination-account') {
+        // UUID from URL: accept any non-empty string; backend validates UUID format.
+        result[fieldKey] = raw.length > 0 ? raw : (defaultValue ?? null)
       } else if (field.type === 'account-type') {
         const VALID_ACCOUNT_TYPE = ['ASSET', 'LIABILITY', 'EQUITY', 'REVENUE', 'EXPENSE']
         result[fieldKey] = VALID_ACCOUNT_TYPE.includes(raw) ? raw : (defaultValue ?? null)


### PR DESCRIPTION
## Summary

- Adds **Source Account** and **Destination Account** FilterBar filters to the Fund Transfers page
- Each filter selects from active cash-equivalent accounts and sends `sourceAccountId` / `destinationAccountId` as server-side query parameters (backend already supported these)
- Filter order: Period → Status → Source Account → Destination Account
- URL sync, chip display, and reset button work via the existing FilterBar system
- Also fixes a pre-existing bug: `FilterFundTransferStatus` was using `pending/completed/cancelled` instead of the correct `ACTIVE/CANCELLED` backend enum values

## Verification

- `cd frontend && npm run type-check` — passed
- `cd frontend && npx vitest run src/pages/accounting/__tests__/FundTransfersPage.test.tsx` — passed, 1 file / 8 tests
- `cd frontend && npm run lint` — passed
- `cd frontend && npm run test` — passed, 157 files / 1027 tests

## Test plan
- [x] Visit Fund Transfers page — two new filter dropdowns appear after Status
- [x] Select a source account — list re-fetches and shows only transfers from that account
- [x] Select a destination account — list re-fetches and shows only transfers to that account
- [x] Both filters together narrow results by AND
- [x] Reset button clears both filters
- [x] URL params `sourceAccountId` and `destinationAccountId` persist on reload
- [x] Status filter now correctly sends `ACTIVE` or `CANCELLED` to backend

Closes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)