### PR TITLE
feat(customer-form): redesign layout to fit on one screen without scrolling

### DIFF
--- a/frontend/src/components/common/AddressSection.tsx
+++ b/frontend/src/components/common/AddressSection.tsx
@@ -58,9 +58,11 @@ export default function AddressSection<T extends FieldValues>({
 
   return (
     <>
-      <Grid size={12}>
-        {title && <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>{title}</Typography>}
-      </Grid>
+      {title && (
+        <Grid size={12}>
+          <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>{title}</Typography>
+        </Grid>
+      )}
 
       <Grid size={12}>
         <Controller

--- a/frontend/src/components/price-lists/PriceListSelector.test.tsx
+++ b/frontend/src/components/price-lists/PriceListSelector.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import PriceListSelector from './PriceListSelector'
+
+vi.mock('@/store/api/priceListApi', () => ({
+  useGetEffectivePriceListsQuery: () => ({ data: [], isLoading: false }),
+  useGetPriceListsQuery: () => ({ data: { data: [] } }),
+}))
+
+describe('PriceListSelector', () => {
+  it('applies compact size and custom styles to the form control', () => {
+    const { container } = render(
+      <PriceListSelector
+        value=""
+        onChange={vi.fn()}
+        label="Price List"
+        size="small"
+        sx={{ marginTop: '8px' }}
+      />,
+    )
+
+    expect(screen.getByLabelText('Price List').closest('.MuiInputBase-root')).toHaveClass('MuiInputBase-sizeSmall')
+    expect(container.firstElementChild).toHaveStyle({ marginTop: '8px' })
+  })
+})

--- a/frontend/src/components/price-lists/PriceListSelector.tsx
+++ b/frontend/src/components/price-lists/PriceListSelector.tsx
@@ -12,6 +12,7 @@ import {
 import { default as StarIcon } from '@mui/icons-material/Star'
 import { useGetEffectivePriceListsQuery, useGetPriceListsQuery } from '@/store/api/priceListApi'
 import type { PriceList } from '@/types'
+import type { SxProps, Theme } from '@mui/material/styles'
 
 interface PriceListSelectorProps {
   value?: string | null
@@ -22,6 +23,8 @@ interface PriceListSelectorProps {
   disabled?: boolean
   fullWidth?: boolean
   showInactive?: boolean
+  size?: 'small' | 'medium'
+  sx?: SxProps<Theme>
 }
 
 const PriceListSelector: React.FC<PriceListSelectorProps> = ({
@@ -33,6 +36,8 @@ const PriceListSelector: React.FC<PriceListSelectorProps> = ({
   disabled = false,
   fullWidth = true,
   showInactive = false,
+  size,
+  sx,
 }) => {
   const { data: effectivePriceLists = [], isLoading: effectiveLoading } = useGetEffectivePriceListsQuery()
   const { data: allPriceLists } = useGetPriceListsQuery({ page: 1, limit: 200, isActive: undefined })
@@ -75,7 +80,7 @@ const PriceListSelector: React.FC<PriceListSelectorProps> = ({
   )
 
   return (
-    <FormControl fullWidth={fullWidth} error={!!error} disabled={disabled || effectiveLoading}>
+    <FormControl fullWidth={fullWidth} error={!!error} disabled={disabled || effectiveLoading} size={size} sx={sx}>
       <InputLabel id="price-list-selector-label" required={required}>
         {label}
       </InputLabel>

--- a/frontend/src/pages/sales/CustomerFormPage.tsx
+++ b/frontend/src/pages/sales/CustomerFormPage.tsx
@@ -410,9 +410,9 @@ const CustomerFormPage: React.FC = () => {
       <form noValidate onSubmit={handleSubmit(handleFormSubmit)}>
         <Grid container spacing={3}>
 
-          {/* Group 1: Basic Info */}
-          <Grid size={12}>
-            <Card>
+          {/* Row 1: Basic Info + Additional side by side */}
+          <Grid size={{ xs: 12, md: 6 }} sx={{ display: 'flex', flexDirection: 'column' }}>
+            <Card sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
               <CardContent>
                 <Typography variant="h6" gutterBottom>Basic Information</Typography>
                 <Grid container spacing={2}>
@@ -553,53 +553,8 @@ const CustomerFormPage: React.FC = () => {
             </Card>
           </Grid>
 
-          {/* Group 2: Addresses */}
-          <Grid size={12}>
-            <Card>
-              <CardContent>
-                <Typography variant="h6" gutterBottom>Addresses</Typography>
-                <Grid container spacing={2}>
-                  <AddressSection
-                    control={control}
-                    errors={errors}
-                    prefix="billing"
-                    title="Billing Address"
-                    disabled={isSaving}
-                  />
-
-                  <Grid size={12}>
-                    <Box sx={{ display: 'flex', alignItems: 'center', mt: 2, mb: 0 }}>
-                      <Typography variant="h6" sx={{ flexGrow: 1 }}>Shipping Address</Typography>
-                      <FormControlLabel
-                        control={
-                          <Switch
-                            size="small"
-                            checked={sameAsBilling}
-                            onChange={(event) => setSameAsBilling(event.target.checked)}
-                            disabled={isSaving}
-                          />
-                        }
-                        label="Same as Billing"
-                        labelPlacement="start"
-                      />
-                    </Box>
-                  </Grid>
-
-                  <AddressSection
-                    control={control}
-                    errors={errors}
-                    prefix="shipping"
-                    title=""
-                    disabled={sameAsBilling || isSaving}
-                  />
-                </Grid>
-              </CardContent>
-            </Card>
-          </Grid>
-
-          {/* Group 3: Additional */}
-          <Grid size={12}>
-            <Card>
+          <Grid size={{ xs: 12, md: 6 }} sx={{ display: 'flex', flexDirection: 'column' }}>
+            <Card sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
               <CardContent sx={{ display: 'flex', flexDirection: 'column', height: '100%', boxSizing: 'border-box' }}>
                 <Typography variant="h6" gutterBottom>Additional</Typography>
                 <Grid container spacing={2} sx={{ flexGrow: 1 }}>
@@ -650,6 +605,50 @@ const CustomerFormPage: React.FC = () => {
                       )}
                     />
                   </Grid>
+                </Grid>
+              </CardContent>
+            </Card>
+          </Grid>
+
+          {/* Row 2: Addresses */}
+          <Grid size={12}>
+            <Card>
+              <CardContent>
+                <Typography variant="h6" gutterBottom>Addresses</Typography>
+                <Grid container spacing={2}>
+                  <AddressSection
+                    control={control}
+                    errors={errors}
+                    prefix="billing"
+                    title="Billing Address"
+                    disabled={isSaving}
+                  />
+
+                  <Grid size={12}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', mt: 2, mb: 0 }}>
+                      <Typography variant="h6" sx={{ flexGrow: 1 }}>Shipping Address</Typography>
+                      <FormControlLabel
+                        control={
+                          <Switch
+                            size="small"
+                            checked={sameAsBilling}
+                            onChange={(event) => setSameAsBilling(event.target.checked)}
+                            disabled={isSaving}
+                          />
+                        }
+                        label="Same as Billing"
+                        labelPlacement="start"
+                      />
+                    </Box>
+                  </Grid>
+
+                  <AddressSection
+                    control={control}
+                    errors={errors}
+                    prefix="shipping"
+                    title=""
+                    disabled={sameAsBilling || isSaving}
+                  />
                 </Grid>
               </CardContent>
             </Card>

--- a/frontend/src/pages/sales/CustomerFormPage.tsx
+++ b/frontend/src/pages/sales/CustomerFormPage.tsx
@@ -614,6 +614,8 @@ const CustomerFormPage: React.FC = () => {
                           error={errors.priceListId?.message}
                           label="Price List"
                           disabled={isSaving}
+                          size="small"
+                          sx={fieldSx}
                         />
                       )}
                     />

--- a/frontend/src/pages/sales/CustomerFormPage.tsx
+++ b/frontend/src/pages/sales/CustomerFormPage.tsx
@@ -557,7 +557,7 @@ const CustomerFormPage: React.FC = () => {
             <Card sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
               <CardContent sx={{ display: 'flex', flexDirection: 'column', height: '100%', boxSizing: 'border-box' }}>
                 <Typography variant="h6" gutterBottom>Additional</Typography>
-                <Grid container spacing={2} sx={{ flexGrow: 1 }}>
+                <Grid container spacing={2}>
                   <Grid size={{ xs: 12, md: 6 }}>
                     <Controller
                       name="priceListId"
@@ -575,37 +575,37 @@ const CustomerFormPage: React.FC = () => {
                       )}
                     />
                   </Grid>
-
-                  <Grid size={12} sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
-                    <Controller
-                      name="notes"
-                      control={control}
-                      render={({ field }) => (
-                        <TextField
-                          {...field}
-                          value={field.value || ''}
-                          fullWidth
-                          multiline
-                          size="small"
-                          label="Notes / Remarks"
-                          disabled={isSaving}
-                          error={!!errors.notes}
-                          helperText={errors.notes?.message}
-                          sx={{
-                            ...fieldSx,
-                            flexGrow: 1,
-                            '& .MuiInputBase-root': { height: '100%', alignItems: 'flex-start' },
-                            '& .MuiInputBase-input': {
-                              ...fieldSx['& .MuiInputBase-input'],
-                              height: '100% !important',
-                              overflow: 'auto !important',
-                            },
-                          }}
-                        />
-                      )}
-                    />
-                  </Grid>
                 </Grid>
+
+                <Box sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', mt: 2 }}>
+                  <Controller
+                    name="notes"
+                    control={control}
+                    render={({ field }) => (
+                      <TextField
+                        {...field}
+                        value={field.value || ''}
+                        fullWidth
+                        multiline
+                        size="small"
+                        label="Notes / Remarks"
+                        disabled={isSaving}
+                        error={!!errors.notes}
+                        helperText={errors.notes?.message}
+                        sx={{
+                          ...fieldSx,
+                          flexGrow: 1,
+                          '& .MuiInputBase-root': { height: '100%', alignItems: 'flex-start' },
+                          '& .MuiInputBase-input': {
+                            ...fieldSx['& .MuiInputBase-input'],
+                            height: '100% !important',
+                            overflow: 'auto !important',
+                          },
+                        }}
+                      />
+                    )}
+                  />
+                </Box>
               </CardContent>
             </Card>
           </Grid>

--- a/frontend/src/pages/sales/CustomerFormPage.tsx
+++ b/frontend/src/pages/sales/CustomerFormPage.tsx
@@ -616,39 +616,46 @@ const CustomerFormPage: React.FC = () => {
               <CardContent>
                 <Typography variant="h6" gutterBottom>Addresses</Typography>
                 <Grid container spacing={2}>
-                  <AddressSection
-                    control={control}
-                    errors={errors}
-                    prefix="billing"
-                    title="Billing Address"
-                    disabled={isSaving}
-                  />
-
-                  <Grid size={12}>
-                    <Box sx={{ display: 'flex', alignItems: 'center', mt: 2, mb: 0 }}>
-                      <Typography variant="h6" sx={{ flexGrow: 1 }}>Shipping Address</Typography>
-                      <FormControlLabel
-                        control={
-                          <Switch
-                            size="small"
-                            checked={sameAsBilling}
-                            onChange={(event) => setSameAsBilling(event.target.checked)}
-                            disabled={isSaving}
-                          />
-                        }
-                        label="Same as Billing"
-                        labelPlacement="start"
+                  <Grid size={{ xs: 12, md: 6 }} data-testid="billing-address-column">
+                    <Grid container spacing={2}>
+                      <AddressSection
+                        control={control}
+                        errors={errors}
+                        prefix="billing"
+                        title="Billing Address"
+                        disabled={isSaving}
                       />
-                    </Box>
+                    </Grid>
                   </Grid>
 
-                  <AddressSection
-                    control={control}
-                    errors={errors}
-                    prefix="shipping"
-                    title=""
-                    disabled={sameAsBilling || isSaving}
-                  />
+                  <Grid size={{ xs: 12, md: 6 }} data-testid="shipping-address-column">
+                    <Grid container spacing={2}>
+                      <Grid size={12}>
+                        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                          <Typography variant="h6" sx={{ flexGrow: 1 }}>Shipping Address</Typography>
+                          <FormControlLabel
+                            control={
+                              <Switch
+                                size="small"
+                                checked={sameAsBilling}
+                                onChange={(event) => setSameAsBilling(event.target.checked)}
+                                disabled={isSaving}
+                              />
+                            }
+                            label="Same as Billing"
+                            labelPlacement="start"
+                          />
+                        </Box>
+                      </Grid>
+                      <AddressSection
+                        control={control}
+                        errors={errors}
+                        prefix="shipping"
+                        title=""
+                        disabled={sameAsBilling || isSaving}
+                      />
+                    </Grid>
+                  </Grid>
                 </Grid>
               </CardContent>
             </Card>

--- a/frontend/src/pages/sales/CustomerFormPage.tsx
+++ b/frontend/src/pages/sales/CustomerFormPage.tsx
@@ -600,9 +600,9 @@ const CustomerFormPage: React.FC = () => {
           {/* Group 3: Additional */}
           <Grid size={12}>
             <Card>
-              <CardContent>
+              <CardContent sx={{ display: 'flex', flexDirection: 'column', height: '100%', boxSizing: 'border-box' }}>
                 <Typography variant="h6" gutterBottom>Additional</Typography>
-                <Grid container spacing={2}>
+                <Grid container spacing={2} sx={{ flexGrow: 1 }}>
                   <Grid size={{ xs: 12, md: 6 }}>
                     <Controller
                       name="priceListId"
@@ -621,7 +621,7 @@ const CustomerFormPage: React.FC = () => {
                     />
                   </Grid>
 
-                  <Grid size={12}>
+                  <Grid size={12} sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
                     <Controller
                       name="notes"
                       control={control}
@@ -631,13 +631,21 @@ const CustomerFormPage: React.FC = () => {
                           value={field.value || ''}
                           fullWidth
                           multiline
-                          rows={4}
                           size="small"
                           label="Notes / Remarks"
                           disabled={isSaving}
                           error={!!errors.notes}
                           helperText={errors.notes?.message}
-                          sx={fieldSx}
+                          sx={{
+                            ...fieldSx,
+                            flexGrow: 1,
+                            '& .MuiInputBase-root': { height: '100%', alignItems: 'flex-start' },
+                            '& .MuiInputBase-input': {
+                              ...fieldSx['& .MuiInputBase-input'],
+                              height: '100% !important',
+                              overflow: 'auto !important',
+                            },
+                          }}
                         />
                       )}
                     />

--- a/frontend/src/pages/sales/CustomerFormPage.tsx
+++ b/frontend/src/pages/sales/CustomerFormPage.tsx
@@ -618,11 +618,16 @@ const CustomerFormPage: React.FC = () => {
                 <Grid container spacing={2}>
                   <Grid size={{ xs: 12, md: 6 }} data-testid="billing-address-column">
                     <Grid container spacing={2}>
+                      <Grid size={12}>
+                        <Box sx={{ display: 'flex', alignItems: 'center', mt: 2, minHeight: 38 }}>
+                          <Typography variant="h6" sx={{ flexGrow: 1 }}>Billing Address</Typography>
+                        </Box>
+                      </Grid>
                       <AddressSection
                         control={control}
                         errors={errors}
                         prefix="billing"
-                        title="Billing Address"
+                        title=""
                         disabled={isSaving}
                       />
                     </Grid>
@@ -631,7 +636,7 @@ const CustomerFormPage: React.FC = () => {
                   <Grid size={{ xs: 12, md: 6 }} data-testid="shipping-address-column">
                     <Grid container spacing={2}>
                       <Grid size={12}>
-                        <Box sx={{ display: 'flex', alignItems: 'center', mt: 2 }}>
+                        <Box sx={{ display: 'flex', alignItems: 'center', mt: 2, minHeight: 38 }}>
                           <Typography variant="h6" sx={{ flexGrow: 1 }}>Shipping Address</Typography>
                           <FormControlLabel
                             control={

--- a/frontend/src/pages/sales/CustomerFormPage.tsx
+++ b/frontend/src/pages/sales/CustomerFormPage.tsx
@@ -631,7 +631,7 @@ const CustomerFormPage: React.FC = () => {
                   <Grid size={{ xs: 12, md: 6 }} data-testid="shipping-address-column">
                     <Grid container spacing={2}>
                       <Grid size={12}>
-                        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                        <Box sx={{ display: 'flex', alignItems: 'center', mt: 2 }}>
                           <Typography variant="h6" sx={{ flexGrow: 1 }}>Shipping Address</Typography>
                           <FormControlLabel
                             control={

--- a/frontend/src/pages/sales/__tests__/CustomerFormPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CustomerFormPage.test.tsx
@@ -186,6 +186,15 @@ describe('CustomerFormPage - Create mode', () => {
 
     expect(additional.compareDocumentPosition(addresses)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
   })
+
+  it('renders billing and shipping address columns with the toggle in shipping', () => {
+    renderCreatePage()
+
+    expect(screen.getByTestId('billing-address-column')).toBeInTheDocument()
+    expect(screen.getByTestId('shipping-address-column')).toContainElement(
+      screen.getByLabelText(/same as billing/i),
+    )
+  })
 })
 
 describe('CustomerFormPage - Edit mode', () => {

--- a/frontend/src/pages/sales/__tests__/CustomerFormPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CustomerFormPage.test.tsx
@@ -17,6 +17,7 @@ const {
   mockShowError,
   mockApiGet,
   mockFetchCustomerBySlug,
+  mockPriceListSelectorProps,
 } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
   mockCreateCustomer: vi.fn(),
@@ -26,6 +27,7 @@ const {
   mockShowError: vi.fn(),
   mockApiGet: vi.fn(),
   mockFetchCustomerBySlug: vi.fn(),
+  mockPriceListSelectorProps: [] as any[],
 }))
 
 vi.mock('react-router-dom', async (importOriginal) => {
@@ -52,13 +54,16 @@ vi.mock('@/hooks/useNotification', () => ({
 }))
 
 vi.mock('@/components/price-lists/PriceListSelector', () => ({
-  default: ({ value, onChange }: any) => (
-    <input
-      data-testid="price-list-selector"
-      value={value || ''}
-      onChange={(event) => onChange(event.target.value)}
-    />
-  ),
+  default: (props: any) => {
+    mockPriceListSelectorProps.push(props)
+    return (
+      <input
+        data-testid="price-list-selector"
+        value={props.value || ''}
+        onChange={(event) => props.onChange(event.target.value)}
+      />
+    )
+  },
 }))
 
 vi.mock('@/services/api', () => ({
@@ -108,6 +113,7 @@ describe('CustomerFormPage - Create mode', () => {
     mockRestoreCustomer.mockReturnValue({ unwrap: vi.fn().mockResolvedValue({}) })
     mockApiGet.mockResolvedValue({ data: { data: [] } })
     mockFetchCustomerBySlug.mockReturnValue({ unwrap: vi.fn().mockResolvedValue(null) })
+    mockPriceListSelectorProps.length = 0
   })
 
   it('renders empty form with New Customer heading', () => {
@@ -150,6 +156,20 @@ describe('CustomerFormPage - Create mode', () => {
     await user.click(screen.getByRole('button', { name: /cancel/i }))
 
     expect(mockNavigate).toHaveBeenCalledWith('/sales/customers')
+  })
+
+  it('renders Price List selector with compact field styling', () => {
+    renderCreatePage()
+
+    expect(mockPriceListSelectorProps.at(-1)).toEqual(
+      expect.objectContaining({
+        size: 'small',
+        sx: expect.objectContaining({
+          '& .MuiInputBase-input': expect.objectContaining({ fontSize: '0.875rem' }),
+          '& .MuiInputLabel-root': expect.objectContaining({ fontSize: '0.875rem' }),
+        }),
+      }),
+    )
   })
 })
 

--- a/frontend/src/pages/sales/__tests__/CustomerFormPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CustomerFormPage.test.tsx
@@ -177,6 +177,15 @@ describe('CustomerFormPage - Create mode', () => {
 
     expect(screen.getByLabelText(/notes/i)).not.toHaveAttribute('rows')
   })
+
+  it('places the Additional card before the Addresses card', () => {
+    renderCreatePage()
+
+    const additional = screen.getByText('Additional')
+    const addresses = screen.getByText('Addresses')
+
+    expect(additional.compareDocumentPosition(addresses)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+  })
 })
 
 describe('CustomerFormPage - Edit mode', () => {

--- a/frontend/src/pages/sales/__tests__/CustomerFormPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CustomerFormPage.test.tsx
@@ -171,6 +171,12 @@ describe('CustomerFormPage - Create mode', () => {
       }),
     )
   })
+
+  it('renders Notes textarea without a fixed row count', () => {
+    renderCreatePage()
+
+    expect(screen.getByLabelText(/notes/i)).not.toHaveAttribute('rows')
+  })
 })
 
 describe('CustomerFormPage - Edit mode', () => {


### PR DESCRIPTION
## Summary

- Places Basic Information and Additional cards side by side (50/50) on desktop, stacked on mobile
- Places Billing and Shipping address columns side by side (50/50) inside the Addresses card, with the "Same as Billing" toggle moved into the Shipping column header
- Notes textarea flexes to fill remaining Additional card height instead of a fixed 4-row height
- `PriceListSelector` gains `size` and `sx` props so it matches the compact field styling of the rest of the form

## Bug fixes (from code review)

- **`AddressSection`**: guarded the title `<Grid>` row so `title=""` no longer emits a blank full-width row that misaligns shipping fields below billing fields
- **Notes height chain**: moved Notes out of the wrapped `<Grid container>` into a plain flex `Box`, fixing the `height: 100%` resolution that collapsed the textarea to a single line

## Test plan

- [x] Create customer form fits on a 1080p screen without scrolling
- [x] Basic Info and Additional cards are the same height; Notes fills the remaining space
- [x] Price List dropdown matches font size and height of Phone / Email fields
- [x] Billing and Shipping address fields align horizontally on desktop
- [x] "Same as Billing" toggle sits in the Shipping column header; syncs and disables fields correctly
- [x] On mobile (~600px), all sections stack vertically with correct spacing
- [x] All 22 unit tests pass: `npx vitest run src/components/price-lists/PriceListSelector.test.tsx src/pages/sales/__tests__/CustomerFormPage.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)