### PR TITLE
feat: fund transfers full lifecycle (DRAFT → POSTED → REVERSED) (#608)

### DIFF
--- a/backend/src/database/entities/fund-transfer.entity.ts
+++ b/backend/src/database/entities/fund-transfer.entity.ts
@@ -21,8 +21,9 @@ import { JournalEntry } from './journal-entry.entity';
 import { FiscalPeriod } from './fiscal-period.entity';
 
 export enum FundTransferStatus {
-  ACTIVE = 'ACTIVE',
-  CANCELLED = 'CANCELLED',
+  DRAFT = 'draft',
+  POSTED = 'posted',
+  REVERSED = 'reversed',
 }
 
 @Entity('fund_transfers')
@@ -86,7 +87,7 @@ export class FundTransfer extends BaseEntity {
   @Column({
     type: 'enum',
     enum: FundTransferStatus,
-    default: FundTransferStatus.ACTIVE,
+    default: FundTransferStatus.DRAFT,
     comment: 'Transfer status',
   })
   @IsEnum(FundTransferStatus)

--- a/backend/src/database/migrations/1779034397938-FundTransferLifecycle.ts
+++ b/backend/src/database/migrations/1779034397938-FundTransferLifecycle.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class FundTransferLifecycle1779034397938 implements MigrationInterface {
+    name = 'FundTransferLifecycle1779034397938'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "fund_transfers" ALTER COLUMN "status" TYPE varchar USING "status"::text`);
+        await queryRunner.query(`UPDATE fund_transfers SET status = 'posted' WHERE status = 'ACTIVE'`);
+        await queryRunner.query(`UPDATE fund_transfers SET status = 'reversed' WHERE status = 'CANCELLED'`);
+        await queryRunner.query(`ALTER TYPE "public"."fund_transfers_status_enum" RENAME TO "fund_transfers_status_enum_old"`);
+        await queryRunner.query(`CREATE TYPE "public"."fund_transfers_status_enum" AS ENUM('draft', 'posted', 'reversed')`);
+        await queryRunner.query(`ALTER TABLE "fund_transfers" ALTER COLUMN "status" DROP DEFAULT`);
+        await queryRunner.query(`ALTER TABLE "fund_transfers" ALTER COLUMN "status" TYPE "public"."fund_transfers_status_enum" USING "status"::"text"::"public"."fund_transfers_status_enum"`);
+        await queryRunner.query(`ALTER TABLE "fund_transfers" ALTER COLUMN "status" SET DEFAULT 'draft'`);
+        await queryRunner.query(`DROP TYPE "public"."fund_transfers_status_enum_old"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "fund_transfers" ALTER COLUMN "status" TYPE varchar USING "status"::text`);
+        await queryRunner.query(`UPDATE fund_transfers SET status = 'ACTIVE' WHERE status = 'posted'`);
+        await queryRunner.query(`UPDATE fund_transfers SET status = 'CANCELLED' WHERE status = 'reversed'`);
+        await queryRunner.query(`CREATE TYPE "public"."fund_transfers_status_enum_old" AS ENUM('ACTIVE', 'CANCELLED')`);
+        await queryRunner.query(`ALTER TABLE "fund_transfers" ALTER COLUMN "status" DROP DEFAULT`);
+        await queryRunner.query(`ALTER TABLE "fund_transfers" ALTER COLUMN "status" TYPE "public"."fund_transfers_status_enum_old" USING "status"::"text"::"public"."fund_transfers_status_enum_old"`);
+        await queryRunner.query(`ALTER TABLE "fund_transfers" ALTER COLUMN "status" SET DEFAULT 'ACTIVE'`);
+        await queryRunner.query(`DROP TYPE "public"."fund_transfers_status_enum"`);
+        await queryRunner.query(`ALTER TYPE "public"."fund_transfers_status_enum_old" RENAME TO "fund_transfers_status_enum"`);
+    }
+
+}

--- a/backend/src/modules/accounting/controllers/fund-transfer.controller.ts
+++ b/backend/src/modules/accounting/controllers/fund-transfer.controller.ts
@@ -1,9 +1,11 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   ParseUUIDPipe,
+  Patch,
   Post,
   Query,
 } from '@nestjs/common';
@@ -13,24 +15,24 @@ import { UserRole } from '../../../database/entities/user.entity';
 import { FundTransferService } from '../services/fund-transfer.service';
 import {
   CreateFundTransferDto,
+  UpdateFundTransferDto,
   QueryFundTransfersDto,
 } from '../dto/fund-transfer.dto';
 
 @Controller('accounting/fund-transfers')
 @Auth()
 export class FundTransferController {
-  constructor(
-    private readonly fundTransferService: FundTransferService,
-  ) {}
+  constructor(private readonly fundTransferService: FundTransferService) {}
 
   @Get()
   findAll(@Query() query: QueryFundTransfersDto) {
     return this.fundTransferService.findAll(query);
   }
 
-  @Get(':id')
-  findOne(@Param('id', ParseUUIDPipe) id: string) {
-    return this.fundTransferService.findOne(id);
+  // NOTE: 'deleted' must be before ':id' — NestJS matches routes in declaration order
+  @Get('deleted')
+  getDeleted() {
+    return this.fundTransferService.getDeleted();
   }
 
   @Post()
@@ -43,13 +45,69 @@ export class FundTransferController {
     return this.fundTransferService.create(dto, userId, username);
   }
 
-  @Post(':id/cancel')
+  @Get(':id')
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.fundTransferService.findOne(id);
+  }
+
+  @Patch(':id')
   @Auth(UserRole.ADMIN, UserRole.MANAGER)
-  cancel(
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateFundTransferDto,
+    @CurrentUser('userId') userId: string,
+    @CurrentUser('username') username: string,
+  ) {
+    return this.fundTransferService.update(id, dto, userId, username);
+  }
+
+  @Delete(':id')
+  @Auth(UserRole.ADMIN)
+  remove(
     @Param('id', ParseUUIDPipe) id: string,
     @CurrentUser('userId') userId: string,
     @CurrentUser('username') username: string,
   ) {
-    return this.fundTransferService.cancel(id, userId, username);
+    return this.fundTransferService.remove(id, userId, username);
+  }
+
+  @Post(':id/post')
+  @Auth(UserRole.ADMIN, UserRole.MANAGER)
+  post(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') userId: string,
+    @CurrentUser('username') username: string,
+  ) {
+    return this.fundTransferService.post(id, userId, username);
+  }
+
+  @Post(':id/unpost')
+  @Auth(UserRole.ADMIN)
+  unpost(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') userId: string,
+    @CurrentUser('username') username: string,
+  ) {
+    return this.fundTransferService.unpost(id, userId, username);
+  }
+
+  @Post(':id/restore')
+  @Auth(UserRole.ADMIN)
+  restore(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') userId: string,
+    @CurrentUser('username') username: string,
+  ) {
+    return this.fundTransferService.restore(id, userId, username);
+  }
+
+  @Delete(':id/permanent')
+  @Auth(UserRole.ADMIN)
+  permanentDelete(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') userId: string,
+    @CurrentUser('username') username: string,
+  ) {
+    return this.fundTransferService.permanentDelete(id, userId, username);
   }
 }

--- a/backend/src/modules/accounting/dto/fund-transfer.dto.ts
+++ b/backend/src/modules/accounting/dto/fund-transfer.dto.ts
@@ -132,6 +132,7 @@ export class FundTransferResponseDto {
   journalEntry?: JournalEntrySummary;
   createdAt: Date;
   updatedAt: Date;
+  deletedAt?: Date | null;
 }
 
 export class FundTransferListResponseDto {

--- a/backend/src/modules/accounting/dto/fund-transfer.dto.ts
+++ b/backend/src/modules/accounting/dto/fund-transfer.dto.ts
@@ -29,6 +29,29 @@ export class CreateFundTransferDto {
   description?: string;
 }
 
+export class UpdateFundTransferDto {
+  @IsOptional()
+  @IsUUID()
+  sourceAccountId?: string;
+
+  @IsOptional()
+  @IsUUID()
+  destinationAccountId?: string;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0.01)
+  amount?: number;
+
+  @IsOptional()
+  @IsDateString()
+  transferDate?: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+}
+
 export class QueryFundTransfersDto {
   @IsOptional()
   @Type(() => Number)

--- a/backend/src/modules/accounting/services/expense.service.ts
+++ b/backend/src/modules/accounting/services/expense.service.ts
@@ -246,10 +246,6 @@ export class ExpenseService {
       throw new BadRequestException('Cannot delete a posted expense');
     }
 
-    if (expense.status === ExpenseStatus.REVERSED) {
-      throw new BadRequestException('Cannot delete a reversed expense');
-    }
-
     await this.expenseRepository.softDelete(id);
     await this.auditLogService.log(
       'DELETE',

--- a/backend/src/modules/accounting/services/fund-transfer.service.spec.ts
+++ b/backend/src/modules/accounting/services/fund-transfer.service.spec.ts
@@ -236,13 +236,29 @@ describe('FundTransferService', () => {
       expect(result.status).toBe(FundTransferStatus.POSTED);
     });
 
-    it('throws BadRequestException when transfer is not DRAFT', async () => {
+    it('throws BadRequestException when transfer is POSTED', async () => {
       transferRepository.findOne.mockResolvedValue({
         ...mockDraftTransfer,
         status: FundTransferStatus.POSTED,
       } as any);
 
       await expect(service.post('trf-1', 'user-1')).rejects.toThrow(BadRequestException);
+    });
+
+    it('posts a REVERSED transfer back to POSTED', async () => {
+      const reversedTransfer = { ...mockDraftTransfer, status: FundTransferStatus.REVERSED };
+      transferRepository.findOne.mockResolvedValueOnce(reversedTransfer as any);
+      accountingService.postFundTransferEntry.mockResolvedValue({ id: 'je-2' } as any);
+      transferRepository.save.mockResolvedValue({} as any);
+      transferRepository.findOne.mockResolvedValueOnce({
+        ...reversedTransfer,
+        status: FundTransferStatus.POSTED,
+        journalEntryId: 'je-2',
+      } as any);
+
+      const result = await service.post('trf-1', 'user-1');
+
+      expect(result.status).toBe(FundTransferStatus.POSTED);
     });
 
     it('throws NotFoundException when transfer does not exist', async () => {

--- a/backend/src/modules/accounting/services/fund-transfer.service.spec.ts
+++ b/backend/src/modules/accounting/services/fund-transfer.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { DataSource, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { FundTransferService } from './fund-transfer.service';
 import {
   FundTransfer,
@@ -21,7 +21,6 @@ describe('FundTransferService', () => {
   let settingsService: jest.Mocked<SettingsService>;
   let fiscalPeriodService: jest.Mocked<FiscalPeriodService>;
   let auditLogService: jest.Mocked<AuditLogService>;
-  let dataSource: jest.Mocked<DataSource>;
 
   const mockCashAccount = (id: string) =>
     ({
@@ -54,8 +53,12 @@ describe('FundTransferService', () => {
           useValue: {
             createQueryBuilder: jest.fn(() => mockQueryBuilder),
             findOne: jest.fn(),
+            find: jest.fn(),
             create: jest.fn(),
             save: jest.fn(),
+            softDelete: jest.fn(),
+            restore: jest.fn(),
+            delete: jest.fn(),
           },
         },
         {
@@ -89,19 +92,6 @@ describe('FundTransferService', () => {
             log: jest.fn(),
           },
         },
-        {
-          provide: DataSource,
-          useValue: {
-            transaction: jest.fn((cb) =>
-              cb({
-                create: jest.fn().mockReturnValue({}),
-                save: jest
-                  .fn()
-                  .mockResolvedValue({ id: 'trf-1', referenceNumber: 'TRF-26-001' }),
-              }),
-            ),
-          },
-        },
       ],
     }).compile();
 
@@ -112,7 +102,6 @@ describe('FundTransferService', () => {
     settingsService = module.get(SettingsService);
     fiscalPeriodService = module.get(FiscalPeriodService);
     auditLogService = module.get(AuditLogService);
-    dataSource = module.get(DataSource);
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -181,7 +170,7 @@ describe('FundTransferService', () => {
       await expect(service.create(dto, 'user-1')).rejects.toThrow(BadRequestException);
     });
 
-    it('creates transfer and posts journal entry on success', async () => {
+    it('creates a draft transfer without posting a journal entry', async () => {
       coaRepository.findOne
         .mockResolvedValueOnce(mockCashAccount('acc-1'))
         .mockResolvedValueOnce(mockCashAccount('acc-2'));
@@ -189,108 +178,148 @@ describe('FundTransferService', () => {
         isValid: true,
         period: { id: 'period-1' },
       } as any);
-
       const savedTransfer = {
         id: 'trf-1',
         referenceNumber: 'TRF-26-001',
-        status: FundTransferStatus.ACTIVE,
-        journalEntryId: 'je-1',
+        status: FundTransferStatus.DRAFT,
+        sourceAccountId: 'acc-1',
+        destinationAccountId: 'acc-2',
+        deletedAt: null,
+      };
+      transferRepository.create.mockReturnValue(savedTransfer as any);
+      transferRepository.save.mockResolvedValue(savedTransfer as any);
+      transferRepository.findOne.mockResolvedValue({
+        ...savedTransfer,
         sourceAccount: mockCashAccount('acc-1'),
         destinationAccount: mockCashAccount('acc-2'),
-        journalEntry: {
-          id: 'je-1',
-          referenceNumber: 'JE-26-001',
-          status: 'POSTED',
-        },
-      } as any;
-
-      dataSource.transaction.mockImplementation(async (cb: any) =>
-        cb({
-          create: jest.fn().mockReturnValue(savedTransfer),
-          save: jest.fn().mockResolvedValue(savedTransfer),
-        }),
-      );
-
-      transferRepository.findOne.mockResolvedValue(savedTransfer);
-      (accountingService as any).postFundTransferEntry.mockResolvedValue({ id: 'je-1' } as any);
+      } as any);
 
       const result = await service.create(dto, 'user-1');
 
-      expect((accountingService as any).postFundTransferEntry).toHaveBeenCalled();
-      expect(auditLogService.log).toHaveBeenCalledWith(
-        'CREATE',
-        'FundTransfer',
-        expect.any(String),
-        expect.any(Object),
-      );
-      expect(result).toBeDefined();
+      expect(accountingService.postFundTransferEntry).not.toHaveBeenCalled();
+      expect(result.status).toBe(FundTransferStatus.DRAFT);
     });
   });
 
-  describe('cancel', () => {
-    it('throws NotFoundException when transfer not found', async () => {
-      transferRepository.findOne.mockResolvedValue(null);
-      await expect(service.cancel('trf-1', 'user-1')).rejects.toThrow(NotFoundException);
-    });
+  describe('post', () => {
+    const mockDraftTransfer = {
+      id: 'trf-1',
+      referenceNumber: 'TRF-26-001',
+      status: FundTransferStatus.DRAFT,
+      deletedAt: null,
+      transferDate: new Date('2026-03-12'),
+      sourceAccount: mockCashAccount('acc-1'),
+      destinationAccount: mockCashAccount('acc-2'),
+    };
 
-    it('throws BadRequestException when already cancelled', async () => {
-      transferRepository.findOne.mockResolvedValue({
-        id: 'trf-1',
-        status: FundTransferStatus.CANCELLED,
-      } as any);
-      await expect(service.cancel('trf-1', 'user-1')).rejects.toThrow(BadRequestException);
-    });
-
-    it('throws BadRequestException when journalEntryId is null', async () => {
-      transferRepository.findOne.mockResolvedValue({
-        id: 'trf-1',
-        status: FundTransferStatus.ACTIVE,
-        journalEntryId: null,
-      } as any);
-      await expect(service.cancel('trf-1', 'user-1')).rejects.toThrow(BadRequestException);
-    });
-
-    it('cancels transfer and reverses journal entry on success', async () => {
-      const transfer = {
-        id: 'trf-1',
-        referenceNumber: 'TRF-26-001',
-        status: FundTransferStatus.ACTIVE,
-        journalEntryId: 'je-1',
-      } as any;
-
-      transferRepository.findOne
-        .mockResolvedValueOnce(transfer)
-        .mockResolvedValueOnce({
-          ...transfer,
-          status: FundTransferStatus.CANCELLED,
-          journalEntry: {
-            id: 'je-1',
-            referenceNumber: 'JE-26-001',
-            status: 'REVERSED',
-          },
-        } as any);
-
+    it('posts a draft transfer and links journal entry', async () => {
+      transferRepository.findOne.mockResolvedValueOnce(mockDraftTransfer as any);
+      accountingService.postFundTransferEntry.mockResolvedValue({ id: 'je-1' } as any);
       transferRepository.save.mockResolvedValue({
-        ...transfer,
-        status: FundTransferStatus.CANCELLED,
+        ...mockDraftTransfer,
+        status: FundTransferStatus.POSTED,
+        journalEntryId: 'je-1',
       } as any);
-      accountingService.reverseSourceEntries.mockResolvedValue(undefined);
+      transferRepository.findOne.mockResolvedValueOnce({
+        ...mockDraftTransfer,
+        status: FundTransferStatus.POSTED,
+        journalEntryId: 'je-1',
+      } as any);
 
-      const result = await service.cancel('trf-1', 'user-1');
+      const result = await service.post('trf-1', 'user-1');
+
+      expect(accountingService.postFundTransferEntry).toHaveBeenCalledWith(
+        mockDraftTransfer,
+        'user-1',
+        undefined,
+      );
+      expect(result.status).toBe(FundTransferStatus.POSTED);
+    });
+
+    it('throws BadRequestException when transfer is not DRAFT', async () => {
+      transferRepository.findOne.mockResolvedValue({
+        ...mockDraftTransfer,
+        status: FundTransferStatus.POSTED,
+      } as any);
+
+      await expect(service.post('trf-1', 'user-1')).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws NotFoundException when transfer does not exist', async () => {
+      transferRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.post('trf-1', 'user-1')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('unpost', () => {
+    const mockPostedTransfer = {
+      id: 'trf-1',
+      referenceNumber: 'TRF-26-001',
+      status: FundTransferStatus.POSTED,
+      deletedAt: null,
+    };
+
+    it('unposted a posted transfer and sets status to REVERSED', async () => {
+      transferRepository.findOne
+        .mockResolvedValueOnce(mockPostedTransfer as any)
+        .mockResolvedValueOnce({ ...mockPostedTransfer, status: FundTransferStatus.REVERSED } as any);
+      accountingService.reverseSourceEntries.mockResolvedValue(undefined);
+      transferRepository.save.mockResolvedValue({} as any);
+
+      const result = await service.unpost('trf-1', 'user-1');
 
       expect(accountingService.reverseSourceEntries).toHaveBeenCalledWith(
         'fund_transfer',
         'trf-1',
         'user-1',
       );
-      expect(transferRepository.save).toHaveBeenCalled();
-      expect(auditLogService.log).toHaveBeenCalledWith(
-        'CANCEL',
-        'FundTransfer',
-        expect.any(String),
-        expect.any(Object),
-      );
-      expect(result).toBeDefined();
+      expect(result.status).toBe(FundTransferStatus.REVERSED);
+    });
+
+    it('throws BadRequestException when transfer is not POSTED', async () => {
+      transferRepository.findOne.mockResolvedValue({
+        ...mockPostedTransfer,
+        status: FundTransferStatus.DRAFT,
+      } as any);
+
+      await expect(service.unpost('trf-1', 'user-1')).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('remove', () => {
+    it('soft-deletes a DRAFT transfer', async () => {
+      transferRepository.findOne.mockResolvedValue({
+        id: 'trf-1',
+        referenceNumber: 'TRF-26-001',
+        status: FundTransferStatus.DRAFT,
+        deletedAt: null,
+      } as any);
+      transferRepository.softDelete.mockResolvedValue({} as any);
+
+      await service.remove('trf-1', 'user-1');
+
+      expect(transferRepository.softDelete).toHaveBeenCalledWith('trf-1');
+    });
+
+    it('throws BadRequestException when trying to delete a POSTED transfer', async () => {
+      transferRepository.findOne.mockResolvedValue({
+        id: 'trf-1',
+        status: FundTransferStatus.POSTED,
+        deletedAt: null,
+      } as any);
+
+      await expect(service.remove('trf-1', 'user-1')).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when trying to delete a REVERSED transfer', async () => {
+      transferRepository.findOne.mockResolvedValue({
+        id: 'trf-1',
+        status: FundTransferStatus.REVERSED,
+        deletedAt: null,
+      } as any);
+
+      await expect(service.remove('trf-1', 'user-1')).rejects.toThrow(BadRequestException);
     });
   });
 
@@ -301,7 +330,7 @@ describe('FundTransferService', () => {
     });
 
     it('returns transfer when found', async () => {
-      const transfer = { id: 'trf-1', status: FundTransferStatus.ACTIVE } as any;
+      const transfer = { id: 'trf-1', status: FundTransferStatus.DRAFT } as any;
       transferRepository.findOne.mockResolvedValue(transfer);
       const result = await service.findOne('trf-1');
       expect(result).toBeDefined();

--- a/backend/src/modules/accounting/services/fund-transfer.service.spec.ts
+++ b/backend/src/modules/accounting/services/fund-transfer.service.spec.ts
@@ -312,14 +312,18 @@ describe('FundTransferService', () => {
       await expect(service.remove('trf-1', 'user-1')).rejects.toThrow(BadRequestException);
     });
 
-    it('throws BadRequestException when trying to delete a REVERSED transfer', async () => {
+    it('soft-deletes a REVERSED transfer', async () => {
       transferRepository.findOne.mockResolvedValue({
         id: 'trf-1',
+        referenceNumber: 'TRF-26-001',
         status: FundTransferStatus.REVERSED,
         deletedAt: null,
       } as any);
+      transferRepository.softDelete.mockResolvedValue({} as any);
 
-      await expect(service.remove('trf-1', 'user-1')).rejects.toThrow(BadRequestException);
+      await service.remove('trf-1', 'user-1');
+
+      expect(transferRepository.softDelete).toHaveBeenCalledWith('trf-1');
     });
   });
 

--- a/backend/src/modules/accounting/services/fund-transfer.service.ts
+++ b/backend/src/modules/accounting/services/fund-transfer.service.ts
@@ -298,9 +298,6 @@ export class FundTransferService {
     if (transfer.status === FundTransferStatus.POSTED) {
       throw new BadRequestException('Cannot delete a posted fund transfer');
     }
-    if (transfer.status === FundTransferStatus.REVERSED) {
-      throw new BadRequestException('Cannot delete a reversed fund transfer');
-    }
 
     await this.transferRepository.softDelete(id);
 

--- a/backend/src/modules/accounting/services/fund-transfer.service.ts
+++ b/backend/src/modules/accounting/services/fund-transfer.service.ts
@@ -5,7 +5,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, Repository } from 'typeorm';
+import { IsNull, Not, Repository } from 'typeorm';
 import {
   FundTransfer,
   FundTransferStatus,
@@ -17,6 +17,7 @@ import { SettingsService } from '../../settings/settings.service';
 import { AuditLogService } from '../../audit-logs/services';
 import {
   CreateFundTransferDto,
+  UpdateFundTransferDto,
   FundTransferListResponseDto,
   FundTransferResponseDto,
   QueryFundTransfersDto,
@@ -35,7 +36,6 @@ export class FundTransferService {
     private readonly fiscalPeriodService: FiscalPeriodService,
     private readonly settingsService: SettingsService,
     private readonly auditLogService: AuditLogService,
-    private readonly dataSource: DataSource,
   ) {}
 
   async create(
@@ -98,46 +98,71 @@ export class FundTransferService {
       'Fund Transfers',
     );
 
-    let savedTransfer!: FundTransfer;
-    await this.dataSource.transaction(async (manager) => {
-      const transfer = manager.create(FundTransfer, {
-        referenceNumber,
-        transferDate: new Date(dto.transferDate),
-        sourceAccountId: dto.sourceAccountId,
-        destinationAccountId: dto.destinationAccountId,
-        amount: dto.amount,
-        description: dto.description,
-        status: FundTransferStatus.ACTIVE,
-        fiscalPeriodId: periodValidation.period.id,
-        journalEntryId: null,
-      });
-
-      savedTransfer = await manager.save(FundTransfer, transfer);
-      savedTransfer.sourceAccount = sourceAccount;
-      savedTransfer.destinationAccount = destinationAccount;
-
-      const postedJournalEntry = await this.accountingService.postFundTransferEntry(
-        savedTransfer,
-        userId,
-        username,
-      );
-
-      savedTransfer.journalEntryId = postedJournalEntry.id;
-      await manager.save(FundTransfer, savedTransfer);
+    const transfer = this.transferRepository.create({
+      referenceNumber,
+      transferDate: new Date(dto.transferDate),
+      sourceAccountId: dto.sourceAccountId,
+      destinationAccountId: dto.destinationAccountId,
+      amount: dto.amount,
+      description: dto.description,
+      status: FundTransferStatus.DRAFT,
+      fiscalPeriodId: periodValidation.period.id,
+      journalEntryId: undefined,
     });
+
+    const saved = await this.transferRepository.save(transfer);
 
     await this.auditLogService.log(
       'CREATE',
       'FundTransfer',
       `Created fund transfer: ${referenceNumber}`,
-      { entityId: savedTransfer.id, userId, username },
+      { entityId: saved.id, userId, username },
     );
 
-    this.logger.log(`Fund transfer created: ${referenceNumber}`);
-    return this.findOne(savedTransfer.id);
+    this.logger.log(`Fund transfer created (draft): ${referenceNumber}`);
+    return this.findOne(saved.id);
   }
 
-  async cancel(
+  async post(
+    id: string,
+    userId: string,
+    username?: string,
+  ): Promise<FundTransferResponseDto> {
+    const transfer = await this.transferRepository.findOne({
+      where: { id },
+      relations: ['sourceAccount', 'destinationAccount'],
+    });
+    if (!transfer || transfer.deletedAt) {
+      throw new NotFoundException(`Fund transfer '${id}' not found`);
+    }
+    if (transfer.status !== FundTransferStatus.DRAFT) {
+      throw new BadRequestException(
+        `Fund transfer '${transfer.referenceNumber}' must be in DRAFT status to post`,
+      );
+    }
+
+    const journalEntry = await this.accountingService.postFundTransferEntry(
+      transfer,
+      userId,
+      username,
+    );
+
+    transfer.status = FundTransferStatus.POSTED;
+    transfer.journalEntryId = journalEntry.id;
+    await this.transferRepository.save(transfer);
+
+    await this.auditLogService.log(
+      'POST',
+      'FundTransfer',
+      `Posted fund transfer: ${transfer.referenceNumber}`,
+      { entityId: id, userId, username },
+    );
+
+    this.logger.log(`Fund transfer posted: ${transfer.referenceNumber}`);
+    return this.findOne(id);
+  }
+
+  async unpost(
     id: string,
     userId: string,
     username?: string,
@@ -146,33 +171,211 @@ export class FundTransferService {
     if (!transfer || transfer.deletedAt) {
       throw new NotFoundException(`Fund transfer '${id}' not found`);
     }
-
-    if (transfer.status === FundTransferStatus.CANCELLED) {
+    if (transfer.status !== FundTransferStatus.POSTED) {
       throw new BadRequestException(
-        `Fund transfer '${transfer.referenceNumber}' is already cancelled`,
-      );
-    }
-
-    if (!transfer.journalEntryId) {
-      throw new BadRequestException(
-        'Cannot cancel transfer — journal entry was not posted. This should not happen if transaction wrapping is in place.',
+        `Fund transfer '${transfer.referenceNumber}' must be in POSTED status to unpost`,
       );
     }
 
     await this.accountingService.reverseSourceEntries('fund_transfer', id, userId);
 
-    transfer.status = FundTransferStatus.CANCELLED;
+    transfer.status = FundTransferStatus.REVERSED;
     await this.transferRepository.save(transfer);
 
     await this.auditLogService.log(
-      'CANCEL',
+      'UNPOST',
       'FundTransfer',
-      `Cancelled fund transfer: ${transfer.referenceNumber}`,
+      `Unposted fund transfer: ${transfer.referenceNumber}`,
       { entityId: id, userId, username },
     );
 
-    this.logger.log(`Fund transfer cancelled: ${transfer.referenceNumber}`);
+    this.logger.log(`Fund transfer unposted: ${transfer.referenceNumber}`);
     return this.findOne(id);
+  }
+
+  async update(
+    id: string,
+    dto: UpdateFundTransferDto,
+    userId: string,
+    username?: string,
+  ): Promise<FundTransferResponseDto> {
+    const transfer = await this.transferRepository.findOne({ where: { id } });
+    if (!transfer || transfer.deletedAt) {
+      throw new NotFoundException(`Fund transfer '${id}' not found`);
+    }
+    if (transfer.status === FundTransferStatus.POSTED) {
+      throw new BadRequestException('Cannot update a posted fund transfer');
+    }
+
+    if (dto.sourceAccountId) {
+      const src = await this.coaRepository.findOne({
+        where: { id: dto.sourceAccountId },
+      });
+      if (!src || !src.isActive || src.deletedAt) {
+        throw new NotFoundException(
+          `Source account '${dto.sourceAccountId}' not found or inactive`,
+        );
+      }
+      if (!src.isCashEquivalent) {
+        throw new BadRequestException(
+          `Source account '${src.name}' is not a cash/bank account`,
+        );
+      }
+      transfer.sourceAccountId = dto.sourceAccountId;
+    }
+
+    if (dto.destinationAccountId) {
+      const dest = await this.coaRepository.findOne({
+        where: { id: dto.destinationAccountId },
+      });
+      if (!dest || !dest.isActive || dest.deletedAt) {
+        throw new NotFoundException(
+          `Destination account '${dto.destinationAccountId}' not found or inactive`,
+        );
+      }
+      if (!dest.isCashEquivalent) {
+        throw new BadRequestException(
+          `Destination account '${dest.name}' is not a cash/bank account`,
+        );
+      }
+      transfer.destinationAccountId = dto.destinationAccountId;
+    }
+
+    if (
+      (dto.sourceAccountId ?? transfer.sourceAccountId) ===
+      (dto.destinationAccountId ?? transfer.destinationAccountId)
+    ) {
+      throw new BadRequestException(
+        'Source and destination accounts must be different',
+      );
+    }
+
+    if (dto.amount !== undefined) {
+      if (dto.amount <= 0) {
+        throw new BadRequestException('Transfer amount must be greater than zero');
+      }
+      transfer.amount = dto.amount;
+    }
+
+    if (dto.transferDate) {
+      const periodValidation = await this.fiscalPeriodService.validatePeriod({
+        date: new Date(dto.transferDate),
+      });
+      if (!periodValidation.isValid || !periodValidation.period) {
+        throw new BadRequestException(
+          `No open fiscal period found for date ${dto.transferDate}.`,
+        );
+      }
+      transfer.transferDate = new Date(dto.transferDate);
+      transfer.fiscalPeriodId = periodValidation.period.id;
+    }
+
+    if (dto.description !== undefined) {
+      transfer.description = dto.description;
+    }
+
+    await this.transferRepository.save(transfer);
+
+    await this.auditLogService.log(
+      'UPDATE',
+      'FundTransfer',
+      `Updated fund transfer: ${transfer.referenceNumber}`,
+      { entityId: id, userId, username },
+    );
+
+    return this.findOne(id);
+  }
+
+  async remove(
+    id: string,
+    userId: string,
+    username?: string,
+  ): Promise<void> {
+    const transfer = await this.transferRepository.findOne({ where: { id } });
+    if (!transfer || transfer.deletedAt) {
+      throw new NotFoundException(`Fund transfer '${id}' not found`);
+    }
+    if (transfer.status === FundTransferStatus.POSTED) {
+      throw new BadRequestException('Cannot delete a posted fund transfer');
+    }
+    if (transfer.status === FundTransferStatus.REVERSED) {
+      throw new BadRequestException('Cannot delete a reversed fund transfer');
+    }
+
+    await this.transferRepository.softDelete(id);
+
+    await this.auditLogService.log(
+      'DELETE',
+      'FundTransfer',
+      `Deleted fund transfer: ${transfer.referenceNumber}`,
+      { entityId: id, userId, username },
+    );
+  }
+
+  async getDeleted(): Promise<FundTransferResponseDto[]> {
+    const records = await this.transferRepository.find({
+      withDeleted: true,
+      where: { deletedAt: Not(IsNull()) },
+      relations: ['sourceAccount', 'destinationAccount', 'journalEntry'],
+      order: { deletedAt: 'DESC' },
+    });
+    return records.map((r) => this.toResponseDto(r));
+  }
+
+  async restore(
+    id: string,
+    userId: string,
+    username?: string,
+  ): Promise<FundTransferResponseDto> {
+    const transfer = await this.transferRepository.findOne({
+      where: { id },
+      withDeleted: true,
+    });
+    if (!transfer) {
+      throw new NotFoundException(`Fund transfer '${id}' not found`);
+    }
+    if (!transfer.deletedAt) {
+      throw new BadRequestException('Fund transfer is not deleted');
+    }
+
+    await this.transferRepository.restore(id);
+
+    await this.auditLogService.log(
+      'RESTORE',
+      'FundTransfer',
+      `Restored fund transfer: ${transfer.referenceNumber}`,
+      { entityId: id, userId, username },
+    );
+
+    return this.findOne(id);
+  }
+
+  async permanentDelete(
+    id: string,
+    userId: string,
+    username?: string,
+  ): Promise<void> {
+    const transfer = await this.transferRepository.findOne({
+      where: { id },
+      withDeleted: true,
+    });
+    if (!transfer) {
+      throw new NotFoundException(`Fund transfer '${id}' not found`);
+    }
+    if (!transfer.deletedAt) {
+      throw new BadRequestException(
+        'Fund transfer must be soft-deleted before permanent deletion',
+      );
+    }
+
+    await this.transferRepository.delete(id);
+
+    await this.auditLogService.log(
+      'DELETE',
+      'FundTransfer',
+      `Permanently deleted fund transfer: ${transfer.referenceNumber}`,
+      { entityId: id, userId, username },
+    );
   }
 
   async findAll(query: QueryFundTransfersDto): Promise<FundTransferListResponseDto> {
@@ -203,14 +406,10 @@ export class FundTransferService {
       qb.andWhere('transfer.transferDate <= :endDate', { endDate });
     }
     if (sourceAccountId) {
-      qb.andWhere('transfer.sourceAccountId = :sourceAccountId', {
-        sourceAccountId,
-      });
+      qb.andWhere('transfer.sourceAccountId = :sourceAccountId', { sourceAccountId });
     }
     if (destinationAccountId) {
-      qb.andWhere('transfer.destinationAccountId = :destinationAccountId', {
-        destinationAccountId,
-      });
+      qb.andWhere('transfer.destinationAccountId = :destinationAccountId', { destinationAccountId });
     }
     if (status) {
       qb.andWhere('transfer.status = :status', { status });
@@ -222,15 +421,8 @@ export class FundTransferService {
       );
     }
 
-    const validSortFields = [
-      'transferDate',
-      'referenceNumber',
-      'amount',
-      'createdAt',
-    ];
-    const safeSortField = validSortFields.includes(sortBy)
-      ? sortBy
-      : 'transferDate';
+    const validSortFields = ['transferDate', 'referenceNumber', 'amount', 'createdAt'];
+    const safeSortField = validSortFields.includes(sortBy) ? sortBy : 'transferDate';
     const safeSortOrder = sortOrder?.toUpperCase() === 'ASC' ? 'ASC' : 'DESC';
 
     qb.orderBy(`transfer.${safeSortField}`, safeSortOrder)
@@ -241,12 +433,7 @@ export class FundTransferService {
 
     return {
       data: rows.map((row) => this.toResponseDto(row)),
-      meta: {
-        page,
-        limit,
-        total,
-        totalPages: Math.ceil(total / limit),
-      },
+      meta: { page, limit, total, totalPages: Math.ceil(total / limit) },
     };
   }
 
@@ -275,12 +462,7 @@ export class FundTransferService {
     transfer: FundTransfer,
   ): FundTransferResponseDto['sourceAccount'] {
     if (account) {
-      return {
-        id: account.id,
-        code: account.code,
-        name: account.name,
-        type: account.type,
-      };
+      return { id: account.id, code: account.code, name: account.name, type: account.type };
     }
 
     this.logger.warn(
@@ -292,12 +474,7 @@ export class FundTransferService {
         ? transfer.sourceAccountId
         : transfer.destinationAccountId;
 
-    return {
-      id: fallbackId ?? '',
-      code: '',
-      name: '',
-      type: '',
-    };
+    return { id: fallbackId ?? '', code: '', name: '', type: '' };
   }
 
   private toResponseDto(transfer: FundTransfer): FundTransferResponseDto {
@@ -310,16 +487,8 @@ export class FundTransferService {
       status: transfer.status,
       fiscalPeriodId: transfer.fiscalPeriodId,
       journalEntryId: transfer.journalEntryId ?? null,
-      sourceAccount: this.buildAccountSummary(
-        transfer.sourceAccount,
-        'sourceAccount',
-        transfer,
-      ),
-      destinationAccount: this.buildAccountSummary(
-        transfer.destinationAccount,
-        'destinationAccount',
-        transfer,
-      ),
+      sourceAccount: this.buildAccountSummary(transfer.sourceAccount, 'sourceAccount', transfer),
+      destinationAccount: this.buildAccountSummary(transfer.destinationAccount, 'destinationAccount', transfer),
       journalEntry: transfer.journalEntry
         ? {
             id: transfer.journalEntry.id,

--- a/backend/src/modules/accounting/services/fund-transfer.service.ts
+++ b/backend/src/modules/accounting/services/fund-transfer.service.ts
@@ -505,6 +505,7 @@ export class FundTransferService {
         : undefined,
       createdAt: transfer.createdAt,
       updatedAt: transfer.updatedAt,
+      deletedAt: transfer.deletedAt ?? null,
     };
   }
 }

--- a/backend/src/modules/accounting/services/fund-transfer.service.ts
+++ b/backend/src/modules/accounting/services/fund-transfer.service.ts
@@ -135,9 +135,9 @@ export class FundTransferService {
     if (!transfer || transfer.deletedAt) {
       throw new NotFoundException(`Fund transfer '${id}' not found`);
     }
-    if (transfer.status !== FundTransferStatus.DRAFT) {
+    if (transfer.status !== FundTransferStatus.DRAFT && transfer.status !== FundTransferStatus.REVERSED) {
       throw new BadRequestException(
-        `Fund transfer '${transfer.referenceNumber}' must be in DRAFT status to post`,
+        `Fund transfer '${transfer.referenceNumber}' must be in DRAFT or REVERSED status to post`,
       );
     }
 

--- a/frontend/src/components/accounting/DeletedFundTransfersDialog.tsx
+++ b/frontend/src/components/accounting/DeletedFundTransfersDialog.tsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import { Typography } from '@mui/material'
+import { default as SyncAltIcon } from '@mui/icons-material/SyncAlt'
+
+import GenericDeletedDialog, { type ColumnDef } from '@/components/common/GenericDeletedDialog'
+import {
+  useGetDeletedFundTransfersQuery,
+  usePermanentDeleteFundTransferMutation,
+  useRestoreFundTransferMutation,
+} from '@/store/api/accountingApi'
+import type { FundTransfer } from '@/types'
+import { formatCurrency, formatDate } from '@/utils/formatters'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  onChanged?: () => void
+}
+
+type DeletedFundTransfer = FundTransfer & { deletedAt?: string | null }
+
+const columns: ColumnDef<DeletedFundTransfer>[] = [
+  {
+    label: 'Reference',
+    width: '20%',
+    render: (item) => (
+      <Typography variant="body2" sx={{ fontWeight: 600 }}>
+        {item.referenceNumber}
+      </Typography>
+    ),
+  },
+  {
+    label: 'From Account',
+    width: '22%',
+    render: (item) => <Typography variant="body2">{item.sourceAccount.name}</Typography>,
+  },
+  {
+    label: 'To Account',
+    width: '22%',
+    render: (item) => <Typography variant="body2">{item.destinationAccount.name}</Typography>,
+  },
+  {
+    label: 'Amount',
+    width: '16%',
+    render: (item) => <Typography variant="body2">{formatCurrency(item.amount)}</Typography>,
+  },
+  {
+    label: 'Date',
+    width: '10%',
+    render: (item) => <Typography variant="body2">{formatDate(item.transferDate)}</Typography>,
+  },
+  {
+    label: 'Deleted',
+    width: '10%',
+    hideOnMobile: true,
+    render: (item) => (
+      <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+        {item.deletedAt ? formatDate(item.deletedAt) : 'Unknown'}
+      </Typography>
+    ),
+  },
+]
+
+const DeletedFundTransfersDialog: React.FC<Props> = ({ open, onClose, onChanged }) => (
+  <GenericDeletedDialog<DeletedFundTransfer>
+    open={open}
+    onClose={onClose}
+    title="Deleted Fund Transfers"
+    entityLabel="fund transfer"
+    entityLabelPlural="fund transfers"
+    icon={<SyncAltIcon sx={{ color: 'error.main' }} />}
+    columns={columns}
+    getItemLabel={(item) => item.referenceNumber}
+    searchPlaceholder="Search deleted fund transfers..."
+    filterItem={(item, term) =>
+      item.referenceNumber.toLowerCase().includes(term) ||
+      item.sourceAccount.name.toLowerCase().includes(term) ||
+      item.destinationAccount.name.toLowerCase().includes(term)
+    }
+    useGetDeletedQuery={useGetDeletedFundTransfersQuery as any}
+    getItems={(data) => (Array.isArray(data) ? (data as DeletedFundTransfer[]) : [])}
+    useRestoreMutation={useRestoreFundTransferMutation}
+    usePermanentDeleteMutation={usePermanentDeleteFundTransferMutation}
+    onChanged={onChanged}
+  />
+)
+
+export default DeletedFundTransfersDialog

--- a/frontend/src/components/filters/FilterFundTransferStatus.tsx
+++ b/frontend/src/components/filters/FilterFundTransferStatus.tsx
@@ -1,8 +1,9 @@
 import { FilterSelect } from './FilterSelect'
 
 const OPTIONS = [
-  { value: 'ACTIVE', label: 'Active' },
-  { value: 'CANCELLED', label: 'Cancelled' },
+  { value: 'draft', label: 'Draft' },
+  { value: 'posted', label: 'Posted' },
+  { value: 'reversed', label: 'Reversed' },
 ]
 
 interface Props {

--- a/frontend/src/pages/accounting/ExpensesPage.tsx
+++ b/frontend/src/pages/accounting/ExpensesPage.tsx
@@ -86,6 +86,14 @@ const ExpensesPage: React.FC = () => {
   const selected = useAppSelector(selectSelectedExpense)
   const workspace = useExpensesWorkspace(() => { void refetch() }, rows, dispatch, selected)
 
+  const filterHandlers = useMemo(() => ({
+    ...handlers,
+    onSearchChange: (value: string) => {
+      handlers.onSearchChange(value)
+      workspace.setShouldPreserveSearchFocus(true)
+    },
+  }), [handlers, workspace])
+
   const openCreate = () => {
     workspace.setEditTarget(null)
     workspace.setFormOpen(true)
@@ -110,7 +118,7 @@ const ExpensesPage: React.FC = () => {
       secondaryAction={{ label: 'View Deleted', onClick: () => setDeletedOpen(true) }}
       filterConfig={filterConfig}
       draftFilters={draftFilters}
-      handlers={handlers}
+      handlers={filterHandlers}
       hasActiveFilters={hasActiveFilters}
       searchInputRef={workspace.searchInputRef}
       sort={{ field: 'referenceNumber', sortBy, sortOrder, onSort: handleSort }}

--- a/frontend/src/pages/accounting/FundTransfersPage.tsx
+++ b/frontend/src/pages/accounting/FundTransfersPage.tsx
@@ -3,7 +3,12 @@ import React, { useMemo, useState } from 'react'
 import GenericListPage from '@/components/common/GenericListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
 import { useAppDispatch, useAppSelector } from '@/hooks/useRedux'
-import { useCreateFundTransferMutation, useGetChartOfAccountsQuery, useGetFundTransfersQuery } from '@/store/api/accountingApi'
+import {
+  useCreateFundTransferMutation,
+  useGetChartOfAccountsQuery,
+  useGetFundTransfersQuery,
+  useUpdateFundTransferMutation,
+} from '@/store/api/accountingApi'
 import { selectSelectedFundTransfer } from '@/store/slices/accountingSlice'
 import { selectCurrentUser } from '@/store/slices/authSlice'
 import type { ChartOfAccount } from '@/types'
@@ -11,20 +16,12 @@ import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
 import { getCurrentDate } from '@/utils/formatters'
 import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
 
+import DeletedFundTransfersDialog from '@/components/accounting/DeletedFundTransfersDialog'
 import { FundTransferContextHeader } from './components/FundTransferContextHeader'
-import { FundTransfersDialogs } from './components/FundTransfersDialogs'
+import { FundTransfersDialogs, type FundTransferFormState } from './components/FundTransfersDialogs'
 import { FundTransfersList } from './components/FundTransfersList'
 import { FundTransferWorkspaceCard } from './components/FundTransferWorkspaceCard'
 import { useFundTransfersWorkspace } from './hooks/useFundTransfersWorkspace'
-
-type FormState = {
-  sourceAccountId: string
-  destinationAccountId: string
-  amount: string
-  transferDate: string
-  description: string
-}
-
 
 interface FTFilters {
   search: string
@@ -45,17 +42,24 @@ const filterConfig: FilterBarConfig<FTFilters> = {
   defaults: { search: '', status: null, period: { key: null, from: null, to: null }, sourceAccountId: null, destinationAccountId: null },
 }
 
-const defaultForm: FormState = { sourceAccountId: '', destinationAccountId: '', amount: '', transferDate: getCurrentDate(), description: '' }
+const defaultForm: FundTransferFormState = {
+  sourceAccountId: '',
+  destinationAccountId: '',
+  amount: '',
+  transferDate: getCurrentDate(),
+  description: '',
+}
 
 const FundTransfersPage: React.FC = () => {
   const currentUser = useAppSelector(selectCurrentUser)
   const dispatch = useAppDispatch()
   const selected = useAppSelector(selectSelectedFundTransfer)
-  const canManageTransfers = currentUser?.role === 'admin' || currentUser?.role === 'manager'
-  const [dialogOpen, setDialogOpen] = useState(false)
-  const [form, setForm] = useState<FormState>(defaultForm)
+  const isAdmin = currentUser?.role === 'admin'
+  const canManageTransfers = isAdmin || currentUser?.role === 'manager'
+  const [form, setForm] = useState<FundTransferFormState>(defaultForm)
   const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
   const weekStartsOn = getStartOfWeek()
+
   const dateRange = useMemo(() => {
     const period = appliedFilters.period
     if (!period || period.key === null) return { fromDate: undefined, toDate: undefined }
@@ -75,42 +79,152 @@ const FundTransfersPage: React.FC = () => {
   const { data, isLoading, refetch } = useGetFundTransfersQuery(filters)
   const { data: accountsResponse } = useGetChartOfAccountsQuery({ isCashEquivalent: true, limit: 200 })
   const [createFundTransfer, { isLoading: creating }] = useCreateFundTransferMutation()
+  const [updateFundTransfer, { isLoading: updating }] = useUpdateFundTransferMutation()
 
-  const cashAccounts = useMemo(() => ((accountsResponse?.data ?? []) as ChartOfAccount[]).filter((account) => account.isActive && account.isCashEquivalent), [accountsResponse])
-  const availableDestinations = useMemo(() => cashAccounts.filter((account) => account.id !== form.sourceAccountId), [cashAccounts, form.sourceAccountId])
+  const cashAccounts = useMemo(
+    () => ((accountsResponse?.data ?? []) as ChartOfAccount[]).filter((a) => a.isActive && a.isCashEquivalent),
+    [accountsResponse],
+  )
+  const availableDestinations = useMemo(
+    () => cashAccounts.filter((a) => a.id !== form.sourceAccountId),
+    [cashAccounts, form.sourceAccountId],
+  )
+
   const transfers = useMemo(() => {
     const rows = data?.data ?? []
     const term = appliedFilters.search.trim().toLowerCase()
     if (!term) return rows
-    return rows.filter((row) => [row.referenceNumber, row.description, row.sourceAccount.name, row.destinationAccount.name].filter(Boolean).join(' ').toLowerCase().includes(term))
+    return rows.filter((row) =>
+      [row.referenceNumber, row.description, row.sourceAccount.name, row.destinationAccount.name]
+        .filter(Boolean).join(' ').toLowerCase().includes(term),
+    )
   }, [appliedFilters.search, data?.data])
+
   const workspace = useFundTransfersWorkspace(() => { void refetch() }, transfers, dispatch, selected)
 
-  const resetForm = () => { setDialogOpen(false); setForm(defaultForm) }
+  const resetForm = () => {
+    workspace.setFormOpen(false)
+    workspace.setEditTarget(null)
+    setForm(defaultForm)
+  }
 
-  const handleCreate = async () => {
-    if (!form.sourceAccountId || !form.destinationAccountId || !form.amount || !form.transferDate || Number(form.amount) <= 0 || form.sourceAccountId === form.destinationAccountId) return
-    await createFundTransfer({ sourceAccountId: form.sourceAccountId, destinationAccountId: form.destinationAccountId, amount: Number(form.amount), transferDate: form.transferDate, description: form.description || undefined }).unwrap()
+  const handleFormChange = (field: keyof FundTransferFormState, value: string) => {
+    setForm((current) => ({
+      ...current,
+      [field]: value,
+      ...(field === 'sourceAccountId' && value === current.destinationAccountId
+        ? { destinationAccountId: '' }
+        : {}),
+    }))
+  }
+
+  const handleOpenEdit = () => {
+    if (!selected) return
+    workspace.setEditTarget(selected)
+    setForm({
+      sourceAccountId: selected.sourceAccount.id,
+      destinationAccountId: selected.destinationAccount.id,
+      amount: String(selected.amount),
+      transferDate: typeof selected.transferDate === 'string'
+        ? selected.transferDate.slice(0, 10)
+        : new Date(selected.transferDate).toISOString().slice(0, 10),
+      description: selected.description ?? '',
+    })
+    workspace.setFormOpen(true)
+  }
+
+  const handleSave = async () => {
+    if (!form.sourceAccountId || !form.destinationAccountId || !form.amount || !form.transferDate
+      || Number(form.amount) <= 0 || form.sourceAccountId === form.destinationAccountId) return
+
+    if (workspace.editTarget) {
+      await updateFundTransfer({
+        id: workspace.editTarget.id,
+        sourceAccountId: form.sourceAccountId,
+        destinationAccountId: form.destinationAccountId,
+        amount: Number(form.amount),
+        transferDate: form.transferDate,
+        description: form.description || undefined,
+      }).unwrap()
+    } else {
+      await createFundTransfer({
+        sourceAccountId: form.sourceAccountId,
+        destinationAccountId: form.destinationAccountId,
+        amount: Number(form.amount),
+        transferDate: form.transferDate,
+        description: form.description || undefined,
+      }).unwrap()
+    }
     resetForm()
     void refetch()
   }
 
+  const secondaryAction = isAdmin
+    ? { label: 'View Deleted', onClick: () => workspace.setDeletedDialogOpen(true) }
+    : undefined
+
   return (
-    <GenericListPage
-      title="Fund Transfers"
-      subtitle="Move funds between accounts and review transfer history"
-      primaryAction={canManageTransfers ? { label: 'New Transfer', onClick: () => setDialogOpen(true) } : undefined}
-      filterConfig={filterConfig}
-      draftFilters={draftFilters}
-      handlers={handlers}
-      hasActiveFilters={hasActiveFilters}
-      searchInputRef={workspace.searchInputRef}
-      sort={{ field: 'transferDate', sortBy: 'transferDate', sortOrder: 'desc', onSort: () => {} }}
-      listSlot={<FundTransfersList transfers={transfers} loading={isLoading} selectedId={selected?.id ?? null} focusedIndex={workspace.focusedIndex} onSelect={workspace.handleSelect} listRef={workspace.listRef} />}
-      headerSlot={<FundTransferContextHeader selected={selected} onCancel={() => selected && workspace.setCancelTarget(selected)} canManageTransfers={canManageTransfers} />}
-      workspaceSlot={<FundTransferWorkspaceCard selected={selected} />}
-      dialogs={<FundTransfersDialogs dialogOpen={dialogOpen} canManageTransfers={canManageTransfers} creating={creating} form={form} cashAccounts={cashAccounts} availableDestinations={availableDestinations} onCloseDialog={resetForm} onFormChange={(field, value) => setForm((current) => ({ ...current, [field]: value, ...(field === 'sourceAccountId' && value === current.destinationAccountId ? { destinationAccountId: '' } : {}) }))} onCreate={() => void handleCreate()} cancelTarget={workspace.cancelTarget} cancelling={workspace.cancelling} onConfirmCancel={() => void workspace.handleConfirmCancel()} onCancelCancel={() => workspace.setCancelTarget(null)} />}
-    />
+    <>
+      <GenericListPage
+        title="Fund Transfers"
+        subtitle="Move funds between accounts and review transfer history"
+        primaryAction={canManageTransfers ? { label: 'New Transfer', onClick: () => workspace.setFormOpen(true) } : undefined}
+        secondaryAction={secondaryAction}
+        filterConfig={filterConfig}
+        draftFilters={draftFilters}
+        handlers={handlers}
+        hasActiveFilters={hasActiveFilters}
+        searchInputRef={workspace.searchInputRef}
+        sort={{ field: 'transferDate', sortBy: 'transferDate', sortOrder: 'desc', onSort: () => {} }}
+        listSlot={<FundTransfersList transfers={transfers} loading={isLoading} selectedId={selected?.id ?? null} focusedIndex={workspace.focusedIndex} onSelect={workspace.handleSelect} listRef={workspace.listRef} />}
+        headerSlot={
+          <FundTransferContextHeader
+            selected={selected}
+            isAdmin={isAdmin}
+            onEdit={handleOpenEdit}
+            onPost={() => selected && workspace.setPostTarget(selected)}
+            onDelete={() => selected && workspace.setDeleteTarget(selected)}
+            onUnpost={() => selected && workspace.setUnpostTarget(selected)}
+            onRestore={() => selected && workspace.setRestoreTarget(selected)}
+          />
+        }
+        workspaceSlot={<FundTransferWorkspaceCard selected={selected} />}
+        dialogs={
+          <FundTransfersDialogs
+            formOpen={workspace.formOpen}
+            editTarget={workspace.editTarget}
+            canManageTransfers={canManageTransfers}
+            saving={creating || updating}
+            form={form}
+            cashAccounts={cashAccounts}
+            availableDestinations={availableDestinations}
+            onCloseForm={resetForm}
+            onFormChange={handleFormChange}
+            onSave={() => void handleSave()}
+            postTarget={workspace.postTarget}
+            deleteTarget={workspace.deleteTarget}
+            unpostTarget={workspace.unpostTarget}
+            restoreTarget={workspace.restoreTarget}
+            actionLoading={workspace.actionLoading}
+            onConfirmPost={() => void workspace.handleConfirmPost()}
+            onCancelPost={() => workspace.setPostTarget(null)}
+            onConfirmDelete={() => void workspace.handleConfirmDelete()}
+            onCancelDelete={() => workspace.setDeleteTarget(null)}
+            onConfirmUnpost={() => void workspace.handleConfirmUnpost()}
+            onCancelUnpost={() => workspace.setUnpostTarget(null)}
+            onConfirmRestore={() => void workspace.handleConfirmRestore()}
+            onCancelRestore={() => workspace.setRestoreTarget(null)}
+          />
+        }
+      />
+      {isAdmin && (
+        <DeletedFundTransfersDialog
+          open={workspace.deletedDialogOpen}
+          onClose={() => workspace.setDeletedDialogOpen(false)}
+          onChanged={() => void refetch()}
+        />
+      )}
+    </>
   )
 }
 

--- a/frontend/src/pages/accounting/FundTransfersPage.tsx
+++ b/frontend/src/pages/accounting/FundTransfersPage.tsx
@@ -102,6 +102,14 @@ const FundTransfersPage: React.FC = () => {
 
   const workspace = useFundTransfersWorkspace(() => { void refetch() }, transfers, dispatch, selected)
 
+  const filterHandlers = useMemo(() => ({
+    ...handlers,
+    onSearchChange: (value: string) => {
+      handlers.onSearchChange(value)
+      workspace.setShouldPreserveSearchFocus(true)
+    },
+  }), [handlers, workspace])
+
   const resetForm = () => {
     workspace.setFormOpen(false)
     workspace.setEditTarget(null)
@@ -172,7 +180,7 @@ const FundTransfersPage: React.FC = () => {
         secondaryAction={secondaryAction}
         filterConfig={filterConfig}
         draftFilters={draftFilters}
-        handlers={handlers}
+        handlers={filterHandlers}
         hasActiveFilters={hasActiveFilters}
         searchInputRef={workspace.searchInputRef}
         sort={{ field: 'transferDate', sortBy: 'transferDate', sortOrder: 'desc', onSort: () => {} }}

--- a/frontend/src/pages/accounting/__tests__/ExpensesPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/ExpensesPage.test.tsx
@@ -29,6 +29,7 @@ const mockedApi = vi.hoisted(() => ({
   useCreateExpenseMutation: vi.fn(),
   useUpdateExpenseMutation: vi.fn(),
   useDeleteExpenseMutation: vi.fn(),
+  useLazyGetExpenseQuery: vi.fn(),
   usePostExpenseMutation: vi.fn(),
   useRestoreExpenseMutation: vi.fn(),
   useUnpostExpenseMutation: vi.fn(),
@@ -108,6 +109,7 @@ describe('ExpensesPage', () => {
     mockedApi.useCreateExpenseMutation.mockReturnValue([vi.fn()])
     mockedApi.useUpdateExpenseMutation.mockReturnValue([vi.fn()])
     mockedApi.useDeleteExpenseMutation.mockReturnValue([vi.fn()])
+    mockedApi.useLazyGetExpenseQuery.mockReturnValue([vi.fn()])
     mockedApi.usePostExpenseMutation.mockReturnValue([vi.fn()])
     mockedApi.useRestoreExpenseMutation.mockReturnValue([vi.fn()])
     mockedApi.useUnpostExpenseMutation.mockReturnValue([vi.fn()])

--- a/frontend/src/pages/accounting/__tests__/FundTransfersPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/FundTransfersPage.test.tsx
@@ -24,8 +24,14 @@ const mockedApi = vi.hoisted(() => ({
   useGetFundTransfersQuery: vi.fn(),
   useGetChartOfAccountsQuery: vi.fn(),
   useCreateFundTransferMutation: vi.fn(),
-  useCancelFundTransferMutation: vi.fn(),
+  useUpdateFundTransferMutation: vi.fn(),
   useLazyGetFundTransferQuery: vi.fn(),
+  usePostFundTransferMutation: vi.fn(),
+  useDeleteFundTransferMutation: vi.fn(),
+  useUnpostFundTransferMutation: vi.fn(),
+  useRestoreFundTransferMutation: vi.fn(),
+  useGetDeletedFundTransfersQuery: vi.fn(),
+  usePermanentDeleteFundTransferMutation: vi.fn(),
 }))
 
 vi.mock('@/store/api/accountingApi', () => mockedApi)
@@ -36,7 +42,7 @@ const mockTransfer = {
   transferDate: '2026-03-12',
   amount: 1000,
   description: 'Test transfer',
-  status: 'ACTIVE',
+  status: 'draft',
   fiscalPeriodId: 'fp-1',
   journalEntryId: 'je-1',
   sourceAccount: { id: 'acc-1', code: '1001', name: 'Cash on Hand', type: 'ASSET' },
@@ -78,8 +84,14 @@ describe('FundTransfersPage', () => {
       isLoading: false,
     })
     mockedApi.useCreateFundTransferMutation.mockReturnValue([vi.fn(), { isLoading: false }])
-    mockedApi.useCancelFundTransferMutation.mockReturnValue([vi.fn(), { isLoading: false }])
+    mockedApi.useUpdateFundTransferMutation.mockReturnValue([vi.fn(), { isLoading: false }])
     mockedApi.useLazyGetFundTransferQuery.mockReturnValue([vi.fn().mockResolvedValue({})])
+    mockedApi.usePostFundTransferMutation.mockReturnValue([vi.fn(), { isLoading: false }])
+    mockedApi.useDeleteFundTransferMutation.mockReturnValue([vi.fn(), { isLoading: false }])
+    mockedApi.useUnpostFundTransferMutation.mockReturnValue([vi.fn(), { isLoading: false }])
+    mockedApi.useRestoreFundTransferMutation.mockReturnValue([vi.fn(), { isLoading: false }])
+    mockedApi.useGetDeletedFundTransfersQuery.mockReturnValue({ data: [], isLoading: false, refetch: vi.fn() })
+    mockedApi.usePermanentDeleteFundTransferMutation.mockReturnValue([vi.fn(), { isLoading: false }])
   })
 
   it('renders page title', () => {
@@ -107,11 +119,11 @@ describe('FundTransfersPage', () => {
     expect(screen.getByRole('button', { name: /new transfer/i })).toBeInTheDocument()
   })
 
-  it('shows ACTIVE status chip in list', () => {
+  it('shows draft status chip in list', () => {
     const { container } = renderPage()
     const listRow = container.querySelector('[data-index="0"]')
     expect(listRow).not.toBeNull()
-    expect(within(listRow as HTMLElement).getByText('ACTIVE')).toBeInTheDocument()
+    expect(within(listRow as HTMLElement).getByText('draft')).toBeInTheDocument()
   })
 
   it('auto-selects the transfer matching the ?highlight= URL param', async () => {

--- a/frontend/src/pages/accounting/components/ExpenseContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/ExpenseContextHeader.tsx
@@ -70,6 +70,7 @@ export function ExpenseContextHeader({
 
   const isDraft = selected.status === 'draft'
   const isPosted = selected.status === 'posted'
+  const isReversed = selected.status === 'reversed'
   const isDeleted = !!selected.deletedAt
 
   const actions = isDeleted ? (
@@ -78,7 +79,7 @@ export function ExpenseContextHeader({
         Restore
       </AppButton>
     ) : null
-  ) : isDraft ? (
+  ) : (isDraft || isReversed) ? (
     <Stack direction="row" spacing={0.5}>
       <AppButton size="small" variant="secondary" startIcon={<EditIcon />} onClick={onEdit}>
         Edit

--- a/frontend/src/pages/accounting/components/FundTransferContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/FundTransferContextHeader.tsx
@@ -70,6 +70,7 @@ export function FundTransferContextHeader({
 
   const isDraft = selected.status === 'draft'
   const isPosted = selected.status === 'posted'
+  const isReversed = selected.status === 'reversed'
   const isDeleted = !!selected.deletedAt
 
   const actions = isDeleted ? (
@@ -78,7 +79,7 @@ export function FundTransferContextHeader({
         Restore
       </AppButton>
     ) : null
-  ) : isDraft ? (
+  ) : (isDraft || isReversed) ? (
     <Stack direction="row" spacing={0.5}>
       <AppButton size="small" variant="secondary" startIcon={<EditIcon />} onClick={onEdit}>
         Edit

--- a/frontend/src/pages/accounting/components/FundTransferContextHeader.tsx
+++ b/frontend/src/pages/accounting/components/FundTransferContextHeader.tsx
@@ -1,6 +1,10 @@
 import { Paper, Stack, Table, TableBody, TableCell, TableContainer, TableRow, Typography } from '@mui/material'
 import Grid from '@mui/material/Grid'
-import { default as CancelIcon } from '@mui/icons-material/Cancel'
+import { default as CheckCircleIcon } from '@mui/icons-material/CheckCircle'
+import { default as DeleteIcon } from '@mui/icons-material/Delete'
+import { default as EditIcon } from '@mui/icons-material/Edit'
+import { default as RestoreIcon } from '@mui/icons-material/Restore'
+import { default as UndoIcon } from '@mui/icons-material/Undo'
 
 import { AppButton } from '@/components/common/AppButton'
 import { EntityContextHeaderBar } from '@/components/common/EntityContextHeaderBar'
@@ -12,8 +16,12 @@ import { formatCurrency, formatDate } from '@/utils/formatters'
 
 interface Props {
   selected: FundTransfer | null
-  onCancel: () => void
-  canManageTransfers: boolean
+  isAdmin: boolean
+  onEdit: () => void
+  onPost: () => void
+  onDelete: () => void
+  onUnpost: () => void
+  onRestore: () => void
 }
 
 const detailTableSx = {
@@ -35,7 +43,15 @@ const sectionHeaderCellSx = {
   borderTop: TABLE_STYLES.cell.border,
 }
 
-export function FundTransferContextHeader({ selected, onCancel, canManageTransfers }: Props) {
+export function FundTransferContextHeader({
+  selected,
+  isAdmin,
+  onEdit,
+  onPost,
+  onDelete,
+  onUnpost,
+  onRestore,
+}: Props) {
   const { journalEntryRef, navigateToJournalEntry } = useJournalEntryRef(
     selected?.journalEntryId
       ? [{ sourceType: 'fund_transfer', sourceId: selected.id }]
@@ -52,20 +68,40 @@ export function FundTransferContextHeader({ selected, onCancel, canManageTransfe
     )
   }
 
+  const isDraft = selected.status === 'draft'
+  const isPosted = selected.status === 'posted'
+  const isDeleted = !!selected.deletedAt
+
+  const actions = isDeleted ? (
+    isAdmin ? (
+      <AppButton size="small" variant="secondary" startIcon={<RestoreIcon />} onClick={onRestore}>
+        Restore
+      </AppButton>
+    ) : null
+  ) : isDraft ? (
+    <Stack direction="row" spacing={0.5}>
+      <AppButton size="small" variant="secondary" startIcon={<EditIcon />} onClick={onEdit}>
+        Edit
+      </AppButton>
+      <AppButton size="small" variant="success" startIcon={<CheckCircleIcon />} onClick={onPost}>
+        Post
+      </AppButton>
+      <AppButton size="small" variant="danger" startIcon={<DeleteIcon />} onClick={onDelete}>
+        Delete
+      </AppButton>
+    </Stack>
+  ) : isPosted && isAdmin ? (
+    <AppButton size="small" variant="danger" startIcon={<UndoIcon />} onClick={onUnpost}>
+      Unpost
+    </AppButton>
+  ) : null
+
   return (
     <Paper sx={{ overflow: 'hidden' }}>
       <EntityContextHeaderBar
         title={selected.referenceNumber}
         statusChip={<EntityStatusChip status={selected.status} />}
-        actions={
-          canManageTransfers && selected.status === 'ACTIVE' ? (
-            <Stack direction="row" spacing={0.5}>
-              <AppButton size="small" variant="danger" startIcon={<CancelIcon />} onClick={onCancel}>
-                Cancel
-              </AppButton>
-            </Stack>
-          ) : null
-        }
+        actions={actions}
       />
       <Grid container spacing={3} sx={{ p: TABLE_STYLES.cell.padding.px }}>
         <Grid size={{ xs: 12, md: 6 }}>

--- a/frontend/src/pages/accounting/components/FundTransfersDialogs.tsx
+++ b/frontend/src/pages/accounting/components/FundTransfersDialogs.tsx
@@ -1,9 +1,10 @@
-import { Dialog, DialogActions, DialogContent, DialogTitle, MenuItem, TextField, Typography } from '@mui/material'
-import { AppButton } from '@/components/common/AppButton'
-import type { ChartOfAccount, FundTransfer } from '@/types'
-import ConfirmationDialog from '@/components/common/ConfirmationDialog'
+import { Dialog, DialogActions, DialogContent, DialogTitle, MenuItem, TextField } from '@mui/material'
 
-interface FormState {
+import { AppButton } from '@/components/common/AppButton'
+import ConfirmationDialog from '@/components/common/ConfirmationDialog'
+import type { ChartOfAccount, FundTransfer } from '@/types'
+
+export interface FundTransferFormState {
   sourceAccountId: string
   destinationAccountId: string
   amount: string
@@ -12,66 +13,127 @@ interface FormState {
 }
 
 interface Props {
-  dialogOpen: boolean
+  formOpen: boolean
+  editTarget: FundTransfer | null
   canManageTransfers: boolean
-  creating: boolean
-  form: FormState
+  saving: boolean
+  form: FundTransferFormState
   cashAccounts: ChartOfAccount[]
   availableDestinations: ChartOfAccount[]
-  onCloseDialog: () => void
-  onFormChange: (field: keyof FormState, value: string) => void
-  onCreate: () => void
-  cancelTarget: FundTransfer | null
-  cancelling: boolean
-  onConfirmCancel: () => void
-  onCancelCancel: () => void
+  onCloseForm: () => void
+  onFormChange: (field: keyof FundTransferFormState, value: string) => void
+  onSave: () => void
+  postTarget: FundTransfer | null
+  deleteTarget: FundTransfer | null
+  unpostTarget: FundTransfer | null
+  restoreTarget: FundTransfer | null
+  actionLoading: boolean
+  onConfirmPost: () => void
+  onCancelPost: () => void
+  onConfirmDelete: () => void
+  onCancelDelete: () => void
+  onConfirmUnpost: () => void
+  onCancelUnpost: () => void
+  onConfirmRestore: () => void
+  onCancelRestore: () => void
 }
 
 export function FundTransfersDialogs({
-  dialogOpen,
+  formOpen,
+  editTarget,
   canManageTransfers,
-  creating,
+  saving,
   form,
   cashAccounts,
   availableDestinations,
-  onCloseDialog,
+  onCloseForm,
   onFormChange,
-  onCreate,
-  cancelTarget,
-  cancelling,
-  onConfirmCancel,
-  onCancelCancel,
+  onSave,
+  postTarget,
+  deleteTarget,
+  unpostTarget,
+  restoreTarget,
+  actionLoading,
+  onConfirmPost,
+  onCancelPost,
+  onConfirmDelete,
+  onCancelDelete,
+  onConfirmUnpost,
+  onCancelUnpost,
+  onConfirmRestore,
+  onCancelRestore,
 }: Props) {
+  const isEditing = !!editTarget
+
   return (
     <>
-      <Dialog open={dialogOpen && canManageTransfers} onClose={onCloseDialog} maxWidth="sm" fullWidth>
-        <DialogTitle>New Fund Transfer</DialogTitle>
+      <Dialog open={formOpen && canManageTransfers} onClose={onCloseForm} maxWidth="sm" fullWidth>
+        <DialogTitle>{isEditing ? 'Edit Fund Transfer' : 'New Fund Transfer'}</DialogTitle>
         <DialogContent>
-          <TextField select fullWidth size="small" sx={{ mt: 1, mb: 2 }} label="From Account *" value={form.sourceAccountId} onChange={(event) => onFormChange('sourceAccountId', event.target.value)}>
-            {cashAccounts.map((account) => <MenuItem key={account.id} value={account.id}>{account.code} - {account.name}</MenuItem>)}
+          <TextField select fullWidth size="small" sx={{ mt: 1, mb: 2 }} label="From Account *" value={form.sourceAccountId} onChange={(e) => onFormChange('sourceAccountId', e.target.value)}>
+            {cashAccounts.map((a) => <MenuItem key={a.id} value={a.id}>{a.code} - {a.name}</MenuItem>)}
           </TextField>
-          <TextField select fullWidth size="small" sx={{ mb: 2 }} label="To Account *" value={form.destinationAccountId} onChange={(event) => onFormChange('destinationAccountId', event.target.value)} disabled={!form.sourceAccountId}>
-            {availableDestinations.map((account) => <MenuItem key={account.id} value={account.id}>{account.code} - {account.name}</MenuItem>)}
+          <TextField select fullWidth size="small" sx={{ mb: 2 }} label="To Account *" value={form.destinationAccountId} onChange={(e) => onFormChange('destinationAccountId', e.target.value)} disabled={!form.sourceAccountId}>
+            {availableDestinations.map((a) => <MenuItem key={a.id} value={a.id}>{a.code} - {a.name}</MenuItem>)}
           </TextField>
-          <TextField fullWidth label="Amount *" type="number" sx={{ mb: 2 }} slotProps={{ htmlInput: { min: 0.01, step: 0.01 } }} value={form.amount} onChange={(event) => onFormChange('amount', event.target.value)} />
-          <TextField fullWidth label="Date *" type="date" sx={{ mb: 2 }} value={form.transferDate} onChange={(event) => onFormChange('transferDate', event.target.value)} slotProps={{ inputLabel: { shrink: true } }} />
-          <TextField fullWidth label="Description" multiline rows={2} value={form.description} onChange={(event) => onFormChange('description', event.target.value)} />
+          <TextField fullWidth label="Amount *" type="number" sx={{ mb: 2 }} slotProps={{ htmlInput: { min: 0.01, step: 0.01 } }} value={form.amount} onChange={(e) => onFormChange('amount', e.target.value)} />
+          <TextField fullWidth label="Date *" type="date" sx={{ mb: 2 }} value={form.transferDate} onChange={(e) => onFormChange('transferDate', e.target.value)} slotProps={{ inputLabel: { shrink: true } }} />
+          <TextField fullWidth label="Description" multiline rows={2} value={form.description} onChange={(e) => onFormChange('description', e.target.value)} />
         </DialogContent>
         <DialogActions>
-          <AppButton variant="outlined" onClick={onCloseDialog}>Cancel</AppButton>
-          <AppButton variant="primary" onClick={onCreate} disabled={creating}>{creating ? 'Creating...' : 'Create Transfer'}</AppButton>
+          <AppButton variant="outlined" onClick={onCloseForm}>Cancel</AppButton>
+          <AppButton variant="primary" onClick={onSave} disabled={saving}>
+            {saving ? (isEditing ? 'Saving...' : 'Creating...') : (isEditing ? 'Save Changes' : 'Create Transfer')}
+          </AppButton>
         </DialogActions>
       </Dialog>
+
       <ConfirmationDialog
-        open={!!cancelTarget}
-        title="Cancel Transfer"
-        message={`Cancel transfer ${cancelTarget?.referenceNumber}? This will post a reversing journal entry.`}
-        confirmText={cancelling ? 'Cancelling...' : 'Cancel Transfer'}
+        open={!!postTarget}
+        title="Post Transfer"
+        message={`Post transfer ${postTarget?.referenceNumber}? This will create a journal entry.`}
+        confirmText={actionLoading ? 'Posting...' : 'Post Transfer'}
+        cancelText="Cancel"
+        onConfirm={onConfirmPost}
+        onCancel={onCancelPost}
+        loading={actionLoading}
+        severity="info"
+      />
+
+      <ConfirmationDialog
+        open={!!deleteTarget}
+        title="Delete Transfer"
+        message={`Delete transfer ${deleteTarget?.referenceNumber}? This can be undone from View Deleted.`}
+        confirmText={actionLoading ? 'Deleting...' : 'Delete'}
         cancelText="Keep"
-        onConfirm={onConfirmCancel}
-        onCancel={onCancelCancel}
-        loading={cancelling}
+        onConfirm={onConfirmDelete}
+        onCancel={onCancelDelete}
+        loading={actionLoading}
         severity="error"
+      />
+
+      <ConfirmationDialog
+        open={!!unpostTarget}
+        title="Unpost Transfer"
+        message={`Unpost transfer ${unpostTarget?.referenceNumber}? This will post a reversing journal entry.`}
+        confirmText={actionLoading ? 'Unposting...' : 'Unpost Transfer'}
+        cancelText="Cancel"
+        onConfirm={onConfirmUnpost}
+        onCancel={onCancelUnpost}
+        loading={actionLoading}
+        severity="error"
+      />
+
+      <ConfirmationDialog
+        open={!!restoreTarget}
+        title="Restore Transfer"
+        message={`Restore transfer ${restoreTarget?.referenceNumber}?`}
+        confirmText={actionLoading ? 'Restoring...' : 'Restore'}
+        cancelText="Cancel"
+        onConfirm={onConfirmRestore}
+        onCancel={onCancelRestore}
+        loading={actionLoading}
+        severity="info"
       />
     </>
   )

--- a/frontend/src/pages/accounting/components/FundTransfersList.tsx
+++ b/frontend/src/pages/accounting/components/FundTransfersList.tsx
@@ -14,7 +14,9 @@ interface Props {
 }
 
 function statusColor(status: string) {
-  return status === 'ACTIVE' ? 'success' as const : 'error' as const
+  if (status === 'posted') return 'success' as const
+  if (status === 'reversed') return 'error' as const
+  return 'warning' as const  // draft
 }
 
 const columns: ColumnConfig<FundTransfer>[] = [

--- a/frontend/src/pages/accounting/components/__tests__/ExpenseContextHeader.test.tsx
+++ b/frontend/src/pages/accounting/components/__tests__/ExpenseContextHeader.test.tsx
@@ -85,11 +85,11 @@ describe('ExpenseContextHeader', () => {
     expect(screen.queryByText('Unpost')).not.toBeInTheDocument()
   })
 
-  it('shows no action buttons for reversed expenses', () => {
+  it('shows Edit, Post, Delete buttons for reversed expenses', () => {
     renderHeader({ selected: { ...draftExpense, status: 'reversed' as const }, isAdmin: true })
-    expect(screen.queryByText('Edit')).not.toBeInTheDocument()
-    expect(screen.queryByText('Post')).not.toBeInTheDocument()
-    expect(screen.queryByText('Delete')).not.toBeInTheDocument()
+    expect(screen.getByText('Edit')).toBeInTheDocument()
+    expect(screen.getByText('Post')).toBeInTheDocument()
+    expect(screen.getByText('Delete')).toBeInTheDocument()
     expect(screen.queryByText('Unpost')).not.toBeInTheDocument()
     expect(screen.queryByText('Restore')).not.toBeInTheDocument()
   })

--- a/frontend/src/pages/accounting/hooks/useExpensesWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useExpensesWorkspace.ts
@@ -71,6 +71,7 @@ export function useExpensesWorkspace(
       setPostTarget(null)
       dispatch(setSelectedExpense(null))
       refetch()
+      workspace.setShouldPreserveSearchFocus(true)
     }
     catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to post expense'))
@@ -78,7 +79,7 @@ export function useExpensesWorkspace(
     finally {
       setActionLoading(false)
     }
-  }, [postTarget, postExpense, showSuccess, showError, refetch, dispatch])
+  }, [postTarget, postExpense, showSuccess, showError, refetch, dispatch, workspace])
 
   const handleConfirmDelete = useCallback(async () => {
     if (!deleteTarget) return
@@ -89,6 +90,7 @@ export function useExpensesWorkspace(
       setDeleteTarget(null)
       dispatch(setSelectedExpense(null))
       refetch()
+      workspace.setShouldPreserveSearchFocus(true)
     }
     catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to delete expense'))
@@ -96,7 +98,7 @@ export function useExpensesWorkspace(
     finally {
       setActionLoading(false)
     }
-  }, [deleteTarget, deleteExpense, showSuccess, showError, refetch, dispatch])
+  }, [deleteTarget, deleteExpense, showSuccess, showError, refetch, dispatch, workspace])
 
   const handleConfirmUnpost = useCallback(async () => {
     if (!unpostTarget) return
@@ -107,6 +109,7 @@ export function useExpensesWorkspace(
       setUnpostTarget(null)
       dispatch(setSelectedExpense(null))
       refetch()
+      workspace.setShouldPreserveSearchFocus(true)
     }
     catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to unpost expense'))
@@ -114,7 +117,7 @@ export function useExpensesWorkspace(
     finally {
       setActionLoading(false)
     }
-  }, [unpostTarget, unpostExpense, showSuccess, showError, refetch, dispatch])
+  }, [unpostTarget, unpostExpense, showSuccess, showError, refetch, dispatch, workspace])
 
   const handleConfirmRestore = useCallback(async () => {
     if (!restoreTarget) return
@@ -125,6 +128,7 @@ export function useExpensesWorkspace(
       setRestoreTarget(null)
       dispatch(setSelectedExpense(null))
       refetch()
+      workspace.setShouldPreserveSearchFocus(true)
     }
     catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to restore expense'))
@@ -132,7 +136,7 @@ export function useExpensesWorkspace(
     finally {
       setActionLoading(false)
     }
-  }, [restoreTarget, restoreExpense, showSuccess, showError, refetch, dispatch])
+  }, [restoreTarget, restoreExpense, showSuccess, showError, refetch, dispatch, workspace])
 
   return {
     focusedIndex: workspace.focusedIndex,
@@ -151,6 +155,7 @@ export function useExpensesWorkspace(
     restoreTarget,
     setRestoreTarget,
     actionLoading,
+    setShouldPreserveSearchFocus: workspace.setShouldPreserveSearchFocus,
     handleSelect: workspace.handleSelect,
     handleConfirmPost,
     handleConfirmDelete,

--- a/frontend/src/pages/accounting/hooks/useExpensesWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useExpensesWorkspace.ts
@@ -6,6 +6,7 @@ import { useNotification } from '@/hooks/useNotification'
 import type { AppDispatch } from '@/store'
 import {
   useDeleteExpenseMutation,
+  useLazyGetExpenseQuery,
   usePostExpenseMutation,
   useRestoreExpenseMutation,
   useUnpostExpenseMutation,
@@ -30,6 +31,7 @@ export function useExpensesWorkspace(
   const [formOpen, setFormOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<ExpenseRecord | null>(null)
 
+  const [fetchItem] = useLazyGetExpenseQuery()
   const [postExpense] = usePostExpenseMutation()
   const [deleteExpense] = useDeleteExpenseMutation()
   const [restoreExpense] = useRestoreExpenseMutation()
@@ -69,9 +71,9 @@ export function useExpensesWorkspace(
       await postExpense(postTarget.id).unwrap()
       showSuccess(`Expense ${postTarget.referenceNumber} posted`)
       setPostTarget(null)
-      dispatch(setSelectedExpense(null))
       refetch()
-      workspace.setShouldPreserveSearchFocus(true)
+      const fresh = await fetchItem(postTarget.id).unwrap()
+      dispatch(setSelectedExpense(fresh))
     }
     catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to post expense'))
@@ -79,7 +81,7 @@ export function useExpensesWorkspace(
     finally {
       setActionLoading(false)
     }
-  }, [postTarget, postExpense, showSuccess, showError, refetch, dispatch, workspace])
+  }, [postTarget, postExpense, showSuccess, showError, refetch, dispatch, fetchItem])
 
   const handleConfirmDelete = useCallback(async () => {
     if (!deleteTarget) return
@@ -90,7 +92,6 @@ export function useExpensesWorkspace(
       setDeleteTarget(null)
       dispatch(setSelectedExpense(null))
       refetch()
-      workspace.setShouldPreserveSearchFocus(true)
     }
     catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to delete expense'))
@@ -98,7 +99,7 @@ export function useExpensesWorkspace(
     finally {
       setActionLoading(false)
     }
-  }, [deleteTarget, deleteExpense, showSuccess, showError, refetch, dispatch, workspace])
+  }, [deleteTarget, deleteExpense, showSuccess, showError, refetch, dispatch])
 
   const handleConfirmUnpost = useCallback(async () => {
     if (!unpostTarget) return
@@ -107,9 +108,9 @@ export function useExpensesWorkspace(
       await unpostExpense(unpostTarget.id).unwrap()
       showSuccess(`Expense ${unpostTarget.referenceNumber} unposted`)
       setUnpostTarget(null)
-      dispatch(setSelectedExpense(null))
       refetch()
-      workspace.setShouldPreserveSearchFocus(true)
+      const fresh = await fetchItem(unpostTarget.id).unwrap()
+      dispatch(setSelectedExpense(fresh))
     }
     catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to unpost expense'))
@@ -117,7 +118,7 @@ export function useExpensesWorkspace(
     finally {
       setActionLoading(false)
     }
-  }, [unpostTarget, unpostExpense, showSuccess, showError, refetch, dispatch, workspace])
+  }, [unpostTarget, unpostExpense, showSuccess, showError, refetch, dispatch, fetchItem])
 
   const handleConfirmRestore = useCallback(async () => {
     if (!restoreTarget) return
@@ -126,9 +127,9 @@ export function useExpensesWorkspace(
       await restoreExpense(restoreTarget.id).unwrap()
       showSuccess(`Expense ${restoreTarget.referenceNumber} restored`)
       setRestoreTarget(null)
-      dispatch(setSelectedExpense(null))
       refetch()
-      workspace.setShouldPreserveSearchFocus(true)
+      const fresh = await fetchItem(restoreTarget.id).unwrap()
+      dispatch(setSelectedExpense(fresh))
     }
     catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to restore expense'))
@@ -136,7 +137,7 @@ export function useExpensesWorkspace(
     finally {
       setActionLoading(false)
     }
-  }, [restoreTarget, restoreExpense, showSuccess, showError, refetch, dispatch, workspace])
+  }, [restoreTarget, restoreExpense, showSuccess, showError, refetch, dispatch, fetchItem])
 
   return {
     focusedIndex: workspace.focusedIndex,

--- a/frontend/src/pages/accounting/hooks/useExpensesWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useExpensesWorkspace.ts
@@ -48,7 +48,10 @@ export function useExpensesWorkspace(
     },
     notifications: { showSuccess, showError },
     onEnter: () => {
-      if (selected) setFormOpen(true)
+      if (selected && (selected.status === 'draft' || selected.status === 'reversed')) {
+        setEditTarget(selected)
+        setFormOpen(true)
+      }
     },
     onEscape: () => {
       dispatch(setSelectedExpense(null))

--- a/frontend/src/pages/accounting/hooks/useFundTransfersWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useFundTransfersWorkspace.ts
@@ -83,6 +83,7 @@ export function useFundTransfersWorkspace(
       setPostTarget(null)
       dispatch(setSelectedFundTransfer(null))
       refetch()
+      workspace.setShouldPreserveSearchFocus(true)
     }
     catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to post transfer'))
@@ -90,7 +91,7 @@ export function useFundTransfersWorkspace(
     finally {
       setActionLoading(false)
     }
-  }, [postTarget, postFundTransfer, showSuccess, showError, refetch, dispatch])
+  }, [postTarget, postFundTransfer, showSuccess, showError, refetch, dispatch, workspace])
 
   const handleConfirmDelete = useCallback(async () => {
     if (!deleteTarget) return
@@ -101,6 +102,7 @@ export function useFundTransfersWorkspace(
       setDeleteTarget(null)
       dispatch(setSelectedFundTransfer(null))
       refetch()
+      workspace.setShouldPreserveSearchFocus(true)
     }
     catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to delete transfer'))
@@ -108,7 +110,7 @@ export function useFundTransfersWorkspace(
     finally {
       setActionLoading(false)
     }
-  }, [deleteTarget, deleteFundTransfer, showSuccess, showError, refetch, dispatch])
+  }, [deleteTarget, deleteFundTransfer, showSuccess, showError, refetch, dispatch, workspace])
 
   const handleConfirmUnpost = useCallback(async () => {
     if (!unpostTarget) return
@@ -119,6 +121,7 @@ export function useFundTransfersWorkspace(
       setUnpostTarget(null)
       dispatch(setSelectedFundTransfer(null))
       refetch()
+      workspace.setShouldPreserveSearchFocus(true)
     }
     catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to unpost transfer'))
@@ -126,7 +129,7 @@ export function useFundTransfersWorkspace(
     finally {
       setActionLoading(false)
     }
-  }, [unpostTarget, unpostFundTransfer, showSuccess, showError, refetch, dispatch])
+  }, [unpostTarget, unpostFundTransfer, showSuccess, showError, refetch, dispatch, workspace])
 
   const handleConfirmRestore = useCallback(async () => {
     if (!restoreTarget) return
@@ -137,6 +140,7 @@ export function useFundTransfersWorkspace(
       setRestoreTarget(null)
       dispatch(setSelectedFundTransfer(null))
       refetch()
+      workspace.setShouldPreserveSearchFocus(true)
     }
     catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to restore transfer'))
@@ -144,7 +148,7 @@ export function useFundTransfersWorkspace(
     finally {
       setActionLoading(false)
     }
-  }, [restoreTarget, restoreFundTransfer, showSuccess, showError, refetch, dispatch])
+  }, [restoreTarget, restoreFundTransfer, showSuccess, showError, refetch, dispatch, workspace])
 
   return {
     focusedIndex: workspace.focusedIndex,
@@ -165,6 +169,7 @@ export function useFundTransfersWorkspace(
     actionLoading,
     deletedDialogOpen,
     setDeletedDialogOpen,
+    setShouldPreserveSearchFocus: workspace.setShouldPreserveSearchFocus,
     handleSelect,
     handleConfirmPost,
     handleConfirmDelete,

--- a/frontend/src/pages/accounting/hooks/useFundTransfersWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useFundTransfersWorkspace.ts
@@ -51,7 +51,10 @@ export function useFundTransfersWorkspace(
     },
     notifications: { showSuccess, showError },
     onEnter: () => {
-      if (selected) setFormOpen(true)
+      if (selected && (selected.status === 'draft' || selected.status === 'reversed')) {
+        setEditTarget(selected)
+        setFormOpen(true)
+      }
     },
     onEscape: () => {
       dispatch(setSelectedFundTransfer(null))

--- a/frontend/src/pages/accounting/hooks/useFundTransfersWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useFundTransfersWorkspace.ts
@@ -4,9 +4,16 @@ import { useNavigate } from 'react-router-dom'
 import { useEntityWorkspace } from '@/hooks/useEntityWorkspace'
 import { useNotification } from '@/hooks/useNotification'
 import type { AppDispatch } from '@/store'
-import { useCancelFundTransferMutation, useLazyGetFundTransferQuery } from '@/store/api/accountingApi'
+import {
+  useDeleteFundTransferMutation,
+  useLazyGetFundTransferQuery,
+  usePostFundTransferMutation,
+  useRestoreFundTransferMutation,
+  useUnpostFundTransferMutation,
+} from '@/store/api/accountingApi'
 import { setSelectedFundTransfer } from '@/store/slices/accountingSlice'
 import type { FundTransfer } from '@/types'
+import { getErrorMessage } from '@/utils/errorMessage'
 
 export function useFundTransfersWorkspace(
   refetch: () => void,
@@ -15,10 +22,21 @@ export function useFundTransfersWorkspace(
   selected: FundTransfer | null,
 ) {
   const navigate = useNavigate()
-  const { showError, showSuccess } = useNotification()
-  const [cancelTarget, setCancelTarget] = useState<FundTransfer | null>(null)
+  const { showSuccess, showError } = useNotification()
+  const [postTarget, setPostTarget] = useState<FundTransfer | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<FundTransfer | null>(null)
+  const [unpostTarget, setUnpostTarget] = useState<FundTransfer | null>(null)
+  const [restoreTarget, setRestoreTarget] = useState<FundTransfer | null>(null)
+  const [actionLoading, setActionLoading] = useState(false)
+  const [formOpen, setFormOpen] = useState(false)
+  const [editTarget, setEditTarget] = useState<FundTransfer | null>(null)
+  const [deletedDialogOpen, setDeletedDialogOpen] = useState(false)
+
   const [fetchItem] = useLazyGetFundTransferQuery()
-  const [cancelFundTransfer, { isLoading: cancelling }] = useCancelFundTransferMutation()
+  const [postFundTransfer] = usePostFundTransferMutation()
+  const [deleteFundTransfer] = useDeleteFundTransferMutation()
+  const [unpostFundTransfer] = useUnpostFundTransferMutation()
+  const [restoreFundTransfer] = useRestoreFundTransferMutation()
 
   const workspace = useEntityWorkspace<FundTransfer>({
     entities: transfers,
@@ -32,46 +50,122 @@ export function useFundTransfersWorkspace(
       edit: () => '/accounting/fund-transfers',
     },
     notifications: { showSuccess, showError },
-    deleteMutation: async () => {},
+    onEnter: () => {
+      if (selected) setFormOpen(true)
+    },
     onEscape: () => {
       dispatch(setSelectedFundTransfer(null))
-      setCancelTarget(null)
+      setPostTarget(null)
+      setDeleteTarget(null)
+      setUnpostTarget(null)
+      setRestoreTarget(null)
     },
   })
 
-  const { handleSelect: workspaceHandleSelect } = workspace
-
   const handleSelect = useCallback(async (item: FundTransfer) => {
-    workspaceHandleSelect(item)
+    workspace.handleSelect(item)
     try {
       const fresh = await fetchItem(item.id).unwrap()
       dispatch(setSelectedFundTransfer(fresh))
     }
     catch { /* keep list-row data */ }
-  }, [fetchItem, workspaceHandleSelect, dispatch])
+  }, [fetchItem, workspace, dispatch])
 
-  const handleConfirmCancel = useCallback(async () => {
-    if (!cancelTarget) return
+  const handleConfirmPost = useCallback(async () => {
+    if (!postTarget) return
+    setActionLoading(true)
     try {
-      const next = await cancelFundTransfer(cancelTarget.id).unwrap()
-      showSuccess(`Transfer ${cancelTarget.referenceNumber} cancelled`)
-      dispatch(setSelectedFundTransfer(next))
-      setCancelTarget(null)
+      await postFundTransfer(postTarget.id).unwrap()
+      showSuccess(`Transfer ${postTarget.referenceNumber} posted`)
+      setPostTarget(null)
+      dispatch(setSelectedFundTransfer(null))
       refetch()
     }
-    catch (error: any) {
-      showError(error?.data?.message ?? error?.message ?? 'Operation failed')
+    catch (error: unknown) {
+      showError(getErrorMessage(error, 'Failed to post transfer'))
     }
-  }, [cancelFundTransfer, cancelTarget, refetch, showError, showSuccess, dispatch])
+    finally {
+      setActionLoading(false)
+    }
+  }, [postTarget, postFundTransfer, showSuccess, showError, refetch, dispatch])
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!deleteTarget) return
+    setActionLoading(true)
+    try {
+      await deleteFundTransfer(deleteTarget.id).unwrap()
+      showSuccess(`Transfer ${deleteTarget.referenceNumber} deleted`)
+      setDeleteTarget(null)
+      dispatch(setSelectedFundTransfer(null))
+      refetch()
+    }
+    catch (error: unknown) {
+      showError(getErrorMessage(error, 'Failed to delete transfer'))
+    }
+    finally {
+      setActionLoading(false)
+    }
+  }, [deleteTarget, deleteFundTransfer, showSuccess, showError, refetch, dispatch])
+
+  const handleConfirmUnpost = useCallback(async () => {
+    if (!unpostTarget) return
+    setActionLoading(true)
+    try {
+      await unpostFundTransfer(unpostTarget.id).unwrap()
+      showSuccess(`Transfer ${unpostTarget.referenceNumber} unposted`)
+      setUnpostTarget(null)
+      dispatch(setSelectedFundTransfer(null))
+      refetch()
+    }
+    catch (error: unknown) {
+      showError(getErrorMessage(error, 'Failed to unpost transfer'))
+    }
+    finally {
+      setActionLoading(false)
+    }
+  }, [unpostTarget, unpostFundTransfer, showSuccess, showError, refetch, dispatch])
+
+  const handleConfirmRestore = useCallback(async () => {
+    if (!restoreTarget) return
+    setActionLoading(true)
+    try {
+      await restoreFundTransfer(restoreTarget.id).unwrap()
+      showSuccess(`Transfer ${restoreTarget.referenceNumber} restored`)
+      setRestoreTarget(null)
+      dispatch(setSelectedFundTransfer(null))
+      refetch()
+    }
+    catch (error: unknown) {
+      showError(getErrorMessage(error, 'Failed to restore transfer'))
+    }
+    finally {
+      setActionLoading(false)
+    }
+  }, [restoreTarget, restoreFundTransfer, showSuccess, showError, refetch, dispatch])
 
   return {
     focusedIndex: workspace.focusedIndex,
     listRef: workspace.listRef,
     searchInputRef: workspace.searchInputRef,
-    cancelTarget,
-    setCancelTarget,
-    cancelling,
+    formOpen,
+    setFormOpen,
+    editTarget,
+    setEditTarget,
+    postTarget,
+    setPostTarget,
+    deleteTarget,
+    setDeleteTarget,
+    unpostTarget,
+    setUnpostTarget,
+    restoreTarget,
+    setRestoreTarget,
+    actionLoading,
+    deletedDialogOpen,
+    setDeletedDialogOpen,
     handleSelect,
-    handleConfirmCancel,
+    handleConfirmPost,
+    handleConfirmDelete,
+    handleConfirmUnpost,
+    handleConfirmRestore,
   }
 }

--- a/frontend/src/pages/accounting/hooks/useFundTransfersWorkspace.ts
+++ b/frontend/src/pages/accounting/hooks/useFundTransfersWorkspace.ts
@@ -81,9 +81,9 @@ export function useFundTransfersWorkspace(
       await postFundTransfer(postTarget.id).unwrap()
       showSuccess(`Transfer ${postTarget.referenceNumber} posted`)
       setPostTarget(null)
-      dispatch(setSelectedFundTransfer(null))
       refetch()
-      workspace.setShouldPreserveSearchFocus(true)
+      const fresh = await fetchItem(postTarget.id).unwrap()
+      dispatch(setSelectedFundTransfer(fresh))
     }
     catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to post transfer'))
@@ -91,7 +91,7 @@ export function useFundTransfersWorkspace(
     finally {
       setActionLoading(false)
     }
-  }, [postTarget, postFundTransfer, showSuccess, showError, refetch, dispatch, workspace])
+  }, [postTarget, postFundTransfer, showSuccess, showError, refetch, dispatch, fetchItem])
 
   const handleConfirmDelete = useCallback(async () => {
     if (!deleteTarget) return
@@ -102,7 +102,6 @@ export function useFundTransfersWorkspace(
       setDeleteTarget(null)
       dispatch(setSelectedFundTransfer(null))
       refetch()
-      workspace.setShouldPreserveSearchFocus(true)
     }
     catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to delete transfer'))
@@ -110,7 +109,7 @@ export function useFundTransfersWorkspace(
     finally {
       setActionLoading(false)
     }
-  }, [deleteTarget, deleteFundTransfer, showSuccess, showError, refetch, dispatch, workspace])
+  }, [deleteTarget, deleteFundTransfer, showSuccess, showError, refetch, dispatch])
 
   const handleConfirmUnpost = useCallback(async () => {
     if (!unpostTarget) return
@@ -119,9 +118,9 @@ export function useFundTransfersWorkspace(
       await unpostFundTransfer(unpostTarget.id).unwrap()
       showSuccess(`Transfer ${unpostTarget.referenceNumber} unposted`)
       setUnpostTarget(null)
-      dispatch(setSelectedFundTransfer(null))
       refetch()
-      workspace.setShouldPreserveSearchFocus(true)
+      const fresh = await fetchItem(unpostTarget.id).unwrap()
+      dispatch(setSelectedFundTransfer(fresh))
     }
     catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to unpost transfer'))
@@ -129,7 +128,7 @@ export function useFundTransfersWorkspace(
     finally {
       setActionLoading(false)
     }
-  }, [unpostTarget, unpostFundTransfer, showSuccess, showError, refetch, dispatch, workspace])
+  }, [unpostTarget, unpostFundTransfer, showSuccess, showError, refetch, dispatch, fetchItem])
 
   const handleConfirmRestore = useCallback(async () => {
     if (!restoreTarget) return
@@ -138,9 +137,9 @@ export function useFundTransfersWorkspace(
       await restoreFundTransfer(restoreTarget.id).unwrap()
       showSuccess(`Transfer ${restoreTarget.referenceNumber} restored`)
       setRestoreTarget(null)
-      dispatch(setSelectedFundTransfer(null))
       refetch()
-      workspace.setShouldPreserveSearchFocus(true)
+      const fresh = await fetchItem(restoreTarget.id).unwrap()
+      dispatch(setSelectedFundTransfer(fresh))
     }
     catch (error: unknown) {
       showError(getErrorMessage(error, 'Failed to restore transfer'))

--- a/frontend/src/store/api/accountingApi.ts
+++ b/frontend/src/store/api/accountingApi.ts
@@ -367,6 +367,11 @@ export const accountingApiSlice = createApi({
       transformResponse: normalizePaginated<ExpenseRecord>,
       providesTags: ['Expense'],
     }),
+    getExpense: builder.query<ExpenseRecord, string>({
+      query: (id) => ({ url: `/accounting/expenses/${id}` }),
+      transformResponse: normalizeSingle<ExpenseRecord>,
+      providesTags: (_result, _error, id) => [{ type: 'Expense', id }],
+    }),
     getFundTransfers: builder.query<PaginatedResponse<FundTransfer>, Record<string, unknown> | undefined>({
       query: (params) => ({ url: '/accounting/fund-transfers', params: params ?? {} }),
       transformResponse: normalizePaginated<FundTransfer>,
@@ -885,6 +890,7 @@ export const {
   useGetPendingSettlementPaymentsQuery,
   useGetOwnerEquityTransactionsQuery,
   useGetExpensesQuery,
+  useLazyGetExpenseQuery,
   useGetFundTransfersQuery,
   useGetFundTransferQuery,
   useLazyGetFundTransferQuery,

--- a/frontend/src/store/api/accountingApi.ts
+++ b/frontend/src/store/api/accountingApi.ts
@@ -90,6 +90,15 @@ type CreateFundTransferPayload = {
   description?: string
 }
 
+type UpdateFundTransferPayload = {
+  id: string
+  sourceAccountId?: string
+  destinationAccountId?: string
+  amount?: number
+  transferDate?: string
+  description?: string
+}
+
 export interface BankReconciliationsParams {
   search?: string
   status?: string
@@ -804,8 +813,17 @@ export const accountingApiSlice = createApi({
       transformResponse: normalizeSingle<FundTransfer>,
       invalidatesTags: ['FundTransfer', 'JournalEntry', 'AccountingReport'],
     }),
-    cancelFundTransfer: builder.mutation<FundTransfer, string>({
-      query: (id) => ({ url: `/accounting/fund-transfers/${id}/cancel`, method: 'POST' }),
+    updateFundTransfer: builder.mutation<FundTransfer, UpdateFundTransferPayload>({
+      query: ({ id, ...body }) => ({ url: `/accounting/fund-transfers/${id}`, method: 'PATCH', data: body }),
+      transformResponse: normalizeSingle<FundTransfer>,
+      invalidatesTags: (_result, _error, { id }) => [{ type: 'FundTransfer', id }, 'FundTransfer'],
+    }),
+    deleteFundTransfer: builder.mutation<void, string>({
+      query: (id) => ({ url: `/accounting/fund-transfers/${id}`, method: 'DELETE' }),
+      invalidatesTags: (_result, _error, id) => [{ type: 'FundTransfer', id }, 'FundTransfer'],
+    }),
+    postFundTransfer: builder.mutation<FundTransfer, string>({
+      query: (id) => ({ url: `/accounting/fund-transfers/${id}/post`, method: 'POST' }),
       transformResponse: normalizeSingle<FundTransfer>,
       invalidatesTags: (_result, _error, id) => [
         { type: 'FundTransfer', id },
@@ -813,6 +831,30 @@ export const accountingApiSlice = createApi({
         'JournalEntry',
         'AccountingReport',
       ],
+    }),
+    unpostFundTransfer: builder.mutation<FundTransfer, string>({
+      query: (id) => ({ url: `/accounting/fund-transfers/${id}/unpost`, method: 'POST' }),
+      transformResponse: normalizeSingle<FundTransfer>,
+      invalidatesTags: (_result, _error, id) => [
+        { type: 'FundTransfer', id },
+        'FundTransfer',
+        'JournalEntry',
+        'AccountingReport',
+      ],
+    }),
+    getDeletedFundTransfers: builder.query<FundTransfer[], void>({
+      query: () => ({ url: '/accounting/fund-transfers/deleted', method: 'GET' }),
+      transformResponse: (response: any) => (Array.isArray(response) ? response : response?.data ?? []),
+      providesTags: ['FundTransfer'],
+    }),
+    restoreFundTransfer: builder.mutation<FundTransfer, string>({
+      query: (id) => ({ url: `/accounting/fund-transfers/${id}/restore`, method: 'POST' }),
+      transformResponse: normalizeSingle<FundTransfer>,
+      invalidatesTags: (_result, _error, id) => [{ type: 'FundTransfer', id }, 'FundTransfer'],
+    }),
+    permanentDeleteFundTransfer: builder.mutation<void, string>({
+      query: (id) => ({ url: `/accounting/fund-transfers/${id}/permanent`, method: 'DELETE' }),
+      invalidatesTags: ['FundTransfer'],
     }),
   }),
 })
@@ -912,5 +954,11 @@ export const {
   useBulkPermanentDeleteExpensesMutation,
   useBulkRestoreExpensesMutation,
   useCreateFundTransferMutation,
-  useCancelFundTransferMutation,
+  useUpdateFundTransferMutation,
+  useDeleteFundTransferMutation,
+  usePostFundTransferMutation,
+  useUnpostFundTransferMutation,
+  useGetDeletedFundTransfersQuery,
+  useRestoreFundTransferMutation,
+  usePermanentDeleteFundTransferMutation,
 } = accountingApiSlice

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -514,9 +514,10 @@ export interface FundTransfer {
   transferDate: string;
   amount: number;
   description?: string;
-  status: 'ACTIVE' | 'CANCELLED';
+  status: 'draft' | 'posted' | 'reversed';
   fiscalPeriodId: string;
   journalEntryId: string | null;
+  deletedAt?: string | null;
   sourceAccount: {
     id: string;
     code: string;


### PR DESCRIPTION
## Summary

- Replaces `ACTIVE/CANCELLED` enum with `DRAFT/POSTED/REVERSED` lifecycle on Fund Transfers, mirroring the Expenses module exactly
- New transfers save as DRAFT with no journal entry; posting creates the JE; unposting reverses it
- Edit, re-post, and soft-delete are allowed on both DRAFT and REVERSED; blocked on POSTED
- Deleted transfers can be viewed, restored, or permanently deleted via a new View Deleted dialog (Admin only)
- Same lifecycle fixes applied to Expenses: REVERSED records now show Edit/Post/Delete buttons and can be deleted
- After post/unpost/restore, the selected record stays selected and the context header updates in place

## Changes

**Backend**
- `fund-transfer.entity.ts` — new `FundTransferStatus` enum (draft/posted/reversed), default DRAFT
- Migration `1779034397938-FundTransferLifecycle` — varchar-cast pattern to migrate existing rows (ACTIVE→posted, CANCELLED→reversed)
- `fund-transfer.service.ts` — new methods: `post`, `unpost`, `update`, `remove`, `getDeleted`, `restore`, `permanentDelete`; removed `cancel`
- `fund-transfer.controller.ts` — full route set with correct ordering (deleted before :id); RBAC per spec
- `expense.service.ts` — removed guard blocking soft-delete on REVERSED

**Frontend**
- `FundTransferContextHeader` / `ExpenseContextHeader` — REVERSED now shows Edit + Post + Delete buttons
- `useFundTransfersWorkspace` / `useExpensesWorkspace` — post/unpost/restore re-fetch and re-select the updated record; Enter key opens edit dialog for editable statuses
- `DeletedFundTransfersDialog` — new component using `GenericDeletedDialog`
- `accountingApi.ts` — added `getExpense` single-record endpoint + all new fund transfer mutations

## Test Plan

- [ ] Create a new fund transfer → saved as DRAFT, no journal entry
- [ ] Post a DRAFT → status becomes POSTED, JE created, Unpost button appears
- [ ] Unpost a POSTED → status becomes REVERSED, Edit/Post/Delete buttons appear, context header stays selected
- [ ] Edit a REVERSED transfer → form opens pre-filled, save updates record
- [ ] Post a REVERSED transfer → status becomes POSTED again
- [ ] Delete a DRAFT or REVERSED → disappears from list, appears in View Deleted
- [ ] Restore from View Deleted → record returns to list
- [ ] Permanently delete from View Deleted → gone
- [ ] Filter by Draft / Posted / Reversed
- [ ] Repeat post/unpost/delete flow for Expenses

Closes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)