### PR TITLE
fix(inventory,sales): replace deletedAt: null with IsNull() for TypeORM 1.0.0

### DIFF
--- a/backend/src/modules/inventory/services/costing-recalculation.service.spec.ts
+++ b/backend/src/modules/inventory/services/costing-recalculation.service.spec.ts
@@ -1,0 +1,135 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { IsNull, Repository } from 'typeorm';
+import { CostingRecalculationService } from './costing-recalculation.service';
+import { Product } from '../../../database/entities/product.entity';
+import { BaseCostCalculatorService } from './base-cost-calculator.service';
+import { CostingStrategyFactory } from './costing/costing-strategy-factory.service';
+
+describe('CostingRecalculationService', () => {
+  let service: CostingRecalculationService;
+  let productRepository: jest.Mocked<Repository<Product>>;
+  let baseCostCalculator: jest.Mocked<BaseCostCalculatorService>;
+  let costingStrategyFactory: jest.Mocked<CostingStrategyFactory>;
+
+  const makeProduct = (overrides: Partial<Product> = {}): Product =>
+    ({
+      id: 'prod-1',
+      name: 'Product A',
+      baseCost: 10,
+      isActive: true,
+      deletedAt: null,
+      ...overrides,
+    }) as Product;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CostingRecalculationService,
+        {
+          provide: getRepositoryToken(Product),
+          useValue: { find: jest.fn(), findOne: jest.fn() },
+        },
+        {
+          provide: BaseCostCalculatorService,
+          useValue: { updateProductBaseCost: jest.fn() },
+        },
+        {
+          provide: CostingStrategyFactory,
+          useValue: { getCurrentCostingMethod: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get(CostingRecalculationService);
+    productRepository = module.get(getRepositoryToken(Product));
+    baseCostCalculator = module.get(BaseCostCalculatorService);
+    costingStrategyFactory = module.get(CostingStrategyFactory);
+  });
+
+  describe('recalculateAllProductCosts', () => {
+    it('queries only active non-deleted products using IsNull()', async () => {
+      costingStrategyFactory.getCurrentCostingMethod.mockResolvedValue('FIFO');
+      productRepository.find.mockResolvedValue([]);
+
+      await service.recalculateAllProductCosts();
+
+      expect(productRepository.find).toHaveBeenCalledWith({
+        where: { isActive: true, deletedAt: IsNull() },
+      });
+    });
+
+    it('returns correct totals when all updates succeed', async () => {
+      const products = [makeProduct({ id: 'p1', baseCost: 10 }), makeProduct({ id: 'p2', baseCost: 20 })];
+      costingStrategyFactory.getCurrentCostingMethod.mockResolvedValue('FIFO');
+      productRepository.find.mockResolvedValue(products);
+      baseCostCalculator.updateProductBaseCost
+        .mockResolvedValueOnce(12)
+        .mockResolvedValueOnce(22);
+
+      const result = await service.recalculateAllProductCosts();
+
+      expect(result.totalProducts).toBe(2);
+      expect(result.updated).toBe(2);
+      expect(result.errors).toBe(0);
+      expect(result.costingMethod).toBe('FIFO');
+      expect(result.results[0]).toMatchObject({ productId: 'p1', oldCost: 10, newCost: 12, success: true });
+      expect(result.results[1]).toMatchObject({ productId: 'p2', oldCost: 20, newCost: 22, success: true });
+    });
+
+    it('counts errors and keeps going when a product update fails', async () => {
+      const products = [makeProduct({ id: 'p1' }), makeProduct({ id: 'p2', name: 'Product B' })];
+      costingStrategyFactory.getCurrentCostingMethod.mockResolvedValue('FIFO');
+      productRepository.find.mockResolvedValue(products);
+      baseCostCalculator.updateProductBaseCost
+        .mockRejectedValueOnce(new Error('calc failed'))
+        .mockResolvedValueOnce(15);
+
+      const result = await service.recalculateAllProductCosts();
+
+      expect(result.updated).toBe(1);
+      expect(result.errors).toBe(1);
+      expect(result.results[0]).toMatchObject({ success: false, error: 'calc failed' });
+      expect(result.results[1]).toMatchObject({ success: true, newCost: 15 });
+    });
+
+    it('returns empty results when no active products exist', async () => {
+      costingStrategyFactory.getCurrentCostingMethod.mockResolvedValue('WAC');
+      productRepository.find.mockResolvedValue([]);
+
+      const result = await service.recalculateAllProductCosts();
+
+      expect(result.totalProducts).toBe(0);
+      expect(result.updated).toBe(0);
+      expect(result.errors).toBe(0);
+      expect(result.results).toEqual([]);
+    });
+  });
+
+  describe('recalculateProductCost', () => {
+    it('throws when product is not found', async () => {
+      productRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.recalculateProductCost('missing-id')).rejects.toThrow(
+        'Product missing-id not found',
+      );
+    });
+
+    it('returns old and new cost with costing method', async () => {
+      const product = makeProduct({ id: 'p1', baseCost: 10 });
+      productRepository.findOne.mockResolvedValue(product);
+      costingStrategyFactory.getCurrentCostingMethod.mockResolvedValue('FIFO');
+      baseCostCalculator.updateProductBaseCost.mockResolvedValue(18);
+
+      const result = await service.recalculateProductCost('p1');
+
+      expect(result).toEqual({
+        productId: 'p1',
+        productName: 'Product A',
+        oldCost: 10,
+        newCost: 18,
+        costingMethod: 'FIFO',
+      });
+    });
+  });
+});

