### PR TITLE
refactor(router): modularize into per-domain route files

### DIFF
--- a/frontend/src/__tests__/router.config.test.ts
+++ b/frontend/src/__tests__/router.config.test.ts
@@ -5,8 +5,45 @@ import { describe, expect, it } from 'vitest'
 
 const pagesDir = resolve(__dirname, '../pages')
 
-const settingsRoutes = readFileSync(resolve(pagesDir, 'settings/settings.routes.tsx'), 'utf8')
+const authRoutes = readFileSync(resolve(pagesDir, 'auth/auth.routes.tsx'), 'utf8')
+const dashboardRoutes = readFileSync(resolve(pagesDir, 'dashboard/dashboard.routes.tsx'), 'utf8')
+const inventoryRoutes = readFileSync(resolve(pagesDir, 'inventory/inventory.routes.tsx'), 'utf8')
 const salesRoutes = readFileSync(resolve(pagesDir, 'sales/sales.routes.tsx'), 'utf8')
+const purchasingRoutes = readFileSync(resolve(pagesDir, 'purchasing/purchasing.routes.tsx'), 'utf8')
+const settingsRoutes = readFileSync(resolve(pagesDir, 'settings/settings.routes.tsx'), 'utf8')
+const auditLogsRoutes = readFileSync(resolve(pagesDir, 'audit-logs/audit-logs.routes.tsx'), 'utf8')
+const accountingRoutes = readFileSync(resolve(pagesDir, 'accounting/accounting.routes.tsx'), 'utf8')
+
+describe('domain route file smoke tests', () => {
+  it('auth routes define login and password change paths', () => {
+    expect(authRoutes).toContain("path: '/login'")
+    expect(authRoutes).toContain("path: '/change-password-required'")
+  })
+
+  it('dashboard routes define the dashboard path', () => {
+    expect(dashboardRoutes).toContain("path: '/dashboard'")
+  })
+
+  it('inventory routes define products and stock adjustment paths', () => {
+    expect(inventoryRoutes).toContain("path: '/inventory/products'")
+    expect(inventoryRoutes).toContain("path: '/inventory/stock-adjustments'")
+  })
+
+  it('purchasing routes define suppliers list before create/edit', () => {
+    const suppliersListIndex = purchasingRoutes.indexOf("path: '/purchasing/suppliers'")
+    const suppliersCreateIndex = purchasingRoutes.indexOf("path: '/purchasing/suppliers/create'")
+    expect(suppliersListIndex).toBeLessThan(suppliersCreateIndex)
+  })
+
+  it('audit-logs routes define the audit-logs path', () => {
+    expect(auditLogsRoutes).toContain("path: '/audit-logs'")
+  })
+
+  it('accounting routes define dashboard and journal entries paths', () => {
+    expect(accountingRoutes).toContain("path: '/accounting/dashboard'")
+    expect(accountingRoutes).toContain("path: '/accounting/journal-entries'")
+  })
+})
 
 describe('router settings paths', () => {
   it('redirects legacy inventory costing path to /settings/inventory-costing', () => {

--- a/frontend/src/__tests__/router.config.test.ts
+++ b/frontend/src/__tests__/router.config.test.ts
@@ -3,22 +3,25 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const routerSource = readFileSync(resolve(__dirname, '../router.tsx'), 'utf8')
+const pagesDir = resolve(__dirname, '../pages')
+
+const settingsRoutes = readFileSync(resolve(pagesDir, 'settings/settings.routes.tsx'), 'utf8')
+const salesRoutes = readFileSync(resolve(pagesDir, 'sales/sales.routes.tsx'), 'utf8')
 
 describe('router settings paths', () => {
   it('redirects legacy inventory costing path to /settings/inventory-costing', () => {
-    expect(routerSource).toContain("{ path: '/settings/price-costing', element: <Navigate to=\"/settings/inventory-costing\" replace /> }")
+    expect(settingsRoutes).toContain("{ path: '/settings/price-costing', element: <Navigate to=\"/settings/inventory-costing\" replace /> }")
   })
 
   it('defines the inventory costing page at /settings/inventory-costing', () => {
-    expect(routerSource).toContain("{ path: '/settings/inventory-costing', element: <InventoryCostingPage />, handle: { title: 'Inventory Costing' } }")
+    expect(settingsRoutes).toContain("{ path: '/settings/inventory-costing', element: <InventoryCostingPage />, handle: { title: 'Inventory Costing' } }")
   })
 
   it('defines customer create and edit routes and removes the old customer profile route', () => {
-    expect(routerSource).toContain("const CustomerFormPage = React.lazy(() => import('./pages/sales/CustomerFormPage'))")
-    expect(routerSource).toContain("{ path: '/sales/customers/create', element: <CustomerFormPage />, handle: { title: 'New Customer' } }")
-    expect(routerSource).toContain("{ path: '/sales/customers/:slug/edit', element: <CustomerFormPage />, handle: { title: 'Edit Customer' } }")
-    expect(routerSource).not.toContain('CustomerProfilePage')
-    expect(routerSource).not.toContain("{ path: '/sales/customers/:id', element: <CustomerProfilePage />, handle: { title: 'Customer Profile' } }")
+    expect(salesRoutes).toContain("const CustomerFormPage = React.lazy(() => import('./CustomerFormPage'))")
+    expect(salesRoutes).toContain("{ path: '/sales/customers/create', element: <CustomerFormPage />, handle: { title: 'New Customer' } }")
+    expect(salesRoutes).toContain("{ path: '/sales/customers/:slug/edit', element: <CustomerFormPage />, handle: { title: 'Edit Customer' } }")
+    expect(salesRoutes).not.toContain('CustomerProfilePage')
+    expect(salesRoutes).not.toContain("{ path: '/sales/customers/:id', element: <CustomerProfilePage />, handle: { title: 'Customer Profile' } }")
   })
 })

--- a/frontend/src/pages/accounting/accounting.routes.tsx
+++ b/frontend/src/pages/accounting/accounting.routes.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { Navigate } from 'react-router-dom'
+import type { RouteObject } from 'react-router-dom'
+
+const AccountingDashboardPage = React.lazy(() => import('./AccountingDashboardPage'))
+const ChartOfAccountsPage = React.lazy(() => import('./ChartOfAccountsPage'))
+const FiscalPeriodsPage = React.lazy(() => import('./FiscalPeriodsPage'))
+const JournalEntriesPage = React.lazy(() => import('./JournalEntriesPage'))
+const AccountMappingsPage = React.lazy(() => import('./AccountMappingsPage'))
+const BankReconciliationsPage = React.lazy(() => import('./BankReconciliationsPage'))
+const SettlementsPage = React.lazy(() => import('./SettlementsPage'))
+const OwnerEquityPage = React.lazy(() => import('./OwnerEquityPage'))
+const ExpensesPage = React.lazy(() => import('./ExpensesPage'))
+const FundTransfersPage = React.lazy(() => import('./FundTransfersPage'))
+const TrialBalancePage = React.lazy(() => import('./reports/TrialBalancePage'))
+const BalanceSheetPage = React.lazy(() => import('./reports/BalanceSheetPage'))
+const ProfitAndLossPage = React.lazy(() => import('./reports/ProfitAndLossPage'))
+const GeneralLedgerPage = React.lazy(() => import('./reports/GeneralLedgerPage'))
+const AccountActivityPage = React.lazy(() => import('./reports/AccountActivityPage'))
+
+export const accountingRoutes: RouteObject[] = [
+  { path: '/accounting', element: <Navigate to="/accounting/dashboard" replace /> },
+  { path: '/accounting/dashboard', element: <AccountingDashboardPage />, handle: { title: 'Dashboard' } },
+  { path: '/accounting/chart-of-accounts', element: <ChartOfAccountsPage />, handle: { title: 'Chart of Accounts' } },
+  { path: '/accounting/fiscal-periods', element: <FiscalPeriodsPage />, handle: { title: 'Fiscal Periods' } },
+  { path: '/accounting/journal-entries', element: <JournalEntriesPage />, handle: { title: 'Journal Entries' } },
+  { path: '/accounting/journal-entries/:id', element: <Navigate to="/accounting/journal-entries" replace /> },
+  { path: '/accounting/account-mappings', element: <AccountMappingsPage />, handle: { title: 'Account Mappings' } },
+  { path: '/accounting/settlements', element: <SettlementsPage />, handle: { title: 'Settlements' } },
+  { path: '/accounting/owner-equity', element: <OwnerEquityPage />, handle: { title: "Owner's Equity" } },
+  { path: '/accounting/expenses', element: <ExpensesPage />, handle: { title: 'Expenses' } },
+  { path: '/accounting/fund-transfers', element: <FundTransfersPage />, handle: { title: 'Fund Transfers' } },
+  { path: '/accounting/bank-reconciliations', element: <BankReconciliationsPage />, handle: { title: 'Bank Reconciliation' } },
+  { path: '/accounting/bank-reconciliations/new', element: <BankReconciliationsPage />, handle: { title: 'New Bank Reconciliation' } },
+  { path: '/accounting/bank-reconciliations/:id', element: <Navigate to="/accounting/bank-reconciliations" replace /> },
+  { path: '/accounting/reports/trial-balance', element: <TrialBalancePage />, handle: { title: 'Trial Balance' } },
+  { path: '/accounting/reports/balance-sheet', element: <BalanceSheetPage />, handle: { title: 'Balance Sheet' } },
+  { path: '/accounting/reports/profit-loss', element: <ProfitAndLossPage />, handle: { title: 'Profit & Loss' } },
+  { path: '/accounting/reports/general-ledger', element: <GeneralLedgerPage />, handle: { title: 'General Ledger' } },
+  { path: '/accounting/reports/account-activity', element: <AccountActivityPage />, handle: { title: 'Account Activity' } },
+]

--- a/frontend/src/pages/audit-logs/audit-logs.routes.tsx
+++ b/frontend/src/pages/audit-logs/audit-logs.routes.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import type { RouteObject } from 'react-router-dom'
+
+const AuditLogsPage = React.lazy(() => import('./AuditLogsPage'))
+
+export const auditLogsRoutes: RouteObject[] = [
+  { path: '/audit-logs', element: <AuditLogsPage />, handle: { title: 'Audit Logs' } },
+]

--- a/frontend/src/pages/auth/auth.routes.tsx
+++ b/frontend/src/pages/auth/auth.routes.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import type { RouteObject } from 'react-router-dom'
+
+const LoginPage = React.lazy(() => import('./LoginPage'))
+const MandatoryPasswordChangePage = React.lazy(() => import('./MandatoryPasswordChangePage'))
+
+export const authRoutes: RouteObject[] = [
+  { path: '/login', element: <LoginPage /> },
+  { path: '/change-password-required', element: <MandatoryPasswordChangePage /> },
+]

--- a/frontend/src/pages/dashboard/dashboard.routes.tsx
+++ b/frontend/src/pages/dashboard/dashboard.routes.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import type { RouteObject } from 'react-router-dom'
+
+const DashboardPage = React.lazy(() => import('./DashboardPage'))
+
+export const dashboardRoutes: RouteObject[] = [
+  { path: '/dashboard', element: <DashboardPage />, handle: { title: 'Dashboard' } },
+]

--- a/frontend/src/pages/inventory/inventory.routes.tsx
+++ b/frontend/src/pages/inventory/inventory.routes.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import type { RouteObject } from 'react-router-dom'
+
+const InventoryPage = React.lazy(() => import('./InventoryPage'))
+const ProductsPage = React.lazy(() => import('./ProductsPage'))
+const CreateProductPage = React.lazy(() => import('./CreateProductPage'))
+const CategoriesPage = React.lazy(() => import('./CategoriesPage'))
+const StockAdjustmentsPage = React.lazy(() => import('./StockAdjustmentsPage'))
+const CreateStockAdjustmentPage = React.lazy(() => import('./CreateStockAdjustmentPage'))
+const InventorySummaryReport = React.lazy(() => import('./InventorySummaryReport'))
+const HistoricalInventoryReport = React.lazy(() => import('./HistoricalInventoryReport'))
+const MovementSummaryReport = React.lazy(() => import('./MovementSummaryReport'))
+const PriceListReport = React.lazy(() => import('./PriceListReport'))
+const ProductCostReport = React.lazy(() => import('./ProductCostReport'))
+
+export const inventoryRoutes: RouteObject[] = [
+  { path: '/inventory', element: <InventoryPage />, handle: { title: 'Inventory' } },
+  { path: '/inventory/products', element: <ProductsPage />, handle: { title: 'Products' } },
+  { path: '/inventory/products/create', element: <CreateProductPage />, handle: { title: 'Create Product' } },
+  { path: '/inventory/products/:slug/edit', element: <CreateProductPage />, handle: { title: 'Edit Product' } },
+  { path: '/inventory/categories', element: <CategoriesPage />, handle: { title: 'Categories' } },
+  { path: '/inventory/stock-adjustments', element: <StockAdjustmentsPage />, handle: { title: 'Stock Adjustments' } },
+  { path: '/inventory/stock-adjustments/create', element: <CreateStockAdjustmentPage />, handle: { title: 'Create Stock Adjustment' } },
+  { path: '/inventory/stock-adjustments/:adjustmentNumber/edit', element: <CreateStockAdjustmentPage />, handle: { title: 'Edit Stock Adjustment' } },
+  { path: '/reports/inventory/summary', element: <InventorySummaryReport />, handle: { title: 'Inventory Summary' } },
+  { path: '/reports/inventory/historical', element: <HistoricalInventoryReport />, handle: { title: 'Historical Inventory' } },
+  { path: '/reports/inventory/movement-summary', element: <MovementSummaryReport />, handle: { title: 'Inventory Movement Summary' } },
+  { path: '/reports/inventory/price-list', element: <PriceListReport />, handle: { title: 'Product Price List' } },
+  { path: '/reports/inventory/product-cost', element: <ProductCostReport />, handle: { title: 'Product Cost Report' } },
+]

--- a/frontend/src/pages/purchasing/purchasing.routes.tsx
+++ b/frontend/src/pages/purchasing/purchasing.routes.tsx
@@ -16,9 +16,9 @@ const VendorProductListReport = React.lazy(() => import('./VendorProductListRepo
 
 export const purchasingRoutes: RouteObject[] = [
   { path: '/purchasing', element: <PurchasingPage />, handle: { title: 'Purchasing' } },
+  { path: '/purchasing/suppliers', element: <SuppliersPage />, handle: { title: 'Suppliers' } },
   { path: '/purchasing/suppliers/create', element: <SupplierFormPage />, handle: { title: 'New Supplier' } },
   { path: '/purchasing/suppliers/:slug/edit', element: <SupplierFormPage />, handle: { title: 'Edit Supplier' } },
-  { path: '/purchasing/suppliers', element: <SuppliersPage />, handle: { title: 'Suppliers' } },
   { path: '/purchasing/orders', element: <PurchaseOrdersPage />, handle: { title: 'Purchase Orders' } },
   { path: '/purchasing/orders/create', element: <CreatePurchaseOrderPage />, handle: { title: 'Create Purchase Order' } },
   { path: '/purchasing/orders/:orderNumber/edit', element: <CreatePurchaseOrderPage />, handle: { title: 'Edit Purchase Order' } },

--- a/frontend/src/pages/purchasing/purchasing.routes.tsx
+++ b/frontend/src/pages/purchasing/purchasing.routes.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import type { RouteObject } from 'react-router-dom'
+
+const PurchasingPage = React.lazy(() => import('./PurchasingPage'))
+const SuppliersPage = React.lazy(() => import('./SuppliersPage'))
+const SupplierFormPage = React.lazy(() => import('./SupplierFormPage'))
+const PurchaseOrdersPage = React.lazy(() => import('./PurchaseOrdersPage'))
+const CreatePurchaseOrderPage = React.lazy(() => import('./CreatePurchaseOrderPage'))
+const GoodsReceivedPage = React.lazy(() => import('./GoodsReceivedPage'))
+const VendorPaymentsPage = React.lazy(() => import('./VendorPaymentsPage'))
+const PurchaseOrderSummary = React.lazy(() => import('./PurchaseOrderSummary'))
+const PurchaseOrderDetailsReport = React.lazy(() => import('./PurchaseOrderDetailsReport'))
+const PurchaseOrderStatusReport = React.lazy(() => import('./PurchaseOrderStatusReport'))
+const VendorPaymentDetailsReport = React.lazy(() => import('./VendorPaymentDetailsReport'))
+const VendorProductListReport = React.lazy(() => import('./VendorProductListReport'))
+
+export const purchasingRoutes: RouteObject[] = [
+  { path: '/purchasing', element: <PurchasingPage />, handle: { title: 'Purchasing' } },
+  { path: '/purchasing/suppliers/create', element: <SupplierFormPage />, handle: { title: 'New Supplier' } },
+  { path: '/purchasing/suppliers/:slug/edit', element: <SupplierFormPage />, handle: { title: 'Edit Supplier' } },
+  { path: '/purchasing/suppliers', element: <SuppliersPage />, handle: { title: 'Suppliers' } },
+  { path: '/purchasing/orders', element: <PurchaseOrdersPage />, handle: { title: 'Purchase Orders' } },
+  { path: '/purchasing/orders/create', element: <CreatePurchaseOrderPage />, handle: { title: 'Create Purchase Order' } },
+  { path: '/purchasing/orders/:orderNumber/edit', element: <CreatePurchaseOrderPage />, handle: { title: 'Edit Purchase Order' } },
+  { path: '/purchasing/goods-received', element: <GoodsReceivedPage />, handle: { title: 'Goods Received' } },
+  { path: '/purchasing/vendor-payments', element: <VendorPaymentsPage />, handle: { title: 'Vendor Payments' } },
+  { path: '/reports/purchasing/order-summary', element: <PurchaseOrderSummary />, handle: { title: 'Purchase Order Summary' } },
+  { path: '/reports/purchasing/order-status', element: <PurchaseOrderStatusReport />, handle: { title: 'Purchase Order Status' } },
+  { path: '/reports/purchasing/order-details', element: <PurchaseOrderDetailsReport />, handle: { title: 'Purchase Order Details' } },
+  { path: '/reports/purchasing/payment-details', element: <VendorPaymentDetailsReport />, handle: { title: 'Vendor Payment Details' } },
+  { path: '/reports/purchasing/vendor-purchase-list', element: <VendorProductListReport />, handle: { title: 'Vendor Product List' } },
+]

--- a/frontend/src/pages/sales/sales.routes.tsx
+++ b/frontend/src/pages/sales/sales.routes.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import type { RouteObject } from 'react-router-dom'
+
+const SalesPage = React.lazy(() => import('./SalesPage'))
+const CustomersPage = React.lazy(() => import('./CustomersPage'))
+const CustomerFormPage = React.lazy(() => import('./CustomerFormPage'))
+const OrdersPage = React.lazy(() => import('./OrdersPage'))
+const CreateSalesOrderPage = React.lazy(() => import('./CreateSalesOrderPage'))
+const InvoicesPage = React.lazy(() => import('./InvoicesPage'))
+const PaymentsPage = React.lazy(() => import('./PaymentsPage'))
+const SalesByProductSummary = React.lazy(() => import('./SalesByProductSummary'))
+const SalesByProductDetails = React.lazy(() => import('./SalesByProductDetails'))
+const SalesOrderSummary = React.lazy(() => import('./SalesOrderSummary'))
+const SalesOrderProfitReport = React.lazy(() => import('./SalesOrderProfitReport'))
+const CustomerPaymentSummary = React.lazy(() => import('./CustomerPaymentSummary'))
+const CustomerPaymentByOrder = React.lazy(() => import('./CustomerPaymentByOrder'))
+const CustomerPaymentDetails = React.lazy(() => import('./CustomerPaymentDetails'))
+const CustomerOrderHistory = React.lazy(() => import('./CustomerOrderHistory'))
+const ProductCustomerReport = React.lazy(() => import('./ProductCustomerReport'))
+
+export const salesRoutes: RouteObject[] = [
+  { path: '/sales', element: <SalesPage />, handle: { title: 'Sales' } },
+  { path: '/sales/customers', element: <CustomersPage />, handle: { title: 'Customers' } },
+  { path: '/sales/customers/create', element: <CustomerFormPage />, handle: { title: 'New Customer' } },
+  { path: '/sales/customers/:slug/edit', element: <CustomerFormPage />, handle: { title: 'Edit Customer' } },
+  { path: '/sales/orders', element: <OrdersPage />, handle: { title: 'Sales Orders' } },
+  { path: '/sales/orders/create', element: <CreateSalesOrderPage />, handle: { title: 'Create Sales Order' } },
+  { path: '/sales/orders/:orderNumber/edit', element: <CreateSalesOrderPage />, handle: { title: 'Edit Sales Order' } },
+  { path: '/sales/invoices', element: <InvoicesPage />, handle: { title: 'Invoices' } },
+  { path: '/sales/payments', element: <PaymentsPage />, handle: { title: 'Payments' } },
+  { path: '/reports/sales/product-summary', element: <SalesByProductSummary />, handle: { title: 'Sales by Product Summary' } },
+  { path: '/reports/sales/product-details', element: <SalesByProductDetails />, handle: { title: 'Sales by Product Details' } },
+  { path: '/reports/sales/order-summary', element: <SalesOrderSummary />, handle: { title: 'Sales Order Summary' } },
+  { path: '/reports/sales/order-profit', element: <SalesOrderProfitReport />, handle: { title: 'Sales Order Profit Report' } },
+  { path: '/reports/sales/customer-payment-summary', element: <CustomerPaymentSummary />, handle: { title: 'Customer Payment Summary' } },
+  { path: '/reports/sales/payment-by-order', element: <CustomerPaymentByOrder />, handle: { title: 'Customer Payment by Order' } },
+  { path: '/reports/sales/payment-details', element: <CustomerPaymentDetails />, handle: { title: 'Customer Payment Details' } },
+  { path: '/reports/sales/order-history', element: <CustomerOrderHistory />, handle: { title: 'Customer Order History' } },
+  { path: '/reports/sales/product-customer', element: <ProductCustomerReport />, handle: { title: 'Product Customer Report' } },
+]

--- a/frontend/src/pages/settings/settings.routes.tsx
+++ b/frontend/src/pages/settings/settings.routes.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Navigate } from 'react-router-dom'
+import type { RouteObject } from 'react-router-dom'
+
+const CompanySettingsPage = React.lazy(() => import('./CompanySettingsPage'))
+const InventoryCostingPage = React.lazy(() => import('./InventoryCostingPage'))
+const StockLevelSettingsPage = React.lazy(() => import('./StockLevelSettingsPage'))
+const RegionalSettingsPage = React.lazy(() => import('./RegionalSettingsPage'))
+const PrintSettingsPage = React.lazy(() => import('./PrintSettingsPage'))
+const DocumentNumbersPage = React.lazy(() => import('./DocumentNumbersPage'))
+const BackupManagement = React.lazy(() => import('./BackupManagement'))
+const UserManagementPage = React.lazy(() => import('./UserManagementPage'))
+const RoleManagementPage = React.lazy(() => import('./RoleManagementPage'))
+const SecuritySettingsPage = React.lazy(() => import('./SecuritySettingsPage'))
+const PriceListsPage = React.lazy(() => import('./PriceListsPage'))
+const PriceListDetailsPage = React.lazy(() => import('./PriceListDetailsPage'))
+const PaymentMethodsPage = React.lazy(() => import('./PaymentMethodsPage'))
+
+export const settingsRoutes: RouteObject[] = [
+  { path: '/settings/company', element: <CompanySettingsPage />, handle: { title: 'Company' } },
+  { path: '/settings/price-costing', element: <Navigate to="/settings/inventory-costing" replace /> },
+  { path: '/settings/inventory-costing', element: <InventoryCostingPage />, handle: { title: 'Inventory Costing' } },
+  { path: '/settings/stock-levels', element: <StockLevelSettingsPage />, handle: { title: 'Stock Levels' } },
+  { path: '/settings/regional', element: <RegionalSettingsPage />, handle: { title: 'Regional' } },
+  { path: '/settings/price-lists', element: <PriceListsPage />, handle: { title: 'Price Lists' } },
+  { path: '/settings/price-lists/:id', element: <PriceListDetailsPage />, handle: { title: 'Price List Details' } },
+  { path: '/settings/payment-methods', element: <PaymentMethodsPage />, handle: { title: 'Payment Methods' } },
+  { path: '/settings/print', element: <PrintSettingsPage />, handle: { title: 'Print Settings' } },
+  { path: '/settings/document-numbers', element: <DocumentNumbersPage />, handle: { title: 'Document Numbers' } },
+  { path: '/settings/users', element: <UserManagementPage />, handle: { title: 'Users' } },
+  { path: '/settings/roles', element: <RoleManagementPage />, handle: { title: 'Roles & Permissions' } },
+  { path: '/settings/security', element: <SecuritySettingsPage />, handle: { title: 'Security' } },
+  { path: '/settings/backup', element: <BackupManagement />, handle: { title: 'Backup & Restore' } },
+]

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -4,87 +4,14 @@ import RouteErrorBoundary from './components/errors/RouteErrorBoundary'
 import MainLayout from './components/common/MainLayout'
 import RootLayout from './RootLayout'
 import { store, persistor } from './store'
-
-const LoginPage = React.lazy(() => import('./pages/auth/LoginPage'))
-const MandatoryPasswordChangePage = React.lazy(() => import('./pages/auth/MandatoryPasswordChangePage'))
-const DashboardPage = React.lazy(() => import('./pages/dashboard/DashboardPage'))
-
-const InventoryPage = React.lazy(() => import('./pages/inventory/InventoryPage'))
-const ProductsPage = React.lazy(() => import('./pages/inventory/ProductsPage'))
-const CreateProductPage = React.lazy(() => import('./pages/inventory/CreateProductPage'))
-const CategoriesPage = React.lazy(() => import('./pages/inventory/CategoriesPage'))
-const StockAdjustmentsPage = React.lazy(() => import('./pages/inventory/StockAdjustmentsPage'))
-const CreateStockAdjustmentPage = React.lazy(() => import('./pages/inventory/CreateStockAdjustmentPage'))
-
-const SalesPage = React.lazy(() => import('./pages/sales/SalesPage'))
-const CustomersPage = React.lazy(() => import('./pages/sales/CustomersPage'))
-const CustomerFormPage = React.lazy(() => import('./pages/sales/CustomerFormPage'))
-const OrdersPage = React.lazy(() => import('./pages/sales/OrdersPage'))
-const CreateSalesOrderPage = React.lazy(() => import('./pages/sales/CreateSalesOrderPage'))
-const InvoicesPage = React.lazy(() => import('./pages/sales/InvoicesPage'))
-const PaymentsPage = React.lazy(() => import('./pages/sales/PaymentsPage'))
-
-const SalesByProductSummary = React.lazy(() => import('./pages/sales/SalesByProductSummary'))
-const SalesByProductDetails = React.lazy(() => import('./pages/sales/SalesByProductDetails'))
-const SalesOrderSummary = React.lazy(() => import('./pages/sales/SalesOrderSummary'))
-const SalesOrderProfitReport = React.lazy(() => import('./pages/sales/SalesOrderProfitReport'))
-const CustomerPaymentSummary = React.lazy(() => import('./pages/sales/CustomerPaymentSummary'))
-const CustomerPaymentByOrder = React.lazy(() => import('./pages/sales/CustomerPaymentByOrder'))
-const CustomerPaymentDetails = React.lazy(() => import('./pages/sales/CustomerPaymentDetails'))
-const CustomerOrderHistory = React.lazy(() => import('./pages/sales/CustomerOrderHistory'))
-const ProductCustomerReport = React.lazy(() => import('./pages/sales/ProductCustomerReport'))
-
-const PurchasingPage = React.lazy(() => import('./pages/purchasing/PurchasingPage'))
-const SuppliersPage = React.lazy(() => import('./pages/purchasing/SuppliersPage'))
-const SupplierFormPage = React.lazy(() => import('./pages/purchasing/SupplierFormPage'))
-const PurchaseOrdersPage = React.lazy(() => import('./pages/purchasing/PurchaseOrdersPage'))
-const CreatePurchaseOrderPage = React.lazy(() => import('./pages/purchasing/CreatePurchaseOrderPage'))
-const GoodsReceivedPage = React.lazy(() => import('./pages/purchasing/GoodsReceivedPage'))
-const VendorPaymentsPage = React.lazy(() => import('./pages/purchasing/VendorPaymentsPage'))
-
-const PurchaseOrderSummary = React.lazy(() => import('./pages/purchasing/PurchaseOrderSummary'))
-const PurchaseOrderDetailsReport = React.lazy(() => import('./pages/purchasing/PurchaseOrderDetailsReport'))
-const PurchaseOrderStatusReport = React.lazy(() => import('./pages/purchasing/PurchaseOrderStatusReport'))
-const VendorPaymentDetailsReport = React.lazy(() => import('./pages/purchasing/VendorPaymentDetailsReport'))
-const VendorProductListReport = React.lazy(() => import('./pages/purchasing/VendorProductListReport'))
-
-const InventorySummaryReport = React.lazy(() => import('./pages/inventory/InventorySummaryReport'))
-const HistoricalInventoryReport = React.lazy(() => import('./pages/inventory/HistoricalInventoryReport'))
-const MovementSummaryReport = React.lazy(() => import('./pages/inventory/MovementSummaryReport'))
-const PriceListReport = React.lazy(() => import('./pages/inventory/PriceListReport'))
-const ProductCostReport = React.lazy(() => import('./pages/inventory/ProductCostReport'))
-
-const CompanySettingsPage = React.lazy(() => import('./pages/settings/CompanySettingsPage'))
-const InventoryCostingPage = React.lazy(() => import('./pages/settings/InventoryCostingPage'))
-const StockLevelSettingsPage = React.lazy(() => import('./pages/settings/StockLevelSettingsPage'))
-const RegionalSettingsPage = React.lazy(() => import('./pages/settings/RegionalSettingsPage'))
-const PrintSettingsPage = React.lazy(() => import('./pages/settings/PrintSettingsPage'))
-const DocumentNumbersPage = React.lazy(() => import('./pages/settings/DocumentNumbersPage'))
-const BackupManagement = React.lazy(() => import('./pages/settings/BackupManagement'))
-const UserManagementPage = React.lazy(() => import('./pages/settings/UserManagementPage'))
-const RoleManagementPage = React.lazy(() => import('./pages/settings/RoleManagementPage'))
-const SecuritySettingsPage = React.lazy(() => import('./pages/settings/SecuritySettingsPage'))
-const PriceListsPage = React.lazy(() => import('./pages/settings/PriceListsPage'))
-const PriceListDetailsPage = React.lazy(() => import('./pages/settings/PriceListDetailsPage'))
-const PaymentMethodsPage = React.lazy(() => import('./pages/settings/PaymentMethodsPage'))
-
-const AuditLogsPage = React.lazy(() => import('./pages/audit-logs/AuditLogsPage'))
-
-const AccountingDashboardPage = React.lazy(() => import('./pages/accounting/AccountingDashboardPage'))
-const ChartOfAccountsPage = React.lazy(() => import('./pages/accounting/ChartOfAccountsPage'))
-const FiscalPeriodsPage = React.lazy(() => import('./pages/accounting/FiscalPeriodsPage'))
-const JournalEntriesPage = React.lazy(() => import('./pages/accounting/JournalEntriesPage'))
-const AccountMappingsPage = React.lazy(() => import('./pages/accounting/AccountMappingsPage'))
-const BankReconciliationsPage = React.lazy(() => import('./pages/accounting/BankReconciliationsPage'))
-const SettlementsPage = React.lazy(() => import('./pages/accounting/SettlementsPage'))
-const OwnerEquityPage = React.lazy(() => import('./pages/accounting/OwnerEquityPage'))
-const ExpensesPage = React.lazy(() => import('./pages/accounting/ExpensesPage'))
-const FundTransfersPage = React.lazy(() => import('./pages/accounting/FundTransfersPage'))
-const TrialBalancePage = React.lazy(() => import('./pages/accounting/reports/TrialBalancePage'))
-const BalanceSheetPage = React.lazy(() => import('./pages/accounting/reports/BalanceSheetPage'))
-const ProfitAndLossPage = React.lazy(() => import('./pages/accounting/reports/ProfitAndLossPage'))
-const GeneralLedgerPage = React.lazy(() => import('./pages/accounting/reports/GeneralLedgerPage'))
-const AccountActivityPage = React.lazy(() => import('./pages/accounting/reports/AccountActivityPage'))
+import { authRoutes } from './pages/auth/auth.routes'
+import { dashboardRoutes } from './pages/dashboard/dashboard.routes'
+import { inventoryRoutes } from './pages/inventory/inventory.routes'
+import { salesRoutes } from './pages/sales/sales.routes'
+import { purchasingRoutes } from './pages/purchasing/purchasing.routes'
+import { settingsRoutes } from './pages/settings/settings.routes'
+import { auditLogsRoutes } from './pages/audit-logs/audit-logs.routes'
+import { accountingRoutes } from './pages/accounting/accounting.routes'
 
 const NotFoundPage = React.lazy(() => import('./pages/NotFoundPage'))
 
@@ -122,103 +49,19 @@ export const router = createBrowserRouter([
     element: <RootLayout />,
     errorElement: <RouteErrorBoundary />,
     children: [
-      { path: '/login', element: <LoginPage /> },
-      { path: '/change-password-required', element: <MandatoryPasswordChangePage /> },
+      ...authRoutes,
       {
         loader: authLoader,
         element: <MainLayout />,
         children: [
           { path: '/', element: <Navigate to="/dashboard" replace /> },
-          { path: '/dashboard', element: <DashboardPage />, handle: { title: 'Dashboard' } },
-
-          { path: '/inventory', element: <InventoryPage />, handle: { title: 'Inventory' } },
-          { path: '/inventory/products', element: <ProductsPage />, handle: { title: 'Products' } },
-          { path: '/inventory/products/create', element: <CreateProductPage />, handle: { title: 'Create Product' } },
-          { path: '/inventory/products/:slug/edit', element: <CreateProductPage />, handle: { title: 'Edit Product' } },
-          { path: '/inventory/categories', element: <CategoriesPage />, handle: { title: 'Categories' } },
-          { path: '/inventory/stock-adjustments', element: <StockAdjustmentsPage />, handle: { title: 'Stock Adjustments' } },
-          { path: '/inventory/stock-adjustments/create', element: <CreateStockAdjustmentPage />, handle: { title: 'Create Stock Adjustment' } },
-          { path: '/inventory/stock-adjustments/:adjustmentNumber/edit', element: <CreateStockAdjustmentPage />, handle: { title: 'Edit Stock Adjustment' } },
-
-          { path: '/sales', element: <SalesPage />, handle: { title: 'Sales' } },
-          { path: '/sales/customers', element: <CustomersPage />, handle: { title: 'Customers' } },
-          { path: '/sales/customers/create', element: <CustomerFormPage />, handle: { title: 'New Customer' } },
-          { path: '/sales/customers/:slug/edit', element: <CustomerFormPage />, handle: { title: 'Edit Customer' } },
-          { path: '/sales/orders', element: <OrdersPage />, handle: { title: 'Sales Orders' } },
-          { path: '/sales/orders/create', element: <CreateSalesOrderPage />, handle: { title: 'Create Sales Order' } },
-          { path: '/sales/orders/:orderNumber/edit', element: <CreateSalesOrderPage />, handle: { title: 'Edit Sales Order' } },
-          { path: '/sales/invoices', element: <InvoicesPage />, handle: { title: 'Invoices' } },
-          { path: '/sales/payments', element: <PaymentsPage />, handle: { title: 'Payments' } },
-
-          { path: '/purchasing', element: <PurchasingPage />, handle: { title: 'Purchasing' } },
-          { path: '/purchasing/suppliers/create', element: <SupplierFormPage />, handle: { title: 'New Supplier' } },
-          { path: '/purchasing/suppliers/:slug/edit', element: <SupplierFormPage />, handle: { title: 'Edit Supplier' } },
-          { path: '/purchasing/suppliers', element: <SuppliersPage />, handle: { title: 'Suppliers' } },
-          { path: '/purchasing/orders', element: <PurchaseOrdersPage />, handle: { title: 'Purchase Orders' } },
-          { path: '/purchasing/orders/create', element: <CreatePurchaseOrderPage />, handle: { title: 'Create Purchase Order' } },
-          { path: '/purchasing/orders/:orderNumber/edit', element: <CreatePurchaseOrderPage />, handle: { title: 'Edit Purchase Order' } },
-          { path: '/purchasing/goods-received', element: <GoodsReceivedPage />, handle: { title: 'Goods Received' } },
-          { path: '/purchasing/vendor-payments', element: <VendorPaymentsPage />, handle: { title: 'Vendor Payments' } },
-
-          { path: '/reports/inventory/summary', element: <InventorySummaryReport />, handle: { title: 'Inventory Summary' } },
-          { path: '/reports/inventory/historical', element: <HistoricalInventoryReport />, handle: { title: 'Historical Inventory' } },
-          { path: '/reports/inventory/movement-summary', element: <MovementSummaryReport />, handle: { title: 'Inventory Movement Summary' } },
-          { path: '/reports/inventory/price-list', element: <PriceListReport />, handle: { title: 'Product Price List' } },
-          { path: '/reports/inventory/product-cost', element: <ProductCostReport />, handle: { title: 'Product Cost Report' } },
-
-          { path: '/reports/purchasing/order-summary', element: <PurchaseOrderSummary />, handle: { title: 'Purchase Order Summary' } },
-          { path: '/reports/purchasing/order-status', element: <PurchaseOrderStatusReport />, handle: { title: 'Purchase Order Status' } },
-          { path: '/reports/purchasing/order-details', element: <PurchaseOrderDetailsReport />, handle: { title: 'Purchase Order Details' } },
-          { path: '/reports/purchasing/payment-details', element: <VendorPaymentDetailsReport />, handle: { title: 'Vendor Payment Details' } },
-          { path: '/reports/purchasing/vendor-purchase-list', element: <VendorProductListReport />, handle: { title: 'Vendor Product List' } },
-
-          { path: '/reports/sales/product-summary', element: <SalesByProductSummary />, handle: { title: 'Sales by Product Summary' } },
-          { path: '/reports/sales/product-details', element: <SalesByProductDetails />, handle: { title: 'Sales by Product Details' } },
-          { path: '/reports/sales/order-summary', element: <SalesOrderSummary />, handle: { title: 'Sales Order Summary' } },
-          { path: '/reports/sales/order-profit', element: <SalesOrderProfitReport />, handle: { title: 'Sales Order Profit Report' } },
-          { path: '/reports/sales/customer-payment-summary', element: <CustomerPaymentSummary />, handle: { title: 'Customer Payment Summary' } },
-          { path: '/reports/sales/payment-by-order', element: <CustomerPaymentByOrder />, handle: { title: 'Customer Payment by Order' } },
-          { path: '/reports/sales/payment-details', element: <CustomerPaymentDetails />, handle: { title: 'Customer Payment Details' } },
-          { path: '/reports/sales/order-history', element: <CustomerOrderHistory />, handle: { title: 'Customer Order History' } },
-          { path: '/reports/sales/product-customer', element: <ProductCustomerReport />, handle: { title: 'Product Customer Report' } },
-
-          { path: '/settings/company', element: <CompanySettingsPage />, handle: { title: 'Company' } },
-          { path: '/settings/price-costing', element: <Navigate to="/settings/inventory-costing" replace /> },
-          { path: '/settings/inventory-costing', element: <InventoryCostingPage />, handle: { title: 'Inventory Costing' } },
-          { path: '/settings/stock-levels', element: <StockLevelSettingsPage />, handle: { title: 'Stock Levels' } },
-          { path: '/settings/regional', element: <RegionalSettingsPage />, handle: { title: 'Regional' } },
-          { path: '/settings/price-lists', element: <PriceListsPage />, handle: { title: 'Price Lists' } },
-          { path: '/settings/price-lists/:id', element: <PriceListDetailsPage />, handle: { title: 'Price List Details' } },
-          { path: '/settings/payment-methods', element: <PaymentMethodsPage />, handle: { title: 'Payment Methods' } },
-          { path: '/settings/print', element: <PrintSettingsPage />, handle: { title: 'Print Settings' } },
-          { path: '/settings/document-numbers', element: <DocumentNumbersPage />, handle: { title: 'Document Numbers' } },
-          { path: '/settings/users', element: <UserManagementPage />, handle: { title: 'Users' } },
-          { path: '/settings/roles', element: <RoleManagementPage />, handle: { title: 'Roles & Permissions' } },
-          { path: '/settings/security', element: <SecuritySettingsPage />, handle: { title: 'Security' } },
-          { path: '/settings/backup', element: <BackupManagement />, handle: { title: 'Backup & Restore' } },
-
-          { path: '/audit-logs', element: <AuditLogsPage />, handle: { title: 'Audit Logs' } },
-
-          { path: '/accounting', element: <Navigate to="/accounting/dashboard" replace /> },
-          { path: '/accounting/dashboard', element: <AccountingDashboardPage />, handle: { title: 'Dashboard' } },
-          { path: '/accounting/chart-of-accounts', element: <ChartOfAccountsPage />, handle: { title: 'Chart of Accounts' } },
-          { path: '/accounting/fiscal-periods', element: <FiscalPeriodsPage />, handle: { title: 'Fiscal Periods' } },
-          { path: '/accounting/journal-entries', element: <JournalEntriesPage />, handle: { title: 'Journal Entries' } },
-          { path: '/accounting/journal-entries/:id', element: <Navigate to="/accounting/journal-entries" replace /> },
-          { path: '/accounting/account-mappings', element: <AccountMappingsPage />, handle: { title: 'Account Mappings' } },
-          { path: '/accounting/settlements', element: <SettlementsPage />, handle: { title: 'Settlements' } },
-          { path: '/accounting/owner-equity', element: <OwnerEquityPage />, handle: { title: "Owner's Equity" } },
-          { path: '/accounting/expenses', element: <ExpensesPage />, handle: { title: 'Expenses' } },
-          { path: '/accounting/fund-transfers', element: <FundTransfersPage />, handle: { title: 'Fund Transfers' } },
-          { path: '/accounting/bank-reconciliations', element: <BankReconciliationsPage />, handle: { title: 'Bank Reconciliation' } },
-          { path: '/accounting/bank-reconciliations/new', element: <BankReconciliationsPage />, handle: { title: 'New Bank Reconciliation' } },
-          { path: '/accounting/bank-reconciliations/:id', element: <Navigate to="/accounting/bank-reconciliations" replace /> },
-          { path: '/accounting/reports/trial-balance', element: <TrialBalancePage />, handle: { title: 'Trial Balance' } },
-          { path: '/accounting/reports/balance-sheet', element: <BalanceSheetPage />, handle: { title: 'Balance Sheet' } },
-          { path: '/accounting/reports/profit-loss', element: <ProfitAndLossPage />, handle: { title: 'Profit & Loss' } },
-          { path: '/accounting/reports/general-ledger', element: <GeneralLedgerPage />, handle: { title: 'General Ledger' } },
-          { path: '/accounting/reports/account-activity', element: <AccountActivityPage />, handle: { title: 'Account Activity' } },
-
+          ...dashboardRoutes,
+          ...inventoryRoutes,
+          ...salesRoutes,
+          ...purchasingRoutes,
+          ...settingsRoutes,
+          ...auditLogsRoutes,
+          ...accountingRoutes,
           { path: '*', element: <NotFoundPage /> },
         ],
       },


### PR DESCRIPTION
## Summary

- Broke `frontend/src/router.tsx` (228 lines, 45+ lazy imports) into 8 per-domain route files co-located with their page components
- Each domain file exports a typed `RouteObject[]` array and owns all its `React.lazy` imports
- Reduced `router.tsx` to a ~55-line assembly file; `authLoader`, `waitForRehydration`, and layout imports remain there
- Updated `router.config.test.ts` to read the correct domain route files; expanded from 3 to 9 tests covering all 8 domain route files
- Fixed route ordering in `purchasing.routes.tsx` (suppliers list before create/edit)

## Test Plan

- [x] `cd frontend && npx vitest run src/__tests__/router.config.test.ts` — 9 tests pass
- [x] `cd frontend && npx vitest run src/__tests__/router.test.tsx src/__tests__/router.config.test.ts` — all pass
- [x] `cd frontend && npm run type-check` — no errors
- [x] `cd frontend && npm run lint` — no errors
- [x] Navigate to one route per domain in the browser to confirm no breakage

Closes #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)