### PR TITLE
test(e2e): add e2e test suite for inventory, sales, and purchasing

### DIFF
--- a/backend/test/e2e/helpers/seed.ts
+++ b/backend/test/e2e/helpers/seed.ts
@@ -1,0 +1,99 @@
+import { DataSource } from 'typeorm';
+import { User, UserRole, UserStatus } from '../../../src/database/entities/user.entity';
+import { Category } from '../../../src/database/entities/category.entity';
+import { Product } from '../../../src/database/entities/product.entity';
+import { PaymentMethodEntity } from '../../../src/database/entities/payment-method.entity';
+import * as bcrypt from 'bcrypt';
+
+/**
+ * Truncates all business tables in dependency order so any spec can start clean.
+ * Uses CASCADE so FK chains are handled automatically.
+ */
+export async function truncateAll(dataSource: DataSource): Promise<void> {
+  await dataSource.query(`
+    TRUNCATE TABLE
+      journal_entry_lines,
+      journal_entries,
+      invoices,
+      payments,
+      sales_order_items,
+      sales_orders,
+      vendor_payments,
+      goods_received_note_items,
+      goods_received_notes,
+      purchase_order_items,
+      purchase_orders,
+      customers,
+      suppliers,
+      stock_movements,
+      stock_adjustments,
+      price_list_items,
+      products,
+      categories,
+      refresh_tokens,
+      users
+    RESTART IDENTITY CASCADE
+  `);
+}
+
+export async function seedAdmin(dataSource: DataSource): Promise<User> {
+  const userRepo = dataSource.getRepository(User);
+  const hashed = await bcrypt.hash('Admin@123!', 12);
+  return userRepo.save(userRepo.create({
+    username: 'admin',
+    email: 'admin@test.com',
+    password: hashed,
+    firstName: 'Admin',
+    lastName: 'User',
+    role: UserRole.ADMIN,
+    status: UserStatus.ACTIVE,
+    isActive: true,
+    failedLoginAttempts: 0,
+  }));
+}
+
+export async function seedCategory(dataSource: DataSource, name = 'Test Category'): Promise<Category> {
+  const categoryRepo = dataSource.getRepository(Category);
+  return categoryRepo.save(categoryRepo.create({ name, level: 0 }));
+}
+
+export async function seedProduct(
+  dataSource: DataSource,
+  categoryId: string,
+  overrides: Partial<{ name: string; baseCost: number; stockQuantity: number }> = {},
+): Promise<Product> {
+  const productRepo = dataSource.getRepository(Product);
+  return productRepo.save(productRepo.create({
+    name: overrides.name ?? 'Test Product',
+    categoryId,
+    baseCost: overrides.baseCost ?? 100,
+    stockQuantity: overrides.stockQuantity ?? 0,
+    isActive: true,
+  }));
+}
+
+export async function seedPaymentMethod(dataSource: DataSource): Promise<PaymentMethodEntity> {
+  const pmRepo = dataSource.getRepository(PaymentMethodEntity);
+  let pm = await pmRepo.findOne({ where: { code: 'CASH' } });
+  if (!pm) {
+    pm = await pmRepo.save(pmRepo.create({ code: 'CASH', name: 'Cash', requiresSettlement: false }));
+  }
+  return pm;
+}
+
+export async function seedDocumentNumberSettings(dataSource: DataSource): Promise<void> {
+  const currentYY = new Date().getFullYear() % 100;
+  const configs = [
+    { documentName: 'Purchase Orders', prefix: 'PO' },
+    { documentName: 'Goods Received', prefix: 'GRN' },
+    { documentName: 'Vendor Payments', prefix: 'VP' },
+  ];
+  for (const cfg of configs) {
+    await dataSource.query(
+      `INSERT INTO document_number_settings ("documentName", prefix, "paddingDigits", "nextNumber", "lastResetYear")
+       VALUES ($1, $2, 3, 1, $3)
+       ON CONFLICT ("documentName") DO NOTHING`,
+      [cfg.documentName, cfg.prefix, currentYY],
+    );
+  }
+}

--- a/backend/test/e2e/inventory.e2e-spec.ts
+++ b/backend/test/e2e/inventory.e2e-spec.ts
@@ -1,11 +1,9 @@
-// backend/test/e2e/inventory.e2e-spec.ts
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import request from 'supertest';
 import { DataSource } from 'typeorm';
 import { AppModule } from '../../src/app.module';
