### PR TITLE
feat(accounting): move statement date inline and add secondary sort in reconciliation list

### DIFF
--- a/backend/src/modules/accounting/services/reconciliation.service.spec.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.spec.ts
@@ -70,6 +70,7 @@ describe('ReconciliationService', () => {
     select: jest.fn().mockReturnThis(),
     addSelect: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
     skip: jest.fn().mockReturnThis(),
     take: jest.fn().mockReturnThis(),
     getOne: jest.fn().mockResolvedValue(result),
@@ -401,6 +402,15 @@ describe('ReconciliationService', () => {
       const result = await service.findAll({ page: 1, limit: 20 });
       expect(result.data).toHaveLength(1);
       expect(result.meta.total).toBe(1);
+    });
+
+    it('should apply secondary sort by account name ASC', async () => {
+      const queryBuilder = createMockQueryBuilder([mockReconciliation], 1);
+      reconciliationRepo.createQueryBuilder.mockReturnValue(queryBuilder as any);
+
+      await service.findAll({ page: 1, limit: 20 });
+
+      expect(queryBuilder.addOrderBy).toHaveBeenCalledWith('account.name', 'ASC');
     });
 
     it('should search by account and fiscal period fields', async () => {

--- a/backend/src/modules/accounting/services/reconciliation.service.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.ts
@@ -176,6 +176,7 @@ export class ReconciliationService {
     const sortField = validSortFields.includes(sortBy) ? sortBy : 'reconciliationDate';
     const safeSortOrder = sortOrder?.toUpperCase() === 'DESC' ? 'DESC' : 'ASC';
     queryBuilder.orderBy(`recon.${sortField}`, safeSortOrder);
+    queryBuilder.addOrderBy('account.name', 'ASC');
 
     const offset = (page - 1) * limit;
     queryBuilder.skip(offset).take(limit);

--- a/backend/src/modules/accounting/services/reconciliation.service.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.ts
@@ -176,6 +176,7 @@ export class ReconciliationService {
     const sortField = validSortFields.includes(sortBy) ? sortBy : 'reconciliationDate';
     const safeSortOrder = sortOrder?.toUpperCase() === 'DESC' ? 'DESC' : 'ASC';
     queryBuilder.orderBy(`recon.${sortField}`, safeSortOrder);
+    // Hardcoded tiebreaker; account.name intentionally excluded from validSortFields to avoid sort-direction conflict
     queryBuilder.addOrderBy('account.name', 'ASC');
 
     const offset = (page - 1) * limit;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erp-frontend",
-  "version": "1.118.1",
+  "version": "1.119.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-frontend",
-      "version": "1.118.1",
+      "version": "1.119.2",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -21,7 +21,7 @@
         "chart.js": "^4.4.0",
         "chartjs-adapter-date-fns": "^3.0.0",
         "chartjs-plugin-zoom": "^2.2.0",
-        "date-fns": "4.1.0",
+        "date-fns": "^4.2.1",
         "dompurify": "^3.4.2",
         "jspdf": "^4.1.0",
         "jspdf-autotable": "^5.0.7",
@@ -3047,6 +3047,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3114,9 +3123,9 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.2.1.tgz",
+      "integrity": "sha512-37RhSdxaG1suen6VDCza6rNrQfooyQh57HFVPwQGEq2QWliVLzPQZ8Oa017weOu+HZCnzI7N3Pf/wyoBKfEqrA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -6447,15 +6456,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/frontend/src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
@@ -156,8 +156,24 @@ describe('BankReconciliationsPage', () => {
     renderPage()
 
     expect(screen.getAllByText('Main Checking').length).toBeGreaterThan(0)
-    expect(screen.getAllByText('October 2024').length).toBeGreaterThan(0)
     expect(screen.getByText('Reconciliations (1)')).toBeInTheDocument()
+  })
+
+  it('renders account name and date inline with bullet separator', () => {
+    mockedApi.useGetBankReconciliationsQuery.mockReturnValue({
+      data: { data: [MOCK_RECONCILIATION_IN_PROGRESS], meta: { total: 1 } },
+      isLoading: false,
+      refetch: vi.fn(),
+    })
+
+    renderPage()
+
+    expect(
+      screen.getByText((_, element) =>
+        element?.tagName.toLowerCase() === 'p' &&
+        /Main Checking\s*•\s*October 2024/.test(element.textContent ?? ''),
+      ),
+    ).toBeInTheDocument()
   })
 
   it('passes committed search to the API query', async () => {

--- a/frontend/src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx
@@ -146,7 +146,7 @@ describe('BankReconciliationsPage', () => {
     expect(screen.queryByText('Account')).not.toBeInTheDocument()
   })
 
-  it('renders reconciliation account name in sidebar', () => {
+  it('renders reconciliation account name and date inline in sidebar', () => {
     mockedApi.useGetBankReconciliationsQuery.mockReturnValue({
       data: { data: [MOCK_RECONCILIATION_IN_PROGRESS], meta: { total: 1 } },
       isLoading: false,
@@ -155,19 +155,7 @@ describe('BankReconciliationsPage', () => {
 
     renderPage()
 
-    expect(screen.getAllByText('Main Checking').length).toBeGreaterThan(0)
     expect(screen.getByText('Reconciliations (1)')).toBeInTheDocument()
-  })
-
-  it('renders account name and date inline with bullet separator', () => {
-    mockedApi.useGetBankReconciliationsQuery.mockReturnValue({
-      data: { data: [MOCK_RECONCILIATION_IN_PROGRESS], meta: { total: 1 } },
-      isLoading: false,
-      refetch: vi.fn(),
-    })
-
-    renderPage()
-
     expect(
       screen.getByText((_, element) =>
         element?.tagName.toLowerCase() === 'p' &&

--- a/frontend/src/pages/accounting/components/BankReconciliationsTable.tsx
+++ b/frontend/src/pages/accounting/components/BankReconciliationsTable.tsx
@@ -14,7 +14,7 @@ const COLUMNS: ColumnConfig<BankReconciliation>[] = [
         {item.account?.name ?? '-'}
         <Box component="span" sx={{ color: 'text.secondary', fontWeight: 400 }}>
           {' • '}
-          {format(new Date(item.reconciliationDate), 'MMMM yyyy')}
+          {item.reconciliationDate ? format(new Date(item.reconciliationDate), 'MMMM yyyy') : ''}
         </Box>
       </Typography>
     ),

--- a/frontend/src/pages/accounting/components/BankReconciliationsTable.tsx
+++ b/frontend/src/pages/accounting/components/BankReconciliationsTable.tsx
@@ -10,14 +10,13 @@ const COLUMNS: ColumnConfig<BankReconciliation>[] = [
     key: 'account',
     raw: true,
     render: (item) => (
-      <Box>
-        <Typography variant="body2" sx={{ fontWeight: 500, fontSize: '0.8rem', lineHeight: 1.3 }}>
-          {item.account?.name ?? '-'}
-        </Typography>
-        <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: '0.75rem' }}>
+      <Typography variant="body2" noWrap sx={{ fontWeight: 500, fontSize: '0.8rem' }}>
+        {item.account?.name ?? '-'}
+        <Box component="span" sx={{ color: 'text.secondary', fontWeight: 400 }}>
+          {' • '}
           {format(new Date(item.reconciliationDate), 'MMMM yyyy')}
-        </Typography>
-      </Box>
+        </Box>
+      </Typography>
     ),
   },
 ]


### PR DESCRIPTION
## Summary

- Collapses the two-line account/date cell in the Bank Reconciliations list into a single inline line: `Account Name • Month Year`
- Adds `account.name ASC` as a hardcoded secondary sort tiebreaker in `reconciliation.service.ts` `findAll`, so records with the same date are consistently ordered A→Z by account name
- Updates frontend lock file to sync `date-fns@4.2.1`

## Test Plan

- [x] Backend: `npx jest src/modules/accounting/services/reconciliation.service.spec.ts --no-coverage` — 51/51 pass
- [x] Frontend: `npx vitest run src/pages/accounting/__tests__/BankReconciliationsPage.test.tsx` — 16/16 pass
- [x] Frontend type-check passes
- [x] Docker build passes (`./deploy.sh`)
- [x] Reconciliation list shows `Account Name • Month Year` inline
- [x] Records with the same date are ordered A→Z by account name

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)