### PR TITLE
chore(deps): upgrade TypeORM to 1.0.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erp-backend",
-  "version": "1.120.4",
+  "version": "1.120.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-backend",
-      "version": "1.120.4",
+      "version": "1.120.5",
       "license": "MIT",
       "dependencies": {
         "@nestjs/bull": "^11.0.3",
@@ -45,7 +45,7 @@
         "rxjs": "^7.8.1",
         "sanitize-html": "^2.17.3",
         "socket.io": "^4.8.1",
-        "typeorm": "^0.3.17",
+        "typeorm": "^1.0.0",
         "uuid": "^14.0.0"
       },
       "devDependencies": {
@@ -4106,6 +4106,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4115,6 +4116,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4147,15 +4149,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/app-root-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.1.0.tgz",
-      "integrity": "sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0"
       }
     },
     "node_modules/append-field": {
@@ -4280,21 +4273,6 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/b4a": {
       "version": "1.8.1",
@@ -4834,24 +4812,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -5090,6 +5050,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -5104,6 +5065,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -5158,6 +5120,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5170,6 +5133,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -5581,23 +5545,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -5872,6 +5819,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -6775,7 +6723,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6891,21 +6838,6 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/for-each": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/fork-ts-checker-webpack-plugin": {
       "version": "9.1.0",
@@ -7129,6 +7061,18 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -7298,18 +7242,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -7326,6 +7258,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -7559,18 +7492,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -7585,6 +7506,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7660,21 +7582,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -7687,12 +7594,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -9798,7 +9699,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9894,15 +9794,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -10276,6 +10167,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10546,23 +10438,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -10574,26 +10449,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
-    },
-    "node_modules/sha.js": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
-      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
-      "license": "(MIT AND BSD-3-Clause)",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "safe-buffer": "^5.2.1",
-        "to-buffer": "^1.2.0"
-      },
-      "bin": {
-        "sha.js": "bin.js"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -10946,6 +10801,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -10960,6 +10816,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -11372,7 +11229,6 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11400,20 +11256,6 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/to-buffer": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
-      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "^2.0.5",
-        "safe-buffer": "^5.2.1",
-        "typed-array-buffer": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -11722,20 +11564,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/typed-array-buffer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -11743,26 +11571,21 @@
       "license": "MIT"
     },
     "node_modules/typeorm": {
-      "version": "0.3.30",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.30.tgz",
-      "integrity": "sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-1.0.0.tgz",
+      "integrity": "sha512-2mSKNqucP8vo+xQLP59xlHUcqLvG6qajxA7q7tnhJgeZjTrA6lK/Ar7LRyiAxdXhyXmGbIPsArPmcUB9Xg+M7w==",
       "license": "MIT",
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
-        "app-root-path": "^3.1.0",
-        "buffer": "^6.0.3",
         "dayjs": "^1.11.20",
         "debug": "^4.4.3",
         "dedent": "^1.7.2",
-        "dotenv": "^16.6.1",
-        "glob": "^10.5.0",
         "reflect-metadata": "^0.2.2",
-        "sha.js": "^2.4.12",
         "sql-highlight": "^6.1.0",
+        "tinyglobby": "^0.2.16",
         "tslib": "^2.8.1",
-        "uuid": "^11.1.1",
-        "yargs": "^17.7.2"
+        "yargs": "^18.0.0"
       },
       "bin": {
         "typeorm": "cli.js",
@@ -11770,28 +11593,27 @@
         "typeorm-ts-node-esm": "cli-ts-node-esm.js"
       },
       "engines": {
-        "node": ">=16.13.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24.11.0"
       },
       "funding": {
         "url": "https://opencollective.com/typeorm"
       },
       "peerDependencies": {
-        "@google-cloud/spanner": "^5.18.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "@google-cloud/spanner": "^8.0.0",
         "@sap/hana-client": "^2.14.22",
-        "better-sqlite3": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
+        "better-sqlite3": "^12.0.0",
         "ioredis": "^5.0.4",
-        "mongodb": "^5.8.0 || ^6.0.0",
-        "mssql": "^9.1.1 || ^10.0.0 || ^11.0.0 || ^12.0.0",
-        "mysql2": "^2.2.5 || ^3.0.1",
+        "mongodb": "^7.0.0",
+        "mssql": "^12.0.0",
+        "mysql2": "^3.15.3",
         "oracledb": "^6.3.0",
         "pg": "^8.5.1",
         "pg-native": "^3.0.0",
         "pg-query-stream": "^4.0.0",
-        "redis": "^3.1.1 || ^4.0.0 || ^5.0.14",
+        "redis": "^5.0.0",
         "sql.js": "^1.4.0",
-        "sqlite3": "^5.0.3",
-        "ts-node": "^10.7.0",
-        "typeorm-aurora-data-api-driver": "^2.0.0 || ^3.0.0"
+        "ts-node": "^10.9.2",
+        "typeorm-aurora-data-api-driver": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "@google-cloud/spanner": {
@@ -11833,9 +11655,6 @@
         "sql.js": {
           "optional": true
         },
-        "sqlite3": {
-          "optional": true
-        },
         "ts-node": {
           "optional": true
         },
@@ -11844,53 +11663,123 @@
         }
       }
     },
