### PR TITLE
fix(accounting): remove status chip from fund transfer list

### DIFF
--- a/frontend/src/pages/accounting/__tests__/FundTransfersPage.test.tsx
+++ b/frontend/src/pages/accounting/__tests__/FundTransfersPage.test.tsx
@@ -119,12 +119,6 @@ describe('FundTransfersPage', () => {
     expect(screen.getByRole('button', { name: /new transfer/i })).toBeInTheDocument()
   })
 
-  it('shows draft status chip in list', () => {
-    const { container } = renderPage()
-    const listRow = container.querySelector('[data-index="0"]')
-    expect(listRow).not.toBeNull()
-    expect(within(listRow as HTMLElement).getByText('draft')).toBeInTheDocument()
-  })
 
   it('auto-selects the transfer matching the ?highlight= URL param', async () => {
     const { store } = renderPage('/accounting/fund-transfers?highlight=trf-1')

--- a/frontend/src/pages/accounting/components/FundTransfersList.tsx
+++ b/frontend/src/pages/accounting/components/FundTransfersList.tsx
@@ -1,5 +1,4 @@
 import type { RefObject } from 'react'
-import { Chip } from '@mui/material'
 
 import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
 import type { FundTransfer } from '@/types'
@@ -13,25 +12,10 @@ interface Props {
   listRef: RefObject<HTMLDivElement | null>
 }
 
-function statusColor(status: string) {
-  if (status === 'posted') return 'success' as const
-  if (status === 'reversed') return 'error' as const
-  return 'warning' as const  // draft
-}
-
 const columns: ColumnConfig<FundTransfer>[] = [
   {
     key: 'reference',
     render: (row) => row.referenceNumber,
-    width: '60%',
-  },
-  {
-    key: 'status',
-    raw: true,
-    render: (row) => (
-      <Chip label={row.status} color={statusColor(row.status)} size="small" />
-    ),
-    width: '40%',
   },
 ]
 


### PR DESCRIPTION
## Summary

- Removes the `Chip` status column from the fund transfer list
- Removes the now-unused `statusColor` helper and `Chip` import
- Reference column now takes full width, consistent with `ExpensesTable`

## Test plan

- [x] Open the Fund Transfers page and confirm no status chip appears in the list
- [x] Confirm the reference number column displays correctly at full width
- [x] Confirm status is still visible in the detail panel (context header) when a transfer is selected

Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)