### PR TITLE
feat(bank-recon): add Edit button and View Deleted (issue #591)

### DIFF
--- a/backend/src/modules/accounting/controllers/reconciliation.controller.ts
+++ b/backend/src/modules/accounting/controllers/reconciliation.controller.ts
@@ -43,6 +43,38 @@ export class ReconciliationController {
     return this.reconciliationService.findAll(query);
   }
 
+  @Get('deleted')
+  @ApiOperation({ summary: 'Get all soft-deleted bank reconciliations' })
+  @ApiResponse({ status: 200, description: 'Returns all deleted bank reconciliations' })
+  async getDeleted(): Promise<BankReconciliationResponseDto[]> {
+    return this.reconciliationService.getDeleted();
+  }
+
+  @Post('bulk-restore')
+  @Auth(UserRole.ADMIN, UserRole.MANAGER)
+  @ApiOperation({ summary: 'Bulk restore soft-deleted bank reconciliations' })
+  @ApiResponse({ status: 200, description: 'Bulk restore result' })
+  async bulkRestore(
+    @Body() body: { ids: string[] },
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<{ restoredCount: number; failedIds: string[] }> {
+    return this.reconciliationService.bulkRestore(body.ids, currentUserId, currentUsername);
+  }
+
+  @Delete('bulk-permanent')
+  @Auth(UserRole.ADMIN)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Bulk permanently delete bank reconciliations' })
+  @ApiResponse({ status: 200, description: 'Bulk permanent delete result' })
+  async bulkPermanentDelete(
+    @Body() body: { ids: string[] },
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<{ deletedCount: number; failedIds: string[] }> {
+    return this.reconciliationService.bulkPermanentDelete(body.ids, currentUserId, currentUsername);
+  }
+
   @Get(':id')
   @ApiOperation({ summary: 'Get bank reconciliation by ID with transactions' })
   @ApiParam({ name: 'id', description: 'Bank reconciliation ID' })
@@ -111,6 +143,40 @@ export class ReconciliationController {
     @CurrentUser('username') currentUsername: string,
   ): Promise<void> {
     await this.reconciliationService.remove(id, currentUserId, currentUsername);
+  }
+
+  @Post(':id/restore')
+  @Auth(UserRole.ADMIN, UserRole.MANAGER)
+  @ApiOperation({ summary: 'Restore a soft-deleted bank reconciliation' })
+  @ApiParam({ name: 'id', description: 'Bank reconciliation ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Bank reconciliation restored',
+    type: BankReconciliationResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Not deleted, or duplicate IN_PROGRESS exists' })
+  @ApiResponse({ status: 404, description: 'Bank reconciliation not found' })
+  async restore(
+    @Param('id') id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<BankReconciliationResponseDto> {
+    return this.reconciliationService.restore(id, currentUserId, currentUsername);
+  }
+
+  @Delete(':id/permanent')
+  @Auth(UserRole.ADMIN)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Permanently delete a bank reconciliation' })
+  @ApiParam({ name: 'id', description: 'Bank reconciliation ID' })
+  @ApiResponse({ status: 204, description: 'Bank reconciliation permanently deleted' })
+  @ApiResponse({ status: 404, description: 'Bank reconciliation not found' })
+  async permanentDelete(
+    @Param('id') id: string,
+    @CurrentUser('userId') currentUserId: string,
+    @CurrentUser('username') currentUsername: string,
+  ): Promise<void> {
+    await this.reconciliationService.permanentDelete(id, currentUserId, currentUsername);
   }
 
   @Post(':id/mark-cleared')

--- a/backend/src/modules/accounting/services/reconciliation.service.spec.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.spec.ts
@@ -324,6 +324,71 @@ describe('ReconciliationService', () => {
 
       await expect(service.permanentDelete('bad-id')).rejects.toThrow(NotFoundException);
     });
+
+    it('throws BadRequestException when reconciliation is not soft-deleted', async () => {
+      reconciliationRepo.findOne.mockResolvedValue(mockReconciliation as any);
+
+      await expect(service.permanentDelete('recon-001')).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('bulkRestore', () => {
+    it('returns zero counts for empty input', async () => {
+      const result = await service.bulkRestore([]);
+      expect(result).toEqual({ restoredCount: 0, failedIds: [] });
+    });
+
+    it('restores all ids and returns restoredCount', async () => {
+      const deletedRecon = { ...mockReconciliation, deletedAt: new Date('2026-02-01'), isActive: false };
+      const restoredRecon = { ...deletedRecon, deletedAt: null, isActive: true, reconciledTransactions: [] };
+      reconciliationRepo.findOne
+        .mockResolvedValueOnce(deletedRecon as any)  // restore: withDeleted lookup
+        .mockResolvedValueOnce(null as any)           // restore: duplicate check
+        .mockResolvedValueOnce(restoredRecon as any); // findOne for response
+      reconciliationRepo.restore.mockResolvedValue(undefined as any);
+      reconciliationRepo.save.mockResolvedValue(restoredRecon as any);
+
+      const result = await service.bulkRestore(['recon-001'], 'user-1', 'admin');
+
+      expect(result.restoredCount).toBe(1);
+      expect(result.failedIds).toEqual([]);
+    });
+
+    it('collects failedIds when restore throws', async () => {
+      reconciliationRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.bulkRestore(['bad-id'], 'user-1', 'admin');
+
+      expect(result.restoredCount).toBe(0);
+      expect(result.failedIds).toEqual(['bad-id']);
+    });
+  });
+
+  describe('bulkPermanentDelete', () => {
+    it('returns zero counts for empty input', async () => {
+      const result = await service.bulkPermanentDelete([]);
+      expect(result).toEqual({ deletedCount: 0, failedIds: [] });
+    });
+
+    it('permanently deletes all ids and returns deletedCount', async () => {
+      const deletedRecon = { ...mockReconciliation, deletedAt: new Date('2026-02-01') };
+      reconciliationRepo.findOne.mockResolvedValue(deletedRecon as any);
+      reconciliationRepo.delete.mockResolvedValue({ affected: 1 } as any);
+
+      const result = await service.bulkPermanentDelete(['recon-001'], 'user-1', 'admin');
+
+      expect(result.deletedCount).toBe(1);
+      expect(result.failedIds).toEqual([]);
+    });
+
+    it('collects failedIds when permanentDelete throws', async () => {
+      reconciliationRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.bulkPermanentDelete(['bad-id'], 'user-1', 'admin');
+
+      expect(result.deletedCount).toBe(0);
+      expect(result.failedIds).toEqual(['bad-id']);
+    });
   });
 
   describe('findAll', () => {

--- a/backend/src/modules/accounting/services/reconciliation.service.spec.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.spec.ts
@@ -94,6 +94,7 @@ describe('ReconciliationService', () => {
             save: jest.fn(),
             softDelete: jest.fn(),
             restore: jest.fn(),
+            delete: jest.fn(),
             createQueryBuilder: jest.fn(),
           },
         },
@@ -305,6 +306,23 @@ describe('ReconciliationService', () => {
         .mockResolvedValueOnce(mockReconciliation as any);
 
       await expect(service.restore('recon-001')).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('permanentDelete', () => {
+    it('permanently deletes a reconciliation', async () => {
+      const deletedRecon = { ...mockReconciliation, deletedAt: new Date('2026-02-01') };
+      reconciliationRepo.findOne.mockResolvedValue(deletedRecon as any);
+      reconciliationRepo.delete.mockResolvedValue({ affected: 1 } as any);
+
+      await expect(service.permanentDelete('recon-001', 'user-1', 'admin')).resolves.toBeUndefined();
+      expect(reconciliationRepo.delete).toHaveBeenCalledWith('recon-001');
+    });
+
+    it('throws NotFoundException when id does not exist', async () => {
+      reconciliationRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.permanentDelete('bad-id')).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/backend/src/modules/accounting/services/reconciliation.service.spec.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.spec.ts
@@ -93,6 +93,7 @@ describe('ReconciliationService', () => {
             create: jest.fn(),
             save: jest.fn(),
             softDelete: jest.fn(),
+            restore: jest.fn(),
             createQueryBuilder: jest.fn(),
           },
         },
@@ -249,6 +250,61 @@ describe('ReconciliationService', () => {
       const result = await service.getDeleted();
 
       expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('restore', () => {
+    it('restores a soft-deleted reconciliation', async () => {
+      const deletedRecon = {
+        ...mockReconciliation,
+        deletedAt: new Date('2026-02-01'),
+        isActive: false,
+      };
+      reconciliationRepo.findOne
+        .mockResolvedValueOnce(deletedRecon as any)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          ...deletedRecon,
+          deletedAt: null,
+          isActive: true,
+          reconciledTransactions: [],
+        } as any);
+      reconciliationRepo.restore.mockResolvedValue(undefined as any);
+      reconciliationRepo.save.mockResolvedValue({
+        ...deletedRecon,
+        deletedAt: null,
+        isActive: true,
+      } as any);
+
+      const result = await service.restore('recon-001', 'user-1', 'admin');
+
+      expect(reconciliationRepo.restore).toHaveBeenCalledWith('recon-001');
+      expect(result.id).toBe('recon-001');
+    });
+
+    it('throws NotFoundException when id does not exist', async () => {
+      reconciliationRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.restore('bad-id')).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequestException when reconciliation is not deleted', async () => {
+      reconciliationRepo.findOne.mockResolvedValue(mockReconciliation as any);
+
+      await expect(service.restore('recon-001')).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when an IN_PROGRESS reconciliation already exists for same account+period', async () => {
+      const deletedRecon = {
+        ...mockReconciliation,
+        deletedAt: new Date('2026-02-01'),
+        isActive: false,
+      };
+      reconciliationRepo.findOne
+        .mockResolvedValueOnce(deletedRecon as any)
+        .mockResolvedValueOnce(mockReconciliation as any);
+
+      await expect(service.restore('recon-001')).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/backend/src/modules/accounting/services/reconciliation.service.spec.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.spec.ts
@@ -224,6 +224,34 @@ describe('ReconciliationService', () => {
     });
   });
 
+  describe('getDeleted', () => {
+    it('returns all soft-deleted reconciliations', async () => {
+      const deletedRecon = {
+        ...mockReconciliation,
+        id: 'recon-deleted-1',
+        deletedAt: new Date('2026-02-01'),
+        isActive: false,
+      };
+      reconciliationRepo.find.mockResolvedValue([deletedRecon] as any);
+
+      const result = await service.getDeleted();
+
+      expect(reconciliationRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({ withDeleted: true }),
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('recon-deleted-1');
+    });
+
+    it('returns empty array when no deleted reconciliations', async () => {
+      reconciliationRepo.find.mockResolvedValue([]);
+
+      const result = await service.getDeleted();
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
   describe('findAll', () => {
     it('should return paginated reconciliations', async () => {
       reconciliationRepo.createQueryBuilder.mockReturnValue(

--- a/backend/src/modules/accounting/services/reconciliation.service.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.ts
@@ -5,7 +5,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, Not, IsNull } from 'typeorm';
 import {
   BankReconciliation,
   BankReconciliationStatus,
@@ -221,12 +221,11 @@ export class ReconciliationService {
   async getDeleted(): Promise<BankReconciliationResponseDto[]> {
     const records = await this.reconciliationRepository.find({
       withDeleted: true,
-      where: {},
+      where: { deletedAt: Not(IsNull()) },
       relations: ['account', 'fiscalPeriod'],
       order: { deletedAt: 'DESC' },
     });
-    const deleted = records.filter((r) => r.deletedAt !== null && r.deletedAt !== undefined);
-    return deleted.map((r) => this.toResponseDto(r));
+    return records.map((r) => this.toResponseDto(r));
   }
 
   async restore(
@@ -269,7 +268,7 @@ export class ReconciliationService {
     } as any);
 
     await this.auditLogService.log(
-      'UPDATE',
+      'RESTORE',
       'BankReconciliation',
       'Restored bank reconciliation',
       { entityId: id, userId: userId ?? 'system', username },
@@ -287,6 +286,10 @@ export class ReconciliationService {
 
     if (!reconciliation) {
       throw new NotFoundException(`Bank reconciliation with ID '${id}' not found`);
+    }
+
+    if (!reconciliation.deletedAt) {
+      throw new BadRequestException('Bank reconciliation must be soft-deleted before permanent deletion');
     }
 
     await this.reconciliationRepository.delete(id);

--- a/backend/src/modules/accounting/services/reconciliation.service.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.ts
@@ -218,6 +218,17 @@ export class ReconciliationService {
     return this.toResponseDto(reconciliation);
   }
 
+  async getDeleted(): Promise<BankReconciliationResponseDto[]> {
+    const records = await this.reconciliationRepository.find({
+      withDeleted: true,
+      where: {},
+      relations: ['account', 'fiscalPeriod'],
+      order: { deletedAt: 'DESC' },
+    });
+    const deleted = records.filter((r) => r.deletedAt !== null && r.deletedAt !== undefined);
+    return deleted.map((r) => this.toResponseDto(r));
+  }
+
   /**
    * Update reconciliation (statement balance, date)
    */

--- a/backend/src/modules/accounting/services/reconciliation.service.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.ts
@@ -229,6 +229,56 @@ export class ReconciliationService {
     return deleted.map((r) => this.toResponseDto(r));
   }
 
+  async restore(
+    id: string,
+    userId?: string,
+    username?: string,
+  ): Promise<BankReconciliationResponseDto> {
+    const reconciliation = await this.reconciliationRepository.findOne({
+      where: { id } as any,
+      withDeleted: true,
+    });
+
+    if (!reconciliation) {
+      throw new NotFoundException(`Bank reconciliation with ID '${id}' not found`);
+    }
+
+    if (!reconciliation.deletedAt) {
+      throw new BadRequestException('Bank reconciliation is not deleted');
+    }
+
+    const duplicate = await this.reconciliationRepository.findOne({
+      where: {
+        accountId: reconciliation.accountId,
+        fiscalPeriodId: reconciliation.fiscalPeriodId,
+        status: BankReconciliationStatus.IN_PROGRESS,
+      },
+    });
+    if (duplicate) {
+      throw new BadRequestException(
+        'Cannot restore: an in-progress reconciliation already exists for this account and period.',
+      );
+    }
+
+    await this.reconciliationRepository.restore(id);
+
+    await this.reconciliationRepository.save({
+      ...reconciliation,
+      isActive: true,
+      deletedAt: null,
+    } as any);
+
+    await this.auditLogService.log(
+      'UPDATE',
+      'BankReconciliation',
+      'Restored bank reconciliation',
+      { entityId: id, userId: userId ?? 'system', username },
+    );
+
+    this.logger.log(`Bank reconciliation restored: ${id}`);
+    return this.findOne(id);
+  }
+
   /**
    * Update reconciliation (statement balance, date)
    */

--- a/backend/src/modules/accounting/services/reconciliation.service.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.ts
@@ -279,6 +279,74 @@ export class ReconciliationService {
     return this.findOne(id);
   }
 
+  async permanentDelete(id: string, userId?: string, username?: string): Promise<void> {
+    const reconciliation = await this.reconciliationRepository.findOne({
+      where: { id } as any,
+      withDeleted: true,
+    });
+
+    if (!reconciliation) {
+      throw new NotFoundException(`Bank reconciliation with ID '${id}' not found`);
+    }
+
+    await this.reconciliationRepository.delete(id);
+
+    await this.auditLogService.log(
+      'DELETE',
+      'BankReconciliation',
+      'Permanently deleted bank reconciliation',
+      { entityId: id, userId: userId ?? 'system', username },
+    );
+
+    this.logger.log(`Bank reconciliation permanently deleted: ${id}`);
+  }
+
+  async bulkRestore(
+    ids: string[],
+    userId?: string,
+    username?: string,
+  ): Promise<{ restoredCount: number; failedIds: string[] }> {
+    if (ids.length === 0) return { restoredCount: 0, failedIds: [] };
+
+    let restoredCount = 0;
+    const failedIds: string[] = [];
+
+    for (const id of ids) {
+      try {
+        await this.restore(id, userId, username);
+        restoredCount += 1;
+      } catch (error: any) {
+        this.logger.warn(`Failed to restore bank reconciliation '${id}': ${error.message}`);
+        failedIds.push(id);
+      }
+    }
+
+    return { restoredCount, failedIds };
+  }
+
+  async bulkPermanentDelete(
+    ids: string[],
+    userId?: string,
+    username?: string,
+  ): Promise<{ deletedCount: number; failedIds: string[] }> {
+    if (ids.length === 0) return { deletedCount: 0, failedIds: [] };
+
+    let deletedCount = 0;
+    const failedIds: string[] = [];
+
+    for (const id of ids) {
+      try {
+        await this.permanentDelete(id, userId, username);
+        deletedCount += 1;
+      } catch (error: any) {
+        this.logger.warn(`Failed to permanently delete bank reconciliation '${id}': ${error.message}`);
+        failedIds.push(id);
+      }
+    }
+
+    return { deletedCount, failedIds };
+  }
+
   /**
    * Update reconciliation (statement balance, date)
    */

--- a/frontend/src/components/accounting/DeletedBankReconciliationsDialog.tsx
+++ b/frontend/src/components/accounting/DeletedBankReconciliationsDialog.tsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import { Typography } from '@mui/material'
+import { default as AccountBalanceIcon } from '@mui/icons-material/AccountBalance'
+import GenericDeletedDialog, { type ColumnDef } from '@/components/common/GenericDeletedDialog'
+import {
+  useBulkPermanentDeleteBankReconciliationsMutation,
+  useBulkRestoreBankReconciliationsMutation,
+  useGetDeletedBankReconciliationsQuery,
+  usePermanentDeleteBankReconciliationMutation,
+  useRestoreBankReconciliationMutation,
+} from '@/store/api/accountingApi'
+import type { BankReconciliation } from '@/types'
+import { formatDate } from '@/utils/formatters'
+
+type DeletedBankReconciliation = BankReconciliation & { deletedAt?: string | Date }
+
+interface DeletedBankReconciliationsDialogProps {
+  open: boolean
+  onClose: () => void
+  onChanged?: () => void
+}
+
+const columns: ColumnDef<DeletedBankReconciliation>[] = [
+  {
+    label: 'Account',
+    width: '30%',
+    render: (item) => (
+      <Typography variant="body2" sx={{ fontWeight: 600 }}>
+        {item.account ? `${item.account.code} - ${item.account.name}` : '-'}
+      </Typography>
+    ),
+  },
+  {
+    label: 'Fiscal Period',
+    width: '25%',
+    render: (item) => <Typography variant="body2">{item.fiscalPeriod?.name ?? '-'}</Typography>,
+  },
+  {
+    label: 'Statement Date',
+    width: '20%',
+    render: (item) => (
+      <Typography variant="body2">{item.reconciliationDate ? formatDate(item.reconciliationDate) : '-'}</Typography>
+    ),
+  },
+  {
+    label: 'Deleted Date',
+    width: '15%',
+    hideOnMobile: true,
+    render: (item) => (
+      <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+        {item.deletedAt ? formatDate(item.deletedAt) : 'Unknown'}
+      </Typography>
+    ),
+  },
+]
+
+const DeletedBankReconciliationsDialog: React.FC<DeletedBankReconciliationsDialogProps> = ({
+  open,
+  onClose,
+  onChanged,
+}) => (
+  <GenericDeletedDialog<DeletedBankReconciliation>
+    open={open}
+    onClose={onClose}
+    title="Deleted Reconciliations"
+    entityLabel="reconciliation"
+    entityLabelPlural="reconciliations"
+    icon={<AccountBalanceIcon sx={{ color: 'error.main' }} />}
+    columns={columns}
+    getItemLabel={(item) => (item.account ? `${item.account.code} - ${item.account.name}` : item.id)}
+    searchPlaceholder="Search deleted reconciliations..."
+    filterItem={(item, term) =>
+      (item.account?.name?.toLowerCase().includes(term) ?? false) ||
+      (item.account?.code?.toLowerCase().includes(term) ?? false) ||
+      (item.fiscalPeriod?.name?.toLowerCase().includes(term) ?? false)
+    }
+    useGetDeletedQuery={useGetDeletedBankReconciliationsQuery as any}
+    getItems={(data) => (Array.isArray(data) ? (data as DeletedBankReconciliation[]) : [])}
+    useRestoreMutation={useRestoreBankReconciliationMutation}
+    usePermanentDeleteMutation={usePermanentDeleteBankReconciliationMutation}
+    useBulkRestoreMutation={useBulkRestoreBankReconciliationsMutation}
+    useBulkPermanentDeleteMutation={useBulkPermanentDeleteBankReconciliationsMutation}
+    onChanged={onChanged}
+  />
+)
+
+export default DeletedBankReconciliationsDialog

--- a/frontend/src/components/accounting/DeletedBankReconciliationsDialog.tsx
+++ b/frontend/src/components/accounting/DeletedBankReconciliationsDialog.tsx
@@ -26,7 +26,7 @@ const columns: ColumnDef<DeletedBankReconciliation>[] = [
     width: '30%',
     render: (item) => (
       <Typography variant="body2" sx={{ fontWeight: 600 }}>
-        {item.account ? `${item.account.code} - ${item.account.name}` : '-'}
+        {item.account ? `${item.account.code} — ${item.account.name}` : '—'}
       </Typography>
     ),
   },
@@ -67,7 +67,7 @@ const DeletedBankReconciliationsDialog: React.FC<DeletedBankReconciliationsDialo
     entityLabelPlural="reconciliations"
     icon={<AccountBalanceIcon sx={{ color: 'error.main' }} />}
     columns={columns}
-    getItemLabel={(item) => (item.account ? `${item.account.code} - ${item.account.name}` : item.id)}
+    getItemLabel={(item) => (item.account ? `${item.account.code} — ${item.account.name}` : item.id)}
     searchPlaceholder="Search deleted reconciliations..."
     filterItem={(item, term) =>
       (item.account?.name?.toLowerCase().includes(term) ?? false) ||

--- a/frontend/src/pages/accounting/BankReconciliationsPage.tsx
+++ b/frontend/src/pages/accounting/BankReconciliationsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
 import BankReconciliationFormDialog from '@/components/accounting/BankReconciliationFormDialog'
+import DeletedBankReconciliationsDialog from '@/components/accounting/DeletedBankReconciliationsDialog'
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
 import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
@@ -42,6 +43,8 @@ const filterConfig: FilterBarConfig<BRFilters> = {
 
 const BankReconciliationsPage: React.FC = () => {
   const [createOpen, setCreateOpen] = useState(false)
+  const [editOpen, setEditOpen] = useState(false)
+  const [deletedOpen, setDeletedOpen] = useState(false)
   const [sortBy, setSortBy] = useState('reconciliationDate')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
 
@@ -101,6 +104,7 @@ const BankReconciliationsPage: React.FC = () => {
       title="Bank Reconciliations"
       subtitle="Reconcile bank accounts with your ledger"
       primaryAction={{ label: 'New Reconciliation', onClick: () => setCreateOpen(true) }}
+      secondaryAction={{ label: 'View Deleted', onClick: () => setDeletedOpen(true) }}
       filterConfig={filterConfig}
       draftFilters={draftFilters}
       handlers={filterHandlers}
@@ -121,6 +125,7 @@ const BankReconciliationsPage: React.FC = () => {
       headerSlot={(
         <BankReconciliationContextHeader
           selected={selected}
+          onEdit={() => setEditOpen(true)}
           onComplete={() => selected && workspace.setCompleteTarget(selected)}
           onReopen={() => selected && workspace.setReopenTarget(selected)}
           onDelete={() => selected && workspace.setDeleteTarget(selected)}
@@ -157,6 +162,22 @@ const BankReconciliationsPage: React.FC = () => {
               }}
             />
           )}
+          {editOpen && selected && (
+            <BankReconciliationFormDialog
+              open={editOpen}
+              reconciliation={selected}
+              onClose={() => setEditOpen(false)}
+              onSuccess={() => {
+                setEditOpen(false)
+                void refetch()
+              }}
+            />
+          )}
+          <DeletedBankReconciliationsDialog
+            open={deletedOpen}
+            onClose={() => setDeletedOpen(false)}
+            onChanged={() => { void refetch() }}
+          />
         </>
       )}
     />

--- a/frontend/src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
@@ -73,6 +73,11 @@ const mockedApi = vi.hoisted(() => ({
   useMarkBankReconciliationClearedMutation: vi.fn(),
   useUnmarkBankReconciliationClearedMutation: vi.fn(),
   useGetChartOfAccountsQuery: vi.fn(),
+  useGetDeletedBankReconciliationsQuery: vi.fn(),
+  useRestoreBankReconciliationMutation: vi.fn(),
+  usePermanentDeleteBankReconciliationMutation: vi.fn(),
+  useBulkRestoreBankReconciliationsMutation: vi.fn(),
+  useBulkPermanentDeleteBankReconciliationsMutation: vi.fn(),
 }))
 
 vi.mock('@/store/api/accountingApi', () => mockedApi)
@@ -105,6 +110,11 @@ describe('BankReconciliationsPage', () => {
     mockedApi.useMarkBankReconciliationClearedMutation.mockReturnValue([vi.fn()])
     mockedApi.useUnmarkBankReconciliationClearedMutation.mockReturnValue([vi.fn()])
     mockedApi.useGetChartOfAccountsQuery.mockReturnValue({ data: { data: [] } })
+    mockedApi.useGetDeletedBankReconciliationsQuery.mockReturnValue({ data: [], isFetching: false, isLoading: false, refetch: vi.fn() })
+    mockedApi.useRestoreBankReconciliationMutation.mockReturnValue([vi.fn()])
+    mockedApi.usePermanentDeleteBankReconciliationMutation.mockReturnValue([vi.fn()])
+    mockedApi.useBulkRestoreBankReconciliationsMutation.mockReturnValue([vi.fn()])
+    mockedApi.useBulkPermanentDeleteBankReconciliationsMutation.mockReturnValue([vi.fn()])
   })
 
   it('renders the page title', () => {
@@ -173,6 +183,48 @@ describe('BankReconciliationsPage', () => {
 
     expect(await screen.findByText('This reconciliation is completed. Reopen it to make changes.')).toBeInTheDocument()
     expect(screen.getByRole('checkbox')).toBeDisabled()
+  })
+
+  it('shows Edit button for IN_PROGRESS reconciliation', async () => {
+    mockedApi.useGetBankReconciliationsQuery.mockReturnValue({
+      data: { data: [MOCK_RECONCILIATION_IN_PROGRESS], meta: { total: 1 } },
+      isLoading: false,
+      refetch: vi.fn(),
+    })
+    mockedApi.useLazyGetBankReconciliationQuery.mockReturnValue([
+      vi.fn(() => ({ unwrap: vi.fn().mockResolvedValue(MOCK_RECONCILIATION_IN_PROGRESS) })),
+    ])
+
+    renderPage()
+    fireEvent.click(screen.getAllByText('Main Checking')[0])
+
+    expect(await screen.findByRole('button', { name: /edit/i })).toBeInTheDocument()
+  })
+
+  it('does not show Edit button for COMPLETED reconciliation', async () => {
+    mockedApi.useGetBankReconciliationsQuery.mockReturnValue({
+      data: { data: [MOCK_RECONCILIATION_COMPLETED], meta: { total: 1 } },
+      isLoading: false,
+      refetch: vi.fn(),
+    })
+    mockedApi.useLazyGetBankReconciliationQuery.mockReturnValue([
+      vi.fn(() => ({ unwrap: vi.fn().mockResolvedValue(MOCK_RECONCILIATION_COMPLETED) })),
+    ])
+
+    renderPage()
+    fireEvent.click(screen.getAllByText('Main Checking')[0])
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument()
+    })
+  })
+
+  it('opens deleted reconciliations dialog when View Deleted is clicked', async () => {
+    renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: /view deleted/i }))
+
+    expect(await screen.findByText('Deleted Reconciliations')).toBeInTheDocument()
   })
 
   it('shows empty context header state when nothing is selected', () => {

--- a/frontend/src/pages/accounting/components/BankReconciliationContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/BankReconciliationContextHeader.tsx
@@ -2,6 +2,7 @@ import { Paper, Stack, Table, TableBody, TableCell, TableContainer, TableRow, Ty
 import Grid from '@mui/material/Grid'
 import { default as CheckCircleIcon } from '@mui/icons-material/CheckCircle'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
+import { default as EditIcon } from '@mui/icons-material/Edit'
 import { default as ReopenIcon } from '@mui/icons-material/LockOpen'
 import { format } from 'date-fns'
 
@@ -14,6 +15,7 @@ import { formatCurrency } from '@/utils/formatters'
 
 interface Props {
   selected: BankReconciliation | null
+  onEdit: () => void
   onComplete: () => void
   onReopen: () => void
   onDelete: () => void
@@ -46,7 +48,7 @@ const sectionHeaderCellSx = {
   borderTop: TABLE_STYLES.cell.border,
 }
 
-export function BankReconciliationContextHeader({ selected, onComplete, onReopen, onDelete }: Props) {
+export function BankReconciliationContextHeader({ selected, onEdit, onComplete, onReopen, onDelete }: Props) {
   if (!selected) {
     return (
       <Paper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 4 }}>
@@ -67,6 +69,11 @@ export function BankReconciliationContextHeader({ selected, onComplete, onReopen
         statusChip={<EntityStatusChip status={selected.status} />}
         actions={(
           <Stack direction="row" spacing={0.5}>
+            {isInProgress && (
+              <AppButton size="small" variant="outlined" startIcon={<EditIcon />} onClick={onEdit}>
+                Edit
+              </AppButton>
+            )}
             {isInProgress && (
               <AppButton size="small" variant="success" startIcon={<CheckCircleIcon />} onClick={onComplete}>
                 Complete

--- a/frontend/src/store/api/accountingApi.ts
+++ b/frontend/src/store/api/accountingApi.ts
@@ -246,6 +246,7 @@ export const accountingApiSlice = createApi({
     'FiscalPeriod',
     'AccountMapping',
     'BankReconciliation',
+    'DeletedBankReconciliation',
     'PaymentMethod',
     'Settlement',
     'OwnerEquity',
@@ -316,6 +317,11 @@ export const accountingApiSlice = createApi({
       query: (id) => ({ url: `/accounting/bank-reconciliations/${id}` }),
       transformResponse: normalizeSingle<BankReconciliation>,
       providesTags: (_result, _error, id) => [{ type: 'BankReconciliation', id }],
+    }),
+    getDeletedBankReconciliations: builder.query<BankReconciliation[], void>({
+      query: () => ({ url: '/accounting/bank-reconciliations/deleted' }),
+      transformResponse: (response: any) => (Array.isArray(response) ? response : response?.data ?? []),
+      providesTags: ['DeletedBankReconciliation'],
     }),
     getPaymentMethods: builder.query<PaginatedResponse<PaymentMethodConfig>, Record<string, unknown> | undefined>({
       query: (params) => ({ url: '/settings/payment-methods', params: params ?? {} }),
@@ -597,6 +603,38 @@ export const accountingApiSlice = createApi({
       transformResponse: normalizeSingle<BankReconciliation>,
       invalidatesTags: (_result, _error, id) => [{ type: 'BankReconciliation', id }, 'BankReconciliation', 'AccountingReport'],
     }),
+    restoreBankReconciliation: builder.mutation<BankReconciliation, string>({
+      query: (id) => ({ url: `/accounting/bank-reconciliations/${id}/restore`, method: 'POST' }),
+      transformResponse: normalizeSingle<BankReconciliation>,
+      invalidatesTags: (_result, _error, id) => [
+        { type: 'BankReconciliation', id },
+        'BankReconciliation',
+        'DeletedBankReconciliation',
+      ],
+    }),
+    permanentDeleteBankReconciliation: builder.mutation<void, string>({
+      query: (id) => ({ url: `/accounting/bank-reconciliations/${id}/permanent`, method: 'DELETE' }),
+      invalidatesTags: (_result, _error, id) => [
+        { type: 'BankReconciliation', id },
+        'DeletedBankReconciliation',
+      ],
+    }),
+    bulkRestoreBankReconciliations: builder.mutation<{ restoredCount: number; failedIds: string[] }, string[]>({
+      query: (ids) => ({
+        url: '/accounting/bank-reconciliations/bulk-restore',
+        method: 'POST',
+        data: { ids },
+      }),
+      invalidatesTags: ['BankReconciliation', 'DeletedBankReconciliation'],
+    }),
+    bulkPermanentDeleteBankReconciliations: builder.mutation<{ deletedCount: number; failedIds: string[] }, string[]>({
+      query: (ids) => ({
+        url: '/accounting/bank-reconciliations/bulk-permanent',
+        method: 'DELETE',
+        data: { ids },
+      }),
+      invalidatesTags: ['DeletedBankReconciliation'],
+    }),
     createPaymentMethod: builder.mutation<PaymentMethodConfig, Partial<PaymentMethodConfig>>({
       query: (body) => ({ url: '/settings/payment-methods', method: 'POST', data: body }),
       transformResponse: normalizeSingle<PaymentMethodConfig>,
@@ -757,6 +795,7 @@ export const {
   useGetBankReconciliationsQuery,
   useGetBankReconciliationQuery,
   useLazyGetBankReconciliationQuery,
+  useGetDeletedBankReconciliationsQuery,
   useGetPaymentMethodsQuery,
   useGetDeletedPaymentMethodsQuery,
   useGetSettlementsQuery,
@@ -804,6 +843,10 @@ export const {
   useUnmarkBankReconciliationClearedMutation,
   useCompleteBankReconciliationMutation,
   useReopenBankReconciliationMutation,
+  useRestoreBankReconciliationMutation,
+  usePermanentDeleteBankReconciliationMutation,
+  useBulkRestoreBankReconciliationsMutation,
+  useBulkPermanentDeleteBankReconciliationsMutation,
   useCreatePaymentMethodMutation,
   useUpdatePaymentMethodMutation,
   useDeletePaymentMethodMutation,


### PR DESCRIPTION
## Summary
- Adds Edit button to context header for IN_PROGRESS reconciliations
- Adds View Deleted secondary action opening a deleted-records dialog with restore, permanent delete, and bulk variants
- Backend: getDeleted, restore, permanentDelete service methods plus five new controller endpoints
- No migration required; deletedAt already exists on the base entity

## Test plan
- [x] cd backend && npx jest src/modules/accounting/services/reconciliation.service.spec.ts --no-coverage
- [x] cd frontend && npx vitest run src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
- [x] cd frontend && npm run type-check
- [x] cd backend && npx tsc --noEmit -p tsconfig.build.json

Closes #591