-import { User, UserRole, UserStatus } from '../../src/database/entities/user.entity';
-import * as bcrypt from 'bcrypt';
+import { truncateAll, seedAdmin, seedCategory, seedProduct } from './helpers/seed';
 
 describe('Inventory (e2e)', () => {
   let app: INestApplication;
@@ -24,34 +22,9 @@ describe('Inventory (e2e)', () => {
     await app.init();
 
     dataSource = app.get(DataSource);
+    await truncateAll(dataSource);
 
-    // Truncate all tables this spec touches
-    await dataSource.query(`
-      TRUNCATE TABLE
-        stock_movements,
-        stock_adjustments,
-        price_list_items,
-        products,
-        categories,
-        refresh_tokens,
-        users
-      RESTART IDENTITY CASCADE
-    `);
-
-    // Seed admin user and get token
-    const userRepo = dataSource.getRepository(User);
-    const hashed = await bcrypt.hash('Admin@123!', 12);
-    await userRepo.save(userRepo.create({
-      username: 'admin',
-      email: 'admin@test.com',
-      password: hashed,
-      firstName: 'Admin',
-      lastName: 'User',
-      role: UserRole.ADMIN,
-      status: UserStatus.ACTIVE,
-      isActive: true,
-      failedLoginAttempts: 0,
-    }));
+    await seedAdmin(dataSource);
 
     const loginRes = await request(app.getHttpServer())
       .post('/auth/login')
@@ -85,8 +58,8 @@ describe('Inventory (e2e)', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 
-      const ids = (res.body.data ?? res.body).map((c: any) => c.id);
-      expect(ids).toContain(categoryId);
+      const items: any[] = Array.isArray(res.body) ? res.body : res.body.data;
+      expect(items.map((c: any) => c.id)).toContain(categoryId);
     });
 
     it('GET /inventory/categories/:id — returns the category', async () => {
@@ -152,9 +125,8 @@ describe('Inventory (e2e)', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 
-      const items = res.body.data ?? res.body;
-      const ids = items.map((p: any) => p.id);
-      expect(ids).toContain(productId);
+      const items: any[] = res.body.data ?? res.body;
+      expect(items.map((p: any) => p.id)).toContain(productId);
     });
 
     it('GET /inventory/products/:id — returns the product', async () => {
@@ -253,18 +225,18 @@ describe('Inventory (e2e)', () => {
 
   describe('Edge cases', () => {
     it('POST /inventory/products — duplicate barcode returns 409', async () => {
-      // Create first product with a barcode
+      const category = await seedCategory(dataSource, 'Edge Case Category');
+
       await request(app.getHttpServer())
         .post('/inventory/products')
         .set('Authorization', `Bearer ${accessToken}`)
-        .send({ name: 'Product A', categoryId, baseCost: 10, barcode: 'BARCODE-001' })
+        .send({ name: 'Product A', categoryId: category.id, baseCost: 10, barcode: 'BARCODE-001' })
         .expect(201);
 
-      // Attempt duplicate barcode
       const res = await request(app.getHttpServer())
         .post('/inventory/products')
         .set('Authorization', `Bearer ${accessToken}`)
-        .send({ name: 'Product B', categoryId, baseCost: 10, barcode: 'BARCODE-001' })
+        .send({ name: 'Product B', categoryId: category.id, baseCost: 10, barcode: 'BARCODE-001' })
         .expect(409);
 
       expect(res.body.message).toBeDefined();

--- a/backend/test/e2e/inventory.e2e-spec.ts
+++ b/backend/test/e2e/inventory.e2e-spec.ts
@@ -125,4 +125,72 @@ describe('Inventory (e2e)', () => {
       expect(res.body.id).toBe(categoryId);
     });
   });
+
+  // ─── Product CRUD ─────────────────────────────────────────────────────────
+
+  describe('Product CRUD', () => {
+    it('POST /inventory/products — creates a product', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/inventory/products')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          name: 'Laptop Pro 15',
+          categoryId,
+          baseCost: 800,
+          stockQuantity: 50,
+        })
+        .expect(201);
+
+      expect(res.body).toHaveProperty('id');
+      expect(res.body.name).toBe('Laptop Pro 15');
+      productId = res.body.id;
+    });
+
+    it('GET /inventory/products — lists products', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/inventory/products')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      const items = res.body.data ?? res.body;
+      const ids = items.map((p: any) => p.id);
+      expect(ids).toContain(productId);
+    });
+
+    it('GET /inventory/products/:id — returns the product', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/inventory/products/${productId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(res.body.id).toBe(productId);
+      expect(res.body.name).toBe('Laptop Pro 15');
+    });
+
+    it('PATCH /inventory/products/:id — updates the product', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(`/inventory/products/${productId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ name: 'Laptop Pro 15 Updated', categoryId, baseCost: 850 })
+        .expect(200);
+
+      expect(res.body.name).toBe('Laptop Pro 15 Updated');
+    });
+
+    it('DELETE /inventory/products/:id — soft-deletes the product', async () => {
+      await request(app.getHttpServer())
+        .delete(`/inventory/products/${productId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(204);
+    });
+
+    it('POST /inventory/products/:id/restore — restores the product', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/inventory/products/${productId}/restore`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(res.body.id).toBe(productId);
+    });
+  });
 });

--- a/backend/test/e2e/inventory.e2e-spec.ts
+++ b/backend/test/e2e/inventory.e2e-spec.ts
@@ -193,4 +193,81 @@ describe('Inventory (e2e)', () => {
       expect(res.body.id).toBe(productId);
     });
   });
+
+  // ─── Stock Adjustments ────────────────────────────────────────────────────
+
+  describe('Stock adjustments', () => {
+    let adjustmentId: string;
+
+    it('POST /inventory/stock-adjustments — creates a draft adjustment', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/inventory/stock-adjustments')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          adjustmentDate: new Date().toISOString(),
+          notes: 'Initial stock count',
+          items: [
+            { productId, oldQuantity: 50, newQuantity: 60, difference: 10 },
+          ],
+        })
+        .expect(201);
+
+      expect(res.body).toHaveProperty('id');
+      adjustmentId = res.body.id;
+    });
+
+    it('POST /inventory/stock-adjustments/:id/complete — completes the adjustment', async () => {
+      await request(app.getHttpServer())
+        .post(`/inventory/stock-adjustments/${adjustmentId}/complete`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(201);
+    });
+
+    it('GET /inventory/products/:id — stock increased after completion', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/inventory/products/${productId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(Number(res.body.stockQuantity)).toBe(60);
+    });
+
+    it('POST /inventory/stock-adjustments/:id/uncomplete — reverses the adjustment', async () => {
+      await request(app.getHttpServer())
+        .post(`/inventory/stock-adjustments/${adjustmentId}/uncomplete`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(201);
+    });
+
+    it('GET /inventory/products/:id — stock reverted after uncomplete', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/inventory/products/${productId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(Number(res.body.stockQuantity)).toBe(50);
+    });
+  });
+
+  // ─── Edge cases ───────────────────────────────────────────────────────────
+
+  describe('Edge cases', () => {
+    it('POST /inventory/products — duplicate barcode returns 409', async () => {
+      // Create first product with a barcode
+      await request(app.getHttpServer())
+        .post('/inventory/products')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ name: 'Product A', categoryId, baseCost: 10, barcode: 'BARCODE-001' })
+        .expect(201);
+
+      // Attempt duplicate barcode
+      const res = await request(app.getHttpServer())
+        .post('/inventory/products')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ name: 'Product B', categoryId, baseCost: 10, barcode: 'BARCODE-001' })
+        .expect(409);
+
+      expect(res.body.message).toBeDefined();
+    });
+  });
 });

--- a/backend/test/e2e/inventory.e2e-spec.ts
+++ b/backend/test/e2e/inventory.e2e-spec.ts
@@ -1,0 +1,128 @@
+// backend/test/e2e/inventory.e2e-spec.ts
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { DataSource } from 'typeorm';
+import { AppModule } from '../../src/app.module';
+import { User, UserRole, UserStatus } from '../../src/database/entities/user.entity';
+import * as bcrypt from 'bcrypt';
+
+describe('Inventory (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+  let accessToken: string;
+  let categoryId: string;
+  let productId: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    await app.init();
+
+    dataSource = app.get(DataSource);
+
+    // Truncate all tables this spec touches
+    await dataSource.query(`
+      TRUNCATE TABLE
+        stock_movements,
+        stock_adjustments,
+        price_list_items,
+        products,
+        categories,
+        refresh_tokens,
+        users
+      RESTART IDENTITY CASCADE
+    `);
+
+    // Seed admin user and get token
+    const userRepo = dataSource.getRepository(User);
+    const hashed = await bcrypt.hash('Admin@123!', 12);
+    await userRepo.save(userRepo.create({
+      username: 'admin',
+      email: 'admin@test.com',
+      password: hashed,
+      firstName: 'Admin',
+      lastName: 'User',
+      role: UserRole.ADMIN,
+      status: UserStatus.ACTIVE,
+      isActive: true,
+      failedLoginAttempts: 0,
+    }));
+
+    const loginRes = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ usernameOrEmail: 'admin', password: 'Admin@123!' });
+    accessToken = loginRes.body.accessToken;
+  });
+
+  afterAll(async () => {
+    if (dataSource?.isInitialized) await dataSource.destroy();
+    await app.close();
+  });
+
+  // ─── Category CRUD ────────────────────────────────────────────────────────
+
+  describe('Category CRUD', () => {
+    it('POST /inventory/categories — creates a category', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/inventory/categories')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ name: 'Electronics' })
+        .expect(201);
+
+      expect(res.body).toHaveProperty('id');
+      expect(res.body.name).toBe('Electronics');
+      categoryId = res.body.id;
+    });
+
+    it('GET /inventory/categories — lists categories', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/inventory/categories')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      const ids = (res.body.data ?? res.body).map((c: any) => c.id);
+      expect(ids).toContain(categoryId);
+    });
+
+    it('GET /inventory/categories/:id — returns the category', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/inventory/categories/${categoryId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(res.body.id).toBe(categoryId);
+      expect(res.body.name).toBe('Electronics');
+    });
+
+    it('PATCH /inventory/categories/:id — updates the category name', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(`/inventory/categories/${categoryId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ name: 'Consumer Electronics' })
+        .expect(200);
+
+      expect(res.body.name).toBe('Consumer Electronics');
+    });
+
+    it('DELETE /inventory/categories/:id — soft-deletes the category', async () => {
+      await request(app.getHttpServer())
+        .delete(`/inventory/categories/${categoryId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+    });
+
+    it('POST /inventory/categories/:id/restore — restores the category', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/inventory/categories/${categoryId}/restore`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(201);
+
+      expect(res.body.id).toBe(categoryId);
+    });
+  });
+});

--- a/backend/test/e2e/purchasing.e2e-spec.ts
+++ b/backend/test/e2e/purchasing.e2e-spec.ts
@@ -95,6 +95,22 @@ describe('Purchasing (e2e)', () => {
     }
     paymentMethodId = pm.id;
 
+    // Seed: document number settings (required for PO, GRN, and vendor payment numbering)
+    const currentYY = new Date().getFullYear() % 100;
+    const docConfigs = [
+      { documentName: 'Purchase Orders', prefix: 'PO' },
+      { documentName: 'Goods Received', prefix: 'GRN' },
+      { documentName: 'Vendor Payments', prefix: 'VP' },
+    ];
+    for (const cfg of docConfigs) {
+      await dataSource.query(
+        `INSERT INTO document_number_settings ("documentName", prefix, "paddingDigits", "nextNumber", "lastResetYear")
+         VALUES ($1, $2, 3, 1, $3)
+         ON CONFLICT ("documentName") DO NOTHING`,
+        [cfg.documentName, cfg.prefix, currentYY],
+      );
+    }
+
     // Login
     const loginRes = await request(app.getHttpServer())
       .post('/auth/login')
@@ -172,6 +188,147 @@ describe('Purchasing (e2e)', () => {
 
       const supplier = res.body.data ?? res.body;
       expect(supplier.id).toBe(supplierId);
+    });
+  });
+
+  // ─── Purchase Order Lifecycle ─────────────────────────────────────────────
+
+  describe('Purchase order lifecycle', () => {
+    it('POST /purchasing/orders — creates a purchase order', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/purchasing/orders')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          supplierId,
+          orderDate: new Date().toISOString().split('T')[0],
+          items: [{ productId, quantity: 10, unitPrice: 55 }],
+        })
+        .expect(201);
+
+      expect(res.body.data).toHaveProperty('id');
+      expect(res.body.data).toHaveProperty('orderNumber');
+      purchaseOrderId = res.body.data.id;
+      purchaseOrderNumber = res.body.data.orderNumber;
+      expect(purchaseOrderId).toBeTruthy();
+    });
+
+    it('GET /purchasing/orders/:id — returns the purchase order', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/purchasing/orders/${purchaseOrderId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      const po = res.body.data ?? res.body;
+      expect(po.id).toBe(purchaseOrderId);
+      expect(po.supplier?.id ?? po.supplierId).toBe(supplierId);
+    });
+
+    it('GET /purchasing/orders/by-number/:orderNumber — returns by order number', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/purchasing/orders/by-number/${purchaseOrderNumber}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      const po = res.body.data ?? res.body;
+      expect(po.id).toBe(purchaseOrderId);
+    });
+
+    it('GET /purchasing/orders/summary — returns summary', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/purchasing/orders/summary')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(res.body).toBeDefined();
+    });
+
+    it('PUT /purchasing/orders/:id — updates the purchase order notes', async () => {
+      const res = await request(app.getHttpServer())
+        .put(`/purchasing/orders/${purchaseOrderId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          supplierId,
+          orderDate: new Date().toISOString().split('T')[0],
+          notes: 'Updated notes',
+          items: [{ productId, quantity: 10, unitPrice: 55 }],
+        })
+        .expect(200);
+
+      const po = res.body.data ?? res.body;
+      expect(po.notes).toBe('Updated notes');
+    });
+  });
+
+  // ─── Goods received (stock impact) ────────────────────────────────────────
+
+  describe('Goods received', () => {
+    it('POST /purchasing/orders/:id/receive — receives goods', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/purchasing/orders/${purchaseOrderId}/receive`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(res.body.data ?? res.body).toBeDefined();
+    });
+
+    it('GET /inventory/products/:id — stock increased after receiving goods', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/inventory/products/${productId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      // Product started at 0 stock; received 10 units
+      expect(Number(res.body.stockQuantity)).toBe(10);
+    });
+  });
+
+  // ─── Vendor payment ───────────────────────────────────────────────────────
+
+  describe('Vendor payment', () => {
+    it('POST /purchasing/orders/:id/record-payment — records a payment', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/purchasing/orders/${purchaseOrderId}/record-payment`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ amount: 550 })
+        .expect(200);
+
+      const po = res.body.data ?? res.body;
+      expect(Number(po.paidAmount)).toBeGreaterThan(0);
+    });
+
+    it('GET /purchasing/orders/:id — paidAmount reflects the payment', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/purchasing/orders/${purchaseOrderId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      const po = res.body.data ?? res.body;
+      expect(Number(po.paidAmount)).toBeGreaterThanOrEqual(550);
+    });
+  });
+
+  // ─── Edge cases ───────────────────────────────────────────────────────────
+
+  describe('Edge cases', () => {
+    it('POST /purchasing/orders/:id/receive — non-existent PO returns 404', async () => {
+      await request(app.getHttpServer())
+        .post('/purchasing/orders/00000000-0000-0000-0000-000000000000/receive')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(404);
+    });
+
+    it('POST /purchasing/orders — unknown supplierId returns 404', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/purchasing/orders')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          supplierId: '00000000-0000-0000-0000-000000000000',
+          orderDate: new Date().toISOString().split('T')[0],
+          items: [{ productId, quantity: 1, unitPrice: 10 }],
+        })
+        .expect(404);
+
+      expect(res.body.message).toBeDefined();
     });
   });
 });

--- a/backend/test/e2e/purchasing.e2e-spec.ts
+++ b/backend/test/e2e/purchasing.e2e-spec.ts
@@ -17,6 +17,8 @@ describe('Purchasing (e2e)', () => {
   let supplierId: string;
   let productId: string;
   let paymentMethodId: string;
+  let purchaseOrderId: string;
+  let purchaseOrderNumber: string;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -119,6 +121,7 @@ describe('Purchasing (e2e)', () => {
       const supplier = res.body.data ?? res.body;
       expect(supplier.companyName).toBe('Tech Supplies Ltd');
       supplierId = supplier.id;
+      expect(supplierId).toBeTruthy();
     });
 
     it('GET /purchasing/suppliers — lists suppliers', async () => {

--- a/backend/test/e2e/purchasing.e2e-spec.ts
+++ b/backend/test/e2e/purchasing.e2e-spec.ts
@@ -1,14 +1,16 @@
-// backend/test/e2e/purchasing.e2e-spec.ts
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import request from 'supertest';
 import { DataSource } from 'typeorm';
 import { AppModule } from '../../src/app.module';
-import { User, UserRole, UserStatus } from '../../src/database/entities/user.entity';
-import { Category } from '../../src/database/entities/category.entity';
-import { Product } from '../../src/database/entities/product.entity';
-import { PaymentMethodEntity } from '../../src/database/entities/payment-method.entity';
-import * as bcrypt from 'bcrypt';
+import {
+  truncateAll,
+  seedAdmin,
+  seedCategory,
+  seedProduct,
+  seedPaymentMethod,
+  seedDocumentNumberSettings,
+} from './helpers/seed';
 
 describe('Purchasing (e2e)', () => {
   let app: INestApplication;
@@ -30,88 +32,17 @@ describe('Purchasing (e2e)', () => {
     await app.init();
 
     dataSource = app.get(DataSource);
+    await truncateAll(dataSource);
 
-    // Truncate all tables this spec touches
-    await dataSource.query(`
-      TRUNCATE TABLE
-        vendor_payments,
-        goods_received_note_items,
-        goods_received_notes,
-        purchase_order_items,
-        purchase_orders,
-        suppliers,
-        stock_movements,
-        stock_adjustments,
-        price_list_items,
-        products,
-        categories,
-        refresh_tokens,
-        users
-      RESTART IDENTITY CASCADE
-    `);
-
-    // Seed: admin user
-    const userRepo = dataSource.getRepository(User);
-    const hashed = await bcrypt.hash('Admin@123!', 12);
-    await userRepo.save(
-      userRepo.create({
-        username: 'admin',
-        email: 'admin@test.com',
-        password: hashed,
-        firstName: 'Admin',
-        lastName: 'User',
-        role: UserRole.ADMIN,
-        status: UserStatus.ACTIVE,
-        isActive: true,
-        failedLoginAttempts: 0,
-      }),
-    );
-
-    // Seed: category + product (zero stock)
-    const categoryRepo = dataSource.getRepository(Category);
-    const category = await categoryRepo.save(
-      categoryRepo.create({ name: 'Test Category', level: 0 }),
-    );
-
-    const productRepo = dataSource.getRepository(Product);
-    const product = await productRepo.save(
-      productRepo.create({
-        name: 'Test Product',
-        categoryId: category.id,
-        baseCost: 50,
-        stockQuantity: 0,
-        isActive: true,
-      }),
-    );
+    await seedAdmin(dataSource);
+    const category = await seedCategory(dataSource);
+    // Product starts at 0 stock — purchasing receives goods will add stock
+    const product = await seedProduct(dataSource, category.id, { stockQuantity: 0, baseCost: 50 });
     productId = product.id;
-
-    // Seed: payment method
-    const pmRepo = dataSource.getRepository(PaymentMethodEntity);
-    let pm = await pmRepo.findOne({ where: { code: 'CASH' } });
-    if (!pm) {
-      pm = await pmRepo.save(
-        pmRepo.create({ code: 'CASH', name: 'Cash', requiresSettlement: false }),
-      );
-    }
+    const pm = await seedPaymentMethod(dataSource);
     paymentMethodId = pm.id;
+    await seedDocumentNumberSettings(dataSource);
 
-    // Seed: document number settings (required for PO, GRN, and vendor payment numbering)
-    const currentYY = new Date().getFullYear() % 100;
-    const docConfigs = [
-      { documentName: 'Purchase Orders', prefix: 'PO' },
-      { documentName: 'Goods Received', prefix: 'GRN' },
-      { documentName: 'Vendor Payments', prefix: 'VP' },
-    ];
-    for (const cfg of docConfigs) {
-      await dataSource.query(
-        `INSERT INTO document_number_settings ("documentName", prefix, "paddingDigits", "nextNumber", "lastResetYear")
-         VALUES ($1, $2, 3, 1, $3)
-         ON CONFLICT ("documentName") DO NOTHING`,
-        [cfg.documentName, cfg.prefix, currentYY],
-      );
-    }
-
-    // Login
     const loginRes = await request(app.getHttpServer())
       .post('/auth/login')
       .send({ usernameOrEmail: 'admin', password: 'Admin@123!' });
@@ -133,8 +64,8 @@ describe('Purchasing (e2e)', () => {
         .send({ type: 'local', companyName: 'Tech Supplies Ltd' })
         .expect(201);
 
-      expect(res.body).toHaveProperty('id');
       const supplier = res.body.data ?? res.body;
+      expect(supplier).toHaveProperty('id');
       expect(supplier.companyName).toBe('Tech Supplies Ltd');
       supplierId = supplier.id;
       expect(supplierId).toBeTruthy();
@@ -146,10 +77,9 @@ describe('Purchasing (e2e)', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 
-      // SupplierListResponseDto returns { suppliers: [...], total: N }
+      // SupplierListResponseDto: { suppliers: [...], total: N }
       const items: any[] = res.body.suppliers ?? res.body.data ?? res.body;
-      const ids = items.map((s: any) => s.id);
-      expect(ids).toContain(supplierId);
+      expect(items.map((s: any) => s.id)).toContain(supplierId);
     });
 
     it('GET /purchasing/suppliers/:id — returns the supplier', async () => {
@@ -158,8 +88,7 @@ describe('Purchasing (e2e)', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 
-      const supplier = res.body.data ?? res.body;
-      expect(supplier.id).toBe(supplierId);
+      expect((res.body.data ?? res.body).id).toBe(supplierId);
     });
 
     it('PATCH /purchasing/suppliers/:id — updates the supplier', async () => {
@@ -169,8 +98,7 @@ describe('Purchasing (e2e)', () => {
         .send({ companyName: 'Tech Supplies International', type: 'local' })
         .expect(200);
 
-      const supplier = res.body.data ?? res.body;
-      expect(supplier.companyName).toBe('Tech Supplies International');
+      expect((res.body.data ?? res.body).companyName).toBe('Tech Supplies International');
     });
 
     it('DELETE /purchasing/suppliers/:id — soft-deletes the supplier', async () => {
@@ -186,8 +114,7 @@ describe('Purchasing (e2e)', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(201);
 
-      const supplier = res.body.data ?? res.body;
-      expect(supplier.id).toBe(supplierId);
+      expect((res.body.data ?? res.body).id).toBe(supplierId);
     });
   });
 
@@ -229,17 +156,18 @@ describe('Purchasing (e2e)', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 
-      const po = res.body.data ?? res.body;
-      expect(po.id).toBe(purchaseOrderId);
+      expect((res.body.data ?? res.body).id).toBe(purchaseOrderId);
     });
 
-    it('GET /purchasing/orders/summary — returns summary', async () => {
+    it('GET /purchasing/orders/summary — returns summary with expected fields', async () => {
       const res = await request(app.getHttpServer())
         .get('/purchasing/orders/summary')
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 
-      expect(res.body).toBeDefined();
+      expect(res.body).toHaveProperty('totalOrders');
+      expect(res.body).toHaveProperty('totalAmount');
+      expect(Number(res.body.totalOrders)).toBeGreaterThan(0);
     });
 
     it('PUT /purchasing/orders/:id — updates the purchase order notes', async () => {
@@ -254,8 +182,7 @@ describe('Purchasing (e2e)', () => {
         })
         .expect(200);
 
-      const po = res.body.data ?? res.body;
-      expect(po.notes).toBe('Updated notes');
+      expect((res.body.data ?? res.body).notes).toBe('Updated notes');
     });
   });
 
@@ -268,7 +195,7 @@ describe('Purchasing (e2e)', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 
-      expect(res.body.data ?? res.body).toBeDefined();
+      expect((res.body.data ?? res.body)).toHaveProperty('id');
     });
 
     it('GET /inventory/products/:id — stock increased after receiving goods', async () => {
@@ -292,8 +219,7 @@ describe('Purchasing (e2e)', () => {
         .send({ amount: 550 })
         .expect(200);
 
-      const po = res.body.data ?? res.body;
-      expect(Number(po.paidAmount)).toBeGreaterThan(0);
+      expect(Number((res.body.data ?? res.body).paidAmount)).toBe(550);
     });
 
     it('GET /purchasing/orders/:id — paidAmount reflects the payment', async () => {
@@ -302,8 +228,7 @@ describe('Purchasing (e2e)', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 
-      const po = res.body.data ?? res.body;
-      expect(Number(po.paidAmount)).toBeGreaterThanOrEqual(550);
+      expect(Number((res.body.data ?? res.body).paidAmount)).toBe(550);
     });
   });
 

--- a/backend/test/e2e/purchasing.e2e-spec.ts
+++ b/backend/test/e2e/purchasing.e2e-spec.ts
@@ -1,0 +1,174 @@
+// backend/test/e2e/purchasing.e2e-spec.ts
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { DataSource } from 'typeorm';
+import { AppModule } from '../../src/app.module';
+import { User, UserRole, UserStatus } from '../../src/database/entities/user.entity';
+import { Category } from '../../src/database/entities/category.entity';
+import { Product } from '../../src/database/entities/product.entity';
+import { PaymentMethodEntity } from '../../src/database/entities/payment-method.entity';
+import * as bcrypt from 'bcrypt';
+
+describe('Purchasing (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+  let accessToken: string;
+  let supplierId: string;
+  let productId: string;
+  let paymentMethodId: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    await app.init();
+
+    dataSource = app.get(DataSource);
+
+    // Truncate all tables this spec touches
+    await dataSource.query(`
+      TRUNCATE TABLE
+        vendor_payments,
+        goods_received_note_items,
+        goods_received_notes,
+        purchase_order_items,
+        purchase_orders,
+        suppliers,
+        stock_movements,
+        stock_adjustments,
+        price_list_items,
+        products,
+        categories,
+        refresh_tokens,
+        users
+      RESTART IDENTITY CASCADE
+    `);
+
+    // Seed: admin user
+    const userRepo = dataSource.getRepository(User);
+    const hashed = await bcrypt.hash('Admin@123!', 12);
+    await userRepo.save(
+      userRepo.create({
+        username: 'admin',
+        email: 'admin@test.com',
+        password: hashed,
+        firstName: 'Admin',
+        lastName: 'User',
+        role: UserRole.ADMIN,
+        status: UserStatus.ACTIVE,
+        isActive: true,
+        failedLoginAttempts: 0,
+      }),
+    );
+
+    // Seed: category + product (zero stock)
+    const categoryRepo = dataSource.getRepository(Category);
+    const category = await categoryRepo.save(
+      categoryRepo.create({ name: 'Test Category', level: 0 }),
+    );
+
+    const productRepo = dataSource.getRepository(Product);
+    const product = await productRepo.save(
+      productRepo.create({
+        name: 'Test Product',
+        categoryId: category.id,
+        baseCost: 50,
+        stockQuantity: 0,
+        isActive: true,
+      }),
+    );
+    productId = product.id;
+
+    // Seed: payment method
+    const pmRepo = dataSource.getRepository(PaymentMethodEntity);
+    let pm = await pmRepo.findOne({ where: { code: 'CASH' } });
+    if (!pm) {
+      pm = await pmRepo.save(
+        pmRepo.create({ code: 'CASH', name: 'Cash', requiresSettlement: false }),
+      );
+    }
+    paymentMethodId = pm.id;
+
+    // Login
+    const loginRes = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ usernameOrEmail: 'admin', password: 'Admin@123!' });
+    accessToken = loginRes.body.accessToken;
+  });
+
+  afterAll(async () => {
+    if (dataSource?.isInitialized) await dataSource.destroy();
+    await app.close();
+  });
+
+  // ─── Supplier CRUD ────────────────────────────────────────────────────────
+
+  describe('Supplier CRUD', () => {
+    it('POST /purchasing/suppliers — creates a supplier', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/purchasing/suppliers')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ type: 'local', companyName: 'Tech Supplies Ltd' })
+        .expect(201);
+
+      expect(res.body).toHaveProperty('id');
+      const supplier = res.body.data ?? res.body;
+      expect(supplier.companyName).toBe('Tech Supplies Ltd');
+      supplierId = supplier.id;
+    });
+
+    it('GET /purchasing/suppliers — lists suppliers', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/purchasing/suppliers')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      // SupplierListResponseDto returns { suppliers: [...], total: N }
+      const items: any[] = res.body.suppliers ?? res.body.data ?? res.body;
+      const ids = items.map((s: any) => s.id);
+      expect(ids).toContain(supplierId);
+    });
+
+    it('GET /purchasing/suppliers/:id — returns the supplier', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/purchasing/suppliers/${supplierId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      const supplier = res.body.data ?? res.body;
+      expect(supplier.id).toBe(supplierId);
+    });
+
+    it('PATCH /purchasing/suppliers/:id — updates the supplier', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(`/purchasing/suppliers/${supplierId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ companyName: 'Tech Supplies International', type: 'local' })
+        .expect(200);
+
+      const supplier = res.body.data ?? res.body;
+      expect(supplier.companyName).toBe('Tech Supplies International');
+    });
+
+    it('DELETE /purchasing/suppliers/:id — soft-deletes the supplier', async () => {
+      await request(app.getHttpServer())
+        .delete(`/purchasing/suppliers/${supplierId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+    });
+
+    it('POST /purchasing/suppliers/:id/restore — restores the supplier', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/purchasing/suppliers/${supplierId}/restore`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(201);
+
+      const supplier = res.body.data ?? res.body;
+      expect(supplier.id).toBe(supplierId);
+    });
+  });
+});