-    "node_modules/typeorm/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
+    "node_modules/typeorm/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/typeorm/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
       "funding": {
-        "url": "https://dotenvx.com"
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
-    "node_modules/typeorm/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
+    "node_modules/typeorm/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/typeorm/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/typeorm/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/typeorm/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typeorm/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/typeorm/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/typeorm/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/typeorm/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/typescript": {
@@ -12356,27 +12245,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -12485,6 +12353,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -12503,6 +12372,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/backend/package.json
+++ b/backend/package.json
@@ -65,7 +65,7 @@
     "rxjs": "^7.8.1",
     "sanitize-html": "^2.17.3",
     "socket.io": "^4.8.1",
-    "typeorm": "^0.3.17",
+    "typeorm": "^1.0.0",
     "uuid": "^14.0.0"
   },
   "devDependencies": {

--- a/backend/src/modules/accounting/services/account-mapping.service.spec.ts
+++ b/backend/src/modules/accounting/services/account-mapping.service.spec.ts
@@ -365,7 +365,7 @@ describe('AccountMappingService', () => {
       expect(result.accountId).toBe(mockMapping.accountId);
       expect(mappingRepository.findOne).toHaveBeenCalledWith({
         where: { id: mockMappingId },
-        relations: ['account'],
+        relations: { account: true },
       });
     });
 

--- a/backend/src/modules/accounting/services/account-mapping.service.ts
+++ b/backend/src/modules/accounting/services/account-mapping.service.ts
@@ -164,7 +164,7 @@ export class AccountMappingService {
   async findOne(id: string): Promise<AccountMappingResponseDto> {
     const mapping = await this.mappingRepository.findOne({
       where: { id },
-      relations: ['account'],
+      relations: { account: true },
     });
 
     if (!mapping) {
@@ -218,7 +218,7 @@ export class AccountMappingService {
           await this.mappingRepository.save(restoredMapping);
         const mappingWithRelations = await this.mappingRepository.findOne({
           where: { id: savedRestoredMapping.id },
-          relations: ['account'],
+          relations: { account: true },
         });
 
         this.logger.log(
@@ -250,7 +250,7 @@ export class AccountMappingService {
           await this.mappingRepository.save(reactivatedMapping);
         const mappingWithRelations = await this.mappingRepository.findOne({
           where: { id: savedReactivatedMapping.id },
-          relations: ['account'],
+          relations: { account: true },
         });
 
         this.logger.log(
@@ -285,7 +285,7 @@ export class AccountMappingService {
     // Reload with relations
     const mappingWithRelations = await this.mappingRepository.findOne({
       where: { id: savedMapping.id },
-      relations: ['account'],
+      relations: { account: true },
     });
 
     this.logger.log(
@@ -313,7 +313,7 @@ export class AccountMappingService {
 
     const mapping = await this.mappingRepository.findOne({
       where: { id },
-      relations: ['account'],
+      relations: { account: true },
     });
 
     if (!mapping) {
@@ -339,7 +339,7 @@ export class AccountMappingService {
     // Reload with relations
     const mappingWithRelations = await this.mappingRepository.findOne({
       where: { id },
-      relations: ['account'],
+      relations: { account: true },
     });
 
     await this.auditLogService.log(

--- a/backend/src/modules/accounting/services/chart-of-accounts.service.spec.ts
+++ b/backend/src/modules/accounting/services/chart-of-accounts.service.spec.ts
@@ -307,7 +307,7 @@ describe('ChartOfAccountsService', () => {
       });
       expect(accountRepository.findOne).toHaveBeenCalledWith({
         where: { id: mockAccount.id },
-        relations: ['parent', 'children'],
+        relations: { parent: true, children: true },
       });
     });
 

--- a/backend/src/modules/accounting/services/chart-of-accounts.service.ts
+++ b/backend/src/modules/accounting/services/chart-of-accounts.service.ts
@@ -193,7 +193,7 @@ export class ChartOfAccountsService {
   async findOne(id: string): Promise<ChartOfAccountResponseDto> {
     const account = await this.accountRepository.findOne({
       where: { id },
-      relations: ['parent', 'children'],
+      relations: { parent: true, children: true },
     });
 
     if (!account) {
@@ -216,7 +216,7 @@ export class ChartOfAccountsService {
 
     const account = await this.accountRepository.findOne({
       where: { id },
-      relations: ['parent', 'children'],
+      relations: { parent: true, children: true },
     });
 
     if (!account) {
@@ -285,7 +285,7 @@ export class ChartOfAccountsService {
     // Reload with relations
     const accountWithRelations = await this.accountRepository.findOne({
       where: { id },
-      relations: ['parent', 'children'],
+      relations: { parent: true, children: true },
     });
 
     await this.auditLogService.log(
@@ -307,7 +307,7 @@ export class ChartOfAccountsService {
 
     const account = await this.accountRepository.findOne({
       where: { id },
-      relations: ['children'],
+      relations: { children: true },
     });
 
     if (!account) {
@@ -355,7 +355,7 @@ export class ChartOfAccountsService {
 
     const deletedAccounts = await this.accountRepository.find({
       where: {},
-      relations: ['parent'],
+      relations: { parent: true },
       withDeleted: true,
       order: { code: 'ASC' },
     });
@@ -375,7 +375,7 @@ export class ChartOfAccountsService {
 
     const account = await this.accountRepository.findOne({
       where: { id },
-      relations: ['parent'],
+      relations: { parent: true },
       withDeleted: true,
     });
 
@@ -404,7 +404,7 @@ export class ChartOfAccountsService {
     // Fetch the restored account
     const restoredAccount = await this.accountRepository.findOne({
       where: { id },
-      relations: ['parent', 'children'],
+      relations: { parent: true, children: true },
     });
 
     await this.auditLogService.log(
@@ -457,7 +457,7 @@ export class ChartOfAccountsService {
     // Get all accounts
     const accounts = await this.accountRepository.find({
       where: { isActive: true },
-      relations: ['parent', 'children'],
+      relations: { parent: true, children: true },
       order: { type: 'ASC', code: 'ASC' },
     });
 
@@ -504,7 +504,7 @@ export class ChartOfAccountsService {
     // Get children
     const children = await this.accountRepository.find({
       where: { parentId, isActive: true },
-      relations: ['parent'],
+      relations: { parent: true },
       order: { code: 'ASC' },
     });
 
@@ -552,7 +552,7 @@ export class ChartOfAccountsService {
 
     const account = await this.accountRepository.findOne({
       where: { id },
-      relations: ['children'],
+      relations: { children: true },
       withDeleted: true,
     });
 
@@ -806,7 +806,7 @@ export class ChartOfAccountsService {
   ): Promise<boolean> {
     const target = await this.accountRepository.findOne({
       where: { id: targetId },
-      relations: ['parent'],
+      relations: { parent: true },
     });
 
     if (!target || !target.parentId) {

--- a/backend/src/modules/accounting/services/expense.service.ts
+++ b/backend/src/modules/accounting/services/expense.service.ts
@@ -115,7 +115,7 @@ export class ExpenseService {
   async findOne(id: string): Promise<ExpenseResponseDto> {
     const expense = await this.expenseRepository.findOne({
       where: { id },
-      relations: ['paymentMethod', 'expenseAccount'],
+      relations: { paymentMethod: true, expenseAccount: true },
     });
 
     if (!expense || expense.deletedAt) {
@@ -258,7 +258,7 @@ export class ExpenseService {
   async post(id: string, userId?: string, username?: string): Promise<ExpenseResponseDto> {
     const expense = await this.expenseRepository.findOne({
       where: { id },
-      relations: ['paymentMethod', 'expenseAccount'],
+      relations: { paymentMethod: true, expenseAccount: true },
     });
 
     if (!expense || expense.deletedAt) {
@@ -420,7 +420,7 @@ export class ExpenseService {
     const records = await this.expenseRepository.find({
       withDeleted: true,
       where: { deletedAt: Not(IsNull()) },
-      relations: ['paymentMethod', 'expenseAccount'],
+      relations: { paymentMethod: true, expenseAccount: true },
       order: { deletedAt: 'DESC' },
     });
     return records.map((r) => this.toResponseDto(r));

--- a/backend/src/modules/accounting/services/fund-transfer.service.ts
+++ b/backend/src/modules/accounting/services/fund-transfer.service.ts
@@ -130,7 +130,7 @@ export class FundTransferService {
   ): Promise<FundTransferResponseDto> {
     const transfer = await this.transferRepository.findOne({
       where: { id },
-      relations: ['sourceAccount', 'destinationAccount'],
+      relations: { sourceAccount: true, destinationAccount: true },
     });
     if (!transfer || transfer.deletedAt) {
       throw new NotFoundException(`Fund transfer '${id}' not found`);
@@ -313,7 +313,7 @@ export class FundTransferService {
     const records = await this.transferRepository.find({
       withDeleted: true,
       where: { deletedAt: Not(IsNull()) },
-      relations: ['sourceAccount', 'destinationAccount', 'journalEntry'],
+      relations: { sourceAccount: true, destinationAccount: true, journalEntry: true },
       order: { deletedAt: 'DESC' },
     });
     return records.map((r) => this.toResponseDto(r));
@@ -437,13 +437,7 @@ export class FundTransferService {
   async findOne(id: string): Promise<FundTransferResponseDto> {
     const transfer = await this.transferRepository.findOne({
       where: { id },
-      relations: [
-        'sourceAccount',
-        'destinationAccount',
-        'journalEntry',
-        'journalEntry.lines',
-        'journalEntry.lines.account',
-      ],
+      relations: { sourceAccount: true, destinationAccount: true, journalEntry: { lines: { account: true } } },
     });
 
     if (!transfer || transfer.deletedAt) {

--- a/backend/src/modules/accounting/services/journal-entry.service.spec.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.spec.ts
@@ -680,7 +680,7 @@ describe('JournalEntryService', () => {
       expect(result.sourceRefNumber).toBe('INV-0042');
       expect(mockInvoiceRepo.findOne).toHaveBeenCalledWith({
         where: { id: 'invoice-1' },
-        select: ['id', 'invoiceNumber'],
+        select: { id: true, invoiceNumber: true },
       });
     });
 
@@ -993,7 +993,7 @@ describe('JournalEntryService', () => {
       expect(mockSalesOrderRepo.find).toHaveBeenCalledTimes(1);
       expect(mockSalesOrderRepo.find).toHaveBeenCalledWith({
         where: { id: expect.anything() },
-        select: ['id', 'orderNumber'],
+        select: { id: true, orderNumber: true },
       });
       expect(mockPaymentRepo.find).toHaveBeenCalledTimes(1);
       expect(map.get('sales_order:so-1')).toBe('SO-001');

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -301,7 +301,7 @@ export class JournalEntryService {
   async findOne(id: string): Promise<JournalEntryResponseDto> {
     const entry = await this.journalEntryRepository.findOne({
       where: { id },
-      relations: ['fiscalPeriod', 'lines', 'lines.account', 'reversalOf', 'reversedBy'],
+      relations: { fiscalPeriod: true, lines: { account: true }, reversalOf: true, reversedBy: true },
     });
 
     if (!entry) {
@@ -324,7 +324,7 @@ export class JournalEntryService {
 
     const entry = await this.journalEntryRepository.findOne({
       where: { id },
-      relations: ['lines'],
+      relations: { lines: true },
     });
 
     if (!entry) {
@@ -414,7 +414,7 @@ export class JournalEntryService {
 
     const entry = await this.journalEntryRepository.findOne({
       where: { id },
-      relations: ['reversedBy'],
+      relations: { reversedBy: true },
     });
 
     if (!entry) {
@@ -485,7 +485,7 @@ export class JournalEntryService {
 
     const entry = await this.journalEntryRepository.findOne({
       where: { id },
-      relations: ['fiscalPeriod', 'lines', 'lines.account'],
+      relations: { fiscalPeriod: true, lines: { account: true } },
     });
 
     if (!entry) {
@@ -551,7 +551,7 @@ export class JournalEntryService {
 
     const originalEntry = await this.journalEntryRepository.findOne({
       where: { id },
-      relations: ['fiscalPeriod', 'lines', 'lines.account'],
+      relations: { fiscalPeriod: true, lines: { account: true } },
     });
 
     if (!originalEntry) {
@@ -639,7 +639,7 @@ export class JournalEntryService {
 
     const originalEntry = await this.journalEntryRepository.findOne({
       where: { id },
-      relations: ['fiscalPeriod', 'lines', 'lines.account'],
+      relations: { fiscalPeriod: true, lines: { account: true } },
     });
 
     if (!originalEntry) {
@@ -716,7 +716,7 @@ export class JournalEntryService {
     // Only return original entries (not reversal entries) to avoid reversing reversals
     return this.journalEntryRepository.find({
       where: { sourceType, sourceId, reversalOfId: IsNull() },
-      relations: ['lines'],
+      relations: { lines: true },
     });
   }
 
@@ -871,7 +871,7 @@ export class JournalEntryService {
           case 'sales_order': {
             const records = await this.salesOrderRepository.find({
               where: { id: In(ids) },
-              select: ['id', 'orderNumber'],
+              select: { id: true, orderNumber: true },
             });
             for (const record of records) {
               refMap.set(`sales_order:${record.id}`, record.orderNumber);
@@ -881,7 +881,7 @@ export class JournalEntryService {
           case 'purchase_order': {
             const records = await this.purchaseOrderRepository.find({
               where: { id: In(ids) },
-              select: ['id', 'orderNumber'],
+              select: { id: true, orderNumber: true },
             });
             for (const record of records) {
               refMap.set(`purchase_order:${record.id}`, record.orderNumber);
@@ -891,7 +891,7 @@ export class JournalEntryService {
           case 'payment': {
             const records = await this.paymentRepository.find({
               where: { id: In(ids) },
-              select: ['id', 'paymentNumber'],
+              select: { id: true, paymentNumber: true },
             });
             for (const record of records) {
               refMap.set(`payment:${record.id}`, record.paymentNumber);
@@ -901,7 +901,7 @@ export class JournalEntryService {
           case 'goods_received_note': {
             const records = await this.grnRepository.find({
               where: { id: In(ids) },
-              select: ['id', 'grnNumber'],
+              select: { id: true, grnNumber: true },
             });
             for (const record of records) {
               refMap.set(`goods_received_note:${record.id}`, record.grnNumber);
@@ -911,7 +911,7 @@ export class JournalEntryService {
           case 'vendor_payment': {
             const records = await this.vendorPaymentRepository.find({
               where: { id: In(ids) },
-              select: ['id', 'paymentNumber'],
+              select: { id: true, paymentNumber: true },
             });
             for (const record of records) {
               refMap.set(`vendor_payment:${record.id}`, record.paymentNumber);
@@ -921,7 +921,7 @@ export class JournalEntryService {
           case 'expense': {
             const records = await this.expenseRepository.find({
               where: { id: In(ids) },
-              select: ['id', 'referenceNumber'],
+              select: { id: true, referenceNumber: true },
             });
             for (const record of records) {
               refMap.set(`expense:${record.id}`, record.referenceNumber);
@@ -931,7 +931,7 @@ export class JournalEntryService {
           case 'owner_equity_transaction': {
             const records = await this.ownerEquityTransactionRepository.find({
               where: { id: In(ids) },
-              select: ['id', 'referenceNumber'],
+              select: { id: true, referenceNumber: true },
             });
             for (const record of records) {
               refMap.set(`owner_equity_transaction:${record.id}`, record.referenceNumber);
@@ -941,7 +941,7 @@ export class JournalEntryService {
           case 'fund_transfer': {
             const records = await this.fundTransferRepository.find({
               where: { id: In(ids) },
-              select: ['id', 'referenceNumber'],
+              select: { id: true, referenceNumber: true },
             });
             for (const record of records) {
               refMap.set(`fund_transfer:${record.id}`, record.referenceNumber);
@@ -951,7 +951,7 @@ export class JournalEntryService {
           case 'stock_adjustment': {
             const records = await this.stockAdjustmentRepository.find({
               where: { id: In(ids) },
-              select: ['id', 'adjustmentNumber'],
+              select: { id: true, adjustmentNumber: true },
             });
             for (const record of records) {
               refMap.set(`stock_adjustment:${record.id}`, record.adjustmentNumber);
@@ -961,7 +961,7 @@ export class JournalEntryService {
           case 'invoice': {
             const records = await this.invoiceRepository.find({
               where: { id: In(ids) },
-              select: ['id', 'invoiceNumber'],
+              select: { id: true, invoiceNumber: true },
             });
             for (const record of records) {
               refMap.set(`invoice:${record.id}`, record.invoiceNumber);
@@ -990,70 +990,70 @@ export class JournalEntryService {
         case 'sales_order': {
           const record = await this.salesOrderRepository.findOne({
             where: { id: sourceId },
-            select: ['id', 'orderNumber'],
+            select: { id: true, orderNumber: true },
           });
           return record?.orderNumber;
         }
         case 'purchase_order': {
           const record = await this.purchaseOrderRepository.findOne({
             where: { id: sourceId },
-            select: ['id', 'orderNumber'],
+            select: { id: true, orderNumber: true },
           });
           return record?.orderNumber;
         }
         case 'payment': {
           const record = await this.paymentRepository.findOne({
             where: { id: sourceId },
-            select: ['id', 'paymentNumber'],
+            select: { id: true, paymentNumber: true },
           });
           return record?.paymentNumber;
         }
         case 'goods_received_note': {
           const record = await this.grnRepository.findOne({
             where: { id: sourceId },
-            select: ['id', 'grnNumber'],
+            select: { id: true, grnNumber: true },
           });
           return record?.grnNumber;
         }
         case 'vendor_payment': {
           const record = await this.vendorPaymentRepository.findOne({
             where: { id: sourceId },
-            select: ['id', 'paymentNumber'],
+            select: { id: true, paymentNumber: true },
           });
           return record?.paymentNumber;
         }
         case 'expense': {
           const record = await this.expenseRepository.findOne({
             where: { id: sourceId },
-            select: ['id', 'referenceNumber'],
+            select: { id: true, referenceNumber: true },
           });
           return record?.referenceNumber;
         }
         case 'owner_equity_transaction': {
           const record = await this.ownerEquityTransactionRepository.findOne({
             where: { id: sourceId },
-            select: ['id', 'referenceNumber'],
+            select: { id: true, referenceNumber: true },
           });
           return record?.referenceNumber;
         }
         case 'fund_transfer': {
           const record = await this.fundTransferRepository.findOne({
             where: { id: sourceId },
-            select: ['id', 'referenceNumber'],
+            select: { id: true, referenceNumber: true },
           });
           return record?.referenceNumber;
         }
         case 'stock_adjustment': {
           const record = await this.stockAdjustmentRepository.findOne({
             where: { id: sourceId },
-            select: ['id', 'adjustmentNumber'],
+            select: { id: true, adjustmentNumber: true },
           });
           return record?.adjustmentNumber;
         }
         case 'invoice': {
           const record = await this.invoiceRepository.findOne({
             where: { id: sourceId },
-            select: ['id', 'invoiceNumber'],
+            select: { id: true, invoiceNumber: true },
           });
           return record?.invoiceNumber;
         }

--- a/backend/src/modules/accounting/services/owner-equity.service.spec.ts
+++ b/backend/src/modules/accounting/services/owner-equity.service.spec.ts
@@ -150,7 +150,7 @@ describe('OwnerEquityService', () => {
     expect(result.id).toBe('tx-1');
     expect(ownerEquityRepository.findOne).toHaveBeenCalledWith({
       where: { id: 'tx-1' },
-      relations: ['paymentMethod'],
+      relations: { paymentMethod: true },
       withDeleted: true,
     });
   });
@@ -327,7 +327,7 @@ describe('OwnerEquityService', () => {
     expect(result.journalEntryId).toBe('je-1');
     expect(ownerEquityRepository.findOne).toHaveBeenCalledWith({
       where: { id: 'tx-1' },
-      relations: ['paymentMethod'],
+      relations: { paymentMethod: true },
       withDeleted: true,
     });
   });

--- a/backend/src/modules/accounting/services/owner-equity.service.ts
+++ b/backend/src/modules/accounting/services/owner-equity.service.ts
@@ -106,7 +106,7 @@ export class OwnerEquityService {
   async findOne(id: string): Promise<OwnerEquityResponseDto> {
     const transaction = await this.ownerEquityRepository.findOne({
       where: { id },
-      relations: ['paymentMethod'],
+      relations: { paymentMethod: true },
       withDeleted: true,
     });
 
@@ -224,7 +224,7 @@ export class OwnerEquityService {
   ): Promise<OwnerEquityResponseDto> {
     const transaction = await this.ownerEquityRepository.findOne({
       where: { id },
-      relations: ['paymentMethod'],
+      relations: { paymentMethod: true },
       withDeleted: true,
     });
 
@@ -268,7 +268,7 @@ export class OwnerEquityService {
   ): Promise<OwnerEquityResponseDto> {
     const transaction = await this.ownerEquityRepository.findOne({
       where: { id },
-      relations: ['paymentMethod'],
+      relations: { paymentMethod: true },
       withDeleted: true,
     });
 

--- a/backend/src/modules/accounting/services/reconciliation.service.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.ts
@@ -201,9 +201,14 @@ export class ReconciliationService {
    * Find one reconciliation by ID with all transactions
    */
   async findOne(id: string): Promise<BankReconciliationResponseDto> {
+    const withTransactions = {
+      account: true,
+      fiscalPeriod: true,
+      reconciledTransactions: { journalEntryLine: { account: true, journalEntry: true } },
+    };
     const reconciliation = await this.reconciliationRepository.findOne({
       where: { id },
-      relations: { account: true, fiscalPeriod: true, reconciledTransactions: { journalEntryLine: { account: true, journalEntry: true } } },
+      relations: withTransactions,
     });
 
     if (!reconciliation) {

--- a/backend/src/modules/accounting/services/reconciliation.service.ts
+++ b/backend/src/modules/accounting/services/reconciliation.service.ts
@@ -203,14 +203,7 @@ export class ReconciliationService {
   async findOne(id: string): Promise<BankReconciliationResponseDto> {
     const reconciliation = await this.reconciliationRepository.findOne({
       where: { id },
-      relations: [
-        'account',
-        'fiscalPeriod',
-        'reconciledTransactions',
-        'reconciledTransactions.journalEntryLine',
-        'reconciledTransactions.journalEntryLine.account',
-        'reconciledTransactions.journalEntryLine.journalEntry',
-      ],
+      relations: { account: true, fiscalPeriod: true, reconciledTransactions: { journalEntryLine: { account: true, journalEntry: true } } },
     });
 
     if (!reconciliation) {
@@ -224,7 +217,7 @@ export class ReconciliationService {
     const records = await this.reconciliationRepository.find({
       withDeleted: true,
       where: { deletedAt: Not(IsNull()) },
-      relations: ['account', 'fiscalPeriod'],
+      relations: { account: true, fiscalPeriod: true },
       order: { deletedAt: 'DESC' },
     });
     return records.map((r) => this.toResponseDto(r));
@@ -575,7 +568,7 @@ export class ReconciliationService {
   ): Promise<BankReconciliationResponseDto> {
     const reconciliation = await this.reconciliationRepository.findOne({
       where: { id },
-      relations: ['reconciledTransactions'],
+      relations: { reconciledTransactions: true },
     });
 
     if (!reconciliation) {

--- a/backend/src/modules/accounting/services/settlement.service.ts
+++ b/backend/src/modules/accounting/services/settlement.service.ts
@@ -85,7 +85,7 @@ export class SettlementService {
   async findOne(id: string): Promise<SettlementResponseDto> {
     const settlement = await this.settlementRepository.findOne({
       where: { id },
-      relations: ['paymentMethod'],
+      relations: { paymentMethod: true },
     });
 
     if (!settlement || settlement.deletedAt) {
@@ -118,7 +118,7 @@ export class SettlementService {
 
     const payments = await this.paymentRepository.find({
       where: { id: In(dto.paymentIds) },
-      relations: ['customer', 'paymentMethodEntity'],
+      relations: { customer: true, paymentMethodEntity: true },
     });
 
     if (payments.length !== dto.paymentIds.length) {
@@ -189,7 +189,7 @@ export class SettlementService {
   async cancel(id: string, userId?: string, username?: string): Promise<SettlementResponseDto> {
     const settlement = await this.settlementRepository.findOne({
       where: { id },
-      relations: ['paymentMethod'],
+      relations: { paymentMethod: true },
     });
 
     if (!settlement || settlement.deletedAt) {
@@ -234,7 +234,7 @@ export class SettlementService {
         paymentMethodId,
         settlementStatus: SettlementStatusEnum.PENDING,
       },
-      relations: ['customer', 'paymentMethodEntity'],
+      relations: { customer: true, paymentMethodEntity: true },
       order: { paymentDate: 'ASC' },
     });
   }

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -185,7 +185,7 @@ export class AuthService {
     // Find refresh token in database
     const refreshTokenRecord = await this.refreshTokenRepository.findOne({
       where: { tokenHash, isActive: true },
-      relations: ['user'],
+      relations: { user: true },
     });
 
     if (!refreshTokenRecord) {

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -46,7 +46,12 @@ export class AuthService {
     ipAddress?: string,
     userAgent?: string,
   ): Promise<AuthResponseDto> {
-    const { usernameOrEmail, password, rememberMe } = loginDto;
+    const { password, rememberMe } = loginDto;
+    const usernameOrEmail = loginDto.usernameOrEmail ?? loginDto.username;
+
+    if (!usernameOrEmail) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
 
     // Find user by username or email
     const user = await this.userRepository.findOne({

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -49,6 +49,7 @@ export class AuthService {
     const { password, rememberMe } = loginDto;
     const usernameOrEmail = loginDto.usernameOrEmail ?? loginDto.username;
 
+    // Empty-check done here (not via @IsNotEmpty on the DTO) to return 401 rather than 400
     if (!usernameOrEmail) {
       throw new UnauthorizedException('Invalid credentials');
     }

--- a/backend/src/modules/auth/dto/login.dto.ts
+++ b/backend/src/modules/auth/dto/login.dto.ts
@@ -3,11 +3,21 @@ import { IsString, IsNotEmpty, IsOptional, IsBoolean } from 'class-validator';
 
 export class LoginDto {
   @ApiProperty({
+    description: 'Legacy username field accepted for CLI and older clients',
+    example: 'admin',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  username?: string;
+
+  @ApiProperty({
     description: 'Username or email address for login',
     example: 'admin',
+    required: false,
   })
+  @IsOptional()
   @IsString()
-  @IsNotEmpty({ message: 'Username or email is required' })
   usernameOrEmail: string;
 
   @ApiProperty({

--- a/backend/src/modules/auth/dto/login.dto.ts
+++ b/backend/src/modules/auth/dto/login.dto.ts
@@ -18,7 +18,7 @@ export class LoginDto {
   })
   @IsOptional()
   @IsString()
-  usernameOrEmail: string;
+  usernameOrEmail?: string;
 
   @ApiProperty({
     description: 'User password',

--- a/backend/src/modules/inventory/services/category.service.spec.ts
+++ b/backend/src/modules/inventory/services/category.service.spec.ts
@@ -109,7 +109,7 @@ describe('CategoryService', () => {
       });
       expect(productRepository.find).toHaveBeenCalledWith({
         where: { categoryId: 'cat-1' },
-        select: ['id', 'name', 'stockQuantity'],
+        select: { id: true, name: true, stockQuantity: true },
       });
     });
 

--- a/backend/src/modules/inventory/services/category.service.ts
+++ b/backend/src/modules/inventory/services/category.service.ts
@@ -239,7 +239,7 @@ export class CategoryService extends BaseCrudService<
 
     const products = await this.productRepository.find({
       where: { categoryId: id },
-      select: ['id', 'name', 'stockQuantity'],
+      select: { id: true, name: true, stockQuantity: true },
     });
 
     return { data: products as CategoryProductDto[] };
@@ -543,7 +543,7 @@ export class CategoryService extends BaseCrudService<
 
     const category = await this.categoryRepository.findOne({
       where: { id },
-      relations: ['children'],
+      relations: { children: true },
     });
 
     if (!category) {
@@ -679,7 +679,7 @@ export class CategoryService extends BaseCrudService<
     // Find the category (including soft-deleted ones)
     const category = await this.categoryRepository.findOne({
       where: { id },
-      relations: ['children', 'products'],
+      relations: { children: true, products: true },
       withDeleted: true,
     });
 
@@ -811,7 +811,7 @@ export class CategoryService extends BaseCrudService<
       try {
         const category = await this.categoryRepository.findOne({
           where: { id: categoryId },
-          relations: ['children', 'products'],
+          relations: { children: true, products: true },
           withDeleted: true,
         });
 

--- a/backend/src/modules/inventory/services/integration.service.ts
+++ b/backend/src/modules/inventory/services/integration.service.ts
@@ -7,7 +7,7 @@ import {
   forwardRef,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { Product } from '../../../database/entities/product.entity';
 import { SalesOrder } from '../../../database/entities/sales-order.entity';
 import { SalesOrderItem } from '../../../database/entities/sales-order-item.entity';
@@ -191,7 +191,7 @@ export class IntegrationService {
     items: Array<{ productId: string; quantity: number }>,
   ): Promise<StockAvailabilityCheck[]> {
     const productIds = items.map(item => item.productId);
-    const products = await this.productRepository.findByIds(productIds);
+    const products = await this.productRepository.findBy({ id: In(productIds) });
 
     const availabilityChecks: StockAvailabilityCheck[] = [];
 
@@ -396,7 +396,7 @@ export class IntegrationService {
   }> {
     const product = await this.productRepository.findOne({
       where: { id: productId },
-      relations: ['priceListItems', 'priceListItems.priceList'],
+      relations: { priceListItems: { priceList: true } },
     });
 
     if (!product) {

--- a/backend/src/modules/inventory/services/pricing.service.ts
+++ b/backend/src/modules/inventory/services/pricing.service.ts
@@ -97,7 +97,7 @@ export class PricingService {
 
     const product = await this.productRepository.findOne({
       where: { id: productId },
-      relations: ['category'],
+      relations: { category: true },
     });
 
     if (!product) {
@@ -113,7 +113,7 @@ export class PricingService {
     if (options.customerId) {
       const customer = await this.customerRepository.findOne({
         where: { id: options.customerId },
-        relations: ['priceList'],
+        relations: { priceList: true },
       });
       if (customer) {
         // Use price list system
@@ -252,7 +252,7 @@ export class PricingService {
   async analyzeMargins(productId: string): Promise<MarginAnalysis> {
     const product = await this.productRepository.findOne({
       where: { id: productId },
-      relations: ['priceListItems', 'priceListItems.priceList'],
+      relations: { priceListItems: { priceList: true } },
     });
 
     if (!product) {
@@ -361,7 +361,7 @@ export class PricingService {
   }>> {
     const products = await this.productRepository.find({
       where: { categoryId, isActive: true },
-      relations: ['priceListItems', 'priceListItems.priceList'],
+      relations: { priceListItems: { priceList: true } },
     });
 
     const recommendations = [];
@@ -428,7 +428,7 @@ export class PricingService {
   }> {
     const product = await this.productRepository.findOne({
       where: { id: productId },
-      relations: ['stockMovements', 'priceListItems', 'priceListItems.priceList'],
+      relations: { stockMovements: true, priceListItems: { priceList: true } },
     });
 
     if (!product) {
@@ -526,7 +526,7 @@ export class PricingService {
   ): Promise<{ amount: number; percentage: number }> {
     const customer = await this.customerRepository.findOne({
       where: { id: customerId },
-      relations: ['priceList'],
+      relations: { priceList: true },
     });
 
     if (!customer || !customer.priceList) {

--- a/backend/src/modules/inventory/services/product.service.ts
+++ b/backend/src/modules/inventory/services/product.service.ts
@@ -444,7 +444,7 @@ export class ProductService extends BaseCrudService<
   async findOne(id: string): Promise<ProductResponseDto> {
     const product = await this.productRepository.findOne({
       where: { id },
-      relations: ['category', 'priceListItems', 'priceListItems.priceList'],
+      relations: { category: true, priceListItems: { priceList: true } },
     });
 
     if (!product) {
@@ -467,7 +467,7 @@ export class ProductService extends BaseCrudService<
   async findByBarcode(barcode: string): Promise<ProductResponseDto> {
     const product = await this.productRepository.findOne({
       where: { barcode },
-      relations: ['category'],
+      relations: { category: true },
     });
 
     if (!product) {
@@ -480,7 +480,7 @@ export class ProductService extends BaseCrudService<
   async findBySlug(slug: string): Promise<ProductResponseDto> {
     const product = await this.productRepository.findOne({
       where: { slug },
-      relations: ['category'],
+      relations: { category: true },
     });
 
     if (!product) {
@@ -599,7 +599,7 @@ export class ProductService extends BaseCrudService<
 
     const product = await this.productRepository.findOne({
       where: { id },
-      relations: ['category'],
+      relations: { category: true },
       withDeleted: true,
     });
 
@@ -628,7 +628,7 @@ export class ProductService extends BaseCrudService<
     // Fetch the restored product
     const restoredProduct = await this.productRepository.findOne({
       where: { id },
-      relations: ['category'],
+      relations: { category: true },
     });
 
     // Log audit trail for restore
@@ -675,7 +675,7 @@ export class ProductService extends BaseCrudService<
         // Find the product (including soft-deleted ones)
         const product = await this.productRepository.findOne({
           where: { id },
-          relations: ['category'],
+          relations: { category: true },
           withDeleted: true,
         });
 
@@ -892,7 +892,7 @@ export class ProductService extends BaseCrudService<
 
     const product = await this.productRepository.findOne({
       where: { id },
-      relations: ['category'],
+      relations: { category: true },
     });
 
     if (!product) {
@@ -994,7 +994,7 @@ export class ProductService extends BaseCrudService<
     // Reload the product with category relation to ensure fresh data
     const productWithCategory = await this.productRepository.findOne({
       where: { id },
-      relations: ['category'],
+      relations: { category: true },
     });
 
     // Log audit trail for update
@@ -1303,7 +1303,7 @@ export class ProductService extends BaseCrudService<
 
     // Get all active products with category info for calculations
     const products = await this.productRepository.find({
-      relations: ['category'],
+      relations: { category: true },
       where: { deletedAt: null }
     });
 
@@ -1396,7 +1396,7 @@ export class ProductService extends BaseCrudService<
   }>> {
     const product = await this.productRepository.findOne({
       where: { id: productId },
-      relations: ['priceListItems', 'priceListItems.priceList'],
+      relations: { priceListItems: { priceList: true } },
     });
 
     if (!product) {

--- a/backend/src/modules/inventory/services/stock-adjustment.service.ts
+++ b/backend/src/modules/inventory/services/stock-adjustment.service.ts
@@ -7,7 +7,7 @@ import {
   forwardRef,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, DataSource } from 'typeorm';
+import { DataSource, In, Repository } from 'typeorm';
 import { BaseCrudService } from '../../../common/services/base-crud.service';
 import {
   StockAdjustment,
@@ -125,7 +125,7 @@ export class StockAdjustmentService extends BaseCrudService<
 
     // Verify all products exist
     const productIds = createDto.items.map(item => item.productId);
-    const products = await this.productRepository.findByIds(productIds);
+    const products = await this.productRepository.findBy({ id: In(productIds) });
     if (products.length !== productIds.length) {
       throw new BadRequestException('One or more products not found');
     }
@@ -258,7 +258,7 @@ export class StockAdjustmentService extends BaseCrudService<
   async findOne(id: string): Promise<StockAdjustmentResponseDto> {
     const adjustment = await this.stockAdjustmentRepository.findOne({
       where: { id },
-      relations: ['items', 'items.product'],
+      relations: { items: { product: true } },
       withDeleted: true, // Include soft-deleted records
     });
 
@@ -277,7 +277,7 @@ export class StockAdjustmentService extends BaseCrudService<
   async findByAdjustmentNumber(adjustmentNumber: string): Promise<StockAdjustmentResponseDto> {
     const adjustment = await this.stockAdjustmentRepository.findOne({
       where: { adjustmentNumber },
-      relations: ['items', 'items.product'],
+      relations: { items: { product: true } },
     });
 
     if (!adjustment) {
@@ -298,7 +298,7 @@ export class StockAdjustmentService extends BaseCrudService<
   ): Promise<StockAdjustmentResponseDto> {
     const adjustment = await this.stockAdjustmentRepository.findOne({
       where: { id },
-      relations: ['items'],
+      relations: { items: true },
     });
 
     if (!adjustment) {
@@ -326,7 +326,7 @@ export class StockAdjustmentService extends BaseCrudService<
 
       // Verify all products exist
       const productIds = updateDto.items.map(item => item.productId);
-      const products = await this.productRepository.findByIds(productIds);
+      const products = await this.productRepository.findBy({ id: In(productIds) });
       if (products.length !== productIds.length) {
         throw new BadRequestException('One or more products not found');
       }
@@ -391,7 +391,7 @@ export class StockAdjustmentService extends BaseCrudService<
   async complete(id: string, userId?: string, username?: string): Promise<StockAdjustmentResponseDto> {
     const adjustment = await this.stockAdjustmentRepository.findOne({
       where: { id },
-      relations: ['items', 'items.product'],
+      relations: { items: { product: true } },
     });
 
     if (!adjustment) {
@@ -490,7 +490,7 @@ export class StockAdjustmentService extends BaseCrudService<
   async uncomplete(id: string): Promise<StockAdjustmentResponseDto> {
     const adjustment = await this.stockAdjustmentRepository.findOne({
       where: { id },
-      relations: ['items', 'items.product'],
+      relations: { items: { product: true } },
     });
 
     if (!adjustment) {
@@ -604,7 +604,7 @@ export class StockAdjustmentService extends BaseCrudService<
     const adjustment = await this.stockAdjustmentRepository.findOne({
       where: { id },
       withDeleted: true, // Include soft-deleted records
-      relations: ['items', 'items.product'],
+      relations: { items: { product: true } },
     });
 
     if (!adjustment) {
@@ -637,7 +637,7 @@ export class StockAdjustmentService extends BaseCrudService<
     // Find the adjustment (including soft-deleted ones)
     const adjustment = await this.stockAdjustmentRepository.findOne({
       where: { id },
-      relations: ['items'],
+      relations: { items: true },
       withDeleted: true,
     });
 

--- a/backend/src/modules/inventory/services/stock-movement.service.ts
+++ b/backend/src/modules/inventory/services/stock-movement.service.ts
@@ -223,7 +223,7 @@ export class StockMovementService {
   async findOne(id: string): Promise<StockMovementResponseDto> {
     const movement = await this.stockMovementRepository.findOne({
       where: { id },
-      relations: { product: { category: true } },
+      relations: { product: { category: true } }, // movedByUser omitted — column removed in migration 1732550000000
     });
 
     if (!movement) {

--- a/backend/src/modules/inventory/services/stock-movement.service.ts
+++ b/backend/src/modules/inventory/services/stock-movement.service.ts
@@ -57,7 +57,7 @@ export class StockMovementService {
 
     const product = await this.productRepository.findOne({
       where: { id: createMovementDto.productId },
-      relations: ['category'],
+      relations: { category: true },
     });
 
     if (!product) {
@@ -116,7 +116,7 @@ export class StockMovementService {
     // Reload with relations for response DTO
     const movementWithRelations = await this.stockMovementRepository.findOne({
       where: { id: savedMovement.id },
-      relations: ['product'],
+      relations: { product: true },
     });
 
     return this.toResponseDto(movementWithRelations);
@@ -223,7 +223,7 @@ export class StockMovementService {
   async findOne(id: string): Promise<StockMovementResponseDto> {
     const movement = await this.stockMovementRepository.findOne({
       where: { id },
-      relations: ['product', 'product.category', 'movedByUser'],
+      relations: { product: { category: true } },
     });
 
     if (!movement) {
@@ -245,7 +245,7 @@ export class StockMovementService {
 
     const movement = await this.stockMovementRepository.findOne({
       where: { id },
-      relations: ['product'],
+      relations: { product: true },
     });
 
     if (!movement) {
@@ -340,7 +340,7 @@ export class StockMovementService {
   ): Promise<StockSummaryDto> {
     const product = await this.productRepository.findOne({
       where: { id: productId },
-      relations: ['category'],
+      relations: { category: true },
     });
 
     if (!product) {
@@ -543,7 +543,7 @@ export class StockMovementService {
       // Fetch product to get current stock
       const product = await this.productRepository.findOne({
         where: { id: item.productId },
-        relations: ['category'],
+        relations: { category: true },
       });
 
       if (!product) {
@@ -691,7 +691,7 @@ export class StockMovementService {
         referenceType,
         referenceId,
       },
-      relations: ['product'],
+      relations: { product: true },
     });
 
     if (movements.length === 0) {

--- a/backend/src/modules/price-lists/services/price-lists.service.ts
+++ b/backend/src/modules/price-lists/services/price-lists.service.ts
@@ -75,7 +75,7 @@ export class PriceListsService {
    * Find one price list by ID with items
    */
   async findOne(id: string, includeItems = true): Promise<PriceList> {
-    const relations = includeItems ? ['items', 'items.product'] : [];
+    const relations = includeItems ? { items: { product: true } } : {};
 
     const priceList = await this.priceListRepository.findOne({
       where: { id, deletedAt: IsNull() },
@@ -95,7 +95,7 @@ export class PriceListsService {
   async findByCode(code: string): Promise<PriceList> {
     const priceList = await this.priceListRepository.findOne({
       where: { code, deletedAt: IsNull() },
-      relations: ['items', 'items.product'],
+      relations: { items: { product: true } },
     });
 
     if (!priceList) {
@@ -223,7 +223,7 @@ export class PriceListsService {
   async getDefaultPriceList(): Promise<PriceList> {
     const priceList = await this.priceListRepository.findOne({
       where: { isDefault: true, deletedAt: IsNull() },
-      relations: ['items', 'items.product'],
+      relations: { items: { product: true } },
     });
 
     if (!priceList) {
@@ -379,7 +379,7 @@ export class PriceListsService {
   async getItems(priceListId: string): Promise<PriceListItem[]> {
     return this.priceListItemRepository.find({
       where: { priceListId },
-      relations: ['product'],
+      relations: { product: true },
       order: { product: { name: 'ASC' } },
     });
   }
@@ -390,7 +390,7 @@ export class PriceListsService {
   async getItemsForProduct(productId: string): Promise<PriceListItem[]> {
     return this.priceListItemRepository.find({
       where: { productId },
-      relations: ['priceList'],
+      relations: { priceList: true },
       order: { priceList: { code: 'ASC' } },
     });
   }

--- a/backend/src/modules/purchasing/services/goods-received-note.service.spec.ts
+++ b/backend/src/modules/purchasing/services/goods-received-note.service.spec.ts
@@ -269,7 +269,7 @@ describe('GoodsReceivedNoteService', () => {
       // Verify findOne was called with correct relations for accounting
       expect(grnRepository.findOne).toHaveBeenCalledWith({
         where: { id: mockGrn.id },
-        relations: ['supplier', 'purchaseOrder', 'items', 'items.product', 'items.purchaseOrderItem'],
+        relations: { supplier: true, purchaseOrder: true, items: { product: true, purchaseOrderItem: true } },
       });
 
       // Verify the full GRN with relations was passed to accounting service

--- a/backend/src/modules/purchasing/services/goods-received-note.service.ts
+++ b/backend/src/modules/purchasing/services/goods-received-note.service.ts
@@ -78,7 +78,7 @@ export class GoodsReceivedNoteService extends BaseCrudService<
     // Validate purchase order exists
     const purchaseOrder = await this.purchaseOrderRepository.findOne({
       where: { id: createDto.purchaseOrderId },
-      relations: ['supplier', 'items', 'items.product'],
+      relations: { supplier: true, items: { product: true } },
     });
 
     if (!purchaseOrder) {
@@ -185,7 +185,7 @@ export class GoodsReceivedNoteService extends BaseCrudService<
       try {
         const fullGrn = await this.grnRepository.findOne({
           where: { id: savedGrn.id },
-          relations: ['supplier', 'purchaseOrder', 'items', 'items.product', 'items.purchaseOrderItem'],
+          relations: { supplier: true, purchaseOrder: true, items: { product: true, purchaseOrderItem: true } },
         });
 
         if (fullGrn) {
@@ -298,7 +298,7 @@ export class GoodsReceivedNoteService extends BaseCrudService<
 
     const grn = await this.grnRepository.findOne({
       where: { id },
-      relations: ['supplier', 'purchaseOrder', 'purchaseOrder.vendorPayments', 'items', 'items.product'],
+      relations: { supplier: true, purchaseOrder: { vendorPayments: true }, items: { product: true } },
     });
 
     if (!grn) {
@@ -367,7 +367,7 @@ export class GoodsReceivedNoteService extends BaseCrudService<
 
     const grn = await this.grnRepository.findOne({
       where: { id },
-      relations: ['purchaseOrder']
+      relations: { purchaseOrder: true }
     });
 
     if (!grn) {
@@ -478,7 +478,7 @@ export class GoodsReceivedNoteService extends BaseCrudService<
     const grn = await this.grnRepository.findOne({
       where: { id },
       withDeleted: true,
-      relations: ['purchaseOrder']
+      relations: { purchaseOrder: true }
     });
 
     if (!grn) {
@@ -511,7 +511,7 @@ export class GoodsReceivedNoteService extends BaseCrudService<
 
       const restoredGrn = await this.grnRepository.findOne({
         where: { id },
-        relations: ['supplier', 'purchaseOrder'],
+        relations: { supplier: true, purchaseOrder: true },
       });
 
       if (!restoredGrn) {

--- a/backend/src/modules/purchasing/services/purchase-order.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.ts
@@ -193,7 +193,7 @@ export class PurchaseOrderService extends BaseCrudService<
       this.logger.error(`Error generating order number: ${error.message}`);
       // Fallback to legacy method
       const orders = await this.purchaseOrderRepository.find({
-        select: ['orderNumber'],
+        select: { orderNumber: true },
         withDeleted: true,
       });
 
@@ -753,7 +753,7 @@ export class PurchaseOrderService extends BaseCrudService<
     const purchaseOrder = await this.purchaseOrderRepository.findOne({
       where: { id },
       withDeleted: true,
-      relations: ['supplier', 'items', 'items.product'],
+      relations: { supplier: true, items: { product: true } },
     });
 
     if (!purchaseOrder) {
@@ -809,7 +809,7 @@ export class PurchaseOrderService extends BaseCrudService<
     // Fetch the restored order
     const restoredOrder = await this.purchaseOrderRepository.findOne({
       where: { id },
-      relations: ['supplier', 'items', 'items.product'],
+      relations: { supplier: true, items: { product: true } },
     });
 
     // Log audit trail for PO restoration
@@ -1015,7 +1015,7 @@ export class PurchaseOrderService extends BaseCrudService<
       // Find GRN associated with this PO
       const grn = await this.grnRepository.findOne({
         where: { purchaseOrderId },
-        relations: ['items'],
+        relations: { items: true },
       });
 
       if (!grn) {
@@ -1032,7 +1032,7 @@ export class PurchaseOrderService extends BaseCrudService<
       // Fetch full PO with relations
       const fullPO = await this.purchaseOrderRepository.findOne({
         where: { id: purchaseOrderId },
-        relations: ['supplier', 'items', 'items.product'],
+        relations: { supplier: true, items: { product: true } },
       });
 
       if (!fullPO) {
@@ -1074,7 +1074,7 @@ export class PurchaseOrderService extends BaseCrudService<
       this.logger.debug(`Reloading GRN ${grn.id} with items`);
       const updatedGrn = await this.grnRepository.findOne({
         where: { id: grn.id },
-        relations: ['items'],
+        relations: { items: true },
       });
 
       if (updatedGrn) {
@@ -1160,7 +1160,7 @@ export class PurchaseOrderService extends BaseCrudService<
       // Fetch full PO with relations for GRN creation
       const fullPO = await this.purchaseOrderRepository.findOne({
         where: { id: purchaseOrder.id },
-        relations: ['supplier', 'items', 'items.product'],
+        relations: { supplier: true, items: { product: true } },
       });
 
       if (!fullPO) {
@@ -1241,7 +1241,7 @@ export class PurchaseOrderService extends BaseCrudService<
 
     const purchaseOrder = await this.purchaseOrderRepository.findOne({
       where: { id },
-      relations: ['items', 'items.product', 'supplier'],
+      relations: { items: { product: true }, supplier: true },
     });
 
     if (!purchaseOrder) {
@@ -1251,7 +1251,7 @@ export class PurchaseOrderService extends BaseCrudService<
     // Find the GRN linked to this PO with relational items
     const grn = await this.grnRepository.findOne({
       where: { purchaseOrderId: id },
-      relations: ['items'],
+      relations: { items: true },
     });
 
     if (!grn) {
@@ -1279,7 +1279,7 @@ export class PurchaseOrderService extends BaseCrudService<
       // Reload GRN with fresh items from database
       const updatedGrn = await this.grnRepository.findOne({
         where: { id: grn.id },
-        relations: ['items'],
+        relations: { items: true },
       });
 
       if (!updatedGrn) {
@@ -1327,7 +1327,7 @@ export class PurchaseOrderService extends BaseCrudService<
       try {
         const fullGrn = await this.grnRepository.findOne({
           where: { id: updatedGrn.id },
-          relations: ['supplier', 'purchaseOrder', 'items', 'items.product', 'items.purchaseOrderItem'],
+          relations: { supplier: true, purchaseOrder: true, items: { product: true, purchaseOrderItem: true } },
         });
 
         if (fullGrn) {
@@ -1382,7 +1382,7 @@ export class PurchaseOrderService extends BaseCrudService<
 
     const purchaseOrder = await this.purchaseOrderRepository.findOne({
       where: { id },
-      relations: ['items', 'items.product', 'supplier'],
+      relations: { items: { product: true }, supplier: true },
     });
 
     if (!purchaseOrder) {
@@ -1392,7 +1392,7 @@ export class PurchaseOrderService extends BaseCrudService<
     // Find the GRN linked to this PO with relational items
     const grn = await this.grnRepository.findOne({
       where: { purchaseOrderId: id },
-      relations: ['items'],
+      relations: { items: true },
     });
 
     if (!grn) {
@@ -1424,7 +1424,7 @@ export class PurchaseOrderService extends BaseCrudService<
       // Reload GRN with fresh items from database
       const updatedGrn = await this.grnRepository.findOne({
         where: { id: grn.id },
-        relations: ['items'],
+        relations: { items: true },
       });
 
       if (!updatedGrn) {
@@ -1504,7 +1504,7 @@ export class PurchaseOrderService extends BaseCrudService<
 
     const purchaseOrder = await this.purchaseOrderRepository.findOne({
       where: { id },
-      relations: ['supplier'], // Removed 'vendorPayments' to prevent TypeORM from trying to manage the relation
+      relations: { supplier: true }, // Removed 'vendorPayments' to prevent TypeORM from trying to manage the relation
     });
 
     if (!purchaseOrder) {
@@ -1554,7 +1554,7 @@ export class PurchaseOrderService extends BaseCrudService<
 
     const purchaseOrder = await this.purchaseOrderRepository.findOne({
       where: { id },
-      relations: ['supplier'],
+      relations: { supplier: true },
     });
 
     if (!purchaseOrder) {
@@ -1647,7 +1647,7 @@ export class PurchaseOrderService extends BaseCrudService<
 
     const purchaseOrder = await this.purchaseOrderRepository.findOne({
       where: { id },
-      relations: ['supplier'],
+      relations: { supplier: true },
     });
 
     if (!purchaseOrder) {

--- a/backend/src/modules/purchasing/services/supplier.service.ts
+++ b/backend/src/modules/purchasing/services/supplier.service.ts
@@ -249,7 +249,7 @@ export class SupplierService extends BaseCrudService<
 
     const supplier = await this.supplierRepository.findOne({
       where: { id },
-      relations: ['purchaseOrders', 'goodsReceivedNotes'],
+      relations: { purchaseOrders: true, goodsReceivedNotes: true },
     });
 
     if (!supplier) {
@@ -730,7 +730,7 @@ export class SupplierService extends BaseCrudService<
   async getSupplierGRNs(supplierId: string): Promise<{ data: GoodsReceivedNote[]; total: number }> {
     const [data, total] = await this.grnRepository.findAndCount({
       where: { supplierId },
-      relations: ['purchaseOrder'],
+      relations: { purchaseOrder: true },
       order: { receivedDate: 'DESC' },
       take: 50,
     });
@@ -741,7 +741,7 @@ export class SupplierService extends BaseCrudService<
   async getSupplierPayments(supplierId: string): Promise<{ data: VendorPayment[]; total: number }> {
     const [data, total] = await this.vendorPaymentRepository.findAndCount({
       where: { supplierId },
-      relations: ['paymentMethodEntity'],
+      relations: { paymentMethodEntity: true },
       order: { paymentDate: 'DESC' },
       take: 50,
     });

--- a/backend/src/modules/purchasing/services/vendor-payment.service.ts
+++ b/backend/src/modules/purchasing/services/vendor-payment.service.ts
@@ -315,14 +315,7 @@ export class VendorPaymentService extends BaseCrudService<
   async findOne(id: string): Promise<VendorPayment> {
     const vendorPayment = await this.vendorPaymentRepository.findOne({
       where: { id, isActive: true },
-      relations: [
-        'supplier',
-        'purchaseOrder',
-        'purchaseOrder.items',
-        'purchaseOrder.items.product',
-        'grn',
-        'paymentMethodEntity',
-      ],
+      relations: { supplier: true, purchaseOrder: { items: { product: true } }, grn: true, paymentMethodEntity: true },
     });
 
     if (!vendorPayment) {
@@ -530,7 +523,7 @@ export class VendorPaymentService extends BaseCrudService<
     // Find the purchase order
     const purchaseOrder = await this.purchaseOrderRepository.findOne({
       where: { id: poId },
-      relations: ['supplier'],
+      relations: { supplier: true },
     });
 
     if (!purchaseOrder) {
@@ -608,7 +601,7 @@ export class VendorPaymentService extends BaseCrudService<
         purchaseOrderId: poId,
         isActive: true,
       },
-      relations: ['supplier', 'purchaseOrder', 'grn', 'paymentMethodEntity'],
+      relations: { supplier: true, purchaseOrder: true, grn: true, paymentMethodEntity: true },
     });
   }
 

--- a/backend/src/modules/sales/services/customer.service.spec.ts
+++ b/backend/src/modules/sales/services/customer.service.spec.ts
@@ -420,7 +420,7 @@ describe('CustomerService', () => {
 
       expect(customerRepository.findOne).toHaveBeenCalledWith({
         where: { slug: 'acme-corp' },
-        relations: ['priceList'],
+        relations: { priceList: true },
       });
       expect(result.id).toBe('c1');
     });

--- a/backend/src/modules/sales/services/customer.service.ts
+++ b/backend/src/modules/sales/services/customer.service.ts
@@ -322,7 +322,7 @@ export class CustomerService extends BaseCrudService<
     const customers = await this.customerRepository.find({
       where: { isActive: true },
       order: { name: 'ASC' },
-      select: ['id', 'name', 'phone'],
+      select: { id: true, name: true, phone: true },
     });
 
     return customers.map(customer => ({
@@ -335,7 +335,7 @@ export class CustomerService extends BaseCrudService<
   async findById(id: string): Promise<CustomerResponseDto> {
     const customer = await this.customerRepository.findOne({
       where: { id },
-      relations: ['priceList']
+      relations: { priceList: true }
     });
     if (!customer) {
       throw new NotFoundException('Customer not found');
@@ -346,7 +346,7 @@ export class CustomerService extends BaseCrudService<
   async findBySlug(slug: string): Promise<CustomerResponseDto> {
     const customer = await this.customerRepository.findOne({
       where: { slug },
-      relations: ['priceList'],
+      relations: { priceList: true },
     });
     if (!customer) throw new NotFoundException(`Customer with slug '${slug}' not found`);
     return this.mapToResponseDto(customer);
@@ -449,7 +449,7 @@ export class CustomerService extends BaseCrudService<
     const orders = await this.salesOrderRepository.find({
       where: { customerId },
       order: { orderDate: 'DESC' },
-      relations: ['items'],
+      relations: { items: true },
     });
 
     return {
@@ -1047,7 +1047,7 @@ export class CustomerService extends BaseCrudService<
   private async findCustomerEntity(id: string): Promise<Customer> {
     const customer = await this.customerRepository.findOne({
       where: { id },
-      relations: ['priceList']
+      relations: { priceList: true }
     });
     if (!customer) {
       throw new NotFoundException('Customer not found');

--- a/backend/src/modules/sales/services/inventory-integration.service.ts
+++ b/backend/src/modules/sales/services/inventory-integration.service.ts
@@ -160,7 +160,7 @@ export class InventoryIntegrationService {
   async fulfillOrder(salesOrderId: string, userId?: string): Promise<void> {
     const order = await this.salesOrderRepository.findOne({
       where: { id: salesOrderId },
-      relations: ['items'],
+      relations: { items: true },
     });
 
     if (!order) {
@@ -229,7 +229,7 @@ export class InventoryIntegrationService {
   async getOrderFulfillmentStatus(salesOrderId: string): Promise<OrderFulfillmentStatus> {
     const order = await this.salesOrderRepository.findOne({
       where: { id: salesOrderId },
-      relations: ['items', 'items.product'],
+      relations: { items: { product: true } },
     });
 
     if (!order) {
@@ -309,7 +309,7 @@ export class InventoryIntegrationService {
         // Get order details
         const order = await this.salesOrderRepository.findOne({
           where: { id: salesOrderId },
-          select: ['orderNumber', 'createdAt'],
+          select: { orderNumber: true, createdAt: true },
         });
 
         reservations.push({

--- a/backend/src/modules/sales/services/invoice.service.ts
+++ b/backend/src/modules/sales/services/invoice.service.ts
@@ -199,7 +199,7 @@ export class InvoiceService extends BaseCrudService<
     if (salesOrderId) {
       salesOrder = await this.salesOrderRepository.findOne({
         where: { id: salesOrderId },
-        relations: ['items']
+        relations: { items: true }
       });
       if (!salesOrder) {
         throw new NotFoundException('Sales order not found');
@@ -266,7 +266,7 @@ export class InvoiceService extends BaseCrudService<
 
   async findSummaries(): Promise<InvoiceSummaryDto[]> {
     const invoices = await this.invoiceRepository.find({
-      relations: ['customer'],
+      relations: { customer: true },
       order: { invoiceDate: 'DESC' },
     });
 
@@ -421,7 +421,7 @@ export class InvoiceService extends BaseCrudService<
   async findById(id: string): Promise<InvoiceResponseDto> {
     const invoice = await this.invoiceRepository.findOne({
       where: { id },
-      relations: ['customer', 'salesOrder', 'items', 'items.product'],
+      relations: { customer: true, salesOrder: true, items: { product: true } },
     });
 
     if (!invoice) {
@@ -434,7 +434,7 @@ export class InvoiceService extends BaseCrudService<
   async findByInvoiceNumber(invoiceNumber: string): Promise<InvoiceResponseDto> {
     const invoice = await this.invoiceRepository.findOne({
       where: { invoiceNumber },
-      relations: ['customer', 'salesOrder', 'items', 'items.product'],
+      relations: { customer: true, salesOrder: true, items: { product: true } },
     });
 
     if (!invoice) {
@@ -502,7 +502,7 @@ export class InvoiceService extends BaseCrudService<
     // Load the sales order with items
     const salesOrder = await this.salesOrderRepository.findOne({
       where: { id: invoice.salesOrderId },
-      relations: ['items']
+      relations: { items: true }
     });
 
     if (!salesOrder) {
@@ -571,7 +571,7 @@ export class InvoiceService extends BaseCrudService<
   async sendInvoice(id: string, sendInvoiceDto: SendInvoiceDto): Promise<InvoiceResponseDto> {
     const invoice = await this.invoiceRepository.findOne({
       where: { id },
-      relations: ['customer'],
+      relations: { customer: true },
     });
 
     if (!invoice) {
@@ -659,7 +659,7 @@ export class InvoiceService extends BaseCrudService<
   async voidInvoice(id: string, _reason: string): Promise<InvoiceResponseDto> {
     const invoice = await this.invoiceRepository.findOne({
       where: { id },
-      relations: ['customer'],
+      relations: { customer: true },
     });
 
     if (!invoice) {
@@ -744,7 +744,7 @@ export class InvoiceService extends BaseCrudService<
   async getInvoiceHistory(id: string) {
     const invoice = await this.invoiceRepository.findOne({
       where: { id },
-      relations: ['payments'],
+      relations: { payments: true },
     });
 
     if (!invoice) {

--- a/backend/src/modules/sales/services/payment.service.spec.ts
+++ b/backend/src/modules/sales/services/payment.service.spec.ts
@@ -260,7 +260,7 @@ describe('PaymentService', () => {
       // Verify findOne was called to get payment with relations before accounting post
       expect(paymentRepository.findOne).toHaveBeenCalledWith({
         where: { id: mockPayment.id },
-        relations: ['customer', 'invoice', 'invoice.salesOrder', 'invoice.items', 'invoice.items.product', 'paymentMethodEntity'],
+        relations: { customer: true, invoice: { salesOrder: true, items: { product: true } }, paymentMethodEntity: true },
       });
 
       // Verify the accounting service received the payment with customer relation

--- a/backend/src/modules/sales/services/payment.service.ts
+++ b/backend/src/modules/sales/services/payment.service.ts
@@ -552,7 +552,7 @@ export class PaymentService extends BaseCrudService<
   private async findPaymentWithRelations(id: string): Promise<Payment> {
     const payment = await this.paymentRepository.findOne({
       where: { id },
-      relations: ['customer', 'invoice', 'invoice.salesOrder', 'invoice.items', 'invoice.items.product', 'paymentMethodEntity'],
+      relations: { customer: true, invoice: { salesOrder: true, items: { product: true } }, paymentMethodEntity: true },
     });
 
     if (!payment) {
@@ -689,7 +689,7 @@ export class PaymentService extends BaseCrudService<
     const payment = await this.paymentRepository.findOne({
       where: { id },
       withDeleted: true, // Include soft-deleted records
-      relations: ['customer', 'invoice'],
+      relations: { customer: true, invoice: true },
     });
 
     if (!payment) {
@@ -722,7 +722,7 @@ export class PaymentService extends BaseCrudService<
     // Return the restored payment
     const restoredPayment = await this.paymentRepository.findOne({
       where: { id },
-      relations: ['customer', 'invoice'],
+      relations: { customer: true, invoice: true },
     });
 
     return this.mapToResponseDto(restoredPayment);

--- a/backend/src/modules/sales/services/sales-analytics-report.service.ts
+++ b/backend/src/modules/sales/services/sales-analytics-report.service.ts
@@ -42,7 +42,7 @@ export class SalesAnalyticsReportService {
     // Get all products matching the filter
     const products = await this.productRepository.find({
       where: productWhere,
-      relations: ['category'],
+      relations: { category: true },
     });
 
     // Build date range for sales and purchase orders
@@ -147,7 +147,7 @@ export class SalesAnalyticsReportService {
     // Get all products matching the filter
     const products = await this.productRepository.find({
       where: productWhere,
-      relations: ['category'],
+      relations: { category: true },
     });
 
     // Get all transaction details for each product
@@ -254,7 +254,7 @@ export class SalesAnalyticsReportService {
     // Get all sales orders with items and invoices for payment status
     const orders = await this.salesOrderRepository.find({
       where: orderWhere,
-      relations: ['customer', 'items', 'items.product', 'invoices', 'invoices.payments'],
+      relations: { customer: true, items: { product: true }, invoices: { payments: true } },
       order: { orderNumber: 'ASC' },
     });
 
@@ -344,7 +344,7 @@ export class SalesAnalyticsReportService {
     // Get all sales orders with invoices and payments
     const orders = await this.salesOrderRepository.find({
       where: orderWhere,
-      relations: ['customer', 'invoices', 'invoices.payments'],
+      relations: { customer: true, invoices: { payments: true } },
       order: { orderDate: 'DESC' },
     });
 
@@ -491,7 +491,7 @@ export class SalesAnalyticsReportService {
     // Get all sales orders with invoices and payments
     const orders = await this.salesOrderRepository.find({
       where: orderWhere,
-      relations: ['customer', 'invoices', 'invoices.payments'],
+      relations: { customer: true, invoices: { payments: true } },
       order: { orderNumber: 'ASC' },
     });
 

--- a/backend/src/modules/sales/services/sales-order-fulfillment.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-fulfillment.service.spec.ts
@@ -174,11 +174,11 @@ describe('SalesOrderFulfillmentService', () => {
 
       expect(salesOrderRepository.findOne).toHaveBeenNthCalledWith(1, {
         where: { id: orderId },
-        relations: ['customer', 'items', 'items.product'],
+        relations: { customer: true, items: { product: true } },
       });
       expect(salesOrderRepository.findOne).toHaveBeenNthCalledWith(2, {
         where: { id: orderId },
-        relations: ['customer', 'items', 'items.product'],
+        relations: { customer: true, items: { product: true } },
       });
     });
 

--- a/backend/src/modules/sales/services/sales-order-fulfillment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-fulfillment.service.ts
@@ -34,7 +34,7 @@ export class SalesOrderFulfillmentService {
   async fulfillOrder(id: string, userId?: string, username?: string): Promise<SalesOrder> {
     const order = await this.salesOrderRepository.findOne({
       where: { id },
-      relations: ['customer', 'items', 'items.product'],
+      relations: { customer: true, items: { product: true } },
     });
 
     if (!order) {
@@ -78,7 +78,7 @@ export class SalesOrderFulfillmentService {
     try {
       const fullOrder = await this.salesOrderRepository.findOne({
         where: { id },
-        relations: ['customer', 'items', 'items.product'],
+        relations: { customer: true, items: { product: true } },
       });
       if (fullOrder) {
         await this.accountingService.postSalesOrderEntry(fullOrder, userId || 'system', username);
@@ -97,7 +97,7 @@ export class SalesOrderFulfillmentService {
   async unfulfillOrder(id: string): Promise<SalesOrder> {
     const order = await this.salesOrderRepository.findOne({
       where: { id },
-      relations: ['customer', 'items', 'items.product'],
+      relations: { customer: true, items: { product: true } },
     });
 
     if (!order) {

--- a/backend/src/modules/sales/services/sales-order-lifecycle.service.ts
+++ b/backend/src/modules/sales/services/sales-order-lifecycle.service.ts
@@ -182,7 +182,7 @@ export class SalesOrderLifecycleService {
     const order = await this.salesOrderRepository.findOne({
       where: { id },
       withDeleted: true,
-      relations: ['customer', 'items', 'items.product'],
+      relations: { customer: true, items: { product: true } },
     });
 
     ValidationUtil.validateForRestore(order, 'Sales order', id);
@@ -255,7 +255,7 @@ export class SalesOrderLifecycleService {
 
     const restoredOrder = await this.salesOrderRepository.findOne({
       where: { id },
-      relations: ['customer', 'items', 'items.product'],
+      relations: { customer: true, items: { product: true } },
     });
 
     await this.auditLogService.log('RESTORE', 'SalesOrder', `Restored sales order: ${order.orderNumber}`, {
@@ -295,7 +295,7 @@ export class SalesOrderLifecycleService {
   async permanentDelete(id: string, userId?: string, username?: string): Promise<void> {
     const order = await this.salesOrderRepository.findOne({
       where: { id },
-      relations: ['customer', 'items'],
+      relations: { customer: true, items: true },
       withDeleted: true,
     });
 
@@ -411,7 +411,7 @@ export class SalesOrderLifecycleService {
       try {
         const order = await this.salesOrderRepository.findOne({
           where: { id },
-          relations: ['customer', 'items'],
+          relations: { customer: true, items: true },
           withDeleted: true,
         });
 

--- a/backend/src/modules/sales/services/sales-order-payment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.ts
@@ -42,7 +42,7 @@ export class SalesOrderPaymentService {
 
     const order = await this.salesOrderRepository.findOne({
       where: { id },
-      relations: ['customer', 'items', 'items.product'],
+      relations: { customer: true, items: { product: true } },
     });
 
     if (!order) {
@@ -191,7 +191,7 @@ export class SalesOrderPaymentService {
 
     const order = await this.salesOrderRepository.findOne({
       where: { id },
-      relations: ['customer', 'items', 'items.product'],
+      relations: { customer: true, items: { product: true } },
     });
 
     if (!order) {
@@ -296,7 +296,7 @@ export class SalesOrderPaymentService {
         try {
           const fullPayment = await paymentRepo.findOne({
             where: { id: savedPayment.id },
-            relations: ['customer', 'paymentMethodEntity'],
+            relations: { customer: true, paymentMethodEntity: true },
           });
           if (fullPayment) {
             await this.accountingService.postCustomerPaymentEntry(fullPayment, 'system');
@@ -325,7 +325,7 @@ export class SalesOrderPaymentService {
   ): Promise<SalesOrderResponseDto> {
     const order = await this.salesOrderRepository.findOne({
       where: { id },
-      relations: ['customer', 'items', 'items.product'],
+      relations: { customer: true, items: { product: true } },
     });
 
     if (!order) {
@@ -392,7 +392,7 @@ export class SalesOrderPaymentService {
       return await this.settingsService.generateDocumentNumber('Payments');
     } catch {
       const allPayments = await paymentRepository.find({
-        select: ['paymentNumber'],
+        select: { paymentNumber: true },
         withDeleted: true,
       });
       let maxNumber = 0;

--- a/backend/src/modules/sales/services/sales-order-query.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-query.service.spec.ts
@@ -85,7 +85,7 @@ describe('SalesOrderQueryService', () => {
 
     expect(salesOrderRepository.findOne).toHaveBeenCalledWith({
       where: { orderNumber: 'SO-000001' },
-      relations: ['customer', 'items', 'items.product'],
+      relations: { customer: true, items: { product: true } },
       withDeleted: true,
     });
     expect(result).toMatchObject({

--- a/backend/src/modules/sales/services/sales-order-query.service.ts
+++ b/backend/src/modules/sales/services/sales-order-query.service.ts
@@ -43,7 +43,7 @@ export class SalesOrderQueryService {
 
     const previousOrder = await this.salesOrderRepository.findOne({
       where: { orderNumber: previousOrderNumber },
-      relations: ['customer', 'items', 'items.product'],
+      relations: { customer: true, items: { product: true } },
       withDeleted: true,
     });
 
@@ -247,7 +247,7 @@ export class SalesOrderQueryService {
   async testInvoiceRelations(orderNumber: string): Promise<any> {
     const order = await this.salesOrderRepository.findOne({
       where: { orderNumber },
-      relations: ['invoices', 'customer', 'items'],
+      relations: { invoices: true, customer: true, items: true },
     });
 
     return {
@@ -267,7 +267,7 @@ export class SalesOrderQueryService {
     } = query;
 
     const findOptions: any = {
-      relations: ['customer', 'items', 'items.product', 'invoices'],
+      relations: { customer: true, items: { product: true }, invoices: true },
       where: { deletedAt: null },
       order: { [sortBy]: sortOrder },
     };
@@ -455,7 +455,7 @@ export class SalesOrderQueryService {
   async findByOrderNumber(orderNumber: string): Promise<SalesOrderResponseDto> {
     const order = await this.salesOrderRepository.findOne({
       where: { orderNumber },
-      relations: ['customer', 'items', 'items.product', 'invoices'],
+      relations: { customer: true, items: { product: true }, invoices: true },
     });
 
     if (!order) {
@@ -468,7 +468,7 @@ export class SalesOrderQueryService {
   async findOrdersByCustomer(customerId: string, limit: number = 10) {
     const orders = await this.salesOrderRepository.find({
       where: { customerId },
-      relations: ['items'],
+      relations: { items: true },
       order: { orderDate: 'DESC' },
       take: limit,
     });

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -375,7 +375,7 @@ describe('SalesOrderService', () => {
       // Verify findOne was called for the initial load with relations
       expect(salesOrderRepository.findOne).toHaveBeenCalledWith({
         where: { id: orderId },
-        relations: ['customer', 'items', 'items.product'],
+        relations: { customer: true, items: { product: true } },
       });
 
       // Verify the accounting service received the order with customer and items

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -179,7 +179,7 @@ export class SalesOrderService extends BaseCrudService<
     // Verify customer exists and can purchase
     const customer = await this.customerRepository.findOne({
       where: { id: customerId },
-      relations: ['priceList']
+      relations: { priceList: true }
     });
     if (!customer) {
       throw new NotFoundException('Customer not found');
@@ -277,7 +277,7 @@ export class SalesOrderService extends BaseCrudService<
       // Reload order with customer relation to populate customerName for invoice
       const orderWithCustomer = await this.salesOrderRepository.findOne({
         where: { id: savedOrder.id },
-        relations: ['customer', 'items']
+        relations: { customer: true, items: true }
       });
 
       if (!orderWithCustomer) {
@@ -485,7 +485,7 @@ export class SalesOrderService extends BaseCrudService<
     if (customerId) {
       customerForPricing = await this.customerRepository.findOne({
         where: { id: customerId },
-        relations: ['priceList']
+        relations: { priceList: true }
       });
       if (!customerForPricing) {
         throw new NotFoundException('Customer not found');
@@ -495,7 +495,7 @@ export class SalesOrderService extends BaseCrudService<
       // Load existing customer for pricing
       customerForPricing = await this.customerRepository.findOne({
         where: { id: order.customerId },
-        relations: ['priceList']
+        relations: { priceList: true }
       });
     }
 
@@ -611,7 +611,7 @@ export class SalesOrderService extends BaseCrudService<
   async duplicateOrder(id: string, userId: string): Promise<SalesOrderResponseDto> {
     const originalOrder = await this.salesOrderRepository.findOne({
       where: { id },
-      relations: ['items'],
+      relations: { items: true },
     });
 
     if (!originalOrder) {
@@ -637,7 +637,7 @@ export class SalesOrderService extends BaseCrudService<
   async getFulfillmentStatus(id: string) {
     const order = await this.salesOrderRepository.findOne({
       where: { id },
-      relations: ['items'],
+      relations: { items: true },
     });
 
     if (!order) {
@@ -665,7 +665,7 @@ export class SalesOrderService extends BaseCrudService<
   async createInvoiceFromOrder(id: string) {
     const order = await this.salesOrderRepository.findOne({
       where: { id },
-      relations: ['customer', 'items', 'items.product'],
+      relations: { customer: true, items: { product: true } },
     });
 
     if (!order) {
@@ -835,7 +835,7 @@ export class SalesOrderService extends BaseCrudService<
       // Find the updated sales order with all relations
       const updatedOrder = await this.salesOrderRepository.findOne({
         where: { id: salesOrderId },
-        relations: ['customer', 'items', 'items.product']
+        relations: { customer: true, items: { product: true } }
       });
 
       if (!updatedOrder) {

--- a/backend/test/e2e/accounting-auto-posting.e2e-spec.ts
+++ b/backend/test/e2e/accounting-auto-posting.e2e-spec.ts
@@ -345,7 +345,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
       // Verify journal entry was created
       const journalEntries = await journalEntryRepo.find({
         where: { sourceType: 'sales_order', sourceId: savedOrder.id },
-        relations: ['lines'],
+        relations: { lines: true },
       });
 
       expect(journalEntries).toHaveLength(1);
@@ -400,7 +400,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
 
       const journalEntries = await journalEntryRepo.find({
         where: { sourceType: 'sales_order', sourceId: savedOrder.id },
-        relations: ['lines'],
+        relations: { lines: true },
       });
 
       const entry = journalEntries[0];
@@ -490,7 +490,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
       // Verify journal entry was created
       const journalEntries = await journalEntryRepo.find({
         where: { sourceType: 'payment', sourceId: payment.id },
-        relations: ['lines'],
+        relations: { lines: true },
       });
 
       expect(journalEntries).toHaveLength(1);
@@ -590,7 +590,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
       // Verify journal entry was created
       const journalEntries = await journalEntryRepo.find({
         where: { sourceType: 'goods_received_note', sourceId: grn.id },
-        relations: ['lines'],
+        relations: { lines: true },
       });
 
       expect(journalEntries).toHaveLength(1);
@@ -639,7 +639,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
 
       const journalEntries = await journalEntryRepo.find({
         where: { sourceType: 'goods_received_note', sourceId: grn.id },
-        relations: ['lines'],
+        relations: { lines: true },
       });
 
       const entry = journalEntries[0];
@@ -687,7 +687,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
       // Journal entry should use the purchase costs
       const journalEntries = await journalEntryRepo.find({
         where: { sourceType: 'goods_received_note' },
-        relations: ['lines'],
+        relations: { lines: true },
       });
 
       const entry = journalEntries[0];
@@ -779,7 +779,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
       // Verify journal entry was created
       const journalEntries = await journalEntryRepo.find({
         where: { sourceType: 'vendor_payment', sourceId: payment.id },
-        relations: ['lines'],
+        relations: { lines: true },
       });
 
       expect(journalEntries).toHaveLength(1);
@@ -829,7 +829,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
       // GRN creates AP credit of 1000
       const grnEntries = await journalEntryRepo.find({
         where: { sourceType: 'goods_received_note', sourceId: grn.id },
-        relations: ['lines'],
+        relations: { lines: true },
       });
       const grnApLine = grnEntries[0].lines.find(l => l.accountId === accounts['2100'].id);
       expect(Number(grnApLine.creditAmount)).toBe(1000.00);
@@ -846,7 +846,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
 
       const paymentEntries = await journalEntryRepo.find({
         where: { sourceType: 'vendor_payment', sourceId: payment.id },
-        relations: ['lines'],
+        relations: { lines: true },
       });
       const paymentApLine = paymentEntries[0].lines.find(l => l.accountId === accounts['2100'].id);
       expect(Number(paymentApLine.debitAmount)).toBe(1000.00);
@@ -912,7 +912,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
       // Manually trigger accounting for second payment
       const fullPayment2 = await vendorPaymentRepo.findOne({
         where: { id: payment2.id },
-        relations: ['supplier', 'purchaseOrder', 'paymentMethodEntity'],
+        relations: { supplier: true, purchaseOrder: true, paymentMethodEntity: true },
       });
       const accountingService = app.get(AccountingService);
       await accountingService.postVendorPaymentEntry(fullPayment2, 'system');
@@ -956,7 +956,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
       // Verify journal entry was created
       const journalEntries = await journalEntryRepo.find({
         where: { sourceType: 'stock_adjustment', sourceId: adjustment.id },
-        relations: ['lines'],
+        relations: { lines: true },
       });
 
       expect(journalEntries).toHaveLength(1);
@@ -995,7 +995,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
 
       const journalEntries = await journalEntryRepo.find({
         where: { sourceType: 'stock_adjustment', sourceId: adjustment.id },
-        relations: ['lines'],
+        relations: { lines: true },
       });
 
       expect(journalEntries).toHaveLength(1);
@@ -1052,7 +1052,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
 
       const journalEntries = await journalEntryRepo.find({
         where: { sourceType: 'stock_adjustment', sourceId: adjustment.id },
-        relations: ['lines'],
+        relations: { lines: true },
       });
 
       const entry = journalEntries[0];
@@ -1100,7 +1100,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
 
       const journalEntries = await journalEntryRepo.find({
         where: { sourceType: 'stock_adjustment', sourceId: adjustment.id },
-        relations: ['lines'],
+        relations: { lines: true },
       });
 
       const entry = journalEntries[0];

--- a/backend/test/e2e/price-lists.e2e-spec.ts
+++ b/backend/test/e2e/price-lists.e2e-spec.ts
@@ -62,7 +62,6 @@ describe('PriceListsController (e2e)', () => {
 
   const mockProductRepository = {
     findOneBy: jest.fn(),
-    findByIds: jest.fn().mockResolvedValue([]),
   };
 
   beforeAll(async () => {

--- a/backend/test/unit/auth.service.spec.ts
+++ b/backend/test/unit/auth.service.spec.ts
@@ -211,6 +211,24 @@ describe('AuthService', () => {
       expect(mockJwtService.sign).toHaveBeenCalled();
     });
 
+    it('should accept username as a legacy alias for usernameOrEmail', async () => {
+      mockedBcrypt.compare.mockResolvedValue(true as never);
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+      mockUserRepository.save.mockResolvedValue({ ...mockUser, lastLoginAt: new Date() });
+      mockRefreshTokenRepository.create.mockReturnValue({});
+      mockRefreshTokenRepository.save.mockResolvedValue({});
+
+      const result = await service.login(
+        { username: 'testuser', password: 'Password@123', rememberMe: false } as any,
+        mockRequest as any,
+      );
+
+      expect(result.user.username).toBe('testuser');
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith({
+        where: [{ username: 'testuser' }, { email: 'testuser' }],
+      });
+    });
+
     it('should increment failed login attempts on wrong password', async () => {
       mockedBcrypt.compare.mockResolvedValue(false as never);
       const userWithFailedAttempts = { ...mockUser, failedLoginAttempts: 2 };

--- a/backend/test/unit/price-list.service.spec.ts
+++ b/backend/test/unit/price-list.service.spec.ts
@@ -86,7 +86,6 @@ describe('PriceListsService', () => {
 
   const mockProductRepository = {
     findOneBy: jest.fn(),
-    findByIds: jest.fn(),
   };
 
   beforeEach(async () => {


### PR DESCRIPTION
## Summary

- Bumps `typeorm` from `0.3.17` to `1.0.0`
- Converts all string-array `relations`/`select` options to object syntax (removed in 1.0.0)
- Replaces removed `findByIds()` with `findBy({ id: In(...) })`
- Fixes login robustness: legacy `{ username, password }` payloads now map to `usernameOrEmail` (exposed by smoke test)
- Cleans up stale `findByIds` mocks, fixes `LoginDto` type, adds explanatory comments

## Verification

- `npm run build` — clean
- `npm run lint` — clean
- `npm run test` — 74 suites, 1028 tests passing
- Docker smoke test — `/api/health`, `/api/inventory/products`, `/api/sales-orders`, `/api/purchasing/orders` all HTTP 200, clean log window

## Test plan

- [ ] `cd backend && npm run build`
- [ ] `cd backend && npm run test`
- [ ] `docker compose build backend && docker compose up -d`
- [ ] Verify login, product list, sales orders, purchase orders all return 2xx

Closes #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)