--- a/backend/src/modules/inventory/services/costing-recalculation.service.ts
+++ b/backend/src/modules/inventory/services/costing-recalculation.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { IsNull, Repository } from 'typeorm';
 import { Product } from '../../../database/entities/product.entity';
 import { BaseCostCalculatorService } from './base-cost-calculator.service';
 import { CostingStrategyFactory } from './costing/costing-strategy-factory.service';
@@ -44,7 +44,7 @@ export class CostingRecalculationService {
 
     // Get all active products
     const products = await this.productRepository.find({
-      where: { isActive: true, deletedAt: null } as any,
+      where: { isActive: true, deletedAt: IsNull() },
     });
 
     const results: Array<{

--- a/backend/src/modules/inventory/services/product.service.ts
+++ b/backend/src/modules/inventory/services/product.service.ts
@@ -13,6 +13,7 @@ import {
   Repository,
   UpdateResult,
   In,
+  IsNull,
   FindOptionsWhere,
   Not,
 } from 'typeorm';
@@ -1293,7 +1294,7 @@ export class ProductService extends BaseCrudService<
 
     // Get total products count
     const totalProducts = await this.productRepository.count({
-      where: { deletedAt: null }
+      where: { deletedAt: IsNull() }
     });
 
     // Get total categories count
@@ -1304,7 +1305,7 @@ export class ProductService extends BaseCrudService<
     // Get all active products with category info for calculations
     const products = await this.productRepository.find({
       relations: { category: true },
-      where: { deletedAt: null }
+      where: { deletedAt: IsNull() }
     });
 
     // Calculate comprehensive statistics

--- a/backend/src/modules/sales/services/sales-order-query.service.ts
+++ b/backend/src/modules/sales/services/sales-order-query.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import {
   Between,
   ILike,
+  IsNull,
   LessThanOrEqual,
   MoreThanOrEqual,
   Repository,
@@ -268,7 +269,7 @@ export class SalesOrderQueryService {
 
     const findOptions: any = {
       relations: { customer: true, items: { product: true }, invoices: true },
-      where: { deletedAt: null },
+      where: { deletedAt: IsNull() },
       order: { [sortBy]: sortOrder },
     };
 


### PR DESCRIPTION
## Summary

- Fixes `GET /api/inventory/products/dashboard-stats` returning 500, which caused the "Could not load: Inventory Stats" warning on the dashboard (issue #631)
- Same fix applied to `sales-order-query.service.ts` (`findSummaries`) and `costing-recalculation.service.ts` — both had the identical broken pattern
- TypeORM 1.0.0 rejects `null` in `where` conditions; `IsNull()` is the required replacement
- Also removed the `as any` cast in `costing-recalculation.service.ts` that was masking the type error without fixing the runtime error

## Test plan

- [x] Rebuild backend: `docker compose build backend && docker compose up -d backend`
- [x] Log in and open the dashboard — "Could not load: Inventory Stats" warning should be gone
- [x] Inventory stats card (Inventory Value, product count) should show real data
- [x] Sales order list and analytics endpoints should continue working
- [x] Admin costing recalculation endpoint should work without 500

Closes #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)