--- a/backend/test/e2e/sales.e2e-spec.ts
+++ b/backend/test/e2e/sales.e2e-spec.ts
@@ -161,4 +161,145 @@ describe('Sales (e2e)', () => {
       expect(res.body.id).toBe(customerId);
     });
   });
+
+  // ─── Sales Order Lifecycle ────────────────────────────────────────────────
+
+  describe('Sales order lifecycle', () => {
+    it('POST /sales-orders — creates a sales order', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/sales-orders')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          customerId,
+          items: [{ productId, quantity: 2, unitPrice: 150 }],
+        })
+        .expect(201);
+
+      expect(res.body.data).toHaveProperty('id');
+      expect(res.body.data).toHaveProperty('orderNumber');
+      salesOrderId = res.body.data.id;
+      salesOrderNumber = res.body.data.orderNumber;
+    });
+
+    it('GET /sales-orders/:id — returns the sales order', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/sales-orders/${salesOrderId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(res.body.id).toBe(salesOrderId);
+      expect(res.body.customerId).toBe(customerId);
+    });
+
+    it('GET /sales-orders/number/:orderNumber — returns by order number', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/sales-orders/number/${salesOrderNumber}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(res.body.id).toBe(salesOrderId);
+    });
+
+    it('GET /sales-orders/:id/fulfillment-status — returns fulfillment status', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/sales-orders/${salesOrderId}/fulfillment-status`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(res.body).toBeDefined();
+    });
+
+    it('PUT /sales-orders/:id — updates the sales order notes', async () => {
+      const res = await request(app.getHttpServer())
+        .put(`/sales-orders/${salesOrderId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          customerId,
+          notes: 'Handle with care',
+          items: [{ productId, quantity: 2, unitPrice: 150 }],
+        })
+        .expect(200);
+
+      const order = res.body.data ?? res.body;
+      expect(order.notes).toBe('Handle with care');
+    });
+
+    it('POST /sales-orders/:id/duplicate — duplicates the order', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/sales-orders/${salesOrderId}/duplicate`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(201);
+
+      const order = res.body.data ?? res.body;
+      expect(order).toHaveProperty('id');
+    });
+  });
+
+  // ─── Payment flow ─────────────────────────────────────────────────────────
+
+  describe('Payment flow', () => {
+    it('POST /sales-orders/:id/record-payment — records a payment', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/sales-orders/${salesOrderId}/record-payment`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ amount: 300, paymentMethodId })
+        .expect(201);
+
+      const order = res.body.data ?? res.body;
+      expect(Number(order.paidAmount)).toBeGreaterThan(0);
+    });
+
+    it('GET /sales-orders/:id — paidAmount reflects the payment', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/sales-orders/${salesOrderId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(Number(res.body.paidAmount)).toBeGreaterThanOrEqual(300);
+    });
+  });
+
+  // ─── Invoice ──────────────────────────────────────────────────────────────
+  // NOTE: create-invoice endpoint has a backend bug — Invoice.fromSalesOrder()
+  // does not populate invoiceNumber, causing a null-constraint DB error (500).
+  // Tests are skipped until the backend is fixed.
+
+  describe.skip('Invoice', () => {
+    it('POST /sales-orders/:id/create-invoice — creates an invoice', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/sales-orders/${salesOrderId}/create-invoice`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(201);
+
+      expect(res.body).toBeDefined();
+    });
+
+    it('GET /sales-orders/:id/invoices — lists invoices for the order', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/sales-orders/${salesOrderId}/invoices`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      const items = res.body.data ?? res.body;
+      expect(Array.isArray(items)).toBe(true);
+      expect(items.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ─── Edge cases ───────────────────────────────────────────────────────────
+
+  describe('Edge cases', () => {
+    it('POST /sales-orders — non-existent product returns 404', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/sales-orders')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          customerId,
+          items: [{ productId: '00000000-0000-0000-0000-000000000000', quantity: 1, unitPrice: 150 }],
+        })
+        .expect(404);
+
+      expect(res.body.message).toBeDefined();
+    });
+  });
 });

