### PR TITLE
refactor: unify document numbering across all modules (#619)

### DIFF
--- a/backend/src/database/entities/payment.entity.ts
+++ b/backend/src/database/entities/payment.entity.ts
@@ -51,12 +51,12 @@ export enum SettlementStatusEnum {
 export class Payment extends BaseEntity {
   @Column({
     type: 'varchar',
-    length: 30,
+    length: 50,
     unique: true,
     comment: 'Unique payment reference number',
   })
   @IsString()
-  @MaxLength(30)
+  @MaxLength(50)
   paymentNumber: string;
 
   

--- a/backend/src/database/entities/payment.entity.ts
+++ b/backend/src/database/entities/payment.entity.ts
@@ -4,7 +4,6 @@ import {
   Index,
   ManyToOne,
   JoinColumn,
-  BeforeInsert,
 } from 'typeorm';
 import {
   IsString,
@@ -174,14 +173,5 @@ export class Payment extends BaseEntity {
   // Computed properties
   get isCompleted(): boolean {
     return this.status === PaymentStatus.COMPLETED;
-  }
-
-  // Hooks
-  @BeforeInsert()
-  generatePaymentNumber() {
-    if (!this.paymentNumber) {
-      const timestamp = Date.now().toString(36).toUpperCase();
-      this.paymentNumber = `PAY-${timestamp}`;
-    }
   }
 }

--- a/backend/src/database/migrations/1779100000000-ExpandPaymentNumberLength.ts
+++ b/backend/src/database/migrations/1779100000000-ExpandPaymentNumberLength.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ExpandPaymentNumberLength1779100000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "payments" ALTER COLUMN "paymentNumber" TYPE varchar(50)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "payments" ALTER COLUMN "paymentNumber" TYPE varchar(30)`,
+    );
+  }
+}

--- a/backend/src/modules/sales/services/invoice.service.spec.ts
+++ b/backend/src/modules/sales/services/invoice.service.spec.ts
@@ -10,6 +10,7 @@ import { Product } from '../../../database/entities/product.entity';
 import { InvoiceItem } from '../../../database/entities/invoice-item.entity';
 import { AuditLogService } from '../../audit-logs/services';
 import { UserRole } from '../../../database/entities/user.entity';
+import { SettingsService } from '../../settings/settings.service';
 
 describe('InvoiceService.searchGlobal', () => {
   let service: InvoiceService;
@@ -39,6 +40,7 @@ describe('InvoiceService.searchGlobal', () => {
         { provide: getRepositoryToken(Product), useValue: {} },
         { provide: getRepositoryToken(InvoiceItem), useValue: {} },
         { provide: AuditLogService, useValue: { log: jest.fn(), createLog: jest.fn() } },
+        { provide: SettingsService, useValue: { generateDocumentNumber: jest.fn() } },
       ],
     }).compile();
 
@@ -153,6 +155,7 @@ describe('InvoiceService.findAll - new filter params', () => {
         { provide: getRepositoryToken(Product), useValue: {} },
         { provide: getRepositoryToken(InvoiceItem), useValue: {} },
         { provide: AuditLogService, useValue: { log: jest.fn(), createLog: jest.fn() } },
+        { provide: SettingsService, useValue: { generateDocumentNumber: jest.fn() } },
       ],
     }).compile();
 
@@ -277,6 +280,7 @@ describe('InvoiceService.softDelete', () => {
         { provide: getRepositoryToken(Product), useValue: {} },
         { provide: getRepositoryToken(InvoiceItem), useValue: {} },
         { provide: AuditLogService, useValue: { log: jest.fn(), createLog: jest.fn() } },
+        { provide: SettingsService, useValue: { generateDocumentNumber: jest.fn() } },
       ],
     }).compile();
 
@@ -309,5 +313,60 @@ describe('InvoiceService.softDelete', () => {
     await expect(service.softDelete('inv-1', 'user-1', 'tester')).rejects.toThrow(
       'Can only delete invoices that are in DRAFT status',
     );
+  });
+});
+
+describe('InvoiceService.create', () => {
+  let service: InvoiceService;
+  let invoiceRepository: jest.Mocked<any>;
+  let customerRepository: jest.Mocked<any>;
+  let settingsService: jest.Mocked<Pick<SettingsService, 'generateDocumentNumber'>>;
+
+  beforeEach(async () => {
+    invoiceRepository = {
+      createQueryBuilder: jest.fn(),
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+    };
+    customerRepository = { findOne: jest.fn() };
+    settingsService = { generateDocumentNumber: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InvoiceService,
+        { provide: getRepositoryToken(Invoice), useValue: invoiceRepository },
+        { provide: getRepositoryToken(Customer), useValue: customerRepository },
+        { provide: getRepositoryToken(SalesOrder), useValue: { findOne: jest.fn() } },
+        { provide: getRepositoryToken(Payment), useValue: {} },
+        { provide: getRepositoryToken(Product), useValue: {} },
+        { provide: getRepositoryToken(InvoiceItem), useValue: { create: jest.fn(), save: jest.fn() } },
+        { provide: AuditLogService, useValue: { log: jest.fn(), createLog: jest.fn() } },
+        { provide: SettingsService, useValue: settingsService },
+      ],
+    }).compile();
+
+    service = module.get(InvoiceService);
+  });
+
+  it('calls generateDocumentNumber("Invoices") when creating an invoice', async () => {
+    const dto = {
+      customerId: 'cust-1',
+      totalAmount: 500,
+    };
+    customerRepository.findOne.mockResolvedValue({ id: 'cust-1', name: 'Test' });
+    settingsService.generateDocumentNumber.mockResolvedValue('INV-26-001');
+    const mockInvoice = { id: 'inv-1', invoiceNumber: 'INV-26-001' };
+    invoiceRepository.create.mockReturnValue(mockInvoice);
+    invoiceRepository.save.mockResolvedValue(mockInvoice);
+    invoiceRepository.findOne.mockResolvedValue({
+      ...mockInvoice,
+      customer: { id: 'cust-1', name: 'Test' },
+      items: [],
+    });
+
+    await service.create(dto as any);
+
+    expect(settingsService.generateDocumentNumber).toHaveBeenCalledWith('Invoices');
   });
 });

--- a/backend/src/modules/sales/services/invoice.service.spec.ts
+++ b/backend/src/modules/sales/services/invoice.service.spec.ts
@@ -368,5 +368,8 @@ describe('InvoiceService.create', () => {
     await service.create(dto as any);
 
     expect(settingsService.generateDocumentNumber).toHaveBeenCalledWith('Invoices');
+    expect(invoiceRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ invoiceNumber: 'INV-26-001' }),
+    );
   });
 });

--- a/backend/src/modules/sales/services/invoice.service.ts
+++ b/backend/src/modules/sales/services/invoice.service.ts
@@ -181,10 +181,6 @@ export class InvoiceService extends BaseCrudService<
     }
   }
 
-  private async generateSequentialInvoiceNumber(): Promise<string> {
-    return this.settingsService.generateDocumentNumber('Invoices');
-  }
-
   async create(
     createInvoiceDto: CreateInvoiceDto,
     userId?: string,
@@ -213,8 +209,7 @@ export class InvoiceService extends BaseCrudService<
     // Calculate total amount from sales order or use provided amount
     const totalAmount = createInvoiceDto.totalAmount || (salesOrder?.totalAmount || 0);
 
-    // Generate sequential invoice number
-    const invoiceNumber = await this.generateSequentialInvoiceNumber();
+    const invoiceNumber = await this.settingsService.generateDocumentNumber('Invoices');
 
     // Create invoice
     const invoice = this.invoiceRepository.create({

--- a/backend/src/modules/sales/services/invoice.service.ts
+++ b/backend/src/modules/sales/services/invoice.service.ts
@@ -39,6 +39,7 @@ import {
 } from '../../search/search.constants';
 import { JwtPayload } from '../../auth/strategies/jwt.strategy';
 import { UserRole } from '../../../database/entities/user.entity';
+import { SettingsService } from '../../settings/settings.service';
 // import { EmailService } from '../../auth/services/email.service'; // Temporarily disabled
 
 @Injectable()
@@ -62,6 +63,7 @@ export class InvoiceService extends BaseCrudService<
     @InjectRepository(InvoiceItem)
     private readonly invoiceItemRepository: Repository<InvoiceItem>,
     auditLogService: AuditLogService,
+    private readonly settingsService: SettingsService,
     // private readonly emailService: EmailService, // Temporarily disabled
   ) {
     super(invoiceRepository, auditLogService);
@@ -180,28 +182,7 @@ export class InvoiceService extends BaseCrudService<
   }
 
   private async generateSequentialInvoiceNumber(): Promise<string> {
-    // Get all existing invoice numbers that match the sequential format
-    const invoices = await this.invoiceRepository.find({
-      select: ['invoiceNumber']
-    });
-
-    let maxNumber = 0;
-    for (const invoice of invoices) {
-      // Extract number from format INV-000001 (only sequential format)
-      const match = invoice.invoiceNumber.match(/^INV-(\d+)$/);
-      if (match) {
-        const num = parseInt(match[1]);
-        if (num > maxNumber) {
-          maxNumber = num;
-        }
-      }
-    }
-
-    // Next sequential number
-    const nextNumber = maxNumber + 1;
-
-    // Format with leading zeros (6 digits)
-    return `INV-${nextNumber.toString().padStart(6, '0')}`;
+    return this.settingsService.generateDocumentNumber('Invoices');
   }
 
   async create(

--- a/backend/src/modules/sales/services/payment.service.spec.ts
+++ b/backend/src/modules/sales/services/payment.service.spec.ts
@@ -10,6 +10,7 @@ import { AuditLogService } from '../../audit-logs/services';
 import { AccountingService } from '../../accounting/services/accounting.service';
 import { NotFoundException } from '@nestjs/common';
 import { UserRole } from '../../../database/entities/user.entity';
+import { SettingsService } from '../../settings/settings.service';
 
 describe('PaymentService', () => {
   let service: PaymentService;
@@ -19,10 +20,11 @@ describe('PaymentService', () => {
   let paymentMethodRepository: jest.Mocked<Repository<PaymentMethodEntity>>;
   let accountingService: jest.Mocked<AccountingService>;
   let auditLogService: jest.Mocked<AuditLogService>;
+  let settingsService: jest.Mocked<Pick<SettingsService, 'generateDocumentNumber'>>;
 
   const createMockPayment = (): Partial<Payment> => ({
     id: '123e4567-e89b-12d3-a456-426614174000',
-    paymentNumber: 'PAY-000001',
+    paymentNumber: 'PAY-26-001',
     amount: 1000,
     paymentDate: new Date('2024-01-15'),
     status: PaymentStatus.COMPLETED,
@@ -85,6 +87,12 @@ describe('PaymentService', () => {
             reverseSourceEntries: jest.fn(),
           },
         },
+        {
+          provide: SettingsService,
+          useValue: {
+            generateDocumentNumber: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -95,6 +103,8 @@ describe('PaymentService', () => {
     paymentMethodRepository = module.get(getRepositoryToken(PaymentMethodEntity));
     accountingService = module.get(AccountingService);
     auditLogService = module.get(AuditLogService);
+    settingsService = module.get(SettingsService);
+    (settingsService.generateDocumentNumber as jest.Mock).mockResolvedValue('PAY-26-001');
   });
 
   it('should be defined', () => {
@@ -155,6 +165,7 @@ describe('PaymentService', () => {
       const result = await service.create(createDto);
 
       // Assert
+      expect(settingsService.generateDocumentNumber).toHaveBeenCalledWith('Payments');
       expect(accountingService.postCustomerPaymentEntry).toHaveBeenCalledWith(
         expect.objectContaining({
           id: mockPayment.id,

--- a/backend/src/modules/sales/services/payment.service.spec.ts
+++ b/backend/src/modules/sales/services/payment.service.spec.ts
@@ -166,6 +166,9 @@ describe('PaymentService', () => {
 
       // Assert
       expect(settingsService.generateDocumentNumber).toHaveBeenCalledWith('Payments');
+      expect(paymentRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ paymentNumber: 'PAY-26-001' }),
+      );
       expect(accountingService.postCustomerPaymentEntry).toHaveBeenCalledWith(
         expect.objectContaining({
           id: mockPayment.id,

--- a/backend/src/modules/sales/services/payment.service.ts
+++ b/backend/src/modules/sales/services/payment.service.ts
@@ -36,6 +36,7 @@ import {
 } from '../../search/search.constants';
 import { JwtPayload } from '../../auth/strategies/jwt.strategy';
 import { UserRole } from '../../../database/entities/user.entity';
+import { SettingsService } from '../../settings/settings.service';
 
 @Injectable()
 export class PaymentService extends BaseCrudService<
@@ -57,6 +58,7 @@ export class PaymentService extends BaseCrudService<
     private readonly paymentMethodRepository: Repository<PaymentMethodEntity>,
     auditLogService: AuditLogService,
     private readonly accountingService: AccountingService,
+    private readonly settingsService: SettingsService,
   ) {
     super(paymentRepository, auditLogService);
   }
@@ -115,9 +117,12 @@ export class PaymentService extends BaseCrudService<
       throw new NotFoundException('Payment method not found');
     }
 
+    const paymentNumber = await this.settingsService.generateDocumentNumber('Payments');
+
     // Create payment
     const payment = this.paymentRepository.create({
       ...createPaymentDto,
+      paymentNumber,
       status: PaymentStatus.COMPLETED,
       paymentMethodId: paymentMethod.id,
       settlementStatus: paymentMethod.requiresSettlement

--- a/backend/src/modules/sales/services/payment.service.ts
+++ b/backend/src/modules/sales/services/payment.service.ts
@@ -490,12 +490,15 @@ export class PaymentService extends BaseCrudService<
 
     const refundMethodCode = originalPayment.paymentMethodEntity?.code || 'CASH';
 
+    const refundNumber = await this.settingsService.generateDocumentNumber('Payments');
+
     // Create a refund payment record (negative amount)
     const refundPayment = this.paymentRepository.create({
       customerId: originalPayment.customerId,
       invoiceId: originalPayment.invoiceId,
       paymentDate: new Date(),
       amount: -refundDto.amount,
+      paymentNumber: refundNumber,
       status: PaymentStatus.REFUNDED,
       paymentMethodId: originalPayment.paymentMethodId,
       settlementStatus: originalPayment.settlementStatus,

--- a/backend/src/modules/settings/settings.service.spec.ts
+++ b/backend/src/modules/settings/settings.service.spec.ts
@@ -39,6 +39,7 @@ describe('SettingsService', () => {
       {} as any,
       {} as any,
       {} as any,
+      {} as any, // dataSource
     );
 
     await service.syncDocumentNumbersWithDatabase();

--- a/backend/src/modules/settings/settings.service.ts
+++ b/backend/src/modules/settings/settings.service.ts
@@ -5,7 +5,7 @@ import {
   InternalServerErrorException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { CompanySettings } from '../../database/entities/company-settings.entity';
 import { RegionalSettings } from '../../database/entities/regional-settings.entity';
 import { DocumentNumberSetting } from '../../database/entities/document-number-settings.entity';
@@ -70,6 +70,7 @@ export class SettingsService {
     private settlementRepository: Repository<Settlement>,
     @InjectRepository(OwnerEquityTransaction)
     private ownerEquityRepository: Repository<OwnerEquityTransaction>,
+    private readonly dataSource: DataSource,
   ) {}
 
   /**
@@ -425,29 +426,35 @@ export class SettingsService {
    * Generate next document number for a specific document type
    */
   async generateDocumentNumber(documentName: string): Promise<string> {
-    const row = await this.documentNumberSettingRepository.findOne({
-      where: { documentName },
+    return this.dataSource.transaction(async (manager) => {
+      const rows = await manager.query(
+        `SELECT * FROM document_number_settings WHERE "documentName" = $1 FOR UPDATE`,
+        [documentName],
+      );
+
+      if (!rows.length) {
+        throw new NotFoundException(`Document number config for '${documentName}' not found`);
+      }
+
+      const row = rows[0];
+      const currentYY = new Date().getFullYear() % 100;
+
+      if (row.lastResetYear !== currentYY) {
+        row.nextNumber = 1;
+        row.lastResetYear = currentYY;
+      }
+
+      const yy = String(currentYY).padStart(2, '0');
+      const seq = String(row.nextNumber).padStart(row.paddingDigits, '0');
+      const documentNumber = `${row.prefix}-${yy}-${seq}`;
+
+      await manager.query(
+        `UPDATE document_number_settings SET "nextNumber" = $1, "lastResetYear" = $2 WHERE "documentName" = $3`,
+        [row.nextNumber + 1, row.lastResetYear, documentName],
+      );
+
+      return documentNumber;
     });
-
-    if (!row) {
-      throw new NotFoundException(`Document number config for '${documentName}' not found`);
-    }
-
-    const currentYY = new Date().getFullYear() % 100;
-
-    if (row.lastResetYear !== currentYY) {
-      row.nextNumber = 1;
-      row.lastResetYear = currentYY;
-    }
-
-    const yy = String(currentYY).padStart(2, '0');
-    const seq = String(row.nextNumber).padStart(row.paddingDigits, '0');
-    const documentNumber = `${row.prefix}-${yy}-${seq}`;
-
-    row.nextNumber += 1;
-    await this.documentNumberSettingRepository.save(row);
-
-    return documentNumber;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Replace legacy O(N) invoice number generation in `InvoiceService` with `SettingsService.generateDocumentNumber('Invoices')`
- Remove `@BeforeInsert` timestamp hook from `Payment` entity; generate payment numbers explicitly in `PaymentService.create()` via `SettingsService.generateDocumentNumber('Payments')`
- Update `invoice.service.spec.ts` and `payment.service.spec.ts` to mock `SettingsService`

New payment number format: `PAY-26-001` (was `PAY-{timestamp}`). Legacy payment numbers are left as-is; `syncDocumentNumbersWithDatabase()` ignores them and starts the sequential counter from 1 for the current year.

Closes #619

## Test plan
- [x] `npx jest src/modules/sales/services/invoice.service.spec.ts --no-coverage` passes
- [x] `npx jest src/modules/sales/services/payment.service.spec.ts --no-coverage` passes
- [x] `npx jest src/modules/sales/ --no-coverage` passes
- [x] `npm run test` passes with no regressions
- [x] `npm run lint` passes