### PR TITLE
fix(validation): return 400 instead of 500 on validation failures

### DIFF
--- a/backend/src/common/utils/validation-errors.util.spec.ts
+++ b/backend/src/common/utils/validation-errors.util.spec.ts
@@ -1,0 +1,53 @@
+import { ValidationError } from 'class-validator';
+import { extractValidationMessages } from './validation-errors.util';
+
+function makeError(property: string, constraints?: Record<string, string>, children?: ValidationError[]): ValidationError {
+  const e = new ValidationError();
+  e.property = property;
+  e.constraints = constraints;
+  e.children = children ?? [];
+  return e;
+}
+
+describe('extractValidationMessages', () => {
+  it('returns all constraints for a field with multiple validators', () => {
+    const error = makeError('name', { isString: 'name must be a string', minLength: 'name must be at least 3 characters' });
+    expect(extractValidationMessages([error])).toEqual([
+      'name must be a string',
+      'name must be at least 3 characters',
+    ]);
+  });
+
+  it('returns constraints from multiple top-level fields', () => {
+    const errors = [
+      makeError('email', { isEmail: 'email must be a valid email' }),
+      makeError('age', { min: 'age must be at least 0' }),
+    ];
+    expect(extractValidationMessages(errors)).toEqual([
+      'email must be a valid email',
+      'age must be at least 0',
+    ]);
+  });
+
+  it('recurses into nested children', () => {
+    const child = makeError('street', { isNotEmpty: 'street must not be empty' });
+    const parent = makeError('address', undefined, [child]);
+    expect(extractValidationMessages([parent])).toEqual(['street must not be empty']);
+  });
+
+  it('recurses multiple levels deep', () => {
+    const grandchild = makeError('zip', { isPostalCode: 'zip must be a valid postal code' });
+    const child = makeError('address', undefined, [grandchild]);
+    const parent = makeError('shipping', undefined, [child]);
+    expect(extractValidationMessages([parent])).toEqual(['zip must be a valid postal code']);
+  });
+
+  it('falls back to property name when no constraints and no children', () => {
+    const error = makeError('mystery');
+    expect(extractValidationMessages([error])).toEqual(['Validation failed for mystery']);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(extractValidationMessages([])).toEqual([]);
+  });
+});

--- a/backend/src/common/utils/validation-errors.util.ts
+++ b/backend/src/common/utils/validation-errors.util.ts
@@ -1,0 +1,18 @@
+import { ValidationError } from 'class-validator';
+
+export function extractValidationMessages(errors: ValidationError[]): string[] {
+  const messages: string[] = [];
+
+  for (const error of errors) {
+    const constraints = Object.values(error.constraints || {});
+    if (constraints.length > 0) {
+      messages.push(...constraints);
+    } else if (error.children && error.children.length > 0) {
+      messages.push(...extractValidationMessages(error.children));
+    } else {
+      messages.push(`Validation failed for ${error.property}`);
+    }
+  }
+
+  return messages;
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,5 +1,5 @@
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe, Logger } from '@nestjs/common';
+import { ValidationPipe, Logger, BadRequestException } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import { NestExpressApplication } from '@nestjs/platform-express';
@@ -42,14 +42,12 @@ async function bootstrap() {
         value: false, // Don't expose the invalid value in error messages
       },
       exceptionFactory: (errors) => {
-        // Custom exception factory for debugging
-        console.log('Validation errors:', JSON.stringify(errors, null, 2));
         const messages = errors.map(error => {
           const constraints = Object.values(error.constraints || {});
           return constraints.length > 0 ? constraints[0] : `Validation failed for ${error.property}`;
         });
 
-        return new Error(`Validation failed: ${messages.join(', ')}`);
+        return new BadRequestException(`Validation failed: ${messages.join(', ')}`);
       },
     }),
   );

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -6,6 +6,7 @@ import { NestExpressApplication } from '@nestjs/platform-express';
 import { join } from 'path';
 import { AppModule } from './app.module';
 import { SecurityApplicationService, SecurityMonitoringMiddleware } from './common/security';
+import { extractValidationMessages } from './common/utils/validation-errors.util';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
@@ -42,11 +43,7 @@ async function bootstrap() {
         value: false, // Don't expose the invalid value in error messages
       },
       exceptionFactory: (errors) => {
-        const messages = errors.map(error => {
-          const constraints = Object.values(error.constraints || {});
-          return constraints.length > 0 ? constraints[0] : `Validation failed for ${error.property}`;
-        });
-
+        const messages = extractValidationMessages(errors);
         return new BadRequestException(`Validation failed: ${messages.join(', ')}`);
       },
     }),


### PR DESCRIPTION
## Summary

- Replaces `new Error(...)` with `new BadRequestException(...)` in the global `ValidationPipe` `exceptionFactory` in `main.ts`
- NestJS now correctly maps validation failures to `400 Bad Request` instead of `500 Internal Server Error`
- Removes leftover debug `console.log` that was logging all validation errors to stdout

## Test plan

- [x] Submit a form with invalid data and confirm the response is `400 Bad Request`
- [x] Confirm `response.data.message` contains the validation error string (e.g. `"Validation failed: field is required"`)
- [x] Confirm no `500` errors appear in backend logs for validation failures

Closes #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)