### PR TITLE
feat(reconciliation): enhanced filters for bank reconciliations page

### DIFF
--- a/backend/src/modules/accounting/dto/reconciliation.dto.ts
+++ b/backend/src/modules/accounting/dto/reconciliation.dto.ts
@@ -7,6 +7,7 @@ import {
   IsUUID,
   IsArray,
   IsBoolean,
+  IsDateString,
   Min,
   Max,
 } from 'class-validator';
@@ -89,12 +90,12 @@ export class QueryBankReconciliationsDto {
 
   @ApiPropertyOptional({ description: 'Filter by reconciliation date (from), e.g. 2026-01-01' })
   @IsOptional()
-  @IsString()
+  @IsDateString()
   startDate?: string;
 
   @ApiPropertyOptional({ description: 'Filter by reconciliation date (to), e.g. 2026-12-31' })
   @IsOptional()
-  @IsString()
+  @IsDateString()
   endDate?: string;
 
   @ApiPropertyOptional({ description: 'Filter by balanced status (difference = 0 when true)' })

--- a/backend/src/modules/accounting/dto/reconciliation.dto.ts
+++ b/backend/src/modules/accounting/dto/reconciliation.dto.ts
@@ -11,7 +11,7 @@ import {
   Min,
   Max,
 } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Type, Transform } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { BankReconciliationStatus } from '../../../database/entities/bank-reconciliation.entity';
 
