### PR TITLE
fix(notifications): fix copy button in HTTP contexts (Popover focus trap)

### DIFF
--- a/frontend/src/components/common/NotificationPanel.test.tsx
+++ b/frontend/src/components/common/NotificationPanel.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
 import NotificationPanel from './NotificationPanel'
+import * as clipboardUtils from '@/utils/clipboard'
 
 const dispatchMock = vi.fn()
 let writeTextMock: ReturnType<typeof vi.fn>
@@ -81,5 +82,30 @@ describe('NotificationPanel copy button', () => {
     expect(await screen.findByTestId('CheckIcon')).toBeInTheDocument()
 
     document.body.removeChild(anchorEl)
+  })
+
+  it('passes the Popover Paper element as container to copyToClipboard', async () => {
+    const copyToClipboardSpy = vi.spyOn(clipboardUtils, 'copyToClipboard').mockResolvedValue(true)
+
+    const anchorEl = document.createElement('button')
+    anchorEl.getBoundingClientRect = vi.fn(() => ({
+      x: 12, y: 12, top: 12, left: 12, right: 52, bottom: 32, width: 40, height: 20,
+      toJSON: () => ({}),
+    } as DOMRect))
+    document.body.appendChild(anchorEl)
+
+    render(<NotificationPanel anchorEl={anchorEl} open={true} onClose={vi.fn()} />)
+
+    const copyButton = screen.getByTestId('ContentCopyIcon').closest('button')
+    fireEvent.click(copyButton as HTMLButtonElement)
+
+    expect(copyToClipboardSpy).toHaveBeenCalledOnce()
+    const container = copyToClipboardSpy.mock.calls[0][1]
+    const popoverPaper = document.querySelector('.MuiPopover-paper')
+    expect(popoverPaper).not.toBeNull()
+    expect(container).toBe(popoverPaper)
+
+    document.body.removeChild(anchorEl)
+    copyToClipboardSpy.mockRestore()
   })
 })

--- a/frontend/src/components/common/NotificationPanel.tsx
+++ b/frontend/src/components/common/NotificationPanel.tsx
@@ -70,6 +70,7 @@ const NotificationPanel: React.FC<NotificationPanelProps> = ({
   const dispatch = useAppDispatch()
   const [copiedId, setCopiedId] = React.useState<string | null>(null)
   const copyTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const popoverPaperRef = React.useRef<HTMLDivElement | null>(null)
 
   const unreadNotifications = notifications.filter(n => !n.read)
   const recentNotifications = notifications.slice(0, 10)
@@ -90,7 +91,7 @@ const NotificationPanel: React.FC<NotificationPanelProps> = ({
 
   const handleCopy = async (notificationId: string, message: string, event: React.MouseEvent) => {
     event.stopPropagation()
-    const success = await copyToClipboard(message, document.body)
+    const success = await copyToClipboard(message, popoverPaperRef.current!)
     if (success) {
       if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current)
       setCopiedId(notificationId)
@@ -118,6 +119,7 @@ const NotificationPanel: React.FC<NotificationPanelProps> = ({
       title="Notifications"
       width={400}
       maxHeight={600}
+      paperRef={popoverPaperRef}
       headerAction={
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           {unreadNotifications.length > 0 && (

--- a/frontend/src/components/common/TopBarUtilityPanel.tsx
+++ b/frontend/src/components/common/TopBarUtilityPanel.tsx
@@ -10,6 +10,7 @@ interface TopBarUtilityPanelProps {
   maxHeight?: number
   headerAction?: React.ReactNode
   children: React.ReactNode
+  paperRef?: React.Ref<HTMLDivElement>
 }
 
 const TopBarUtilityPanel: React.FC<TopBarUtilityPanelProps> = ({
@@ -20,6 +21,7 @@ const TopBarUtilityPanel: React.FC<TopBarUtilityPanelProps> = ({
   maxHeight = 600,
   headerAction,
   children,
+  paperRef,
 }) => {
   return (
     <Popover
@@ -30,6 +32,7 @@ const TopBarUtilityPanel: React.FC<TopBarUtilityPanelProps> = ({
       transformOrigin={{ vertical: 'top', horizontal: 'right' }}
       slotProps={{
         paper: {
+          ref: paperRef,
           sx: { width, maxHeight, mt: 1, borderRadius: '12px', overflow: 'hidden' },
         },
       }}


### PR DESCRIPTION
## Summary

- The copy-to-clipboard button in `NotificationPanel` silently failed when `navigator.clipboard` was unavailable (HTTP / non-HTTPS contexts)
- The `execCommand` fallback in `copyToClipboard` appends a textarea to a container and calls `focus()` before running the copy — but `document.body` was passed as the container, causing the MUI Popover's focus trap to immediately steal focus and abort the operation
- Fixed by forwarding the Popover's Paper element (`paperRef` via `slotProps.paper.ref`) as the container, so the textarea is mounted inside the focus trap boundary

## Changes

- `TopBarUtilityPanel.tsx` — added optional `paperRef` prop forwarded to `slotProps.paper.ref`
- `NotificationPanel.tsx` — replaced `document.body` with `popoverPaperRef.current!` as the clipboard container
- `NotificationPanel.test.tsx` — added test asserting the container passed to `copyToClipboard` is exactly the `.MuiPopover-paper` element

## Test plan

- [x] Verify copy button works in HTTPS context (navigator.clipboard path — unchanged)
- [x] Verify copy button works in HTTP context (execCommand fallback path — was broken, now fixed)
- [x] `npx vitest run src/components/common/NotificationPanel.test.tsx` — 2/2 pass
- [x] `npm run type-check` — clean

Closes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)