### PR TITLE
fix(build): disable incremental in tsconfig.build.json to fix nest start:dev

### DIFF
--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": false
   },
   "include": ["src"],
   "exclude": [


### PR DESCRIPTION
## Summary

- `nest start --watch` failed with `Cannot find module dist/main` when `dist/` was deleted by `deleteOutDir: true` but the stale `tsconfig.build.tsbuildinfo` caused tsc to skip emitting `main.js`
- Adds `"incremental": false` to `backend/tsconfig.build.json` so tsc always does a full emit; base `tsconfig.json` keeps `incremental: true` for IDE/editor tooling

## Test Plan

- [x] `rm -rf dist && npm run start:dev` compiles cleanly, `Cannot find module dist/main` does not appear
- [x] `npm run build` passes
- [x] `npm run test` passes (78 suites, 1059 tests)

Closes #646