@@ -100,7 +100,7 @@ export class QueryBankReconciliationsDto {
 
   @ApiPropertyOptional({ description: 'Filter by balanced status (difference = 0 when true)' })
   @IsOptional()
-  @Type(() => Boolean)
+  @Transform(({ value }) => value === 'true' || value === true)
   @IsBoolean()
   isBalanced?: boolean;
 

--- a/backend/src/modules/accounting/dto/reconciliation.dto.ts
+++ b/backend/src/modules/accounting/dto/reconciliation.dto.ts
@@ -6,6 +6,7 @@ import {
   IsNumber,
   IsUUID,
   IsArray,
+  IsBoolean,
   Min,
   Max,
 } from 'class-validator';
@@ -85,6 +86,22 @@ export class QueryBankReconciliationsDto {
   @IsOptional()
   @IsString()
   search?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by reconciliation date (from), e.g. 2026-01-01' })
+  @IsOptional()
+  @IsString()
+  startDate?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by reconciliation date (to), e.g. 2026-12-31' })
+  @IsOptional()
+  @IsString()
+  endDate?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by balanced status (difference = 0 when true)' })
+  @IsOptional()
+  @Type(() => Boolean)
+  @IsBoolean()
+  isBalanced?: boolean;
 
   @ApiPropertyOptional({ description: 'Sort field', enum: ['reconciliationDate', 'createdAt'] })
   @IsOptional()

--- a/backend/src/modules/accounting/services/reconciliation.service.spec.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.spec.ts
@@ -277,7 +277,7 @@ describe('ReconciliationService', () => {
 
       await service.findAll({ page: 1, limit: 20, isBalanced: true } as any);
 
-      expect(queryBuilder.andWhere).toHaveBeenCalledWith('recon.difference = 0');
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith('ABS(recon.difference) < 0.01');
     });
 
     it('should filter unbalanced reconciliations (difference != 0)', async () => {
@@ -286,7 +286,7 @@ describe('ReconciliationService', () => {
 
       await service.findAll({ page: 1, limit: 20, isBalanced: false } as any);
 
-      expect(queryBuilder.andWhere).toHaveBeenCalledWith('recon.difference != 0');
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith('ABS(recon.difference) >= 0.01');
     });
   });
 

--- a/backend/src/modules/accounting/services/reconciliation.service.spec.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.spec.ts
@@ -246,6 +246,48 @@ describe('ReconciliationService', () => {
         { search: '%cash%' },
       );
     });
+
+    it('should filter by startDate', async () => {
+      const queryBuilder = createMockQueryBuilder([mockReconciliation], 1);
+      reconciliationRepo.createQueryBuilder.mockReturnValue(queryBuilder as any);
+
+      await service.findAll({ page: 1, limit: 20, startDate: '2026-01-01' } as any);
+
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+        'recon.reconciliationDate >= :startDate',
+        { startDate: '2026-01-01' },
+      );
+    });
+
+    it('should filter by endDate', async () => {
+      const queryBuilder = createMockQueryBuilder([mockReconciliation], 1);
+      reconciliationRepo.createQueryBuilder.mockReturnValue(queryBuilder as any);
+
+      await service.findAll({ page: 1, limit: 20, endDate: '2026-12-31' } as any);
+
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+        'recon.reconciliationDate <= :endDate',
+        { endDate: '2026-12-31' },
+      );
+    });
+
+    it('should filter balanced reconciliations (difference = 0)', async () => {
+      const queryBuilder = createMockQueryBuilder([mockReconciliation], 1);
+      reconciliationRepo.createQueryBuilder.mockReturnValue(queryBuilder as any);
+
+      await service.findAll({ page: 1, limit: 20, isBalanced: true } as any);
+
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith('recon.difference = 0');
+    });
+
+    it('should filter unbalanced reconciliations (difference != 0)', async () => {
+      const queryBuilder = createMockQueryBuilder([mockReconciliation], 1);
+      reconciliationRepo.createQueryBuilder.mockReturnValue(queryBuilder as any);
+
+      await service.findAll({ page: 1, limit: 20, isBalanced: false } as any);
+
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith('recon.difference != 0');
+    });
   });
 
   describe('update', () => {

--- a/backend/src/modules/accounting/services/reconciliation.service.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.ts
@@ -132,6 +132,9 @@ export class ReconciliationService {
       sortBy = 'reconciliationDate',
       sortOrder = 'DESC',
       search,
+      startDate,
+      endDate,
+      isBalanced,
     } = query;
 
     const queryBuilder = this.reconciliationRepository
@@ -154,6 +157,19 @@ export class ReconciliationService {
         '(account.name ILIKE :search OR account.code ILIKE :search OR fiscalPeriod.name ILIKE :search)',
         { search: `%${search}%` },
       );
+    }
+    if (startDate) {
+      queryBuilder.andWhere('recon.reconciliationDate >= :startDate', { startDate });
+    }
+    if (endDate) {
+      queryBuilder.andWhere('recon.reconciliationDate <= :endDate', { endDate });
+    }
+    if (isBalanced !== undefined) {
+      if (isBalanced) {
+        queryBuilder.andWhere('recon.difference = 0');
+      } else {
+        queryBuilder.andWhere('recon.difference != 0');
+      }
     }
 
     const validSortFields = ['reconciliationDate', 'createdAt'];

--- a/backend/src/modules/accounting/services/reconciliation.service.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.ts
@@ -166,9 +166,9 @@ export class ReconciliationService {
     }
     if (isBalanced !== undefined) {
       if (isBalanced) {
-        queryBuilder.andWhere('recon.difference = 0');
+        queryBuilder.andWhere('ABS(recon.difference) < 0.01');
       } else {
-        queryBuilder.andWhere('recon.difference != 0');
+        queryBuilder.andWhere('ABS(recon.difference) >= 0.01');
       }
     }
 

--- a/frontend/src/components/accounting/BankReconciliationFormDialog.tsx
+++ b/frontend/src/components/accounting/BankReconciliationFormDialog.tsx
@@ -45,7 +45,7 @@ const BankReconciliationFormDialog: React.FC<BankReconciliationFormDialogProps> 
 }) => {
   const { showError } = useNotification();
   const { data: accountsResponse } = useGetChartOfAccountsQuery(
-    { page: 1, isActive: true, isCashEquivalent: true },
+    { page: 1, isActive: true, isCashEquivalent: true, limit: 200 },
     { skip: !open },
   );
   const { data: periodsResponse } = useGetFiscalPeriodsQuery(

--- a/frontend/src/components/accounting/BankReconciliationFormDialog.tsx
+++ b/frontend/src/components/accounting/BankReconciliationFormDialog.tsx
@@ -45,7 +45,7 @@ const BankReconciliationFormDialog: React.FC<BankReconciliationFormDialogProps> 
 }) => {
   const { showError } = useNotification();
   const { data: accountsResponse } = useGetChartOfAccountsQuery(
-    { page: 1, isActive: true },
+    { page: 1, isActive: true, isCashEquivalent: true },
     { skip: !open },
   );
   const { data: periodsResponse } = useGetFiscalPeriodsQuery(
@@ -84,11 +84,6 @@ const BankReconciliationFormDialog: React.FC<BankReconciliationFormDialogProps> 
     }
     setErrors({});
   }, [reconciliation, open]);
