### PR TITLE
fix(inventory): restore Import button on Products page

### DIFF
--- a/frontend/src/pages/inventory/ProductsPage.tsx
+++ b/frontend/src/pages/inventory/ProductsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react'
+import { default as CloudUploadIcon } from '@mui/icons-material/CloudUpload'
 import { default as TableChartIcon } from '@mui/icons-material/TableChart'
 
 import GenericListPage from '@/components/common/GenericListPage'
@@ -111,15 +112,25 @@ const ProductsPage: React.FC = () => {
       searchInputRef={workspace.searchInputRef}
       sort={{ field: 'name', sortBy, sortOrder, onSort: handleSort }}
       filterExtra={(
-        <AppButton
-          size="filter"
-          variant="outlined"
-          startIcon={<TableChartIcon />}
-          loading={workspace.isExporting}
-          onClick={workspace.handleExportClick}
-        >
-          Export
-        </AppButton>
+        <>
+          <AppButton
+            size="filter"
+            variant="outlined"
+            startIcon={<CloudUploadIcon />}
+            onClick={() => workspace.setImportDialogOpen(true)}
+          >
+            Import
+          </AppButton>
+          <AppButton
+            size="filter"
+            variant="outlined"
+            startIcon={<TableChartIcon />}
+            loading={workspace.isExporting}
+            onClick={workspace.handleExportClick}
+          >
+            Export
+          </AppButton>
+        </>
       )}
       listSlot={(
         <ProductList


### PR DESCRIPTION
## Summary

- Restores the missing Import button in the `filterExtra` slot of `ProductsPage`
- Uses `CloudUploadIcon` consistent with the `ProductImportDialog` styling
- Button placed before Export, wired to `workspace.setImportDialogOpen(true)`
- No logic changes needed — the dialog, state, and handlers were already fully wired

## Test plan

- [x] Navigate to Inventory → Products
- [x] Confirm the Import button appears in the filter bar alongside Export
- [x] Click Import and verify the import dialog opens
- [x] Confirm Export button still works as before

Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)