### PR TITLE
chore: remove unused common/services/index.ts barrel

### DIFF
--- a/backend/src/common/services/index.ts
+++ b/backend/src/common/services/index.ts
@@ -1,2 +1,0 @@
-export * from './base-crud.service';
-export * from './export.service';


### PR DESCRIPTION
## Summary
- Removes `backend/src/common/services/index.ts` which was identified by Knip as dead code
- All consumers already import `BaseCrudService` and `ExportService` directly from their source files, not from this barrel
- Lint and TypeScript type-check pass cleanly after removal

## Test plan
- [x] Confirmed no imports of `common/services` barrel in the codebase
- [x] `npm run lint` passes with no errors
- [x] `tsc --noEmit` passes with no errors

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)