-
-  const assetAccounts = useMemo(
-    () => accounts.filter((account: any) => String(account.type).toUpperCase() === 'ASSET'),
-    [accounts],
-  );
 
   const openPeriods = useMemo(
     () => periods.filter((period: any) => period.status === FiscalPeriodStatus.OPEN),
@@ -171,7 +166,7 @@ const BankReconciliationFormDialog: React.FC<BankReconciliationFormDialogProps> 
               label="Account"
               onChange={(e) => handleChange('accountId', e.target.value)}
             >
-              {assetAccounts.map((account: any) => (
+              {accounts.map((account: any) => (
                 <MenuItem key={account.id} value={account.id}>
                   {account.code} - {account.name}
                 </MenuItem>

--- a/frontend/src/components/filters/FilterBalancedStatus.tsx
+++ b/frontend/src/components/filters/FilterBalancedStatus.tsx
@@ -1,0 +1,18 @@
+import { FilterSelect } from './FilterSelect'
+
+const OPTIONS = [
+  { value: 'balanced', label: 'Balanced' },
+  { value: 'unbalanced', label: 'Unbalanced' },
+]
+
+interface Props {
+  field: string
+  value: string | null
+  onChange: (value: string | null) => void
+}
+
+export function FilterBalancedStatus({ field, value, onChange }: Props) {
+  return (
+    <FilterSelect field={field} label="Balanced" value={value} options={OPTIONS} onChange={onChange} />
+  )
+}

--- a/frontend/src/components/filters/FilterBalancedStatus.tsx
+++ b/frontend/src/components/filters/FilterBalancedStatus.tsx
@@ -13,6 +13,6 @@ interface Props {
 
 export function FilterBalancedStatus({ field, value, onChange }: Props) {
   return (
-    <FilterSelect field={field} label="Balanced" value={value} options={OPTIONS} onChange={onChange} />
+    <FilterSelect field={field} label="Balance Status" value={value} options={OPTIONS} onChange={onChange} />
   )
 }

--- a/frontend/src/components/filters/FilterBankAccount.tsx
+++ b/frontend/src/components/filters/FilterBankAccount.tsx
@@ -1,0 +1,26 @@
+import { useGetChartOfAccountsQuery } from '@/store/api/accountingApi'
+
+import { FilterSelect } from './FilterSelect'
+
+interface Props {
+  field: string
+  value: string | null
+  onChange: (value: string | null) => void
+}
+
+export function FilterBankAccount({ field, value, onChange }: Props) {
+  const { data } = useGetChartOfAccountsQuery({ isCashEquivalent: true, limit: 200 })
+  const options = ((data?.data ?? []) as { id: string; code: string; name: string; isActive: boolean }[])
+    .filter((account) => account.isActive)
+    .map((account) => ({ value: account.id, label: `${account.code} - ${account.name}` }))
+
+  return (
+    <FilterSelect
+      field={field}
+      label="Bank Account"
+      value={value}
+      options={options}
+      onChange={onChange}
+    />
+  )
+}

--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -1,6 +1,8 @@
 import { CircularProgress, Stack } from '@mui/material'
 
 import { FilterAccountType } from './FilterAccountType'
+import { FilterBalancedStatus } from './FilterBalancedStatus'
+import { FilterBankAccount } from './FilterBankAccount'
 import { FilterCategory } from './FilterCategory'
 import { FilterExpenseStatus } from './FilterExpenseStatus'
 import { FilterBankReconciliationStatus } from './FilterBankReconciliationStatus'
@@ -390,6 +392,28 @@ function renderQuickField<TFilters extends object>(
   if (field.type === 'fund-transfer-destination-account') {
     return (
       <FilterDestinationAccount
+        key={fieldKey}
+        field={fieldKey}
+        value={(value as string | null) ?? null}
+        onChange={onChange}
+      />
+    )
+  }
+
+  if (field.type === 'bank-reconciliation-account') {
+    return (
+      <FilterBankAccount
+        key={fieldKey}
+        field={fieldKey}
+        value={(value as string | null) ?? null}
+        onChange={onChange}
+      />
+    )
+  }
+
+  if (field.type === 'bank-reconciliation-balanced') {
+    return (
+      <FilterBalancedStatus
         key={fieldKey}
         field={fieldKey}
         value={(value as string | null) ?? null}

--- a/frontend/src/pages/accounting/BankReconciliationsPage.tsx
+++ b/frontend/src/pages/accounting/BankReconciliationsPage.tsx
@@ -19,6 +19,8 @@ interface BRFilters {
   search: string
   status: string | null
   period: PeriodValue
+  accountId: string | null
+  isBalanced: string | null
 }
 
 const filterConfig: FilterBarConfig<BRFilters> = {
@@ -26,11 +28,15 @@ const filterConfig: FilterBarConfig<BRFilters> = {
   fields: [
     { field: 'period', label: 'Period', type: 'period' },
     { field: 'status', label: 'Status', type: 'bank-reconciliation-status' },
+    { field: 'accountId', label: 'Bank Account', type: 'bank-reconciliation-account' },
+    { field: 'isBalanced', label: 'Balanced', type: 'bank-reconciliation-balanced' },
   ],
   defaults: {
     search: '',
     status: null,
     period: { key: null, from: null, to: null },
+    accountId: null,
+    isBalanced: null,
   },
 }
 
@@ -54,6 +60,11 @@ const BankReconciliationsPage: React.FC = () => {
     status: appliedFilters.status ? appliedFilters.status.toUpperCase() : undefined,
     startDate: dateRange.fromDate,
     endDate: dateRange.toDate,
+    accountId: appliedFilters.accountId ?? undefined,
+    isBalanced:
+      appliedFilters.isBalanced === 'balanced' ? true
+      : appliedFilters.isBalanced === 'unbalanced' ? false
+      : undefined,
     sortBy,
     sortOrder: sortOrder.toUpperCase() as 'ASC' | 'DESC',
   })

--- a/frontend/src/pages/accounting/BankReconciliationsPage.tsx
+++ b/frontend/src/pages/accounting/BankReconciliationsPage.tsx
@@ -29,7 +29,7 @@ const filterConfig: FilterBarConfig<BRFilters> = {
     { field: 'period', label: 'Period', type: 'period' },
     { field: 'status', label: 'Status', type: 'bank-reconciliation-status' },
     { field: 'accountId', label: 'Bank Account', type: 'bank-reconciliation-account' },
-    { field: 'isBalanced', label: 'Balanced', type: 'bank-reconciliation-balanced' },
+    { field: 'isBalanced', label: 'Balance Status', type: 'bank-reconciliation-balanced' },
   ],
   defaults: {
     search: '',

--- a/frontend/src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
@@ -72,6 +72,7 @@ const mockedApi = vi.hoisted(() => ({
   useReopenBankReconciliationMutation: vi.fn(),
   useMarkBankReconciliationClearedMutation: vi.fn(),
   useUnmarkBankReconciliationClearedMutation: vi.fn(),
+  useGetChartOfAccountsQuery: vi.fn(),
 }))
 
 vi.mock('@/store/api/accountingApi', () => mockedApi)
@@ -103,11 +104,22 @@ describe('BankReconciliationsPage', () => {
     mockedApi.useReopenBankReconciliationMutation.mockReturnValue([vi.fn()])
     mockedApi.useMarkBankReconciliationClearedMutation.mockReturnValue([vi.fn()])
     mockedApi.useUnmarkBankReconciliationClearedMutation.mockReturnValue([vi.fn()])
+    mockedApi.useGetChartOfAccountsQuery.mockReturnValue({ data: { data: [] } })
   })
 
   it('renders the page title', () => {
     renderPage()
     expect(screen.getByText('Bank Reconciliations')).toBeInTheDocument()
+  })
+
+  it('renders the Bank Account filter dropdown', () => {
+    renderPage()
+    expect(screen.getByRole('combobox', { name: /bank account/i })).toBeInTheDocument()
+  })
+
+  it('renders the Balanced Status filter dropdown', () => {
+    renderPage()
+    expect(screen.getByRole('combobox', { name: /balanced/i })).toBeInTheDocument()
   })
 
   it('shows empty state via EntityTable when no reconciliations', () => {

--- a/frontend/src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
@@ -119,7 +119,7 @@ describe('BankReconciliationsPage', () => {
 
   it('renders the Balanced Status filter dropdown', () => {
     renderPage()
-    expect(screen.getByRole('combobox', { name: /balanced/i })).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: /balance status/i })).toBeInTheDocument()
   })
 
   it('shows empty state via EntityTable when no reconciliations', () => {

--- a/frontend/src/store/api/accountingApi.ts
+++ b/frontend/src/store/api/accountingApi.ts
@@ -90,7 +90,7 @@ type CreateFundTransferPayload = {
   description?: string
 }
 
-export interface BankReconciliationsParams extends Record<string, unknown> {
+export interface BankReconciliationsParams {
   search?: string
   status?: string
   startDate?: string
@@ -101,6 +101,7 @@ export interface BankReconciliationsParams extends Record<string, unknown> {
   sortOrder?: 'ASC' | 'DESC'
   page?: number
   limit?: number
+  [key: string]: unknown
 }
 
 const toNumber = (value: unknown, fallback = 0): number => {

--- a/frontend/src/store/api/accountingApi.ts
+++ b/frontend/src/store/api/accountingApi.ts
@@ -90,6 +90,19 @@ type CreateFundTransferPayload = {
   description?: string
 }
 
+export interface BankReconciliationsParams extends Record<string, unknown> {
+  search?: string
+  status?: string
+  startDate?: string
+  endDate?: string
+  accountId?: string
+  isBalanced?: boolean
+  sortBy?: string
+  sortOrder?: 'ASC' | 'DESC'
+  page?: number
+  limit?: number
+}
+
 const toNumber = (value: unknown, fallback = 0): number => {
   const parsed = typeof value === 'number' ? value : Number(value)
   return Number.isFinite(parsed) ? parsed : fallback
@@ -293,7 +306,7 @@ export const accountingApiSlice = createApi({
       query: () => ({ url: '/accounting/account-mappings/validate' }),
       providesTags: ['AccountMapping'],
     }),
-    getBankReconciliations: builder.query<PaginatedResponse<BankReconciliation>, Record<string, unknown> | undefined>({
+    getBankReconciliations: builder.query<PaginatedResponse<BankReconciliation>, BankReconciliationsParams | undefined>({
       query: (params) => ({ url: '/accounting/bank-reconciliations', params: params ?? {} }),
       transformResponse: (response: any) => normalizeNamedCollection<BankReconciliation>(response, 'reconciliations'),
       providesTags: ['BankReconciliation'],

--- a/frontend/src/types/filterBar.types.ts
+++ b/frontend/src/types/filterBar.types.ts
@@ -39,6 +39,8 @@ export type FilterFieldType =
   | 'account-type'
   | 'fund-transfer-source-account'
   | 'fund-transfer-destination-account'
+  | 'bank-reconciliation-account'
+  | 'bank-reconciliation-balanced'
 
 interface BaseFilterFieldConfig<TFilters, K extends keyof TFilters> {
   field: K
@@ -199,6 +201,16 @@ export interface FundTransferDestinationAccountFilterFieldConfig<TFilters, K ext
   type: 'fund-transfer-destination-account'
 }
 
+export interface BankReconciliationAccountFilterFieldConfig<TFilters, K extends keyof TFilters>
+  extends BaseFilterFieldConfig<TFilters, K> {
+  type: 'bank-reconciliation-account'
+}
+
+export interface BankReconciliationBalancedFilterFieldConfig<TFilters, K extends keyof TFilters>
+  extends BaseFilterFieldConfig<TFilters, K> {
+  type: 'bank-reconciliation-balanced'
+}
+
 export type FilterFieldConfig<TFilters> =
   | StatusFilterFieldConfig<TFilters, keyof TFilters>
   | UserStatusFilterFieldConfig<TFilters, keyof TFilters>
@@ -230,6 +242,8 @@ export type FilterFieldConfig<TFilters> =
   | AccountTypeFilterFieldConfig<TFilters, keyof TFilters>
   | FundTransferSourceAccountFilterFieldConfig<TFilters, keyof TFilters>
   | FundTransferDestinationAccountFilterFieldConfig<TFilters, keyof TFilters>
+  | BankReconciliationAccountFilterFieldConfig<TFilters, keyof TFilters>
+  | BankReconciliationBalancedFilterFieldConfig<TFilters, keyof TFilters>
 
 export interface FilterBarConfig<TFilters> {
   search?: {


### PR DESCRIPTION
## Summary

- **Backend:** Add `startDate`, `endDate`, and `isBalanced` query filters to `QueryBankReconciliationsDto`; apply them in `ReconciliationService.findAll` using date range comparisons and `ABS(difference) < 0.01` tolerance for balance check
- **Frontend:** New `FilterBankAccount` (cash/bank accounts only) and `FilterBalancedStatus` (Balanced / Unbalanced) filter components wired into the FilterBar system; `getBankReconciliations` RTK query properly typed with `BankReconciliationsParams`
- **Fix:** `BankReconciliationFormDialog` account picker now queries `isCashEquivalent: true` instead of fetching all accounts and filtering client-side to assets

## Bug Fixes

- `@Type(() => Boolean)` replaced with `@Transform` for `isBalanced` — `Boolean("false")` returns `true` in JS, causing the Unbalanced filter to silently apply the wrong condition
- Date filters (`startDate`/`endDate`) now validated with `@IsDateString()` to reject malformed strings before they reach the DB
- Form dialog account query includes `limit: 200` to prevent silent truncation at the default 20

## Test Plan

- [x] Backend: `npx jest src/modules/accounting/services/reconciliation.service.spec.ts --no-coverage` — 26 tests pass
- [x] Frontend: `npx vitest run src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx` — 9 tests pass
- [x] `npm run type-check` — no errors
- [x] `npm run lint` — no errors
- [x] Manual: Bank Account dropdown shows only Cash/Bank accounts (isCashEquivalent = true)
- [x] Manual: Balance Status filter correctly shows balanced / unbalanced reconciliations
- [x] Manual: New Reconciliation dialog shows only cash/bank accounts in the account picker
- [x] Manual: Date range filter correctly scopes results by reconciliation date

Closes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)