--- a/backend/test/e2e/sales.e2e-spec.ts
+++ b/backend/test/e2e/sales.e2e-spec.ts
@@ -1,14 +1,9 @@
-// backend/test/e2e/sales.e2e-spec.ts
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import request from 'supertest';
 import { DataSource } from 'typeorm';
 import { AppModule } from '../../src/app.module';
-import { User, UserRole, UserStatus } from '../../src/database/entities/user.entity';
-import { Category } from '../../src/database/entities/category.entity';
-import { Product } from '../../src/database/entities/product.entity';
-import { PaymentMethodEntity } from '../../src/database/entities/payment-method.entity';
-import * as bcrypt from 'bcrypt';
+import { truncateAll, seedAdmin, seedCategory, seedProduct, seedPaymentMethod } from './helpers/seed';
 
 describe('Sales (e2e)', () => {
   let app: INestApplication;
@@ -30,64 +25,15 @@ describe('Sales (e2e)', () => {
     await app.init();
 
     dataSource = app.get(DataSource);
+    await truncateAll(dataSource);
 
-    // Truncate all tables this spec touches (order matters for FK constraints)
-    await dataSource.query(`
-      TRUNCATE TABLE
-        invoices,
-        payments,
-        sales_order_items,
-        sales_orders,
-        customers,
-        stock_movements,
-        stock_adjustments,
-        price_list_items,
-        products,
-        categories,
-        refresh_tokens,
-        users
-      RESTART IDENTITY CASCADE
-    `);
-
-    // Seed: admin user
-    const userRepo = dataSource.getRepository(User);
-    const hashed = await bcrypt.hash('Admin@123!', 12);
-    await userRepo.save(userRepo.create({
-      username: 'admin',
-      email: 'admin@test.com',
-      password: hashed,
-      firstName: 'Admin',
-      lastName: 'User',
-      role: UserRole.ADMIN,
-      status: UserStatus.ACTIVE,
-      isActive: true,
-      failedLoginAttempts: 0,
-    }));
-
-    // Seed: category
-    const categoryRepo = dataSource.getRepository(Category);
-    const category = await categoryRepo.save(categoryRepo.create({ name: 'Test Category', level: 0 }));
-
-    // Seed: product with stock
-    const productRepo = dataSource.getRepository(Product);
-    const product = await productRepo.save(productRepo.create({
-      name: 'Test Product',
-      categoryId: category.id,
-      baseCost: 100,
-      stockQuantity: 100,
-      isActive: true,
-    }));
+    await seedAdmin(dataSource);
+    const category = await seedCategory(dataSource);
+    const product = await seedProduct(dataSource, category.id, { stockQuantity: 100, baseCost: 100 });
     productId = product.id;
-
-    // Seed: payment method (needed for recording payments)
-    const pmRepo = dataSource.getRepository(PaymentMethodEntity);
-    let pm = await pmRepo.findOne({ where: { code: 'CASH' } });
-    if (!pm) {
-      pm = await pmRepo.save(pmRepo.create({ code: 'CASH', name: 'Cash', requiresSettlement: false }));
-    }
+    const pm = await seedPaymentMethod(dataSource);
     paymentMethodId = pm.id;
 
-    // Login
     const loginRes = await request(app.getHttpServer())
       .post('/auth/login')
       .send({ usernameOrEmail: 'admin', password: 'Admin@123!' });
@@ -120,9 +66,8 @@ describe('Sales (e2e)', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 
-      const items = res.body.data ?? res.body;
-      const ids = items.map((c: any) => c.id);
-      expect(ids).toContain(customerId);
+      const items: any[] = res.body.data ?? res.body;
+      expect(items.map((c: any) => c.id)).toContain(customerId);
     });
 
     it('GET /customers/:id — returns the customer', async () => {
@@ -206,7 +151,8 @@ describe('Sales (e2e)', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 
-      expect(res.body).toBeDefined();
+      expect(res.body).toHaveProperty('orderId', salesOrderId);
+      expect(res.body).toHaveProperty('totalItems');
     });
 
     it('PUT /sales-orders/:id — updates the sales order notes', async () => {
@@ -246,7 +192,7 @@ describe('Sales (e2e)', () => {
         .expect(201);
 
       const order = res.body.data ?? res.body;
-      expect(Number(order.paidAmount)).toBeGreaterThan(0);
+      expect(Number(order.paidAmount)).toBe(300);
     });
 
     it('GET /sales-orders/:id — paidAmount reflects the payment', async () => {
@@ -255,14 +201,13 @@ describe('Sales (e2e)', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 
-      expect(Number(res.body.paidAmount)).toBeGreaterThanOrEqual(300);
+      expect(Number(res.body.paidAmount)).toBe(300);
     });
   });
 
   // ─── Invoice ──────────────────────────────────────────────────────────────
-  // NOTE: create-invoice endpoint has a backend bug — Invoice.fromSalesOrder()
-  // does not populate invoiceNumber, causing a null-constraint DB error (500).
-  // Tests are skipped until the backend is fixed.
+  // TODO(#625): unskip once Invoice.fromSalesOrder() populates invoiceNumber.
+  // Currently fails with 500: null constraint violation on invoiceNumber column.
 
   describe.skip('Invoice', () => {
     it('POST /sales-orders/:id/create-invoice — creates an invoice', async () => {
@@ -271,7 +216,7 @@ describe('Sales (e2e)', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(201);
 
-      expect(res.body).toBeDefined();
+      expect(res.body).toHaveProperty('id');
     });
 
     it('GET /sales-orders/:id/invoices — lists invoices for the order', async () => {
@@ -280,8 +225,7 @@ describe('Sales (e2e)', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 
-      const items = res.body.data ?? res.body;
-      expect(Array.isArray(items)).toBe(true);
+      const items: any[] = Array.isArray(res.body) ? res.body : res.body.data;
       expect(items.length).toBeGreaterThan(0);
     });
   });

--- a/backend/test/e2e/sales.e2e-spec.ts
+++ b/backend/test/e2e/sales.e2e-spec.ts
@@ -1,0 +1,164 @@
+// backend/test/e2e/sales.e2e-spec.ts
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { DataSource } from 'typeorm';
+import { AppModule } from '../../src/app.module';
+import { User, UserRole, UserStatus } from '../../src/database/entities/user.entity';
+import { Category } from '../../src/database/entities/category.entity';
+import { Product } from '../../src/database/entities/product.entity';
+import { PaymentMethodEntity } from '../../src/database/entities/payment-method.entity';
+import * as bcrypt from 'bcrypt';
+
+describe('Sales (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+  let accessToken: string;
+  let customerId: string;
+  let productId: string;
+  let salesOrderId: string;
+  let salesOrderNumber: string;
+  let paymentMethodId: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    await app.init();
+
+    dataSource = app.get(DataSource);
+
+    // Truncate all tables this spec touches (order matters for FK constraints)
+    await dataSource.query(`
+      TRUNCATE TABLE
+        invoices,
+        payments,
+        sales_order_items,
+        sales_orders,
+        customers,
+        stock_movements,
+        stock_adjustments,
+        price_list_items,
+        products,
+        categories,
+        refresh_tokens,
+        users
+      RESTART IDENTITY CASCADE
+    `);
+
+    // Seed: admin user
+    const userRepo = dataSource.getRepository(User);
+    const hashed = await bcrypt.hash('Admin@123!', 12);
+    await userRepo.save(userRepo.create({
+      username: 'admin',
+      email: 'admin@test.com',
+      password: hashed,
+      firstName: 'Admin',
+      lastName: 'User',
+      role: UserRole.ADMIN,
+      status: UserStatus.ACTIVE,
+      isActive: true,
+      failedLoginAttempts: 0,
+    }));
+
+    // Seed: category
+    const categoryRepo = dataSource.getRepository(Category);
+    const category = await categoryRepo.save(categoryRepo.create({ name: 'Test Category', level: 0 }));
+
+    // Seed: product with stock
+    const productRepo = dataSource.getRepository(Product);
+    const product = await productRepo.save(productRepo.create({
+      name: 'Test Product',
+      categoryId: category.id,
+      baseCost: 100,
+      stockQuantity: 100,
+      isActive: true,
+    }));
+    productId = product.id;
+
+    // Seed: payment method (needed for recording payments)
+    const pmRepo = dataSource.getRepository(PaymentMethodEntity);
+    let pm = await pmRepo.findOne({ where: { code: 'CASH' } });
+    if (!pm) {
+      pm = await pmRepo.save(pmRepo.create({ code: 'CASH', name: 'Cash', requiresSettlement: false }));
+    }
+    paymentMethodId = pm.id;
+
+    // Login
+    const loginRes = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ usernameOrEmail: 'admin', password: 'Admin@123!' });
+    accessToken = loginRes.body.accessToken;
+  });
+
+  afterAll(async () => {
+    if (dataSource?.isInitialized) await dataSource.destroy();
+    await app.close();
+  });
+
+  // ─── Customer CRUD ────────────────────────────────────────────────────────
+
+  describe('Customer CRUD', () => {
+    it('POST /customers — creates a customer', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/customers')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ type: 'business', name: 'Acme Corp' })
+        .expect(201);
+
+      expect(res.body).toHaveProperty('id');
+      expect(res.body.name).toBe('Acme Corp');
+      customerId = res.body.id;
+    });
+
+    it('GET /customers — lists customers', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/customers')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      const items = res.body.data ?? res.body;
+      const ids = items.map((c: any) => c.id);
+      expect(ids).toContain(customerId);
+    });
+
+    it('GET /customers/:id — returns the customer', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/customers/${customerId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(res.body.id).toBe(customerId);
+      expect(res.body.name).toBe('Acme Corp');
+    });
+
+    it('PUT /customers/:id — updates the customer', async () => {
+      const res = await request(app.getHttpServer())
+        .put(`/customers/${customerId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ name: 'Acme Corporation Ltd' })
+        .expect(200);
+
+      expect(res.body.name).toBe('Acme Corporation Ltd');
+    });
+
+    it('DELETE /customers/:id — soft-deletes the customer', async () => {
+      await request(app.getHttpServer())
+        .delete(`/customers/${customerId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(204);
+    });
+
+    it('POST /customers/:id/restore — restores the customer', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/customers/${customerId}/restore`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(201);
+
+      expect(res.body.id).toBe(customerId);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `backend/test/e2e/inventory.e2e-spec.ts`: category CRUD, product CRUD, stock adjustment lifecycle (complete/uncomplete with stock verification), edge cases (duplicate barcode)
- Adds `backend/test/e2e/sales.e2e-spec.ts`: customer CRUD, sales order lifecycle (create, get, get-by-number, fulfillment-status, update, duplicate), payment recording, invoice creation (2 tests skipped — pre-existing backend bug: `Invoice.fromSalesOrder()` does not populate `invoiceNumber`, causing null constraint violation), edge cases
- Adds `backend/test/e2e/purchasing.e2e-spec.ts`: supplier CRUD, purchase order lifecycle, goods received (with stock impact verification), vendor payment, edge cases (404 paths)

All three specs use the existing e2e infrastructure (real PostgreSQL, real Redis, migrations) and follow the per-file truncate + sequential pattern established in `accounting-auto-posting.e2e-spec.ts`.

Also discovered: pre-existing bug in `Invoice.fromSalesOrder()` — `invoiceNumber` is not populated, causing a null constraint violation on save. Tracked in the skipped tests with a comment.

Closes #622

## Test plan

- [x] `npm run test:e2e` passes (requires `.env.test` with a test DB)
- [x] CI passes on this PR (PostgreSQL + Redis already configured in workflow)
- [x] 2 skipped invoice tests are tracked and will be re-enabled once the invoice bug is fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)