### PR TITLE
fix(sales): generate invoiceNumber in createInvoiceFromOrder

### DIFF
--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -672,9 +672,9 @@ export class SalesOrderService extends BaseCrudService<
       throw new NotFoundException('Sales order not found');
     }
 
-    // Create invoice using the Invoice service (would need to inject)
+    const invoiceNumber = await this.generateInvoiceNumber();
     const invoiceData = Invoice.fromSalesOrder(order);
-    const invoice = this.invoiceRepository.create(invoiceData);
+    const invoice = this.invoiceRepository.create({ ...invoiceData, invoiceNumber });
 
     // lineItems removed from invoice model
 

--- a/backend/test/e2e/sales.e2e-spec.ts
+++ b/backend/test/e2e/sales.e2e-spec.ts
@@ -223,8 +223,8 @@ describe('Sales (e2e)', () => {
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 
-      const items: any[] = Array.isArray(res.body) ? res.body : res.body.data;
-      expect(items.length).toBeGreaterThan(0);
+      expect(res.body).toHaveProperty('invoices');
+      expect(res.body.invoices.length).toBeGreaterThan(0);
     });
   });
 

--- a/backend/test/e2e/sales.e2e-spec.ts
+++ b/backend/test/e2e/sales.e2e-spec.ts
@@ -206,17 +206,15 @@ describe('Sales (e2e)', () => {
   });
 
   // ─── Invoice ──────────────────────────────────────────────────────────────
-  // TODO(#625): unskip once Invoice.fromSalesOrder() populates invoiceNumber.
-  // Currently fails with 500: null constraint violation on invoiceNumber column.
-
-  describe.skip('Invoice', () => {
+  describe('Invoice', () => {
     it('POST /sales-orders/:id/create-invoice — creates an invoice', async () => {
       const res = await request(app.getHttpServer())
         .post(`/sales-orders/${salesOrderId}/create-invoice`)
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(201);
 
-      expect(res.body).toHaveProperty('id');
+      expect(res.body).toHaveProperty('invoiceId');
+      expect(res.body).toHaveProperty('invoiceNumber');
     });
 
     it('GET /sales-orders/:id/invoices — lists invoices for the order', async () => {


### PR DESCRIPTION
## Summary

- `createInvoiceFromOrder()` was calling `Invoice.fromSalesOrder()` and saving immediately without generating an `invoiceNumber`, causing a null constraint violation (500 on every `POST /sales-orders/:id/create-invoice` call)
- Fixed by calling the existing `generateInvoiceNumber()` helper before creating the entity — same pattern already used in the auto-invoice path
- Unskipped the two e2e tests gated on this fix and corrected the assertion to match the actual response shape (`invoiceId`/`invoiceNumber`, not `id`)

## Test plan

- [ ] `POST /sales-orders/:id/create-invoice` returns 201 with `invoiceId` and `invoiceNumber`
- [ ] `GET /sales-orders/:id/invoices` lists the newly created invoice
- [ ] E2e suite: `describe('Invoice')` block in `sales.e2e-spec.ts` passes (was previously skipped)

Closes #625

🤖 Generated with [Claude Code](https://claude.com/claude-code)