### PR TITLE
feat: block soft delete for completed bank reconciliations with reopen prompt (#606)

### DIFF
--- a/backend/src/modules/accounting/services/reconciliation.service.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.ts
@@ -472,7 +472,9 @@ export class ReconciliationService {
     }
 
     if (reconciliation.status === BankReconciliationStatus.COMPLETED) {
-      throw new BadRequestException('Cannot delete a completed reconciliation');
+      throw new BadRequestException(
+        'Cannot delete a completed reconciliation. Please reopen it first.',
+      );
     }
 
     await this.reconciliationRepository.softDelete(id);

--- a/frontend/src/components/accounting/BlockedBankReconciliationDialog.tsx
+++ b/frontend/src/components/accounting/BlockedBankReconciliationDialog.tsx
@@ -1,0 +1,104 @@
+import React from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  Typography,
+} from '@mui/material'
+import WarningIcon from '@mui/icons-material/Warning'
+import LockOpenIcon from '@mui/icons-material/LockOpen'
+
+interface BlockedBankReconciliationDialogProps {
+  open: boolean
+  onClose: () => void
+  onReopenOnly: () => void
+  onReopenAndDelete: () => void
+  loading?: boolean
+}
+
+const BlockedBankReconciliationDialog: React.FC<BlockedBankReconciliationDialogProps> = ({
+  open,
+  onClose,
+  onReopenOnly,
+  onReopenAndDelete,
+  loading = false,
+}) => {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      slotProps={{ paper: { sx: { borderRadius: 2 } } }}
+    >
+      <DialogTitle>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+          <WarningIcon color="warning" sx={{ fontSize: 28 }} />
+          <Typography variant="h6" component="div">
+            Reconciliation Already Completed
+          </Typography>
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <Stack spacing={3}>
+          <Alert severity="warning" sx={{ borderRadius: 1.5 }}>
+            <Typography variant="body2">
+              This reconciliation is completed and must be reopened before it can be deleted.
+            </Typography>
+          </Alert>
+          <Box
+            sx={{
+              p: 2.5,
+              bgcolor: 'grey.50',
+              borderRadius: 1.5,
+              border: '1px solid',
+              borderColor: 'grey.200',
+            }}
+          >
+            <Typography variant="body2" gutterBottom sx={{ color: 'text.secondary' }}>
+              What happens when you reopen:
+            </Typography>
+            <Stack spacing={0.5} sx={{ mt: 1.5 }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <LockOpenIcon sx={{ fontSize: 16, color: 'primary.main' }} />
+                <Typography variant="body2">
+                  Reconciliation returns to In Progress status
+                </Typography>
+              </Box>
+            </Stack>
+          </Box>
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2.5, gap: 1 }}>
+        <Button onClick={onClose} disabled={loading} sx={{ minWidth: 80 }}>
+          Cancel
+        </Button>
+        <Button
+          onClick={onReopenOnly}
+          variant="outlined"
+          color="warning"
+          disabled={loading}
+          sx={{ minWidth: 130 }}
+        >
+          Reopen Only
+        </Button>
+        <Button
+          onClick={onReopenAndDelete}
+          variant="contained"
+          color="error"
+          disabled={loading}
+          sx={{ minWidth: 160 }}
+        >
+          Reopen &amp; Delete
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default BlockedBankReconciliationDialog

