### PR TITLE
ci: skip semantic-release on redundant merge commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,18 @@ jobs:
       new_release_version: ${{ steps.semantic_release.outputs.new_release_version }}
 
     steps:
+      - name: Check for redundant trigger
+        id: guard
+        env:
+          MSG: ${{ github.event.head_commit.message }}
+        run: |
+          if echo "$MSG" | grep -qE "^Merge branch"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Detected merge commit — skipping semantic-release."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v5
         with:
@@ -48,6 +60,7 @@ jobs:
             conventional-changelog-angular@8.1.0
 
       - name: Run semantic-release
+        if: steps.guard.outputs.skip != 'true'
         id: semantic_release
         run: |
           npx semantic-release | tee /tmp/sr-output.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
         env:
           MSG: ${{ github.event.head_commit.message }}
         run: |
+          # Matches local "git pull" merge commits (merge.ff=false) that re-push the semantic-release auto-commit
           if echo "$MSG" | grep -qE "^Merge branch"; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Detected merge commit — skipping semantic-release."


### PR DESCRIPTION
## Summary

- Adds a `Check for redundant trigger` guard step as the first step in the `release` job
- Detects local `git pull` merge commits (message starts with `Merge branch`) and sets `skip=true`
- `Run semantic-release` is skipped when `skip=true`; all other steps are unaffected
- `build-and-push` remains naturally gated by `new_release_published == 'true'`

Closes #604

## Test plan

- [ ] Merge this PR — the Release workflow should run normally (guard outputs `skip=false`)
- [ ] After the release commit lands, do a local `git pull` that creates a merge commit, then push — the Release workflow should log "Detected merge commit — skipping semantic-release." and exit without running semantic-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)