### PR TITLE
feat(customers): Customer List UI polish - column headers, remove duplicate headers, fix loading indicator

### DIFF
--- a/frontend/src/components/common/EntityTable.tsx
+++ b/frontend/src/components/common/EntityTable.tsx
@@ -176,8 +176,8 @@ function EntityTable<T extends { id: string }>({
                       key={i}
                       width={columns[i]?.width}
                       sx={{
-                        ...(i === 0 && { borderRadius: '12px 0 0 0' }),
-                        ...(i === headers.length - 1 && { borderRadius: '0 12px 0 0' }),
+                        ...(i === 0 && { borderRadius: '8px 0 0 0' }),
+                        ...(i === headers.length - 1 && { borderRadius: '0 8px 0 0' }),
                       }}
                     >
                       <Typography

--- a/frontend/src/components/common/EntityTable.tsx
+++ b/frontend/src/components/common/EntityTable.tsx
@@ -167,7 +167,7 @@ function EntityTable<T extends { id: string }>({
           >
             {headers && (
               <TableHead>
-                <TableRow>
+                <TableRow sx={{ backgroundColor: 'action.hover' }}>
                   {headers.map((header, i) => (
                     <TableCell key={i} width={columns[i]?.width}>
                       <Typography

--- a/frontend/src/components/common/EntityTable.tsx
+++ b/frontend/src/components/common/EntityTable.tsx
@@ -184,7 +184,7 @@ function EntityTable<T extends { id: string }>({
                         variant="tableHeader"
                         sx={{
                           fontWeight: 600,
-                          fontSize: '0.75rem',
+                          fontSize: '0.8rem',
                           textTransform: 'uppercase',
                           letterSpacing: '0.5px',
                         }}

--- a/frontend/src/components/common/EntityTable.tsx
+++ b/frontend/src/components/common/EntityTable.tsx
@@ -152,7 +152,7 @@ function EntityTable<T extends { id: string }>({
       )}
       <Box
         ref={listRef}
-        sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}
+        sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', borderRadius: 'inherit' }}
       >
         <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
           <Table
@@ -175,10 +175,6 @@ function EntityTable<T extends { id: string }>({
                     <TableCell
                       key={i}
                       width={columns[i]?.width}
-                      sx={{
-                        ...(i === 0 && { borderRadius: '8px 0 0 0' }),
-                        ...(i === headers.length - 1 && { borderRadius: '0 8px 0 0' }),
-                      }}
                     >
                       <Typography
                         variant="tableHeader"

--- a/frontend/src/components/common/EntityTable.tsx
+++ b/frontend/src/components/common/EntityTable.tsx
@@ -163,6 +163,9 @@ function EntityTable<T extends { id: string }>({
                 py: TABLE_STYLES.cell.padding.py * 0.75,
                 px: TABLE_STYLES.cell.padding.px * 0.75,
               },
+              '& .MuiTableHead-root .MuiTableCell-root': {
+                py: 1,
+              },
               '& tr:last-child .MuiTableCell-root': {
                 borderBottom: 'none',
               },

--- a/frontend/src/components/common/EntityTable.tsx
+++ b/frontend/src/components/common/EntityTable.tsx
@@ -172,7 +172,14 @@ function EntityTable<T extends { id: string }>({
               <TableHead>
                 <TableRow sx={{ backgroundColor: TABLE_STYLES.header.backgroundColor }}>
                   {headers.map((header, i) => (
-                    <TableCell key={i} width={columns[i]?.width}>
+                    <TableCell
+                      key={i}
+                      width={columns[i]?.width}
+                      sx={{
+                        ...(i === 0 && { borderRadius: '12px 0 0 0' }),
+                        ...(i === headers.length - 1 && { borderRadius: '0 12px 0 0' }),
+                      }}
+                    >
                       <Typography
                         variant="tableHeader"
                         sx={{

--- a/frontend/src/components/common/EntityTable.tsx
+++ b/frontend/src/components/common/EntityTable.tsx
@@ -167,7 +167,7 @@ function EntityTable<T extends { id: string }>({
           >
             {headers && (
               <TableHead>
-                <TableRow sx={{ backgroundColor: 'action.hover' }}>
+                <TableRow sx={{ backgroundColor: TABLE_STYLES.header.backgroundColor }}>
                   {headers.map((header, i) => (
                     <TableCell key={i} width={columns[i]?.width}>
                       <Typography

--- a/frontend/src/components/common/EntityTable.tsx
+++ b/frontend/src/components/common/EntityTable.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from 'react'
+import type { ReactNode } from 'react'
 import {
   alpha,
   Box,
@@ -36,6 +37,7 @@ export interface EntityTableProps<T extends { id: string }> {
   dataAttr?: string
   showHeader?: boolean
   headers?: string[]
+  paginationSlot?: ReactNode
 }
 
 interface RowProps<T extends { id: string }> {
@@ -117,6 +119,7 @@ function EntityTable<T extends { id: string }>({
   dataAttr = 'row',
   showHeader = true,
   headers,
+  paginationSlot,
 }: EntityTableProps<T>) {
   return (
     <Paper sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
@@ -226,6 +229,11 @@ function EntityTable<T extends { id: string }>({
           </Table>
         </TableContainer>
       </Box>
+      {paginationSlot && (
+        <Box sx={{ borderTop: TABLE_STYLES.cell.border }}>
+          {paginationSlot}
+        </Box>
+      )}
     </Paper>
   )
 }

--- a/frontend/src/components/common/EntityTable.tsx
+++ b/frontend/src/components/common/EntityTable.tsx
@@ -8,6 +8,7 @@ import {
   TableBody,
   TableCell,
   TableContainer,
+  TableHead,
   TableRow,
   Typography,
 } from '@mui/material'
@@ -33,6 +34,8 @@ export interface EntityTableProps<T extends { id: string }> {
   onSelect: (row: T) => void
   listRef: React.RefObject<HTMLDivElement | null>
   dataAttr?: string
+  showHeader?: boolean
+  headers?: string[]
 }
 
 interface RowProps<T extends { id: string }> {
@@ -112,34 +115,38 @@ function EntityTable<T extends { id: string }>({
   onSelect,
   listRef,
   dataAttr = 'row',
+  showHeader = true,
+  headers,
 }: EntityTableProps<T>) {
   return (
     <Paper sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <Typography
-            variant="tableHeader"
-            sx={{
-              fontWeight: 600,
-              fontSize: '0.8rem',
-              textTransform: 'uppercase',
-              letterSpacing: '0.5px',
-            }}
-          >
-            {label} ({total})
-          </Typography>
-          {loading && rows.length > 0 && (
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-                Searching...
-              </Typography>
-              <Box sx={{ width: 16, height: 16 }}>
-                <Skeleton variant="circular" width={16} height={16} />
+      {showHeader && (
+        <Box sx={{ p: TABLE_STYLES.cell.padding.px, borderBottom: TABLE_STYLES.cell.border }}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Typography
+              variant="tableHeader"
+              sx={{
+                fontWeight: 600,
+                fontSize: '0.8rem',
+                textTransform: 'uppercase',
+                letterSpacing: '0.5px',
+              }}
+            >
+              {label} ({total})
+            </Typography>
+            {loading && rows.length > 0 && (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                  Searching...
+                </Typography>
+                <Box sx={{ width: 16, height: 16 }}>
+                  <Skeleton variant="circular" width={16} height={16} />
+                </Box>
               </Box>
-            </Box>
-          )}
+            )}
+          </Box>
         </Box>
-      </Box>
+      )}
       <Box
         ref={listRef}
         sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}
@@ -158,6 +165,27 @@ function EntityTable<T extends { id: string }>({
               },
             }}
           >
+            {headers && (
+              <TableHead>
+                <TableRow>
+                  {headers.map((header, i) => (
+                    <TableCell key={i} width={columns[i]?.width}>
+                      <Typography
+                        variant="tableHeader"
+                        sx={{
+                          fontWeight: 600,
+                          fontSize: '0.75rem',
+                          textTransform: 'uppercase',
+                          letterSpacing: '0.5px',
+                        }}
+                      >
+                        {header}
+                      </Typography>
+                    </TableCell>
+                  ))}
+                </TableRow>
+              </TableHead>
+            )}
             <TableBody>
               {loading && rows.length === 0
                 ? [...Array(10)].map((_, index) => (

--- a/frontend/src/components/common/EntityTable.tsx
+++ b/frontend/src/components/common/EntityTable.tsx
@@ -165,6 +165,7 @@ function EntityTable<T extends { id: string }>({
               },
               '& .MuiTableHead-root .MuiTableCell-root': {
                 py: 1,
+                borderBottom: TABLE_STYLES.cell.border,
               },
               '& tr:last-child .MuiTableCell-root': {
                 borderBottom: 'none',

--- a/frontend/src/components/common/EntityTable.tsx
+++ b/frontend/src/components/common/EntityTable.tsx
@@ -167,9 +167,11 @@ function EntityTable<T extends { id: string }>({
                 py: 1,
                 borderBottom: TABLE_STYLES.cell.border,
               },
-              '& tr:last-child .MuiTableCell-root': {
-                borderBottom: 'none',
-              },
+              ...(!paginationSlot && {
+                '& tr:last-child .MuiTableCell-root': {
+                  borderBottom: 'none',
+                },
+              }),
             }}
           >
             {headers && (
@@ -237,7 +239,7 @@ function EntityTable<T extends { id: string }>({
         </TableContainer>
       </Box>
       {paginationSlot && (
-        <Box sx={{ borderTop: TABLE_STYLES.cell.border }}>
+        <Box>
           {paginationSlot}
         </Box>
       )}

--- a/frontend/src/components/common/SimpleListPage.test.tsx
+++ b/frontend/src/components/common/SimpleListPage.test.tsx
@@ -76,4 +76,14 @@ describe('SimpleListPage', () => {
     )
     expect(screen.getByTestId('dialogs')).toBeInTheDocument()
   })
+
+  it('shows a loading spinner in the filter bar when isFetching is true', () => {
+    render(<SimpleListPage {...baseProps} isFetching={true} />)
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('does not show a loading spinner when isFetching is false', () => {
+    render(<SimpleListPage {...baseProps} isFetching={false} />)
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/common/SimpleListPage.tsx
+++ b/frontend/src/components/common/SimpleListPage.tsx
@@ -21,6 +21,7 @@ interface SimpleListPageProps<F extends object> {
   hasActiveFilters: boolean
   searchInputRef: RefObject<HTMLInputElement | null>
   sort: FilterBarSortConfig
+  isFetching?: boolean
   error?: string | null
   onErrorClose?: () => void
   tableSlot: ReactNode
@@ -39,6 +40,7 @@ export default function SimpleListPage<F extends object>({
   hasActiveFilters,
   searchInputRef,
   sort,
+  isFetching,
   error,
   onErrorClose,
   tableSlot,
@@ -61,6 +63,7 @@ export default function SimpleListPage<F extends object>({
             hasActiveFilters={hasActiveFilters}
             searchInputRef={searchInputRef}
             sort={sort}
+            isFetching={isFetching}
           />
         }
       />

--- a/frontend/src/pages/sales/CustomersPage.tsx
+++ b/frontend/src/pages/sales/CustomersPage.tsx
@@ -110,6 +110,7 @@ const CustomersPage: React.FC = () => {
       hasActiveFilters={hasActiveFilters}
       searchInputRef={searchInputRef}
       sort={{ field: 'name', sortBy, sortOrder, onSort: handleSort }}
+      isFetching={isFetching}
       error={pageError || (error ? 'Failed to load customers.' : null)}
       onErrorClose={() => setPageError(null)}
       tableSlot={(

--- a/frontend/src/pages/sales/CustomersPage.tsx
+++ b/frontend/src/pages/sales/CustomersPage.tsx
@@ -119,16 +119,16 @@ const CustomersPage: React.FC = () => {
           loading={isLoading || isFetching}
           total={total}
           onStatusToggle={handleStatusToggle}
-        />
-      )}
-      paginationSlot={(
-        <PagePagination
-          total={total}
-          page={page}
-          limit={limit}
-          onPageChange={setPage}
-          onLimitChange={handleLimitChange}
-          pageSizeOptions={PAGE_SIZE_OPTIONS}
+          paginationSlot={(
+            <PagePagination
+              total={total}
+              page={page}
+              limit={limit}
+              onPageChange={setPage}
+              onLimitChange={handleLimitChange}
+              pageSizeOptions={PAGE_SIZE_OPTIONS}
+            />
+          )}
         />
       )}
     />

--- a/frontend/src/pages/sales/CustomersPage.tsx
+++ b/frontend/src/pages/sales/CustomersPage.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import PagePagination from '@/components/common/PagePagination'
-import PageSection from '@/components/common/PageSection'
 import SimpleListPage from '@/components/common/SimpleListPage'
 import { useFilterBar } from '@/hooks/useFilterBar'
 import { useNotification } from '@/hooks/useNotification'
@@ -114,17 +113,12 @@ const CustomersPage: React.FC = () => {
       error={pageError || (error ? 'Failed to load customers.' : null)}
       onErrorClose={() => setPageError(null)}
       tableSlot={(
-        <PageSection
-          label="Customer list"
-          meta={<span style={{ fontSize: '0.8rem', color: 'inherit' }}>{limit} per page</span>}
-        >
-          <CustomerList
-            customers={customers}
-            loading={isLoading || isFetching}
-            total={total}
-            onStatusToggle={handleStatusToggle}
-          />
-        </PageSection>
+        <CustomerList
+          customers={customers}
+          loading={isLoading || isFetching}
+          total={total}
+          onStatusToggle={handleStatusToggle}
+        />
       )}
       paginationSlot={(
         <PagePagination

--- a/frontend/src/pages/sales/__tests__/CustomersPage.filter.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CustomersPage.filter.test.tsx
@@ -37,12 +37,13 @@ vi.mock('@/store/api/priceListApi', () => ({
 }))
 
 vi.mock('../components/CustomerList', () => ({
-  default: ({ customers, total }: any) => (
+  default: ({ customers, total, paginationSlot }: any) => (
     <div data-testid="customer-list">
       <span data-testid="customer-count">{total}</span>
       {customers.map((c: any) => (
         <div key={c.id}>{c.name}</div>
       ))}
+      {paginationSlot}
     </div>
   ),
 }))

--- a/frontend/src/pages/sales/__tests__/CustomersPage.filterbar.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CustomersPage.filterbar.test.tsx
@@ -41,7 +41,9 @@ vi.mock('react-router-dom', async (importOriginal) => {
 })
 
 vi.mock('../components/CustomerList', () => ({
-  default: () => <div data-testid="customer-list" />,
+  default: ({ paginationSlot }: any) => (
+    <div data-testid="customer-list">{paginationSlot}</div>
+  ),
 }))
 
 function makeStore() {

--- a/frontend/src/pages/sales/components/CustomerList.tsx
+++ b/frontend/src/pages/sales/components/CustomerList.tsx
@@ -26,7 +26,7 @@ export default function CustomerList({
   const navigate = useNavigate()
 
   const columns: ColumnConfig<Customer>[] = [
-    { key: 'name', render: (customer) => customer.name },
+    { key: 'name', width: '100%', render: (customer) => customer.name },
     { key: 'phone', width: 150, render: (customer) => customer.phone ?? '—' },
     { key: 'type', width: 110, render: (customer) => formatCustomerType(customer.type) },
     { key: 'priceList', width: 130, render: (customer) => customer.priceList?.name ?? '—' },

--- a/frontend/src/pages/sales/components/CustomerList.tsx
+++ b/frontend/src/pages/sales/components/CustomerList.tsx
@@ -62,6 +62,8 @@ export default function CustomerList({
       loading={loading}
       total={total}
       label="Customers"
+      showHeader={false}
+      headers={['Name', 'Phone', 'Type', 'Price List', 'Status', '']}
       selectedId={undefined}
       focusedIndex={-1}
       onSelect={() => {}}

--- a/frontend/src/pages/sales/components/CustomerList.tsx
+++ b/frontend/src/pages/sales/components/CustomerList.tsx
@@ -26,13 +26,13 @@ export default function CustomerList({
   const navigate = useNavigate()
 
   const columns: ColumnConfig<Customer>[] = [
-    { key: 'name', width: '100%', render: (customer) => customer.name },
-    { key: 'phone', width: 150, render: (customer) => customer.phone ?? '—' },
-    { key: 'type', width: 110, render: (customer) => formatCustomerType(customer.type) },
-    { key: 'priceList', width: 130, render: (customer) => customer.priceList?.name ?? '—' },
+    { key: 'name', width: '30%', render: (customer) => customer.name },
+    { key: 'phone', width: '18%', render: (customer) => customer.phone ?? '—' },
+    { key: 'type', width: '13%', render: (customer) => formatCustomerType(customer.type) },
+    { key: 'priceList', width: '16%', render: (customer) => customer.priceList?.name ?? '—' },
     {
       key: 'status',
-      width: 100,
+      width: '12%',
       raw: true,
       render: (customer) => (
         <EntityStatusChip status={customer.isActive ? 'active' : 'inactive'} />
@@ -40,7 +40,7 @@ export default function CustomerList({
     },
     {
       key: 'actions',
-      width: 48,
+      width: '6%',
       raw: true,
       render: (customer) => (
         <RowActionMenu

--- a/frontend/src/pages/sales/components/CustomerList.tsx
+++ b/frontend/src/pages/sales/components/CustomerList.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import type { ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import EntityTable, { type ColumnConfig } from '@/components/common/EntityTable'
@@ -12,6 +13,7 @@ interface CustomerListProps {
   loading: boolean
   total: number
   onStatusToggle: (customer: Customer) => void
+  paginationSlot?: ReactNode
 }
 
 export default function CustomerList({
@@ -19,6 +21,7 @@ export default function CustomerList({
   loading,
   total,
   onStatusToggle,
+  paginationSlot,
 }: CustomerListProps) {
   const navigate = useNavigate()
 
@@ -69,6 +72,7 @@ export default function CustomerList({
       onSelect={() => {}}
       listRef={{ current: null }}
       dataAttr="customer"
+      paginationSlot={paginationSlot}
     />
   )
 }

--- a/frontend/src/pages/sales/components/CustomerList.tsx
+++ b/frontend/src/pages/sales/components/CustomerList.tsx
@@ -66,7 +66,7 @@ export default function CustomerList({
       total={total}
       label="Customers"
       showHeader={false}
-      headers={['Name', 'Phone', 'Type', 'Price List', 'Status', '']}
+      headers={['Name', 'Phone', 'Type', 'Price List', 'Status', 'Actions']}
       selectedId={undefined}
       focusedIndex={-1}
       onSelect={() => {}}

--- a/frontend/src/pages/sales/components/__tests__/CustomerList.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/CustomerList.test.tsx
@@ -41,6 +41,20 @@ function renderList(customers = [baseCustomer]) {
 }
 
 describe('CustomerList columns', () => {
+  it('renders column headers', () => {
+    renderList()
+    expect(screen.getByText('Name')).toBeInTheDocument()
+    expect(screen.getByText('Phone')).toBeInTheDocument()
+    expect(screen.getByText('Type')).toBeInTheDocument()
+    expect(screen.getByText('Price List')).toBeInTheDocument()
+    expect(screen.getByText('Status')).toBeInTheDocument()
+  })
+
+  it('does not render the Customers count header', () => {
+    renderList()
+    expect(screen.queryByText(/Customers \(/)).not.toBeInTheDocument()
+  })
+
   it('renders customer name', () => {
     renderList()
     expect(screen.getByText('Acme Corp')).toBeInTheDocument()

--- a/frontend/src/pages/sales/components/__tests__/CustomerList.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/CustomerList.test.tsx
@@ -55,6 +55,21 @@ describe('CustomerList columns', () => {
     expect(screen.queryByText(/Customers \(/)).not.toBeInTheDocument()
   })
 
+  it('renders paginationSlot inside the table card', () => {
+    render(
+      <MemoryRouter>
+        <CustomerList
+          customers={[baseCustomer] as any}
+          loading={false}
+          total={1}
+          onStatusToggle={vi.fn()}
+          paginationSlot={<div data-testid="pagination-slot">Pagination</div>}
+        />
+      </MemoryRouter>,
+    )
+    expect(screen.getByTestId('pagination-slot')).toBeInTheDocument()
+  })
+
   it('renders customer name', () => {
     renderList()
     expect(screen.getByText('Acme Corp')).toBeInTheDocument()

--- a/frontend/src/pages/sales/components/__tests__/CustomerList.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/CustomerList.test.tsx
@@ -48,6 +48,7 @@ describe('CustomerList columns', () => {
     expect(screen.getByText('Type')).toBeInTheDocument()
     expect(screen.getByText('Price List')).toBeInTheDocument()
     expect(screen.getByText('Status')).toBeInTheDocument()
+    expect(screen.getByText('Actions')).toBeInTheDocument()
   })
 
   it('does not render the Customers count header', () => {


### PR DESCRIPTION
## Summary

- Add column headers (Name, Phone, Type, Price List, Status) to the Customer List table via new optional `headers` prop on `EntityTable`
- Remove the redundant `PageSection` wrapper and `EntityTable` internal label/count header row from the Customer List page
- Fix mid-query loading indicator: wire `isFetching` through `SimpleListPage` → `FilterBar` so the spinner shows when a search is in-flight with rows already visible

## Changes

- `EntityTable`: add `showHeader?: boolean` (default `true`) and `headers?: string[]` props; renders `<TableHead>` when `headers` provided
- `CustomerList`: pass `showHeader={false}` and column header labels
- `CustomersPage`: remove `PageSection` wrapper from `tableSlot`; pass `isFetching` to `SimpleListPage`
- `SimpleListPage`: accept and forward `isFetching` prop to `FilterBar`

## Test Plan

- [x] All 31 tests pass: `npx vitest run src/components/common/SimpleListPage.test.tsx src/pages/sales/components/__tests__/CustomerList.test.tsx src/pages/sales/__tests__/CustomersPage.filterbar.test.tsx src/pages/sales/__tests__/CustomersPage.filter.test.tsx`
- [x] TypeScript check passes: `npm run type-check`
- [x] Customer List page shows column headers (Name, Phone, Type, Price List, Status)
- [x] No "Customer list" section header or "Customers (N)" count row visible
- [x] Spinner appears in filter bar when typing a search with results already loaded

Closes #653