--- a/frontend/src/components/accounting/__tests__/BlockedBankReconciliationDialog.test.tsx
+++ b/frontend/src/components/accounting/__tests__/BlockedBankReconciliationDialog.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import BlockedBankReconciliationDialog from '../BlockedBankReconciliationDialog'
+
+function renderDialog(overrides: Partial<Parameters<typeof BlockedBankReconciliationDialog>[0]> = {}) {
+  const props = {
+    open: true,
+    onClose: vi.fn(),
+    onReopenOnly: vi.fn(),
+    onReopenAndDelete: vi.fn(),
+    loading: false,
+    ...overrides,
+  }
+  render(<BlockedBankReconciliationDialog {...props} />)
+  return props
+}
+
+describe('BlockedBankReconciliationDialog', () => {
+  it('renders the dialog title when open', () => {
+    renderDialog()
+    expect(screen.getByText('Reconciliation Already Completed')).toBeInTheDocument()
+  })
+
+  it('renders warning alert text', () => {
+    renderDialog()
+    expect(screen.getByText(/must be reopened before it can be deleted/i)).toBeInTheDocument()
+  })
+
+  it('renders Reopen Only and Reopen & Delete buttons', () => {
+    renderDialog()
+    expect(screen.getByRole('button', { name: /reopen only/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reopen & delete/i })).toBeInTheDocument()
+  })
+
+  it('calls onReopenOnly when Reopen Only is clicked', () => {
+    const props = renderDialog()
+    fireEvent.click(screen.getByRole('button', { name: /reopen only/i }))
+    expect(props.onReopenOnly).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onReopenAndDelete when Reopen & Delete is clicked', () => {
+    const props = renderDialog()
+    fireEvent.click(screen.getByRole('button', { name: /reopen & delete/i }))
+    expect(props.onReopenAndDelete).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when Cancel is clicked', () => {
+    const props = renderDialog()
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(props.onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables buttons when loading', () => {
+    renderDialog({ loading: true })
+    expect(screen.getByRole('button', { name: /reopen only/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /reopen & delete/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled()
+  })
+
+  it('does not render when closed', () => {
+    renderDialog({ open: false })
+    expect(screen.queryByText('Reconciliation Already Completed')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/accounting/BankReconciliationsPage.tsx
+++ b/frontend/src/pages/accounting/BankReconciliationsPage.tsx
@@ -143,6 +143,7 @@ const BankReconciliationsPage: React.FC = () => {
             completeTarget={workspace.completeTarget}
             reopenTarget={workspace.reopenTarget}
             deleteTarget={workspace.deleteTarget}
+            blockedDeleteTarget={workspace.blockedDeleteTarget}
             actionLoading={workspace.actionLoading}
             onConfirmComplete={workspace.handleConfirmComplete}
             onConfirmReopen={workspace.handleConfirmReopen}
@@ -150,6 +151,9 @@ const BankReconciliationsPage: React.FC = () => {
             onCancelComplete={() => workspace.setCompleteTarget(null)}
             onCancelReopen={() => workspace.setReopenTarget(null)}
             onCancelDelete={() => workspace.setDeleteTarget(null)}
+            onCancelBlockedDelete={() => workspace.setBlockedDeleteTarget(null)}
+            onReopenOnly={workspace.handleReopenOnly}
+            onReopenAndDelete={workspace.handleReopenAndDelete}
           />
           {createOpen && (
             <BankReconciliationFormDialog

--- a/frontend/src/pages/accounting/BankReconciliationsPage.tsx
+++ b/frontend/src/pages/accounting/BankReconciliationsPage.tsx
@@ -7,6 +7,7 @@ import { useFilterBar } from '@/hooks/useFilterBar'
 import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
 import { useGetBankReconciliationsQuery } from '@/store/api/accountingApi'
 import { selectSelectedBankReconciliation } from '@/store/slices/accountingSlice'
+import { BankReconciliationStatus } from '@/types'
 import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
 import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
 
@@ -128,7 +129,14 @@ const BankReconciliationsPage: React.FC = () => {
           onEdit={() => setEditOpen(true)}
           onComplete={() => selected && workspace.setCompleteTarget(selected)}
           onReopen={() => selected && workspace.setReopenTarget(selected)}
-          onDelete={() => selected && workspace.setDeleteTarget(selected)}
+          onDelete={() => {
+            if (!selected) return
+            if (selected.status === BankReconciliationStatus.COMPLETED) {
+              workspace.setBlockedDeleteTarget(selected)
+            } else {
+              workspace.setDeleteTarget(selected)
+            }
+          }}
         />
       )}
       workspaceSlot={(

--- a/frontend/src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
@@ -300,4 +300,73 @@ describe('BankReconciliationsPage', () => {
       expect(periodSelect).toHaveAttribute('aria-disabled', 'true')
     })
   })
+
+  it('shows BlockedBankReconciliationDialog when deleting a completed reconciliation', async () => {
+    const deleteMock = vi.fn(() => ({
+      unwrap: vi.fn().mockRejectedValue({
+        data: { message: 'Cannot delete a completed reconciliation. Please reopen it first.' },
+      }),
+    }))
+    mockedApi.useDeleteBankReconciliationMutation.mockReturnValue([deleteMock])
+    mockedApi.useGetBankReconciliationsQuery.mockReturnValue({
+      data: { data: [MOCK_RECONCILIATION_COMPLETED], meta: { total: 1 } },
+      isLoading: false,
+      refetch: vi.fn(),
+    })
+    mockedApi.useLazyGetBankReconciliationQuery.mockReturnValue([
+      vi.fn(() => ({ unwrap: vi.fn().mockResolvedValue(MOCK_RECONCILIATION_COMPLETED) })),
+    ])
+
+    renderPage()
+
+    // Select the completed reconciliation
+    fireEvent.click(screen.getByText('Main Checking'))
+    await waitFor(() => expect(screen.getByText('Delete')).toBeInTheDocument())
+
+    // Click Delete in the context header
+    fireEvent.click(screen.getByText('Delete'))
+    await waitFor(() => expect(screen.getByText('Delete Reconciliation')).toBeInTheDocument())
+
+    // Confirm deletion in the confirmation dialog
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+
+    // Blocked dialog should appear
+    await waitFor(() =>
+      expect(screen.getByText('Reconciliation Already Completed')).toBeInTheDocument()
+    )
+  })
+
+  it('calls reopen then delete when Reopen & Delete is clicked in blocked dialog', async () => {
+    const reopenMock = vi.fn(() => ({
+      unwrap: vi.fn().mockResolvedValue({ ...MOCK_RECONCILIATION_COMPLETED, status: 'IN_PROGRESS', isCompleted: false, isInProgress: true }),
+    }))
+    const deleteMock = vi.fn()
+      .mockReturnValueOnce({ unwrap: vi.fn().mockRejectedValue({ data: { message: 'Cannot delete a completed reconciliation. Please reopen it first.' } }) })
+      .mockReturnValueOnce({ unwrap: vi.fn().mockResolvedValue(undefined) })
+
+    mockedApi.useReopenBankReconciliationMutation.mockReturnValue([reopenMock])
+    mockedApi.useDeleteBankReconciliationMutation.mockReturnValue([deleteMock])
+    mockedApi.useGetBankReconciliationsQuery.mockReturnValue({
+      data: { data: [MOCK_RECONCILIATION_COMPLETED], meta: { total: 1 } },
+      isLoading: false,
+      refetch: vi.fn(),
+    })
+    mockedApi.useLazyGetBankReconciliationQuery.mockReturnValue([
+      vi.fn(() => ({ unwrap: vi.fn().mockResolvedValue(MOCK_RECONCILIATION_COMPLETED) })),
+    ])
+
+    renderPage()
+
+    fireEvent.click(screen.getByText('Main Checking'))
+    await waitFor(() => expect(screen.getByText('Delete')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Delete'))
+    await waitFor(() => expect(screen.getByText('Delete Reconciliation')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    await waitFor(() => expect(screen.getByText('Reconciliation Already Completed')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /reopen & delete/i }))
+
+    await waitFor(() => expect(reopenMock).toHaveBeenCalledWith('rec-2'))
+    await waitFor(() => expect(deleteMock).toHaveBeenCalledTimes(2))
+  })
 })

--- a/frontend/src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
@@ -301,14 +301,7 @@ describe('BankReconciliationsPage', () => {
     })
   })
 
-  it('shows BlockedBankReconciliationDialog when deleting a completed reconciliation', async () => {
-    const deleteMock = vi.fn(() => ({
-      unwrap: vi.fn().mockRejectedValue({
-        status: 400,
-        data: 'Cannot delete a completed reconciliation. Please reopen it first.',
-      }),
-    }))
-    mockedApi.useDeleteBankReconciliationMutation.mockReturnValue([deleteMock])
+  it('shows BlockedBankReconciliationDialog immediately when deleting a completed reconciliation', async () => {
     mockedApi.useGetBankReconciliationsQuery.mockReturnValue({
       data: { data: [MOCK_RECONCILIATION_COMPLETED], meta: { total: 1 } },
       isLoading: false,
@@ -324,26 +317,19 @@ describe('BankReconciliationsPage', () => {
     fireEvent.click(screen.getAllByText('Main Checking')[0])
     await waitFor(() => expect(screen.getByText('Delete')).toBeInTheDocument())
 
-    // Click Delete in the context header
+    // Click Delete — blocked dialog should appear immediately, no confirmation dialog
     fireEvent.click(screen.getByText('Delete'))
-    await waitFor(() => expect(screen.getByText('Delete Reconciliation')).toBeInTheDocument())
-
-    // Confirm deletion in the confirmation dialog
-    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
-
-    // Blocked dialog should appear
     await waitFor(() =>
       expect(screen.getByText('Reconciliation Already Completed')).toBeInTheDocument()
     )
+    expect(screen.queryByText('Delete Reconciliation')).not.toBeInTheDocument()
   })
 
   it('calls reopen then delete when Reopen & Delete is clicked in blocked dialog', async () => {
     const reopenMock = vi.fn(() => ({
       unwrap: vi.fn().mockResolvedValue({ ...MOCK_RECONCILIATION_COMPLETED, status: 'IN_PROGRESS', isCompleted: false, isInProgress: true }),
     }))
-    const deleteMock = vi.fn()
-      .mockReturnValueOnce({ unwrap: vi.fn().mockRejectedValue({ status: 400, data: 'Cannot delete a completed reconciliation. Please reopen it first.' }) })
-      .mockReturnValueOnce({ unwrap: vi.fn().mockResolvedValue(undefined) })
+    const deleteMock = vi.fn(() => ({ unwrap: vi.fn().mockResolvedValue(undefined) }))
 
     mockedApi.useReopenBankReconciliationMutation.mockReturnValue([reopenMock])
     mockedApi.useDeleteBankReconciliationMutation.mockReturnValue([deleteMock])
@@ -361,13 +347,11 @@ describe('BankReconciliationsPage', () => {
     fireEvent.click(screen.getAllByText('Main Checking')[0])
     await waitFor(() => expect(screen.getByText('Delete')).toBeInTheDocument())
     fireEvent.click(screen.getByText('Delete'))
-    await waitFor(() => expect(screen.getByText('Delete Reconciliation')).toBeInTheDocument())
-    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
     await waitFor(() => expect(screen.getByText('Reconciliation Already Completed')).toBeInTheDocument())
 
     fireEvent.click(screen.getByRole('button', { name: /reopen & delete/i }))
 
     await waitFor(() => expect(reopenMock).toHaveBeenCalledWith('rec-2'))
-    await waitFor(() => expect(deleteMock).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(deleteMock).toHaveBeenCalledWith('rec-2'))
   })
 })

--- a/frontend/src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
@@ -304,7 +304,8 @@ describe('BankReconciliationsPage', () => {
   it('shows BlockedBankReconciliationDialog when deleting a completed reconciliation', async () => {
     const deleteMock = vi.fn(() => ({
       unwrap: vi.fn().mockRejectedValue({
-        data: { message: 'Cannot delete a completed reconciliation. Please reopen it first.' },
+        status: 400,
+        data: 'Cannot delete a completed reconciliation. Please reopen it first.',
       }),
     }))
     mockedApi.useDeleteBankReconciliationMutation.mockReturnValue([deleteMock])
@@ -320,7 +321,7 @@ describe('BankReconciliationsPage', () => {
     renderPage()
 
     // Select the completed reconciliation
-    fireEvent.click(screen.getByText('Main Checking'))
+    fireEvent.click(screen.getAllByText('Main Checking')[0])
     await waitFor(() => expect(screen.getByText('Delete')).toBeInTheDocument())
 
     // Click Delete in the context header
@@ -341,7 +342,7 @@ describe('BankReconciliationsPage', () => {
       unwrap: vi.fn().mockResolvedValue({ ...MOCK_RECONCILIATION_COMPLETED, status: 'IN_PROGRESS', isCompleted: false, isInProgress: true }),
     }))
     const deleteMock = vi.fn()
-      .mockReturnValueOnce({ unwrap: vi.fn().mockRejectedValue({ data: { message: 'Cannot delete a completed reconciliation. Please reopen it first.' } }) })
+      .mockReturnValueOnce({ unwrap: vi.fn().mockRejectedValue({ status: 400, data: 'Cannot delete a completed reconciliation. Please reopen it first.' }) })
       .mockReturnValueOnce({ unwrap: vi.fn().mockResolvedValue(undefined) })
 
     mockedApi.useReopenBankReconciliationMutation.mockReturnValue([reopenMock])
@@ -357,7 +358,7 @@ describe('BankReconciliationsPage', () => {
 
     renderPage()
 
-    fireEvent.click(screen.getByText('Main Checking'))
+    fireEvent.click(screen.getAllByText('Main Checking')[0])
     await waitFor(() => expect(screen.getByText('Delete')).toBeInTheDocument())
     fireEvent.click(screen.getByText('Delete'))
     await waitFor(() => expect(screen.getByText('Delete Reconciliation')).toBeInTheDocument())

--- a/frontend/src/pages/accounting/components/BankReconciliationsDialogs.tsx
+++ b/frontend/src/pages/accounting/components/BankReconciliationsDialogs.tsx
@@ -1,3 +1,4 @@
+import BlockedBankReconciliationDialog from '@/components/accounting/BlockedBankReconciliationDialog'
 import ConfirmationDialog from '@/components/common/ConfirmationDialog'
 import { BankReconciliation } from '@/types'
 
@@ -5,6 +6,7 @@ interface Props {
   completeTarget: BankReconciliation | null
   reopenTarget: BankReconciliation | null
   deleteTarget: BankReconciliation | null
+  blockedDeleteTarget: BankReconciliation | null
   actionLoading: boolean
   onConfirmComplete: () => void
   onConfirmReopen: () => void
@@ -12,12 +14,16 @@ interface Props {
   onCancelComplete: () => void
   onCancelReopen: () => void
   onCancelDelete: () => void
+  onCancelBlockedDelete: () => void
+  onReopenOnly: () => void
+  onReopenAndDelete: () => void
 }
 
 export function BankReconciliationsDialogs({
   completeTarget,
   reopenTarget,
   deleteTarget,
+  blockedDeleteTarget,
   actionLoading,
   onConfirmComplete,
   onConfirmReopen,
@@ -25,12 +31,22 @@ export function BankReconciliationsDialogs({
   onCancelComplete,
   onCancelReopen,
   onCancelDelete,
+  onCancelBlockedDelete,
+  onReopenOnly,
+  onReopenAndDelete,
 }: Props) {
   return (
     <>
       <ConfirmationDialog open={!!completeTarget} title="Complete Reconciliation" message="Mark this reconciliation as complete?" confirmText="Complete" cancelText="Cancel" onConfirm={onConfirmComplete} onCancel={onCancelComplete} loading={actionLoading} />
       <ConfirmationDialog open={!!reopenTarget} title="Reopen Reconciliation" message="Reopen this reconciliation for editing?" confirmText="Reopen" cancelText="Cancel" onConfirm={onConfirmReopen} onCancel={onCancelReopen} loading={actionLoading} />
       <ConfirmationDialog open={!!deleteTarget} title="Delete Reconciliation" message="Delete this reconciliation? This cannot be undone." confirmText="Delete" cancelText="Cancel" onConfirm={onConfirmDelete} onCancel={onCancelDelete} loading={actionLoading} />
+      <BlockedBankReconciliationDialog
+        open={!!blockedDeleteTarget}
+        onClose={onCancelBlockedDelete}
+        onReopenOnly={onReopenOnly}
+        onReopenAndDelete={onReopenAndDelete}
+        loading={actionLoading}
+      />
     </>
   )
 }

--- a/frontend/src/pages/accounting/hooks/useBankReconciliationsWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useBankReconciliationsWorkspace.ts
@@ -34,6 +34,7 @@ export function useBankReconciliationsWorkspace({
   const [completeTarget, setCompleteTarget] = useState<BankReconciliation | null>(null)
   const [reopenTarget, setReopenTarget] = useState<BankReconciliation | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<BankReconciliation | null>(null)
+  const [blockedDeleteTarget, setBlockedDeleteTarget] = useState<BankReconciliation | null>(null)
   const [actionLoading, setActionLoading] = useState(false)
 
   const [fetchItem] = useLazyGetBankReconciliationQuery()
@@ -61,6 +62,7 @@ export function useBankReconciliationsWorkspace({
       setCompleteTarget(null)
       setReopenTarget(null)
       setDeleteTarget(null)
+      setBlockedDeleteTarget(null)
     },
   })
 
@@ -136,12 +138,55 @@ export function useBankReconciliationsWorkspace({
       refetch()
     }
     catch (error: unknown) {
-      showError(getErrorMessage(error, 'Failed to delete reconciliation'))
+      const message = getErrorMessage(error, '')
+      if (message.includes('completed reconciliation')) {
+        setDeleteTarget(null)
+        setBlockedDeleteTarget(deleteTarget)
+      } else {
+        showError(getErrorMessage(error, 'Failed to delete reconciliation'))
+      }
     }
     finally {
       setActionLoading(false)
     }
   }, [deleteTarget, deleteReconciliation, showSuccess, showError, refetch, dispatch])
+
+  const handleReopenOnly = useCallback(async () => {
+    if (!blockedDeleteTarget) return
+    setActionLoading(true)
+    try {
+      const fresh = await reopenReconciliation(blockedDeleteTarget.id).unwrap()
+      showSuccess('Reconciliation reopened')
+      setBlockedDeleteTarget(null)
+      dispatch(setSelectedBankReconciliation(fresh))
+      refetch()
+    }
+    catch (error: unknown) {
+      showError(getErrorMessage(error, 'Failed to reopen reconciliation'))
+    }
+    finally {
+      setActionLoading(false)
+    }
+  }, [blockedDeleteTarget, reopenReconciliation, showSuccess, showError, refetch, dispatch])
+
+  const handleReopenAndDelete = useCallback(async () => {
+    if (!blockedDeleteTarget) return
+    setActionLoading(true)
+    try {
+      await reopenReconciliation(blockedDeleteTarget.id).unwrap()
+      await deleteReconciliation(blockedDeleteTarget.id).unwrap()
+      showSuccess('Reconciliation reopened and deleted')
+      setBlockedDeleteTarget(null)
+      dispatch(setSelectedBankReconciliation(null))
+      refetch()
+    }
+    catch (error: unknown) {
+      showError(getErrorMessage(error, 'Failed to reopen and delete reconciliation'))
+    }
+    finally {
+      setActionLoading(false)
+    }
+  }, [blockedDeleteTarget, reopenReconciliation, deleteReconciliation, showSuccess, showError, refetch, dispatch])
 
   return {
     completeTarget,
@@ -150,6 +195,8 @@ export function useBankReconciliationsWorkspace({
     setReopenTarget,
     deleteTarget,
     setDeleteTarget,
+    blockedDeleteTarget,
+    setBlockedDeleteTarget,
     actionLoading,
     focusedIndex: workspace.focusedIndex,
     searchInputRef: workspace.searchInputRef,
@@ -159,5 +206,7 @@ export function useBankReconciliationsWorkspace({
     handleConfirmComplete,
     handleConfirmReopen,
     handleConfirmDelete,
+    handleReopenOnly,
+    handleReopenAndDelete,
   }
 }

--- a/frontend/src/pages/accounting/hooks/useBankReconciliationsWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useBankReconciliationsWorkspace.ts
@@ -138,14 +138,7 @@ export function useBankReconciliationsWorkspace({
       refetch()
     }
     catch (error: unknown) {
-      const rtkMessage = (error as any)?.data
-      const isCompleted = typeof rtkMessage === 'string' && rtkMessage.includes('completed reconciliation')
-      if (isCompleted) {
-        setDeleteTarget(null)
-        setBlockedDeleteTarget(deleteTarget)
-      } else {
-        showError(getErrorMessage(error, 'Failed to delete reconciliation'))
-      }
+      showError(getErrorMessage(error, 'Failed to delete reconciliation'))
     }
     finally {
       setActionLoading(false)

--- a/frontend/src/pages/accounting/hooks/useBankReconciliationsWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useBankReconciliationsWorkspace.ts
@@ -138,8 +138,9 @@ export function useBankReconciliationsWorkspace({
       refetch()
     }
     catch (error: unknown) {
-      const message = getErrorMessage(error, '')
-      if (message.includes('completed reconciliation')) {
+      const rtkMessage = (error as any)?.data
+      const isCompleted = typeof rtkMessage === 'string' && rtkMessage.includes('completed reconciliation')
+      if (isCompleted) {
         setDeleteTarget(null)
         setBlockedDeleteTarget(deleteTarget)
       } else {
@@ -173,15 +174,21 @@ export function useBankReconciliationsWorkspace({
     if (!blockedDeleteTarget) return
     setActionLoading(true)
     try {
-      await reopenReconciliation(blockedDeleteTarget.id).unwrap()
-      await deleteReconciliation(blockedDeleteTarget.id).unwrap()
-      showSuccess('Reconciliation reopened and deleted')
-      setBlockedDeleteTarget(null)
-      dispatch(setSelectedBankReconciliation(null))
+      const fresh = await reopenReconciliation(blockedDeleteTarget.id).unwrap()
+      try {
+        await deleteReconciliation(blockedDeleteTarget.id).unwrap()
+        showSuccess('Reconciliation reopened and deleted')
+        setBlockedDeleteTarget(null)
+        dispatch(setSelectedBankReconciliation(null))
+      } catch (deleteError: unknown) {
+        showError('Reconciliation was reopened but could not be deleted. Please delete it manually.')
+        setBlockedDeleteTarget(null)
+        dispatch(setSelectedBankReconciliation(fresh))
+      }
       refetch()
     }
     catch (error: unknown) {
-      showError(getErrorMessage(error, 'Failed to reopen and delete reconciliation'))
+      showError(getErrorMessage(error, 'Failed to reopen reconciliation'))
     }
     finally {
       setActionLoading(false)


### PR DESCRIPTION
## Summary
- Backend: improved error message in `ReconciliationService.remove` for completed reconciliations to hint "Please reopen it first"
- Added `BlockedBankReconciliationDialog` component mirroring the Sales Order blocked dialog pattern
- Workspace hook catches the RTK error for a completed-reconciliation delete and shows the blocked dialog instead of a raw error toast
- Dialog offers **Reopen Only** (returns to In Progress, stays selected) or **Reopen & Delete** (atomic: reopens then deletes; handles partial failure gracefully)

Closes #606