### PR TITLE
feat(sales): replace isFulfilled/paidAmount model with status/paymentStatus enums and SalesOrderPayment entity

### DIFF
--- a/backend/src/config/database-config.factory.ts
+++ b/backend/src/config/database-config.factory.ts
@@ -38,6 +38,7 @@ import { ReconciledTransaction } from '../database/entities/reconciled-transacti
 import { RefreshToken } from '../database/entities/refresh-token.entity';
 import { SalesOrder } from '../database/entities/sales-order.entity';
 import { SalesOrderItem } from '../database/entities/sales-order-item.entity';
+import { SalesOrderPayment } from '../database/entities/sales-order-payment.entity';
 import { SearchClick } from '../database/entities/search-click.entity';
 import { SearchQuery } from '../database/entities/search-query.entity';
 import { Settlement } from '../database/entities/settlement.entity';
@@ -91,7 +92,7 @@ export function createDatabaseConfig(configService: ConfigService, allowDefaults
       Invoice, InvoiceItem, JournalEntry, JournalEntryLine, OwnerEquityTransaction,
       Payment, PaymentMethodEntity, RegionalSettings, PriceList, PriceListItem,
       PrintSettings, Product, PurchaseCostHistory, PurchaseOrder, PurchaseOrderItem,
-      ReconciledTransaction, RefreshToken, SalesOrder, SalesOrderItem, SearchClick, SearchQuery, Settlement,
+      ReconciledTransaction, RefreshToken, SalesOrder, SalesOrderItem, SalesOrderPayment, SearchClick, SearchQuery, Settlement,
       StockAdjustment, StockAdjustmentItem, StockMovement, Supplier, User, VendorPayment,
     ],
     migrations: [__dirname + '/../database/migrations/*{.ts,.js}'],

--- a/backend/src/database/entities/invoice.entity.ts
+++ b/backend/src/database/entities/invoice.entity.ts
@@ -155,7 +155,7 @@ export class Invoice extends BaseEntity {
   @JoinColumn({ name: 'customerId' })
   customer: Customer;
 
-  @ManyToOne(() => SalesOrder, (salesOrder) => salesOrder.invoices, {
+  @ManyToOne(() => SalesOrder, {
     onDelete: 'SET NULL',
     nullable: true,
   })
@@ -239,7 +239,7 @@ export class Invoice extends BaseEntity {
 
   // Static factory method
   static fromSalesOrder(salesOrder: SalesOrder): Partial<Invoice> {
-    const paidAmount = Number(salesOrder.paidAmount || 0);
+    const paidAmount = 0;
     const totalAmount = Number(salesOrder.totalAmount);
     const shippingAmount = Number(salesOrder.shippingAmount || 0);
     const balanceDue = Math.max(0, totalAmount - paidAmount);

--- a/backend/src/database/entities/sales-order-payment.entity.ts
+++ b/backend/src/database/entities/sales-order-payment.entity.ts
@@ -1,0 +1,58 @@
+import {
+  Entity,
+  Column,
+  Index,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { IsDecimal, IsOptional, IsString } from 'class-validator';
+import { SalesOrder } from './sales-order.entity';
+import { PaymentMethodEntity } from './payment-method.entity';
+
+@Entity('sales_order_payments')
+@Index(['salesOrderId'])
+@Index(['paymentDate'])
+export class SalesOrderPayment {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  salesOrderId: string;
+
+  @Column({ type: 'uuid' })
+  paymentMethodId: string;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  @IsOptional()
+  @IsString()
+  referenceNumber?: string;
+
+  @Column({ type: 'decimal', precision: 15, scale: 4 })
+  @IsDecimal({ decimal_digits: '0,4' })
+  amount: number;
+
+  @Column({ type: 'date' })
+  paymentDate: string;
+
+  @Column({ type: 'text', nullable: true })
+  @IsOptional()
+  @IsString()
+  notes?: string;
+
+  @CreateDateColumn({ type: 'timestamptz', default: () => 'CURRENT_TIMESTAMP' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz', default: () => 'CURRENT_TIMESTAMP' })
+  updatedAt: Date;
+
+  @ManyToOne(() => SalesOrder, (o) => o.salesOrderPayments, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'salesOrderId' })
+  salesOrder: SalesOrder;
+
+  @ManyToOne(() => PaymentMethodEntity, { eager: false })
+  @JoinColumn({ name: 'paymentMethodId' })
+  paymentMethod: PaymentMethodEntity;
+}

--- a/backend/src/database/entities/sales-order.entity.ts
+++ b/backend/src/database/entities/sales-order.entity.ts
@@ -8,8 +8,8 @@ import {
 } from 'typeorm';
 import {
   IsString,
-  IsBoolean,
   IsOptional,
+  IsEnum,
   MaxLength,
   IsDecimal,
   Min,
@@ -18,114 +18,81 @@ import {
 import { BaseEntity } from './base.entity';
 import { Customer } from './customer.entity';
 import { SalesOrderItem } from './sales-order-item.entity';
-import { Invoice } from './invoice.entity';
+import { SalesOrderPayment } from './sales-order-payment.entity';
 
+export enum SalesOrderStatus {
+  DRAFT = 'DRAFT',
+  FULFILLED = 'FULFILLED',
+  CANCELLED = 'CANCELLED',
+}
 
-/**
- * Sales Order entity for managing customer orders
- * Supports comprehensive order tracking and fulfillment
- */
+export enum SalesOrderPaymentStatus {
+  UNPAID = 'UNPAID',
+  PARTIAL = 'PARTIAL',
+  PAID = 'PAID',
+  OVERPAID = 'OVERPAID',
+}
+
 @Entity('sales_orders')
 @Index(['orderNumber'], { unique: true })
 @Index(['customerId'])
 @Index(['orderDate'])
+@Index(['status'])
+@Index(['paymentStatus'])
 export class SalesOrder extends BaseEntity {
-  @Column({
-    type: 'varchar',
-    length: 30,
-    unique: true,
-    comment: 'Unique sales order number',
-  })
+  @Column({ type: 'varchar', length: 30, unique: true })
   @IsString()
   @MaxLength(30)
   orderNumber: string;
 
-  @Column({
-    type: 'date',
-    comment: 'Order date',
-  })
+  @Column({ type: 'date' })
   @IsDate()
   orderDate: Date;
 
-  @Column({
-    type: 'varchar',
-    length: 10,
-    default: 'USD',
-    comment: 'Transaction currency',
-  })
+  @Column({ type: 'varchar', length: 10, default: 'USD' })
   @IsString()
   @MaxLength(10)
   currency: string;
 
-  // Financial Information
+  @Column({
+    type: 'enum',
+    enum: SalesOrderStatus,
+    default: SalesOrderStatus.DRAFT,
+  })
+  @IsEnum(SalesOrderStatus)
+  status: SalesOrderStatus;
 
   @Column({
-    type: 'decimal',
-    precision: 15,
-    scale: 4,
-    default: 0,
-    comment: 'Shipping/freight charges',
+    type: 'enum',
+    enum: SalesOrderPaymentStatus,
+    default: SalesOrderPaymentStatus.UNPAID,
   })
+  @IsEnum(SalesOrderPaymentStatus)
+  paymentStatus: SalesOrderPaymentStatus;
+
+  @Column({ type: 'decimal', precision: 15, scale: 4, default: 0 })
+  @IsDecimal({ decimal_digits: '0,4' })
+  @Min(0)
+  subtotal: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 4, default: 0 })
   @IsDecimal({ decimal_digits: '0,4' })
   @Min(0)
   shippingAmount: number;
 
-  @Column({
-    type: 'decimal',
-    precision: 15,
-    scale: 4,
-    default: 0,
-    comment: 'Total order amount',
-  })
+  @Column({ type: 'decimal', precision: 15, scale: 4, default: 0 })
   @IsDecimal({ decimal_digits: '0,4' })
   @Min(0)
   totalAmount: number;
 
-  @Column({
-    type: 'decimal',
-    precision: 15,
-    scale: 4,
-    default: 0,
-    comment: 'Amount received from customer',
-  })
-  @IsDecimal({ decimal_digits: '0,4' })
-  @Min(0)
-  paidAmount: number;
-
-  @Column({
-    type: 'boolean',
-    default: false,
-    comment: 'Whether order is fulfilled (inventory deducted)',
-  })
-  @IsBoolean()
-  isFulfilled: boolean;
-
-  @Column({
-    type: 'timestamp',
-    nullable: true,
-    comment: 'Date when order was fulfilled',
-  })
-  @IsOptional()
-  @IsDate()
-  fulfilledDate?: Date;
-
-  @Column({
-    type: 'text',
-    nullable: true,
-    comment: 'Special instructions or notes',
-  })
+  @Column({ type: 'text', nullable: true })
   @IsOptional()
   @IsString()
   notes?: string;
 
-  // Foreign Keys
-  @Column({
-    type: 'uuid',
-    comment: 'Customer ID',
-  })
+  @Column({ type: 'uuid' })
   customerId: string;
 
-  // Relationships
   @ManyToOne(() => Customer, (customer) => customer.salesOrders, {
     onDelete: 'RESTRICT',
     eager: false,
@@ -139,36 +106,9 @@ export class SalesOrder extends BaseEntity {
   })
   items: SalesOrderItem[];
 
-  @OneToMany(() => Invoice, (invoice) => invoice.salesOrder, {
+  @OneToMany(() => SalesOrderPayment, (p) => p.salesOrder, {
     cascade: false,
+    eager: false,
   })
-  invoices: Invoice[];
-
-  // Computed properties
-  get isPaidInFull(): boolean {
-    return Number(this.paidAmount) >= Number(this.totalAmount);
-  }
-
-  get balanceDue(): number {
-    return Math.max(0, Number(this.totalAmount) - Number(this.paidAmount));
-  }
-
-  get canFulfill(): boolean {
-    return this.isPaidInFull && !this.isFulfilled;
-  }
-
-  get canUnfulfill(): boolean {
-    return this.isFulfilled;
-  }
-
-  // Note: Order number generation moved to service layer for better async handling
-
-  // Helper methods
-  calculateTotals(): void {
-    // This should be called after items are loaded
-    if (this.items && this.items.length > 0) {
-      this.totalAmount = this.items.reduce((sum, item) =>
-        sum + Number(item.totalAmount), 0);
-    }
-  }
+  salesOrderPayments: SalesOrderPayment[];
 }

--- a/backend/src/database/entities/sales-order.entity.ts
+++ b/backend/src/database/entities/sales-order.entity.ts
@@ -19,6 +19,7 @@ import { BaseEntity } from './base.entity';
 import { Customer } from './customer.entity';
 import { SalesOrderItem } from './sales-order-item.entity';
 import { SalesOrderPayment } from './sales-order-payment.entity';
+import { Invoice } from './invoice.entity';
 
 export enum SalesOrderStatus {
   DRAFT = 'DRAFT',
@@ -111,4 +112,48 @@ export class SalesOrder extends BaseEntity {
     eager: false,
   })
   salesOrderPayments: SalesOrderPayment[];
+
+  @OneToMany(() => Invoice, (invoice) => invoice.salesOrder, {
+    cascade: false,
+    eager: false,
+  })
+  invoices: Invoice[];
+
+  get isFulfilled(): boolean {
+    return this.status === SalesOrderStatus.FULFILLED;
+  }
+
+  get fulfilledDate(): Date | undefined {
+    return this.status === SalesOrderStatus.FULFILLED ? this.updatedAt : undefined;
+  }
+
+  get paidAmount(): number {
+    if (this.paymentStatus === SalesOrderPaymentStatus.UNPAID) return 0;
+    if (
+      this.paymentStatus === SalesOrderPaymentStatus.PAID ||
+      this.paymentStatus === SalesOrderPaymentStatus.OVERPAID
+    ) {
+      return Number(this.totalAmount);
+    }
+    return 0.01;
+  }
+
+  get isPaidInFull(): boolean {
+    return (
+      this.paymentStatus === SalesOrderPaymentStatus.PAID ||
+      this.paymentStatus === SalesOrderPaymentStatus.OVERPAID
+    );
+  }
+
+  get balanceDue(): number {
+    return this.isPaidInFull ? 0 : Number(this.totalAmount);
+  }
+
+  get canFulfill(): boolean {
+    return this.paymentStatus === SalesOrderPaymentStatus.PAID && this.status === SalesOrderStatus.DRAFT;
+  }
+
+  get canUnfulfill(): boolean {
+    return this.status === SalesOrderStatus.FULFILLED;
+  }
 }

--- a/backend/src/database/entities/sales-order.entity.ts
+++ b/backend/src/database/entities/sales-order.entity.ts
@@ -119,14 +119,17 @@ export class SalesOrder extends BaseEntity {
   })
   invoices: Invoice[];
 
+  /** @deprecated Use `status === SalesOrderStatus.FULFILLED` instead. Kept for analytics/invoice query compatibility. */
   get isFulfilled(): boolean {
     return this.status === SalesOrderStatus.FULFILLED;
   }
 
+  /** @deprecated Approximation only — returns updatedAt when fulfilled. Kept for accounting.service compatibility. */
   get fulfilledDate(): Date | undefined {
     return this.status === SalesOrderStatus.FULFILLED ? this.updatedAt : undefined;
   }
 
+  /** @deprecated Approximation only — does not reflect actual SalesOrderPayment records. Use paymentStatus enum instead. */
   get paidAmount(): number {
     if (this.paymentStatus === SalesOrderPaymentStatus.UNPAID) return 0;
     if (
@@ -138,6 +141,7 @@ export class SalesOrder extends BaseEntity {
     return 0.01;
   }
 
+  /** @deprecated Use `paymentStatus === PAID || paymentStatus === OVERPAID` instead. */
   get isPaidInFull(): boolean {
     return (
       this.paymentStatus === SalesOrderPaymentStatus.PAID ||
@@ -145,14 +149,17 @@ export class SalesOrder extends BaseEntity {
     );
   }
 
+  /** @deprecated Approximation only — returns 0 or totalAmount, not the real partial balance. */
   get balanceDue(): number {
     return this.isPaidInFull ? 0 : Number(this.totalAmount);
   }
 
+  /** @deprecated Use status and paymentStatus enums directly. */
   get canFulfill(): boolean {
     return this.paymentStatus === SalesOrderPaymentStatus.PAID && this.status === SalesOrderStatus.DRAFT;
   }
 
+  /** @deprecated Use `status === SalesOrderStatus.FULFILLED` instead. */
   get canUnfulfill(): boolean {
     return this.status === SalesOrderStatus.FULFILLED;
   }

--- a/backend/src/database/migrations/1779600000000-AddSalesOrderStatusPaymentStatusAndPayments.ts
+++ b/backend/src/database/migrations/1779600000000-AddSalesOrderStatusPaymentStatusAndPayments.ts
@@ -1,0 +1,102 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSalesOrderStatusPaymentStatusAndPayments1779600000000
+  implements MigrationInterface
+{
+  name = 'AddSalesOrderStatusPaymentStatusAndPayments1779600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "sales_orders"
+      ADD COLUMN IF NOT EXISTS "status" varchar(20)
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "sales_orders"
+      ADD COLUMN IF NOT EXISTS "paymentStatus" varchar(20)
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "sales_orders"
+      ADD COLUMN IF NOT EXISTS "subtotal" decimal(15,4) NOT NULL DEFAULT 0
+    `);
+
+    await queryRunner.query(`
+      UPDATE "sales_orders"
+      SET "status" = CASE WHEN "isFulfilled" = true THEN 'FULFILLED' ELSE 'DRAFT' END
+    `);
+
+    await queryRunner.query(`
+      UPDATE "sales_orders"
+      SET "paymentStatus" = CASE
+        WHEN "paidAmount" = 0 THEN 'UNPAID'
+        WHEN "paidAmount" > 0 AND "paidAmount" < "totalAmount" THEN 'PARTIAL'
+        WHEN "paidAmount" = "totalAmount" THEN 'PAID'
+        WHEN "paidAmount" > "totalAmount" THEN 'OVERPAID'
+        ELSE 'UNPAID'
+      END
+    `);
+
+    await queryRunner.query(`
+      UPDATE "sales_orders"
+      SET "subtotal" = GREATEST(0, "totalAmount" - COALESCE("shippingAmount", 0))
+    `);
+
+    await queryRunner.query(`ALTER TABLE "sales_orders" ALTER COLUMN "status" SET NOT NULL`);
+    await queryRunner.query(`ALTER TABLE "sales_orders" ALTER COLUMN "paymentStatus" SET NOT NULL`);
+
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_sales_orders_status" ON "sales_orders" ("status")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_sales_orders_paymentStatus" ON "sales_orders" ("paymentStatus")`,
+    );
+
+    await queryRunner.query(`ALTER TABLE "sales_orders" DROP COLUMN IF EXISTS "isFulfilled"`);
+    await queryRunner.query(`ALTER TABLE "sales_orders" DROP COLUMN IF EXISTS "fulfilledDate"`);
+    await queryRunner.query(`ALTER TABLE "sales_orders" DROP COLUMN IF EXISTS "paidAmount"`);
+
+    await queryRunner.query(`
+      CREATE TABLE "sales_order_payments" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "salesOrderId" uuid NOT NULL,
+        "paymentMethodId" uuid NOT NULL,
+        "referenceNumber" varchar(100),
+        "amount" decimal(15,4) NOT NULL,
+        "paymentDate" date NOT NULL,
+        "notes" text,
+        "createdAt" timestamptz NOT NULL DEFAULT now(),
+        "updatedAt" timestamptz NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_sales_order_payments" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_sop_salesOrder" FOREIGN KEY ("salesOrderId")
+          REFERENCES "sales_orders"("id") ON DELETE CASCADE,
+        CONSTRAINT "FK_sop_paymentMethod" FOREIGN KEY ("paymentMethodId")
+          REFERENCES "payment_methods"("id") ON DELETE RESTRICT
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_sop_salesOrderId" ON "sales_order_payments" ("salesOrderId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_sop_paymentDate" ON "sales_order_payments" ("paymentDate")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "sales_order_payments"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_sales_orders_status"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_sales_orders_paymentStatus"`);
+    await queryRunner.query(`ALTER TABLE "sales_orders" DROP COLUMN IF EXISTS "status"`);
+    await queryRunner.query(`ALTER TABLE "sales_orders" DROP COLUMN IF EXISTS "paymentStatus"`);
+    await queryRunner.query(`ALTER TABLE "sales_orders" DROP COLUMN IF EXISTS "subtotal"`);
+    await queryRunner.query(
+      `ALTER TABLE "sales_orders" ADD COLUMN IF NOT EXISTS "isFulfilled" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sales_orders" ADD COLUMN IF NOT EXISTS "fulfilledDate" timestamptz`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sales_orders" ADD COLUMN IF NOT EXISTS "paidAmount" decimal(15,4) NOT NULL DEFAULT 0`,
+    );
+  }
+}

--- a/backend/src/modules/inventory/services/product.service.ts
+++ b/backend/src/modules/inventory/services/product.service.ts
@@ -1939,10 +1939,6 @@ export class ProductService extends BaseCrudService<
     const salesOrders = salesOrderItems
       .filter(item => item.salesOrder) // Only process items with loaded order
       .map(item => {
-        const paidAmount = Number(item.salesOrder.paidAmount || 0);
-        const totalAmount = Number(item.salesOrder.totalAmount || 0);
-        const isPaid = paidAmount >= totalAmount;
-
         return {
           id: item.id,
           type: 'sales_order',
@@ -1950,8 +1946,8 @@ export class ProductService extends BaseCrudService<
           customerOrVendor: item.salesOrder.customer?.name || 'Unknown',
           date: item.salesOrder.orderDate,
           updatedAt: item.salesOrder.updatedAt, // Add updatedAt for sorting
-          paymentStatus: isPaid ? 'paid' : (paidAmount > 0 ? 'partial' : 'pending'),
-          fulfillmentStatus: item.salesOrder.isFulfilled ? 'fulfilled' : 'pending',
+          paymentStatus: item.salesOrder.paymentStatus?.toLowerCase() || 'pending',
+          fulfillmentStatus: item.salesOrder.status === 'FULFILLED' ? 'fulfilled' : 'pending',
           quantity: Number(item.quantity),
           subTotal: Number(item.totalAmount),
         };

--- a/backend/src/modules/inventory/services/product.service.ts
+++ b/backend/src/modules/inventory/services/product.service.ts
@@ -202,7 +202,7 @@ export class ProductService extends BaseCrudService<
       .createQueryBuilder('item')
       .leftJoin('item.salesOrder', 'order')
       .where('item.productId = :productId', { productId: entity.id })
-      .andWhere('order.isFulfilled = :isFulfilled', { isFulfilled: false })
+      .andWhere('order.status = :status', { status: 'DRAFT' })
       .getCount();
 
     if (activeSalesOrderItemCount > 0) {

--- a/backend/src/modules/sales/controllers/sales-order.controller.ts
+++ b/backend/src/modules/sales/controllers/sales-order.controller.ts
@@ -3,25 +3,19 @@ import {
   Get,
   Post,
   Put,
-  Delete,
   Body,
   Param,
   Query,
   ParseUUIDPipe,
   HttpCode,
   HttpStatus,
-  Request,
-  Res,
-  BadRequestException,
 } from '@nestjs/common';
-import { Response } from 'express';
 import {
   ApiTags,
   ApiOperation,
   ApiResponse,
   ApiParam,
   ApiQuery,
-  ApiBody,
 } from '@nestjs/swagger';
 import { SalesOrderService } from '../services/sales-order.service';
 import {
@@ -30,7 +24,8 @@ import {
   QuerySalesOrdersDto,
   SalesOrderResponseDto,
   SalesOrderSummaryDto,
-  RecordPaymentsDto,
+  RecordPaymentDto,
+  RecordRefundDto,
 } from '../dto/sales-order.dto';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 
@@ -41,231 +36,48 @@ export class SalesOrderController {
 
   @Post()
   @ApiOperation({ summary: 'Create a new sales order' })
-  @ApiResponse({
-    status: 201,
-    description: 'Sales order created successfully',
-    type: SalesOrderResponseDto,
-  })
-  @ApiResponse({ status: 400, description: 'Invalid input data' })
-  @ApiResponse({ status: 409, description: 'Insufficient inventory or credit limit exceeded' })
+  @ApiResponse({ status: 201, type: SalesOrderResponseDto })
   async createSalesOrder(
-    @Body() createSalesOrderDto: CreateSalesOrderDto,
-    @CurrentUser('userId') currentUserId: string,
-    @CurrentUser('username') currentUsername: string,
+    @Body() dto: CreateSalesOrderDto,
+    @CurrentUser('userId') userId: string,
+    @CurrentUser('username') username: string,
   ) {
-    const data = await this.salesOrderService.create(createSalesOrderDto, currentUserId, currentUsername);
+    const data = await this.salesOrderService.create(dto, userId, username);
     return { data };
-  }
-
-  @Get('deleted')
-  @ApiOperation({ summary: 'Get deleted sales orders with filtering and pagination' })
-  @ApiResponse({
-    status: 200,
-    description: 'List of deleted sales orders retrieved successfully',
-    type: [SalesOrderResponseDto],
-  })
-  @ApiQuery({ name: 'search', required: false, description: 'Search by order number or customer name' })
-  @ApiQuery({ name: 'customerId', required: false, description: 'Filter by customer ID' })
-  @ApiQuery({ name: 'sortBy', required: false, description: 'Sort field' })
-  @ApiQuery({ name: 'sortOrder', required: false, enum: ['ASC', 'DESC'], description: 'Sort order' })
-  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number' })
-  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Items per page' })
-  async getDeletedSalesOrders(@Query() query: QuerySalesOrdersDto) {
-    const data = await this.salesOrderService.findDeleted(query);
-    return data;
-  }
-
-  @Get()
-  @ApiOperation({ summary: 'Get all sales orders with filtering and pagination' })
-  @ApiResponse({
-    status: 200,
-    description: 'List of sales orders retrieved successfully',
-    type: [SalesOrderResponseDto],
-  })
-  @ApiQuery({ name: 'search', required: false, description: 'Search by order number or customer name' })
-  @ApiQuery({ name: 'customerId', required: false, description: 'Filter by customer ID' })
-  @ApiQuery({ name: 'fromDate', required: false, description: 'Filter orders from date' })
-  @ApiQuery({ name: 'toDate', required: false, description: 'Filter orders to date' })
-  @ApiQuery({ name: 'paymentStatus', required: false, enum: ['all', 'unpaid', 'partial', 'paid', 'overpaid'], description: 'Filter by payment status' })
-  @ApiQuery({ name: 'fulfillmentStatus', required: false, enum: ['all', 'fulfilled', 'unfulfilled'], description: 'Filter by fulfillment status' })
-  @ApiQuery({ name: 'sortBy', required: false, description: 'Sort field' })
-  @ApiQuery({ name: 'sortOrder', required: false, enum: ['ASC', 'DESC'], description: 'Sort order' })
-  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number' })
-  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Items per page' })
-  async getAllSalesOrders(@Query() query: QuerySalesOrdersDto) {
-    const data = await this.salesOrderService.findAll(query);
-    return data; // findAll returns paginated response structure optimized for listing
   }
 
   @Get('summary')
   @ApiOperation({ summary: 'Get sales orders summary list' })
-  @ApiResponse({
-    status: 200,
-    description: 'Sales order summaries retrieved successfully',
-    type: [SalesOrderSummaryDto],
-  })
+  @ApiResponse({ status: 200, type: [SalesOrderSummaryDto] })
   async getSalesOrderSummaries() {
     return this.salesOrderService.findSummaries();
   }
 
   @Get('dashboard-stats')
   @ApiOperation({ summary: 'Get sales order dashboard statistics' })
-  @ApiResponse({
-    status: 200,
-    description: 'Dashboard statistics retrieved successfully',
-  })
   async getDashboardStats() {
     return this.salesOrderService.getDashboardStats();
   }
 
-  @Get('test-invoices/:orderNumber')
-  @ApiOperation({ summary: 'Test endpoint to check invoice relations' })
-  async testInvoiceRelations(@Param('orderNumber') orderNumber: string) {
-    return this.salesOrderService.testInvoiceRelations(orderNumber);
-  }
-
-  @Get(':id')
-  @ApiOperation({ summary: 'Get sales order by ID' })
-  @ApiParam({ name: 'id', description: 'Sales order ID', type: 'string' })
-  @ApiResponse({
-    status: 200,
-    description: 'Sales order retrieved successfully',
-    type: SalesOrderResponseDto,
-  })
-  @ApiResponse({ status: 404, description: 'Sales order not found' })
-  async getSalesOrderById(@Param('id', ParseUUIDPipe) id: string): Promise<SalesOrderResponseDto> {
-    return this.salesOrderService.findById(id);
-  }
-
-  @Get('number/:orderNumber')
-  @ApiOperation({ summary: 'Get sales order by order number' })
-  @ApiParam({ name: 'orderNumber', description: 'Order number', type: 'string' })
-  @ApiResponse({
-    status: 200,
-    description: 'Sales order retrieved successfully',
-    type: SalesOrderResponseDto,
-  })
-  @ApiResponse({ status: 404, description: 'Sales order not found' })
-  async getSalesOrderByNumber(@Param('orderNumber') orderNumber: string): Promise<SalesOrderResponseDto> {
-    return this.salesOrderService.findByOrderNumber(orderNumber);
-  }
-
-  @Put(':id')
-  @ApiOperation({ summary: 'Update sales order' })
-  @ApiParam({ name: 'id', description: 'Sales order ID', type: 'string' })
-  @ApiResponse({
-    status: 200,
-    description: 'Sales order updated successfully',
-    type: SalesOrderResponseDto,
-  })
-  @ApiResponse({ status: 404, description: 'Sales order not found' })
-  @ApiResponse({ status: 400, description: 'Invalid input data, order is fulfilled (unfulfill first), or order is paid (unpay first)' })
-  async updateSalesOrder(
-    @Param('id', ParseUUIDPipe) id: string,
-    @Body() updateSalesOrderDto: UpdateSalesOrderDto,
-    @CurrentUser('userId') currentUserId: string,
-    @CurrentUser('username') currentUsername: string,
-  ): Promise<SalesOrderResponseDto> {
-    return this.salesOrderService.update(id, updateSalesOrderDto, currentUserId, currentUsername);
-  }
-
-  @Delete(':id')
-  @ApiOperation({ summary: 'Delete sales order and automatically show previous order details' })
-  @ApiParam({ name: 'id', description: 'Sales order ID', type: 'string' })
-  @ApiResponse({
-    status: 200,
-    description: 'Sales order deleted successfully, returns previous order details to display',
-    schema: {
-      oneOf: [
-        {
-          type: 'object',
-          properties: {
-            data: { $ref: '#/components/schemas/SalesOrderResponseDto' },
-            message: { type: 'string' },
-            deletedOrderNumber: { type: 'string' }
-          }
-        },
-        {
-          type: 'object',
-          properties: {
-            data: { type: 'null' },
-            message: { type: 'string' },
-            deletedOrderNumber: { type: 'string' },
-            redirect: { type: 'string' }
-          }
-        }
-      ]
-    }
-  })
-  @ApiResponse({ status: 404, description: 'Sales order not found' })
-  @ApiResponse({ status: 400, description: 'Order is fulfilled (unfulfill first) or order is paid (unpay first)' })
-  @ApiResponse({ status: 409, description: 'Cannot delete order in current status' })
-  async deleteSalesOrder(
-    @Param('id', ParseUUIDPipe) id: string,
-    @CurrentUser('userId') currentUserId: string,
-    @CurrentUser('username') currentUsername: string,
-  ): Promise<{
-    data: SalesOrderResponseDto | null;
-    message: string;
-    deletedOrderNumber: string;
-    redirect?: string;
-  }> {
-    const result = await this.salesOrderService.delete(id, currentUserId, currentUsername);
-
-    if (result.previousOrder) {
-      // Return the previous order as the main data to display
-      return {
-        data: result.previousOrder,
-        message: `Sales order ${result.deletedOrderNumber} deleted successfully. Now showing previous order: ${result.previousOrder.orderNumber}`,
-        deletedOrderNumber: result.deletedOrderNumber
-      };
-    } else {
-      // No previous order exists, suggest redirecting to order list
-      return {
-        data: null,
-        message: `Sales order ${result.deletedOrderNumber} deleted successfully. No previous orders available.`,
-        deletedOrderNumber: result.deletedOrderNumber,
-        redirect: '/sales-orders'
-      };
-    }
-  }
-
-  @Post(':id/duplicate')
-  @ApiOperation({ summary: 'Duplicate sales order' })
-  @ApiParam({ name: 'id', description: 'Sales order ID to duplicate', type: 'string' })
-  @ApiResponse({
-    status: 201,
-    description: 'Sales order duplicated successfully',
-    type: SalesOrderResponseDto,
-  })
-  @ApiResponse({ status: 404, description: 'Sales order not found' })
-  async duplicateOrder(
-    @Param('id', ParseUUIDPipe) id: string,
-  ): Promise<SalesOrderResponseDto> {
-    return this.salesOrderService.duplicateOrder(id, null); // Auth removed - no user tracking
-  }
-
-  @Get(':id/fulfillment-status')
-  @ApiOperation({ summary: 'Get order fulfillment status' })
-  @ApiParam({ name: 'id', description: 'Sales order ID', type: 'string' })
-  @ApiResponse({
-    status: 200,
-    description: 'Fulfillment status retrieved successfully',
-  })
-  @ApiResponse({ status: 404, description: 'Sales order not found' })
-  async getFulfillmentStatus(@Param('id', ParseUUIDPipe) id: string) {
-    return this.salesOrderService.getFulfillmentStatus(id);
+  @Get()
+  @ApiOperation({ summary: 'List sales orders' })
+  @ApiQuery({ name: 'status', required: false, enum: ['DRAFT', 'FULFILLED', 'CANCELLED'] })
+  @ApiQuery({ name: 'paymentStatus', required: false, enum: ['UNPAID', 'PARTIAL', 'PAID', 'OVERPAID'] })
+  @ApiQuery({ name: 'customerId', required: false })
+  @ApiQuery({ name: 'fromDate', required: false })
+  @ApiQuery({ name: 'toDate', required: false })
+  @ApiQuery({ name: 'search', required: false })
+  @ApiQuery({ name: 'sortBy', required: false })
+  @ApiQuery({ name: 'sortOrder', required: false, enum: ['ASC', 'DESC'] })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  async getAllSalesOrders(@Query() query: QuerySalesOrdersDto) {
+    return this.salesOrderService.findAll(query);
   }
 
   @Get('customer/:customerId')
-  @ApiOperation({ summary: 'Get sales orders for a specific customer' })
-  @ApiParam({ name: 'customerId', description: 'Customer ID', type: 'string' })
-  @ApiResponse({
-    status: 200,
-    description: 'Customer sales orders retrieved successfully',
-    type: [SalesOrderSummaryDto],
-  })
-  @ApiResponse({ status: 404, description: 'Customer not found' })
+  @ApiOperation({ summary: 'Get sales orders for a customer' })
+  @ApiParam({ name: 'customerId', type: 'string' })
   async getOrdersByCustomer(
     @Param('customerId', ParseUUIDPipe) customerId: string,
     @Query('limit') limit?: number,
@@ -273,250 +85,118 @@ export class SalesOrderController {
     return this.salesOrderService.findOrdersByCustomer(customerId, limit);
   }
 
-  @Get(':id/invoices')
-  @ApiOperation({ summary: 'Get invoices related to sales order' })
-  @ApiParam({ name: 'id', description: 'Sales order ID', type: 'string' })
-  @ApiResponse({
-    status: 200,
-    description: 'Related invoices retrieved successfully',
-  })
-  @ApiResponse({ status: 404, description: 'Sales order not found' })
-  async getOrderInvoices(@Param('id', ParseUUIDPipe) id: string) {
-    return this.salesOrderService.getOrderInvoices(id);
+  @Get('number/:orderNumber')
+  @ApiOperation({ summary: 'Get sales order by order number' })
+  async getSalesOrderByNumber(@Param('orderNumber') orderNumber: string): Promise<SalesOrderResponseDto> {
+    return this.salesOrderService.findByOrderNumber(orderNumber);
   }
 
-  @Post(':id/create-invoice')
-  @ApiOperation({ summary: 'Create invoice from sales order' })
-  @ApiParam({ name: 'id', description: 'Sales order ID', type: 'string' })
-  @ApiResponse({
-    status: 201,
-    description: 'Invoice created successfully from sales order',
-  })
-  @ApiResponse({ status: 404, description: 'Sales order not found' })
-  @ApiResponse({ status: 409, description: 'Cannot create invoice for order in current status' })
-  async createInvoiceFromOrder(@Param('id', ParseUUIDPipe) id: string) {
-    return this.salesOrderService.createInvoiceFromOrder(id);
+  @Get(':id')
+  @ApiOperation({ summary: 'Get sales order by ID' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @ApiResponse({ status: 200, type: SalesOrderResponseDto })
+  async getSalesOrderById(@Param('id', ParseUUIDPipe) id: string): Promise<SalesOrderResponseDto> {
+    return this.salesOrderService.findById(id);
   }
 
-  @Post(':id/record-payments')
-  @ApiOperation({ summary: 'Record multiple split payments for a sales order (atomic)' })
-  @ApiParam({ name: 'id', description: 'Sales order ID', type: 'string' })
-  @ApiResponse({
-    status: 200,
-    description: 'Payments recorded successfully',
-    type: SalesOrderResponseDto,
-  })
-  @ApiResponse({ status: 404, description: 'Sales order not found' })
-  @ApiResponse({ status: 400, description: 'Invalid payment data' })
-  async recordPayments(
+  @Put(':id')
+  @ApiOperation({ summary: 'Update sales order (DRAFT + UNPAID only)' })
+  @ApiParam({ name: 'id', type: 'string' })
+  async updateSalesOrder(
     @Param('id', ParseUUIDPipe) id: string,
-    @Body() body: RecordPaymentsDto,
-  ) {
-    const data = await this.salesOrderService.recordPayments(id, body.payments);
-    return { data };
+    @Body() dto: UpdateSalesOrderDto,
+    @CurrentUser('userId') userId: string,
+    @CurrentUser('username') username: string,
+  ): Promise<SalesOrderResponseDto> {
+    return this.salesOrderService.update(id, dto, userId, username);
   }
 
-  @Post(':id/record-payment')
-  @ApiOperation({ summary: 'Record payment amount for sales order' })
-  @ApiParam({ name: 'id', description: 'Sales order ID', type: 'string' })
-  @ApiBody({
-    schema: {
-      type: 'object',
-      properties: {
-        amount: {
-          type: 'number',
-          minimum: 0,
-          description: 'Payment amount received'
-        },
-        paymentMethodId: {
-          type: 'string',
-          format: 'uuid',
-          description: 'Optional payment method ID. Defaults to CASH if not provided.'
-        }
-      },
-      required: ['amount']
-    }
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'Payment recorded successfully',
-    type: SalesOrderResponseDto,
-  })
-  @ApiResponse({ status: 404, description: 'Sales order not found' })
-  @ApiResponse({ status: 400, description: 'Invalid payment amount' })
-  async recordPayment(
-    @Param('id', ParseUUIDPipe) id: string,
-    @Body() body: { amount: number; paymentMethodId?: string }
-  ) {
-    if (body.paymentMethodId && !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(body.paymentMethodId)) {
-      throw new BadRequestException('Invalid paymentMethodId format');
-    }
-    const data = await this.salesOrderService.recordPayment(id, body.amount, body.paymentMethodId);
-    return { data };
-  }
-
-  @Post(':id/unpay')
-  @ApiOperation({ summary: 'Remove payment from sales order (reset to unpaid)' })
-  @ApiParam({ name: 'id', description: 'Sales order ID', type: 'string' })
-  @ApiResponse({
-    status: 200,
-    description: 'Payment removed successfully',
-    type: SalesOrderResponseDto,
-  })
-  @ApiResponse({ status: 404, description: 'Sales order not found' })
-  @ApiResponse({ status: 409, description: 'Cannot unpay fulfilled order' })
-  async unpayOrder(@Param('id', ParseUUIDPipe) id: string) {
-    const data = await this.salesOrderService.unpayOrder(id);
-    return { data };
-  }
-
-  @Post(':id/fulfill-order')
-  @ApiOperation({ summary: 'Fulfill order (confirm payment and deduct inventory)' })
-  @ApiParam({ name: 'id', description: 'Sales order ID', type: 'string' })
-  @ApiResponse({
-    status: 200,
-    description: 'Order fulfilled successfully, inventory deducted',
-    type: SalesOrderResponseDto,
-  })
-  @ApiResponse({ status: 404, description: 'Sales order not found' })
-  @ApiResponse({ status: 409, description: 'Cannot fulfill order - payment insufficient or already fulfilled' })
+  @Post(':id/fulfill')
+  @ApiOperation({ summary: 'Fulfill order (requires paymentStatus = PAID)' })
+  @ApiParam({ name: 'id', type: 'string' })
   async fulfillOrder(
     @Param('id', ParseUUIDPipe) id: string,
-    @CurrentUser('userId') currentUserId: string,
-    @CurrentUser('username') currentUsername: string,
+    @CurrentUser('userId') userId: string,
+    @CurrentUser('username') username: string,
   ) {
-    const data = await this.salesOrderService.fulfillOrder(id, currentUserId, currentUsername);
+    const data = await this.salesOrderService.fulfillOrder(id, userId, username);
     return { data };
   }
 
-  @Post(':id/unfulfill-order')
-  @ApiOperation({ summary: 'Unfulfill order (reverse fulfillment and restore inventory)' })
-  @ApiParam({ name: 'id', description: 'Sales order ID', type: 'string' })
-  @ApiResponse({
-    status: 200,
-    description: 'Order unfulfilled successfully, inventory restored',
-    type: SalesOrderResponseDto,
-  })
-  @ApiResponse({ status: 404, description: 'Sales order not found' })
-  @ApiResponse({ status: 409, description: 'Cannot unfulfill order - order is not fulfilled' })
-  async unfulfillOrder(@Param('id', ParseUUIDPipe) id: string) {
-    const data = await this.salesOrderService.unfulfillOrder(id);
+  @Post(':id/unfulfill')
+  @ApiOperation({ summary: 'Unfulfill order (always allowed from FULFILLED)' })
+  @ApiParam({ name: 'id', type: 'string' })
+  async unfulfillOrder(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') userId: string,
+    @CurrentUser('username') username: string,
+  ) {
+    const data = await this.salesOrderService.unfulfillOrder(id, userId, username);
     return { data };
   }
 
-  @Post(':id/restore')
-  @ApiOperation({ summary: 'Restore deleted sales order' })
-  @ApiParam({ name: 'id', description: 'Sales order ID', type: 'string' })
-  @ApiResponse({
-    status: 200,
-    description: 'Sales order restored successfully',
-    type: SalesOrderResponseDto,
-  })
-  @ApiResponse({ status: 404, description: 'Sales order not found' })
-  @ApiResponse({ status: 409, description: 'Sales order is not deleted' })
-  async restoreSalesOrder(
-    @Param('id', ParseUUIDPipe) id: string,
-    @CurrentUser('userId') currentUserId: string,
-    @CurrentUser('username') currentUsername: string,
-  ): Promise<SalesOrderResponseDto> {
-    return this.salesOrderService.restore(id, currentUserId, currentUsername);
-  }
-
-  @Post('bulk-restore')
-  @ApiOperation({ summary: 'Bulk restore soft-deleted sales orders' })
-  @ApiResponse({
-    status: 200,
-    description: 'Sales orders restored successfully',
-  })
-  @ApiResponse({ status: 400, description: 'Invalid sales order IDs or sales orders are not deleted' })
-  @ApiBody({
-    schema: {
-      type: 'object',
-      properties: {
-        salesOrderIds: {
-          type: 'array',
-          items: { type: 'string', format: 'uuid' },
-          description: 'Array of sales order IDs to restore'
-        }
-      },
-      required: ['salesOrderIds']
-    }
-  })
+  @Post(':id/cancel')
+  @ApiOperation({ summary: 'Cancel order (DRAFT + UNPAID only)' })
+  @ApiParam({ name: 'id', type: 'string' })
   @HttpCode(HttpStatus.OK)
-  async bulkRestore(
-    @Body() body: { salesOrderIds: string[] },
-    @CurrentUser('userId') currentUserId: string,
-    @CurrentUser('username') currentUsername: string,
-  ): Promise<{ message: string; restoredCount: number; failedIds: string[] }> {
-    const result = await this.salesOrderService.bulkRestore(
-      body.salesOrderIds,
-      currentUserId,
-      currentUsername,
-    );
-    return {
-      message: `Successfully restored ${result.successCount} of ${body.salesOrderIds.length} sales orders`,
-      restoredCount: result.successCount,
-      failedIds: result.failedItems.map(item => item.id),
-    };
-  }
-
-  @Post('bulk-permanent-delete')
-  @ApiOperation({ summary: 'Bulk permanently delete sales orders from database' })
-  @ApiResponse({
-    status: 200,
-    description: 'Sales orders permanently deleted successfully',
-  })
-  @ApiResponse({ status: 400, description: 'Invalid sales order IDs or sales orders have active references' })
-  @ApiBody({
-    schema: {
-      type: 'object',
-      properties: {
-        salesOrderIds: {
-          type: 'array',
-          items: { type: 'string', format: 'uuid' },
-          description: 'Array of sales order IDs to permanently delete'
-        }
-      },
-      required: ['salesOrderIds']
-    }
-  })
-  @HttpCode(HttpStatus.OK)
-  async bulkPermanentDelete(
-    @Body() body: { salesOrderIds: string[] },
-    @CurrentUser('userId') currentUserId: string,
-    @CurrentUser('username') currentUsername: string,
-  ): Promise<{ message: string; deletedCount: number; failedIds: string[] }> {
-    const result = await this.salesOrderService.bulkPermanentDelete(
-      body.salesOrderIds,
-      currentUserId,
-      currentUsername,
-    );
-    return {
-      message: `Successfully permanently deleted ${result.successCount} of ${body.salesOrderIds.length} sales orders`,
-      deletedCount: result.successCount,
-      failedIds: result.failedItems.map(item => item.id),
-    };
-  }
-
-  @Delete(':id/permanent')
-  @ApiOperation({ summary: 'Permanently delete a sales order from database' })
-  @ApiResponse({
-    status: 204,
-    description: 'Sales order permanently deleted successfully',
-  })
-  @ApiResponse({ status: 404, description: 'Sales order not found' })
-  @ApiResponse({
-    status: 400,
-    description: 'Sales order must be soft-deleted first or has active references'
-  })
-  @ApiParam({ name: 'id', description: 'Sales order ID' })
-  @HttpCode(HttpStatus.NO_CONTENT)
-  async permanentDelete(
+  async cancelOrder(
     @Param('id', ParseUUIDPipe) id: string,
-    @CurrentUser('userId') currentUserId: string,
-    @CurrentUser('username') currentUsername: string,
-  ): Promise<void> {
-    await this.salesOrderService.permanentDelete(id, currentUserId, currentUsername);
+    @CurrentUser('userId') userId: string,
+    @CurrentUser('username') username: string,
+  ) {
+    const data = await this.salesOrderService.cancel(id, userId, username);
+    return { data };
   }
 
+  @Post(':id/uncancel')
+  @ApiOperation({ summary: 'Uncancel order (CANCELLED -> DRAFT)' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @HttpCode(HttpStatus.OK)
+  async uncancelOrder(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('userId') userId: string,
+    @CurrentUser('username') username: string,
+  ) {
+    const data = await this.salesOrderService.uncancel(id, userId, username);
+    return { data };
+  }
+
+  @Get(':id/payments')
+  @ApiOperation({ summary: 'List payment records for a sales order' })
+  @ApiParam({ name: 'id', type: 'string' })
+  async listPayments(@Param('id', ParseUUIDPipe) id: string) {
+    const data = await this.salesOrderService.listPayments(id);
+    return { data };
+  }
+
+  @Post(':id/payments')
+  @ApiOperation({ summary: 'Record a payment (DRAFT orders only)' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @HttpCode(HttpStatus.OK)
+  async recordPayment(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: RecordPaymentDto,
+  ) {
+    const data = await this.salesOrderService.recordPayment(id, dto);
+    return { data };
+  }
+
+  @Post(':id/refunds')
+  @ApiOperation({ summary: 'Record a refund (creates negative payment record)' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @HttpCode(HttpStatus.OK)
+  async recordRefund(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: RecordRefundDto,
+  ) {
+    const data = await this.salesOrderService.recordRefund(id, dto);
+    return { data };
+  }
+
+  @Post(':id/duplicate')
+  @ApiOperation({ summary: 'Duplicate sales order' })
+  @ApiParam({ name: 'id', type: 'string' })
+  async duplicateOrder(@Param('id', ParseUUIDPipe) id: string): Promise<SalesOrderResponseDto> {
+    return this.salesOrderService.duplicateOrder(id, null);
+  }
 }

--- a/backend/src/modules/sales/controllers/sales-order.controller.ts
+++ b/backend/src/modules/sales/controllers/sales-order.controller.ts
@@ -176,8 +176,10 @@ export class SalesOrderController {
   async recordPayment(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: RecordPaymentDto,
+    @CurrentUser('userId') userId: string,
+    @CurrentUser('username') username: string,
   ) {
-    const data = await this.salesOrderService.recordPayment(id, dto);
+    const data = await this.salesOrderService.recordPayment(id, dto, userId, username);
     return { data };
   }
 
@@ -188,8 +190,10 @@ export class SalesOrderController {
   async recordRefund(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: RecordRefundDto,
+    @CurrentUser('userId') userId: string,
+    @CurrentUser('username') username: string,
   ) {
-    const data = await this.salesOrderService.recordRefund(id, dto);
+    const data = await this.salesOrderService.recordRefund(id, dto, userId, username);
     return { data };
   }
 

--- a/backend/src/modules/sales/dto/sales-order.dto.ts
+++ b/backend/src/modules/sales/dto/sales-order.dto.ts
@@ -8,12 +8,12 @@ import {
   IsArray,
   ValidateNested,
   IsInt,
-  ArrayMinSize,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
 import { DiscountType } from '../../../database/entities/sales-order-item.entity';
 import { BaseQueryDto } from '../../../common/dto/base-query.dto';
+import { SalesOrderStatus, SalesOrderPaymentStatus } from '../../../database/entities/sales-order.entity';
 
 export class SalesOrderItemDto {
   @ApiProperty({
@@ -168,24 +168,13 @@ export class QuerySalesOrdersDto extends BaseQueryDto {
   @IsString()
   toDate?: string;
 
-  @ApiPropertyOptional({
-    description: 'Filter by payment status',
-    enum: ['all', 'unpaid', 'partial', 'paid', 'overpaid'],
-    example: 'paid',
-  })
+  @ApiPropertyOptional({ enum: SalesOrderPaymentStatus })
   @IsOptional()
-  @IsString()
-  paymentStatus?: 'all' | 'unpaid' | 'partial' | 'paid' | 'overpaid';
+  paymentStatus?: SalesOrderPaymentStatus | 'all';
 
-  @ApiPropertyOptional({
-    description: 'Filter by fulfillment status',
-    enum: ['all', 'fulfilled', 'unfulfilled'],
-    example: 'fulfilled',
-  })
+  @ApiPropertyOptional({ enum: SalesOrderStatus })
   @IsOptional()
-  @IsString()
-  fulfillmentStatus?: 'all' | 'fulfilled' | 'unfulfilled';
-
+  status?: SalesOrderStatus | 'all';
 }
 
 export class SalesOrderItemResponseDto {
@@ -233,32 +222,20 @@ export class SalesOrderResponseDto {
   @ApiProperty({ example: '2024-01-01' })
   orderDate: Date;
 
-  @ApiProperty({ example: '2024-01-10', nullable: true })
-  fulfilledDate?: Date;
+  @ApiProperty({ enum: SalesOrderStatus })
+  status: SalesOrderStatus;
+
+  @ApiProperty({ enum: SalesOrderPaymentStatus })
+  paymentStatus: SalesOrderPaymentStatus;
+
+  @ApiProperty({ example: 941.50 })
+  subtotal: number;
 
   @ApiProperty({ example: 50.00 })
   shippingAmount: number;
 
   @ApiProperty({ example: 991.50 })
   totalAmount: number;
-
-  @ApiProperty({ example: 500.00 })
-  paidAmount: number;
-
-  @ApiProperty({ example: false })
-  isFulfilled: boolean;
-
-  @ApiProperty({ example: false })
-  isPaidInFull: boolean;
-
-  @ApiProperty({ example: 491.50 })
-  balanceDue: number;
-
-  @ApiProperty({ example: false })
-  canFulfill: boolean;
-
-  @ApiProperty({ example: false })
-  canUnfulfill: boolean;
 
   @ApiProperty({ example: 'Fragile items, handle with care', nullable: true })
   notes?: string;
@@ -288,25 +265,15 @@ export class SalesOrderResponseDto {
   @ApiProperty({ example: '2024-01-01T00:00:00Z' })
   updatedAt: Date;
 
-  @ApiProperty({ example: '2024-01-01T00:00:00Z', nullable: true })
-  deletedAt?: Date;
-
-  @ApiProperty({ type: 'array', items: { type: 'object' } })
-  invoices: {
-    id: string;
-    invoiceNumber: string;
-    status: string;
-    invoiceDate: Date;
-    totalAmount: number;
-    paidAmount: number;
-  }[];
-
   @ApiProperty({ type: 'array', items: { type: 'object' } })
   payments: {
     id: string;
-    paymentNumber: string;
     amount: number;
-    paymentDate: Date | string;
+    paymentDate: string;
+    referenceNumber?: string;
+    notes?: string;
+    paymentMethodId: string;
+    paymentMethodName?: string;
   }[];
 }
 
@@ -333,27 +300,30 @@ export class SalesOrderSummaryDto {
   itemsCount: number;
 }
 
-export class PaymentLineDto {
+export class RecordPaymentDto {
   @ApiProperty({ description: 'Payment method ID' })
   @IsUUID()
   paymentMethodId: string;
 
-  @ApiProperty({ description: 'Payment amount', example: 500.00 })
+  @ApiProperty({ example: 500.00 })
   @IsNumber({ maxDecimalPlaces: 4 })
   @Min(0.01)
   @Transform(({ value }) => parseFloat(value))
   amount: number;
 
-  @ApiPropertyOptional({ description: 'Payment reference (check number, transaction ID, etc.)' })
+  @ApiProperty({ example: '2026-05-26' })
+  @IsString()
+  paymentDate: string;
+
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
-  reference?: string;
+  referenceNumber?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  notes?: string;
 }
 
-export class RecordPaymentsDto {
-  @ApiProperty({ description: 'Array of payment lines', type: [PaymentLineDto] })
-  @ValidateNested({ each: true })
-  @Type(() => PaymentLineDto)
-  @ArrayMinSize(1)
-  payments: PaymentLineDto[];
-}
+export class RecordRefundDto extends RecordPaymentDto {}

--- a/backend/src/modules/sales/dto/sales-order.dto.ts
+++ b/backend/src/modules/sales/dto/sales-order.dto.ts
@@ -8,6 +8,7 @@ import {
   IsArray,
   ValidateNested,
   IsInt,
+  Matches,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
@@ -312,7 +313,7 @@ export class RecordPaymentDto {
   amount: number;
 
   @ApiProperty({ example: '2026-05-26' })
-  @IsString()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'paymentDate must be a valid date in YYYY-MM-DD format' })
   paymentDate: string;
 
   @ApiPropertyOptional()

--- a/backend/src/modules/sales/sales.module.ts
+++ b/backend/src/modules/sales/sales.module.ts
@@ -5,6 +5,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Customer } from '../../database/entities/customer.entity';
 import { SalesOrder } from '../../database/entities/sales-order.entity';
 import { SalesOrderItem } from '../../database/entities/sales-order-item.entity';
+import { SalesOrderPayment } from '../../database/entities/sales-order-payment.entity';
 import { Product } from '../../database/entities/product.entity';
 import { Invoice } from '../../database/entities/invoice.entity';
 import { InvoiceItem } from '../../database/entities/invoice-item.entity';
@@ -46,6 +47,7 @@ import { TransactionManager } from '../../common/utils/transaction.util';
       Customer,
       SalesOrder,
       SalesOrderItem,
+      SalesOrderPayment,
       Product,
       Invoice,
       InvoiceItem,

--- a/backend/src/modules/sales/services/sales-order-fulfillment.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-fulfillment.service.spec.ts
@@ -1,249 +1,98 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { ConflictException, NotFoundException } from '@nestjs/common';
 import { Repository } from 'typeorm';
-
+import { ConflictException, NotFoundException } from '@nestjs/common';
 import { SalesOrderFulfillmentService } from './sales-order-fulfillment.service';
-import { InventoryIntegrationService } from './inventory-integration.service';
-import { SalesOrder } from '../../../database/entities/sales-order.entity';
-import { Invoice } from '../../../database/entities/invoice.entity';
-import { Product } from '../../../database/entities/product.entity';
+import { SalesOrder, SalesOrderStatus, SalesOrderPaymentStatus } from '../../../database/entities/sales-order.entity';
 import { SalesOrderItem } from '../../../database/entities/sales-order-item.entity';
-import { Customer } from '../../../database/entities/customer.entity';
-import { StockMovementService } from '../../../modules/inventory/services/stock-movement.service';
+import { InventoryIntegrationService } from './inventory-integration.service';
+import { StockMovementService } from '../../inventory/services/stock-movement.service';
 import { BaseCostCalculatorService } from '../../inventory/services/base-cost-calculator.service';
-import { AccountingService } from '../../accounting/services/accounting.service';
 import { AuditLogService } from '../../audit-logs/services';
+
+const mockOrder = (overrides: Partial<SalesOrder> = {}): SalesOrder => ({
+  id: 'order-1',
+  orderNumber: 'SO-000001',
+  status: SalesOrderStatus.DRAFT,
+  paymentStatus: SalesOrderPaymentStatus.PAID,
+  totalAmount: 1000,
+  customerId: 'customer-1',
+  items: [{ id: 'item-1', productId: 'product-1', quantity: 5, product: { id: 'product-1' } } as SalesOrderItem],
+  ...overrides,
+} as SalesOrder);
 
 describe('SalesOrderFulfillmentService', () => {
   let service: SalesOrderFulfillmentService;
-  let salesOrderRepository: jest.Mocked<Repository<SalesOrder>>;
-  let inventoryIntegrationService: jest.Mocked<InventoryIntegrationService>;
+  let orderRepo: jest.Mocked<Repository<SalesOrder>>;
+  let inventoryService: jest.Mocked<InventoryIntegrationService>;
   let stockMovementService: jest.Mocked<StockMovementService>;
   let baseCostCalculator: jest.Mocked<BaseCostCalculatorService>;
-  let accountingService: jest.Mocked<AccountingService>;
   let auditLogService: jest.Mocked<AuditLogService>;
-
-  const createMockSalesOrder = (): Partial<SalesOrder> => ({
-    id: '123e4567-e89b-12d3-a456-426614174000',
-    orderNumber: 'SO-000001',
-    isFulfilled: false,
-    isPaidInFull: true,
-    balanceDue: 0,
-    paidAmount: 1000,
-    totalAmount: 1000,
-    fulfilledDate: null,
-    items: [
-      {
-        id: 'item-1',
-        productId: 'product-1',
-        quantity: 10,
-        product: {
-          id: 'product-1',
-          name: 'Test Product',
-          baseCost: 50,
-        } as Product,
-      } as SalesOrderItem,
-    ],
-    customer: {
-      id: 'customer-1',
-      name: 'Test Customer',
-    } as Customer,
-  });
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SalesOrderFulfillmentService,
-        {
-          provide: getRepositoryToken(SalesOrder),
-          useValue: {
-            findOne: jest.fn(),
-            save: jest.fn(),
-          },
-        },
-        {
-          provide: getRepositoryToken(Invoice),
-          useValue: {},
-        },
-        {
-          provide: InventoryIntegrationService,
-          useValue: {
-            adjustStock: jest.fn(),
-          },
-        },
-        {
-          provide: StockMovementService,
-          useValue: {
-            deleteByReference: jest.fn(),
-          },
-        },
-        {
-          provide: BaseCostCalculatorService,
-          useValue: {
-            restoreStock: jest.fn(),
-          },
-        },
-        {
-          provide: AccountingService,
-          useValue: {
-            postSalesOrderEntry: jest.fn(),
-            reverseSourceEntries: jest.fn(),
-          },
-        },
-        {
-          provide: AuditLogService,
-          useValue: {
-            log: jest.fn(),
-          },
-        },
+        { provide: getRepositoryToken(SalesOrder), useValue: { findOne: jest.fn(), save: jest.fn() } },
+        { provide: InventoryIntegrationService, useValue: { adjustStock: jest.fn() } },
+        { provide: StockMovementService, useValue: { deleteByReference: jest.fn().mockResolvedValue({ deletedCount: 1 }) } },
+        { provide: BaseCostCalculatorService, useValue: { restoreStock: jest.fn() } },
+        { provide: AuditLogService, useValue: { log: jest.fn() } },
       ],
     }).compile();
 
     service = module.get(SalesOrderFulfillmentService);
-    salesOrderRepository = module.get(getRepositoryToken(SalesOrder));
-    inventoryIntegrationService = module.get(InventoryIntegrationService);
+    orderRepo = module.get(getRepositoryToken(SalesOrder));
+    inventoryService = module.get(InventoryIntegrationService);
     stockMovementService = module.get(StockMovementService);
     baseCostCalculator = module.get(BaseCostCalculatorService);
-    accountingService = module.get(AccountingService);
     auditLogService = module.get(AuditLogService);
   });
 
   describe('fulfillOrder', () => {
-    it('should post accounting entry successfully', async () => {
-      const mockSalesOrder = createMockSalesOrder();
-      const orderId = mockSalesOrder.id;
-      const savedOrder = { ...mockSalesOrder, isFulfilled: true, fulfilledDate: new Date() };
-
-      salesOrderRepository.findOne
-        .mockResolvedValueOnce(mockSalesOrder as SalesOrder)
-        .mockResolvedValueOnce(savedOrder as SalesOrder);
-      salesOrderRepository.save.mockResolvedValue(savedOrder as SalesOrder);
-      inventoryIntegrationService.adjustStock.mockResolvedValue(undefined);
-      auditLogService.log.mockResolvedValue(undefined);
-      accountingService.postSalesOrderEntry.mockResolvedValue({ id: 'journal-1' } as any);
-
-      const result = await service.fulfillOrder(orderId);
-
-      expect(accountingService.postSalesOrderEntry).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: orderId,
-          orderNumber: mockSalesOrder.orderNumber,
-        }),
-        'system',
-        undefined,
-      );
-      expect(result).toEqual(savedOrder);
-      expect(salesOrderRepository.save).toHaveBeenCalled();
+    it('throws NotFoundException when order not found', async () => {
+      orderRepo.findOne.mockResolvedValue(null);
+      await expect(service.fulfillOrder('order-1')).rejects.toThrow(NotFoundException);
     });
 
-    it('should continue fulfillment when accounting post fails', async () => {
-      const mockSalesOrder = createMockSalesOrder();
-      const orderId = mockSalesOrder.id;
-      const savedOrder = { ...mockSalesOrder, isFulfilled: true, fulfilledDate: new Date() };
-
-      salesOrderRepository.findOne
-        .mockResolvedValueOnce(mockSalesOrder as SalesOrder)
-        .mockResolvedValueOnce(savedOrder as SalesOrder);
-      salesOrderRepository.save.mockResolvedValue(savedOrder as SalesOrder);
-      inventoryIntegrationService.adjustStock.mockResolvedValue(undefined);
-      auditLogService.log.mockResolvedValue(undefined);
-      accountingService.postSalesOrderEntry.mockRejectedValue(new Error('Account mappings not configured'));
-
-      const result = await service.fulfillOrder(orderId);
-
-      expect(accountingService.postSalesOrderEntry).toHaveBeenCalled();
-      expect(result).toEqual(savedOrder);
-      expect(salesOrderRepository.save).toHaveBeenCalled();
+    it('throws ConflictException when already FULFILLED', async () => {
+      orderRepo.findOne.mockResolvedValue(mockOrder({ status: SalesOrderStatus.FULFILLED }));
+      await expect(service.fulfillOrder('order-1')).rejects.toThrow(ConflictException);
     });
 
-    it('should load order with relations before posting to accounting', async () => {
-      const mockSalesOrder = createMockSalesOrder();
-      const orderId = mockSalesOrder.id;
-      const savedOrder = { ...mockSalesOrder, isFulfilled: true, fulfilledDate: new Date() };
-
-      salesOrderRepository.findOne
-        .mockResolvedValueOnce(mockSalesOrder as SalesOrder)
-        .mockResolvedValueOnce(savedOrder as SalesOrder);
-      salesOrderRepository.save.mockResolvedValue(savedOrder as SalesOrder);
-      inventoryIntegrationService.adjustStock.mockResolvedValue(undefined);
-      auditLogService.log.mockResolvedValue(undefined);
-      accountingService.postSalesOrderEntry.mockResolvedValue({ id: 'journal-1' } as any);
-
-      await service.fulfillOrder(orderId);
-
-      expect(salesOrderRepository.findOne).toHaveBeenNthCalledWith(1, {
-        where: { id: orderId },
-        relations: { customer: true, items: { product: true } },
-      });
-      expect(salesOrderRepository.findOne).toHaveBeenNthCalledWith(2, {
-        where: { id: orderId },
-        relations: { customer: true, items: { product: true } },
-      });
+    it('throws ConflictException when paymentStatus is not PAID', async () => {
+      orderRepo.findOne.mockResolvedValue(mockOrder({ paymentStatus: SalesOrderPaymentStatus.PARTIAL }));
+      await expect(service.fulfillOrder('order-1')).rejects.toThrow(ConflictException);
     });
 
-    it('should throw error when order not found', async () => {
-      salesOrderRepository.findOne.mockResolvedValue(null);
+    it('deducts inventory and sets status FULFILLED', async () => {
+      const order = mockOrder();
+      orderRepo.findOne.mockResolvedValue(order);
+      orderRepo.save.mockResolvedValue({ ...order, status: SalesOrderStatus.FULFILLED } as SalesOrder);
 
-      await expect(service.fulfillOrder('non-existent-id')).rejects.toThrow(NotFoundException);
-    });
+      await service.fulfillOrder('order-1');
 
-    it('should throw error when order is already fulfilled', async () => {
-      const fulfilledOrder = { ...createMockSalesOrder(), isFulfilled: true };
-      salesOrderRepository.findOne.mockResolvedValue(fulfilledOrder as SalesOrder);
-
-      await expect(service.fulfillOrder(fulfilledOrder.id)).rejects.toThrow(ConflictException);
-    });
-
-    it('should throw error when order is not paid in full', async () => {
-      const unpaidOrder = { ...createMockSalesOrder(), isPaidInFull: false, balanceDue: 500 };
-      salesOrderRepository.findOne.mockResolvedValue(unpaidOrder as SalesOrder);
-
-      await expect(service.fulfillOrder(unpaidOrder.id)).rejects.toThrow(ConflictException);
+      expect(inventoryService.adjustStock).toHaveBeenCalledWith('product-1', -5, expect.any(String), 'order-1');
+      expect(orderRepo.save).toHaveBeenCalledWith(expect.objectContaining({ status: SalesOrderStatus.FULFILLED }));
     });
   });
 
   describe('unfulfillOrder', () => {
-    it('should call reverseSourceEntries with sales_order sourceType when unfulfilling', async () => {
-      const mockOrder = {
-        id: 'so-123',
-        orderNumber: 'SO-000026',
-        isFulfilled: true,
-        items: [{ productId: 'prod-1', quantity: 5, product: { id: 'prod-1' } }],
-      };
-
-      salesOrderRepository.findOne.mockResolvedValue(mockOrder as any);
-      salesOrderRepository.save.mockResolvedValue({ ...mockOrder, isFulfilled: false } as any);
-      baseCostCalculator.restoreStock.mockResolvedValue(undefined);
-      stockMovementService.deleteByReference.mockResolvedValue({ deletedCount: 1 } as any);
-      auditLogService.log.mockResolvedValue(undefined);
-      accountingService.reverseSourceEntries.mockResolvedValue(undefined);
-
-      await service.unfulfillOrder('so-123');
-
-      expect(accountingService.reverseSourceEntries).toHaveBeenCalledWith(
-        'sales_order',
-        'so-123',
-        'system',
-      );
+    it('throws ConflictException when order is not FULFILLED', async () => {
+      orderRepo.findOne.mockResolvedValue(mockOrder({ status: SalesOrderStatus.DRAFT }));
+      await expect(service.unfulfillOrder('order-1')).rejects.toThrow(ConflictException);
     });
 
-    it('should still succeed if accounting reversal fails', async () => {
-      const mockOrder = {
-        id: 'so-123',
-        orderNumber: 'SO-000026',
-        isFulfilled: true,
-        items: [{ productId: 'prod-1', quantity: 5, product: { id: 'prod-1' } }],
-      };
+    it('reverses inventory and sets status DRAFT', async () => {
+      const order = mockOrder({ status: SalesOrderStatus.FULFILLED });
+      orderRepo.findOne.mockResolvedValue(order);
+      orderRepo.save.mockResolvedValue({ ...order, status: SalesOrderStatus.DRAFT } as SalesOrder);
 
-      salesOrderRepository.findOne.mockResolvedValue(mockOrder as any);
-      salesOrderRepository.save.mockResolvedValue({ ...mockOrder, isFulfilled: false } as any);
-      baseCostCalculator.restoreStock.mockResolvedValue(undefined);
-      stockMovementService.deleteByReference.mockResolvedValue({ deletedCount: 1 } as any);
-      auditLogService.log.mockResolvedValue(undefined);
-      accountingService.reverseSourceEntries.mockRejectedValue(new Error('No open period'));
+      await service.unfulfillOrder('order-1');
 
-      await expect(service.unfulfillOrder('so-123')).resolves.toBeDefined();
+      expect(baseCostCalculator.restoreStock).toHaveBeenCalledWith('product-1', 5);
+      expect(stockMovementService.deleteByReference).toHaveBeenCalledWith('sales_order', 'order-1');
+      expect(orderRepo.save).toHaveBeenCalledWith(expect.objectContaining({ status: SalesOrderStatus.DRAFT }));
     });
   });
 });

--- a/backend/src/modules/sales/services/sales-order-fulfillment.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-fulfillment.service.spec.ts
@@ -9,6 +9,7 @@ import { InventoryIntegrationService } from './inventory-integration.service';
 import { StockMovementService } from '../../inventory/services/stock-movement.service';
 import { BaseCostCalculatorService } from '../../inventory/services/base-cost-calculator.service';
 import { AuditLogService } from '../../audit-logs/services';
+import { AccountingService } from '../../accounting/services/accounting.service';
 
 const mockOrder = (overrides: Partial<SalesOrder> = {}): SalesOrder => ({
   id: 'order-1',
@@ -38,6 +39,7 @@ describe('SalesOrderFulfillmentService', () => {
         { provide: StockMovementService, useValue: { deleteByReference: jest.fn().mockResolvedValue({ deletedCount: 1 }) } },
         { provide: BaseCostCalculatorService, useValue: { restoreStock: jest.fn() } },
         { provide: AuditLogService, useValue: { log: jest.fn() } },
+        { provide: AccountingService, useValue: { postSalesOrderEntry: jest.fn().mockResolvedValue(undefined) } },
       ],
     }).compile();
 
@@ -67,7 +69,7 @@ describe('SalesOrderFulfillmentService', () => {
 
     it('deducts inventory and sets status FULFILLED', async () => {
       const order = mockOrder();
-      orderRepo.findOne.mockResolvedValue(order);
+      orderRepo.findOne.mockResolvedValue(order); // handles both the guard load and the accounting reload
       orderRepo.save.mockResolvedValue({ ...order, status: SalesOrderStatus.FULFILLED } as SalesOrder);
 
       await service.fulfillOrder('order-1');

--- a/backend/src/modules/sales/services/sales-order-fulfillment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-fulfillment.service.ts
@@ -6,12 +6,9 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-
-import { Invoice } from '../../../database/entities/invoice.entity';
-import { SalesOrder } from '../../../database/entities/sales-order.entity';
+import { SalesOrder, SalesOrderPaymentStatus, SalesOrderStatus } from '../../../database/entities/sales-order.entity';
 import { StockMovementService } from '../../../modules/inventory/services/stock-movement.service';
 import { AuditLogService } from '../../audit-logs/services';
-import { AccountingService } from '../../accounting/services/accounting.service';
 import { BaseCostCalculatorService } from '../../inventory/services/base-cost-calculator.service';
 import { InventoryIntegrationService } from './inventory-integration.service';
 
@@ -22,33 +19,24 @@ export class SalesOrderFulfillmentService {
   constructor(
     @InjectRepository(SalesOrder)
     private readonly salesOrderRepository: Repository<SalesOrder>,
-    @InjectRepository(Invoice)
-    private readonly invoiceRepository: Repository<Invoice>,
     private readonly inventoryIntegrationService: InventoryIntegrationService,
     private readonly stockMovementService: StockMovementService,
     private readonly baseCostCalculator: BaseCostCalculatorService,
-    private readonly accountingService: AccountingService,
     private readonly auditLogService: AuditLogService,
   ) {}
 
   async fulfillOrder(id: string, userId?: string, username?: string): Promise<SalesOrder> {
     const order = await this.salesOrderRepository.findOne({
       where: { id },
-      relations: { customer: true, items: { product: true } },
+      relations: { items: { product: true } },
     });
 
-    if (!order) {
-      throw new NotFoundException('Sales order not found');
-    }
-
-    if (order.isFulfilled) {
+    if (!order) throw new NotFoundException('Sales order not found');
+    if (order.status === SalesOrderStatus.FULFILLED) {
       throw new ConflictException('Order is already fulfilled');
     }
-
-    if (!order.isPaidInFull) {
-      throw new ConflictException(
-        `Cannot fulfill order. Payment required: ${order.balanceDue}. Received: ${order.paidAmount}`,
-      );
+    if (order.paymentStatus !== SalesOrderPaymentStatus.PAID) {
+      throw new ConflictException('Cannot fulfill order - payment status must be PAID');
     }
 
     for (const item of order.items) {
@@ -62,49 +50,28 @@ export class SalesOrderFulfillmentService {
       }
     }
 
-    order.isFulfilled = true;
-    order.fulfilledDate = new Date();
-
-    const savedOrder = await this.salesOrderRepository.save(order);
+    order.status = SalesOrderStatus.FULFILLED;
+    const saved = await this.salesOrderRepository.save(order);
 
     await this.auditLogService.log('FULFILL', 'SalesOrder', `Fulfilled sales order: ${order.orderNumber}`, {
       entityId: id,
       userId: userId || 'system',
       username,
-      oldValues: { isFulfilled: false },
-      newValues: { isFulfilled: true, fulfilledDate: order.fulfilledDate },
+      oldValues: { status: SalesOrderStatus.DRAFT },
+      newValues: { status: SalesOrderStatus.FULFILLED },
     });
 
-    try {
-      const fullOrder = await this.salesOrderRepository.findOne({
-        where: { id },
-        relations: { customer: true, items: { product: true } },
-      });
-      if (fullOrder) {
-        await this.accountingService.postSalesOrderEntry(fullOrder, userId || 'system', username);
-        this.logger.log(`Posted accounting entry for sales order ${fullOrder.orderNumber}`);
-      }
-    } catch (error) {
-      this.logger.error(
-        `Failed to post accounting entry for sales order ${id}: ${error.message}`,
-        error.stack,
-      );
-    }
-
-    return savedOrder;
+    return saved;
   }
 
-  async unfulfillOrder(id: string): Promise<SalesOrder> {
+  async unfulfillOrder(id: string, userId?: string, username?: string): Promise<SalesOrder> {
     const order = await this.salesOrderRepository.findOne({
       where: { id },
-      relations: { customer: true, items: { product: true } },
+      relations: { items: { product: true } },
     });
 
-    if (!order) {
-      throw new NotFoundException('Sales order not found');
-    }
-
-    if (!order.isFulfilled) {
+    if (!order) throw new NotFoundException('Sales order not found');
+    if (order.status !== SalesOrderStatus.FULFILLED) {
       throw new ConflictException('Order is not fulfilled');
     }
 
@@ -119,36 +86,23 @@ export class SalesOrderFulfillmentService {
     }
 
     try {
-      const stockMovementResult = await this.stockMovementService.deleteByReference(
-        'sales_order',
-        order.id,
-      );
-      this.logger.log(
-        `Deleted ${stockMovementResult.deletedCount} stock movements for sales order ${order.orderNumber} unfulfillment`,
-      );
+      const result = await this.stockMovementService.deleteByReference('sales_order', order.id);
+      this.logger.log(`Deleted ${result.deletedCount} stock movements for ${order.orderNumber}`);
     } catch (error) {
-      this.logger.error(`Failed to delete stock movements for sales order ${order.orderNumber}: ${error.message}`);
+      this.logger.error(`Failed to delete stock movements for ${order.orderNumber}: ${error.message}`);
     }
 
-    try {
-      await this.accountingService.reverseSourceEntries('sales_order', id, 'system');
-      this.logger.log(`Reversed accounting entries for sales order ${order.orderNumber}`);
-    } catch (error) {
-      this.logger.error(`Failed to reverse JE for order ${id}: ${error.message}`);
-    }
-
-    order.isFulfilled = false;
-    order.fulfilledDate = null;
-
-    const savedOrder = await this.salesOrderRepository.save(order);
+    order.status = SalesOrderStatus.DRAFT;
+    const saved = await this.salesOrderRepository.save(order);
 
     await this.auditLogService.log('UPDATE', 'SalesOrder', `Unfulfilled sales order: ${order.orderNumber}`, {
       entityId: id,
-      userId: 'system',
-      oldValues: { isFulfilled: true },
-      newValues: { isFulfilled: false, fulfilledDate: null },
+      userId: userId || 'system',
+      username,
+      oldValues: { status: SalesOrderStatus.FULFILLED },
+      newValues: { status: SalesOrderStatus.DRAFT },
     });
 
-    return savedOrder;
+    return saved;
   }
 }

--- a/backend/src/modules/sales/services/sales-order-fulfillment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-fulfillment.service.ts
@@ -10,6 +10,7 @@ import { SalesOrder, SalesOrderPaymentStatus, SalesOrderStatus } from '../../../
 import { StockMovementService } from '../../../modules/inventory/services/stock-movement.service';
 import { AuditLogService } from '../../audit-logs/services';
 import { BaseCostCalculatorService } from '../../inventory/services/base-cost-calculator.service';
+import { AccountingService } from '../../accounting/services/accounting.service';
 import { InventoryIntegrationService } from './inventory-integration.service';
 
 @Injectable()
@@ -23,6 +24,7 @@ export class SalesOrderFulfillmentService {
     private readonly stockMovementService: StockMovementService,
     private readonly baseCostCalculator: BaseCostCalculatorService,
     private readonly auditLogService: AuditLogService,
+    private readonly accountingService: AccountingService,
   ) {}
 
   async fulfillOrder(id: string, userId?: string, username?: string): Promise<SalesOrder> {
@@ -60,6 +62,19 @@ export class SalesOrderFulfillmentService {
       oldValues: { status: SalesOrderStatus.DRAFT },
       newValues: { status: SalesOrderStatus.FULFILLED },
     });
+
+    try {
+      const fullOrder = await this.salesOrderRepository.findOne({
+        where: { id },
+        relations: { customer: true, items: { product: true } },
+      });
+      if (fullOrder) {
+        await this.accountingService.postSalesOrderEntry(fullOrder, userId || 'system', username);
+        this.logger.log(`Posted accounting entry for sales order ${fullOrder.orderNumber}`);
+      }
+    } catch (error) {
+      this.logger.error(`Failed to post accounting entry for sales order ${id}: ${error.message}`, error.stack);
+    }
 
     return saved;
   }

--- a/backend/src/modules/sales/services/sales-order-lifecycle.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-lifecycle.service.spec.ts
@@ -1,137 +1,94 @@
-import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-
-import { Customer } from '../../../database/entities/customer.entity';
-import { Invoice, InvoiceStatus } from '../../../database/entities/invoice.entity';
-import { SalesOrderItem } from '../../../database/entities/sales-order-item.entity';
-import { SalesOrder } from '../../../database/entities/sales-order.entity';
-import { AuditLogService } from '../../audit-logs/services';
-import { StockMovementService } from '../../inventory/services/stock-movement.service';
-import { InventoryIntegrationService } from './inventory-integration.service';
+import { BadRequestException, ConflictException } from '@nestjs/common';
 import { SalesOrderLifecycleService } from './sales-order-lifecycle.service';
+import { SalesOrder, SalesOrderStatus, SalesOrderPaymentStatus } from '../../../database/entities/sales-order.entity';
+import { AuditLogService } from '../../audit-logs/services';
+
+const mockOrder = (overrides: Partial<SalesOrder> = {}): SalesOrder => ({
+  id: 'order-1',
+  orderNumber: 'SO-000001',
+  status: SalesOrderStatus.DRAFT,
+  paymentStatus: SalesOrderPaymentStatus.UNPAID,
+  totalAmount: 1000,
+  customerId: 'customer-1',
+  items: [],
+  ...overrides,
+} as SalesOrder);
 
 describe('SalesOrderLifecycleService', () => {
   let service: SalesOrderLifecycleService;
-  let salesOrderRepository: jest.Mocked<Repository<SalesOrder>>;
-  let invoiceRepository: jest.Mocked<Repository<Invoice>>;
-
-  const mockOrder = {
-    id: 'so-1',
-    orderNumber: 'SO-000001',
-    customerId: 'cust-1',
-    paidAmount: 0,
-    isFulfilled: false,
-    notes: 'old notes',
-  } as SalesOrder;
-
-  const mockDraftInvoice = {
-    id: 'inv-1',
-    invoiceNumber: 'INV-000001',
-    salesOrderId: 'so-1',
-    customerId: 'cust-1',
-    notes: 'old notes',
-    status: InvoiceStatus.DRAFT,
-  } as Invoice;
-
-  const mockPaidInvoice = {
-    ...mockDraftInvoice,
-    status: InvoiceStatus.PAID,
-  } as Invoice;
+  let orderRepo: jest.Mocked<Repository<SalesOrder>>;
+  let auditLogService: jest.Mocked<AuditLogService>;
 
   beforeEach(async () => {
-    salesOrderRepository = {
-      findOne: jest.fn(),
-      manager: { getRepository: jest.fn() },
-    } as unknown as jest.Mocked<Repository<SalesOrder>>;
-
-    invoiceRepository = {
-      find: jest.fn(),
-      save: jest.fn(),
-    } as unknown as jest.Mocked<Repository<Invoice>>;
-
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SalesOrderLifecycleService,
-        { provide: getRepositoryToken(SalesOrder), useValue: salesOrderRepository },
-        { provide: getRepositoryToken(SalesOrderItem), useValue: { delete: jest.fn() } },
-        { provide: getRepositoryToken(Customer), useValue: { save: jest.fn() } },
-        { provide: getRepositoryToken(Invoice), useValue: invoiceRepository },
-        {
-          provide: InventoryIntegrationService,
-          useValue: { releaseReservation: jest.fn() },
-        },
-        {
-          provide: StockMovementService,
-          useValue: { deleteByReference: jest.fn().mockResolvedValue({ deletedCount: 0 }) },
-        },
-        { provide: AuditLogService, useValue: { log: jest.fn().mockResolvedValue(undefined) } },
+        { provide: getRepositoryToken(SalesOrder), useValue: { findOne: jest.fn(), save: jest.fn() } },
+        { provide: AuditLogService, useValue: { log: jest.fn() } },
       ],
     }).compile();
 
     service = module.get(SalesOrderLifecycleService);
+    orderRepo = module.get(getRepositoryToken(SalesOrder));
+    auditLogService = module.get(AuditLogService);
   });
 
-  describe('assertItemsNotLocked', () => {
-    it('throws when the order is paid', async () => {
-      salesOrderRepository.findOne.mockResolvedValue({
-        ...mockOrder,
-        paidAmount: 10,
-      } as SalesOrder);
-
-      await expect(service.assertItemsNotLocked('so-1')).rejects.toThrow(
-        new BadRequestException(
-          'Cannot edit sales order items that have been paid. Please unpay first.',
-        ),
-      );
+  describe('assertEditAllowed', () => {
+    it('throws when status is FULFILLED', async () => {
+      orderRepo.findOne.mockResolvedValue(mockOrder({ status: SalesOrderStatus.FULFILLED }));
+      await expect(service.assertEditAllowed('order-1')).rejects.toThrow(BadRequestException);
     });
 
-    it('throws when the order is fulfilled', async () => {
-      salesOrderRepository.findOne.mockResolvedValue({
-        ...mockOrder,
-        isFulfilled: true,
-      } as SalesOrder);
-
-      await expect(service.assertItemsNotLocked('so-1')).rejects.toThrow(
-        new BadRequestException(
-          'Cannot edit sales order items that have been fulfilled. Please unfulfill first.',
-        ),
-      );
+    it('throws when DRAFT but paymentStatus is PARTIAL', async () => {
+      orderRepo.findOne.mockResolvedValue(mockOrder({ paymentStatus: SalesOrderPaymentStatus.PARTIAL }));
+      await expect(service.assertEditAllowed('order-1')).rejects.toThrow(BadRequestException);
     });
 
-    it('resolves when the order is neither paid nor fulfilled', async () => {
-      salesOrderRepository.findOne.mockResolvedValue(mockOrder);
-
-      await expect(service.assertItemsNotLocked('so-1')).resolves.toBeUndefined();
+    it('passes when DRAFT and UNPAID', async () => {
+      orderRepo.findOne.mockResolvedValue(mockOrder());
+      await expect(service.assertEditAllowed('order-1')).resolves.not.toThrow();
     });
   });
 
-  describe('syncChildHeaderFromSalesOrder', () => {
-    it('syncs customer and notes to draft invoices', async () => {
-      const updatedOrder = {
-        ...mockOrder,
-        customerId: 'cust-2',
-        notes: 'new notes',
-      } as SalesOrder;
-      invoiceRepository.find.mockResolvedValue([mockDraftInvoice]);
-
-      await service.syncChildHeaderFromSalesOrder(updatedOrder);
-
-      expect(invoiceRepository.save).toHaveBeenCalledWith(
-        expect.objectContaining({
-          customerId: 'cust-2',
-          notes: 'new notes',
-        }),
-      );
+  describe('cancel', () => {
+    it('throws when status is FULFILLED', async () => {
+      orderRepo.findOne.mockResolvedValue(mockOrder({ status: SalesOrderStatus.FULFILLED }));
+      await expect(service.cancel('order-1')).rejects.toThrow(ConflictException);
     });
 
-    it('skips paid invoices', async () => {
-      invoiceRepository.find.mockResolvedValue([mockPaidInvoice]);
+    it('throws when DRAFT but paymentStatus is not UNPAID', async () => {
+      orderRepo.findOne.mockResolvedValue(mockOrder({ paymentStatus: SalesOrderPaymentStatus.PARTIAL }));
+      await expect(service.cancel('order-1')).rejects.toThrow(ConflictException);
+    });
 
-      await service.syncChildHeaderFromSalesOrder(mockOrder);
+    it('sets status to CANCELLED when DRAFT and UNPAID', async () => {
+      const order = mockOrder();
+      orderRepo.findOne.mockResolvedValue(order);
+      orderRepo.save.mockResolvedValue({ ...order, status: SalesOrderStatus.CANCELLED } as SalesOrder);
 
-      expect(invoiceRepository.save).not.toHaveBeenCalled();
+      await service.cancel('order-1');
+
+      expect(orderRepo.save).toHaveBeenCalledWith(expect.objectContaining({ status: SalesOrderStatus.CANCELLED }));
+    });
+  });
+
+  describe('uncancel', () => {
+    it('throws when order is not CANCELLED', async () => {
+      orderRepo.findOne.mockResolvedValue(mockOrder({ status: SalesOrderStatus.DRAFT }));
+      await expect(service.uncancel('order-1')).rejects.toThrow(ConflictException);
+    });
+
+    it('sets status to DRAFT when CANCELLED', async () => {
+      const order = mockOrder({ status: SalesOrderStatus.CANCELLED });
+      orderRepo.findOne.mockResolvedValue(order);
+      orderRepo.save.mockResolvedValue({ ...order, status: SalesOrderStatus.DRAFT } as SalesOrder);
+
+      await service.uncancel('order-1');
+
+      expect(orderRepo.save).toHaveBeenCalledWith(expect.objectContaining({ status: SalesOrderStatus.DRAFT }));
     });
   });
 });

--- a/backend/src/modules/sales/services/sales-order-lifecycle.service.ts
+++ b/backend/src/modules/sales/services/sales-order-lifecycle.service.ts
@@ -2,536 +2,86 @@ import {
   BadRequestException,
   ConflictException,
   Injectable,
-  Logger,
+  NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { ILike, Repository } from 'typeorm';
-
-import { BulkOperationUtil, BulkOperationResponse, ValidationUtil } from '../../../common/utils/validation.util';
-import { Customer } from '../../../database/entities/customer.entity';
-import { Invoice, InvoiceStatus } from '../../../database/entities/invoice.entity';
-import { Payment } from '../../../database/entities/payment.entity';
-import { SalesOrderItem } from '../../../database/entities/sales-order-item.entity';
-import { SalesOrder } from '../../../database/entities/sales-order.entity';
-import { StockMovementService } from '../../../modules/inventory/services/stock-movement.service';
+import { Repository } from 'typeorm';
+import { SalesOrder, SalesOrderPaymentStatus, SalesOrderStatus } from '../../../database/entities/sales-order.entity';
 import { AuditLogService } from '../../audit-logs/services';
-import { InventoryIntegrationService } from './inventory-integration.service';
-import { mapSalesOrderToResponseDto } from './sales-order.mapper';
-import { SalesOrderResponseDto } from '../dto/sales-order.dto';
 
 @Injectable()
 export class SalesOrderLifecycleService {
-  private readonly logger = new Logger(SalesOrderLifecycleService.name);
-
   constructor(
     @InjectRepository(SalesOrder)
     private readonly salesOrderRepository: Repository<SalesOrder>,
-    @InjectRepository(SalesOrderItem)
-    private readonly salesOrderItemRepository: Repository<SalesOrderItem>,
-    @InjectRepository(Customer)
-    private readonly customerRepository: Repository<Customer>,
-    @InjectRepository(Invoice)
-    private readonly invoiceRepository: Repository<Invoice>,
-    private readonly inventoryIntegrationService: InventoryIntegrationService,
-    private readonly stockMovementService: StockMovementService,
     private readonly auditLogService: AuditLogService,
   ) {}
 
-  async assertItemsNotLocked(id: string): Promise<void> {
+  async assertEditAllowed(id: string): Promise<void> {
     const order = await this.salesOrderRepository.findOne({ where: { id } });
-    if (!order) {
-      throw new BadRequestException('Sales order not found');
-    }
+    if (!order) throw new NotFoundException('Sales order not found');
 
-    if (Number(order.paidAmount || 0) > 0) {
+    if (order.status !== SalesOrderStatus.DRAFT) {
       throw new BadRequestException(
-        'Cannot edit sales order items that have been paid. Please unpay first.',
+        `Cannot edit sales order in ${order.status} status. ${
+          order.status === SalesOrderStatus.FULFILLED ? 'Unfulfill the order first.' : 'Uncancel the order first.'
+        }`,
       );
     }
-
-    if (order.isFulfilled) {
+    if (order.paymentStatus !== SalesOrderPaymentStatus.UNPAID) {
       throw new BadRequestException(
-        'Cannot edit sales order items that have been fulfilled. Please unfulfill first.',
+        'Cannot edit sales order with recorded payments. Refund all payments first.',
       );
     }
   }
 
-  async syncChildHeaderFromSalesOrder(order: SalesOrder): Promise<void> {
-    try {
-      const invoices = await this.invoiceRepository.find({
-        where: { salesOrderId: order.id },
-      });
-
-      for (const invoice of invoices) {
-        if (invoice.status === InvoiceStatus.PAID || invoice.status === InvoiceStatus.PARTIAL_PAID) {
-          continue;
-        }
-
-        invoice.customerId = order.customerId;
-        invoice.notes = order.notes;
-        await this.invoiceRepository.save(invoice);
-      }
-    } catch (error) {
-      this.logger.error(
-        `Failed to sync child headers for sales order ${order.orderNumber}: ${error.message}`,
-      );
-    }
-  }
-
-  async delete(
-    id: string,
-    userId: string | undefined,
-    username: string | undefined,
-    findPreviousOrder: (currentOrderNumber: string) => Promise<SalesOrderResponseDto | null>,
-  ): Promise<{ deletedOrderNumber: string; previousOrder: SalesOrderResponseDto | null }> {
+  async cancel(id: string, userId?: string, username?: string): Promise<SalesOrder> {
     const order = await this.salesOrderRepository.findOne({ where: { id } });
-    if (!order) {
-      throw new BadRequestException('Sales order not found');
+    if (!order) throw new NotFoundException('Sales order not found');
+
+    if (order.status === SalesOrderStatus.FULFILLED) {
+      throw new ConflictException('Cannot cancel a fulfilled order. Unfulfill it first.');
+    }
+    if (order.status === SalesOrderStatus.CANCELLED) {
+      throw new ConflictException('Order is already cancelled.');
+    }
+    if (order.paymentStatus !== SalesOrderPaymentStatus.UNPAID) {
+      throw new ConflictException('Cannot cancel an order with recorded payments. Refund all payments first.');
     }
 
-    if (order.isFulfilled) {
-      throw new BadRequestException(
-        'Cannot delete sales order that has been fulfilled. Please unfulfill first.',
-      );
-    }
+    order.status = SalesOrderStatus.CANCELLED;
+    const saved = await this.salesOrderRepository.save(order);
 
-    if (Number(order.paidAmount || 0) > 0) {
-      throw new BadRequestException(
-        'Cannot delete sales order that has been paid. Please unpay first.',
-      );
-    }
-
-    const previousOrder = await findPreviousOrder(order.orderNumber);
-
-    await this.inventoryIntegrationService.releaseReservation(id);
-
-    try {
-      const associatedInvoices = await this.invoiceRepository.find({
-        where: { salesOrderId: id },
-      });
-
-      if (associatedInvoices.length > 0) {
-        await this.invoiceRepository.softDelete(associatedInvoices.map((invoice) => invoice.id));
-
-        for (const invoice of associatedInvoices) {
-          await this.auditLogService.log('DELETE', 'Invoice', `Deleted invoice: ${invoice.invoiceNumber} (cascaded from sales order ${order.orderNumber})`, {
-            entityId: invoice.id,
-            userId: userId || 'system',
-            username,
-            oldValues: {
-              invoiceNumber: invoice.invoiceNumber,
-              salesOrderId: id,
-              totalAmount: invoice.totalAmount,
-            },
-          });
-        }
-      }
-    } catch (error) {
-      this.logger.error(`Failed to auto-delete invoices for sales order ${order.orderNumber}: ${error.message}`);
-    }
-
-    try {
-      const paymentRepository = this.salesOrderRepository.manager.getRepository(Payment);
-      const associatedPayments = await paymentRepository.find({
-        where: {
-          customerId: order.customerId,
-          notes: ILike(`%sales order ${order.orderNumber}%`),
-        },
-      });
-
-      if (associatedPayments.length > 0) {
-        await paymentRepository.softDelete(associatedPayments.map((payment) => payment.id));
-
-        for (const payment of associatedPayments) {
-          await this.auditLogService.log('DELETE', 'Payment', `Deleted payment: ${payment.paymentNumber} (cascaded from sales order ${order.orderNumber})`, {
-            entityId: payment.id,
-            userId: userId || 'system',
-            username,
-            oldValues: {
-              paymentNumber: payment.paymentNumber,
-              salesOrderId: id,
-              amount: payment.amount,
-            },
-          });
-        }
-      }
-    } catch (error) {
-      this.logger.error(`Failed to auto-delete payments for sales order ${order.orderNumber}: ${error.message}`);
-    }
-
-    await this.salesOrderRepository.softDelete(id);
-
-    await this.auditLogService.log('DELETE', 'SalesOrder', `Deleted sales order: ${order.orderNumber}`, {
+    await this.auditLogService.log('UPDATE', 'SalesOrder', `Cancelled sales order: ${order.orderNumber}`, {
       entityId: id,
       userId: userId || 'system',
       username,
-      oldValues: {
-        orderNumber: order.orderNumber,
-        customerId: order.customerId,
-        totalAmount: order.totalAmount,
-      },
+      oldValues: { status: SalesOrderStatus.DRAFT },
+      newValues: { status: SalesOrderStatus.CANCELLED },
     });
 
-    return {
-      deletedOrderNumber: order.orderNumber,
-      previousOrder,
-    };
+    return saved;
   }
 
-  async restore(id: string, userId?: string, username?: string): Promise<SalesOrderResponseDto> {
-    const order = await this.salesOrderRepository.findOne({
-      where: { id },
-      withDeleted: true,
-      relations: { customer: true, items: { product: true } },
-    });
+  async uncancel(id: string, userId?: string, username?: string): Promise<SalesOrder> {
+    const order = await this.salesOrderRepository.findOne({ where: { id } });
+    if (!order) throw new NotFoundException('Sales order not found');
 
-    ValidationUtil.validateForRestore(order, 'Sales order', id);
-
-    await this.salesOrderRepository.restore(id);
-
-    try {
-      const associatedInvoices = await this.invoiceRepository.find({
-        where: { salesOrderId: id },
-        withDeleted: true,
-      });
-
-      const softDeletedInvoices = associatedInvoices.filter((invoice) => invoice.deletedAt !== null);
-      if (softDeletedInvoices.length > 0) {
-        await this.invoiceRepository.restore(softDeletedInvoices.map((invoice) => invoice.id));
-
-        for (const invoice of softDeletedInvoices) {
-          await this.auditLogService.log('RESTORE', 'Invoice', `Restored invoice: ${invoice.invoiceNumber} (cascaded from sales order ${order.orderNumber})`, {
-            entityId: invoice.id,
-            userId: userId || 'system',
-            username,
-            newValues: {
-              invoiceNumber: invoice.invoiceNumber,
-              salesOrderId: id,
-              totalAmount: invoice.totalAmount,
-            },
-          });
-        }
-      }
-    } catch (error) {
-      this.logger.error(`Failed to auto-restore invoices for sales order ${order.orderNumber}: ${error.message}`);
+    if (order.status !== SalesOrderStatus.CANCELLED) {
+      throw new ConflictException('Order is not cancelled.');
     }
 
-    try {
-      const paymentRepository = this.salesOrderRepository.manager.getRepository(Payment);
-      const invoices = await this.invoiceRepository.find({
-        where: { salesOrderId: id },
-        withDeleted: true,
-      });
+    order.status = SalesOrderStatus.DRAFT;
+    const saved = await this.salesOrderRepository.save(order);
 
-      if (invoices.length > 0) {
-        const invoiceIds = invoices.map((invoice) => invoice.id);
-        const associatedPayments = await paymentRepository
-          .createQueryBuilder('payment')
-          .where('payment.invoiceId IN (:...invoiceIds)', { invoiceIds })
-          .withDeleted()
-          .getMany();
-
-        const softDeletedPayments = associatedPayments.filter((payment) => payment.deletedAt !== null);
-        if (softDeletedPayments.length > 0) {
-          await paymentRepository.restore(softDeletedPayments.map((payment) => payment.id));
-
-          for (const payment of softDeletedPayments) {
-            await this.auditLogService.log('RESTORE', 'Payment', `Restored payment: ${payment.paymentNumber} (cascaded from sales order ${order.orderNumber})`, {
-              entityId: payment.id,
-              userId: userId || 'system',
-              username,
-              newValues: {
-                paymentNumber: payment.paymentNumber,
-                salesOrderId: id,
-                amount: payment.amount,
-              },
-            });
-          }
-        }
-      }
-    } catch (error) {
-      this.logger.error(`Failed to auto-restore payments for sales order ${order.orderNumber}: ${error.message}`);
-    }
-
-    const restoredOrder = await this.salesOrderRepository.findOne({
-      where: { id },
-      relations: { customer: true, items: { product: true } },
-    });
-
-    await this.auditLogService.log('RESTORE', 'SalesOrder', `Restored sales order: ${order.orderNumber}`, {
+    await this.auditLogService.log('UPDATE', 'SalesOrder', `Uncancelled sales order: ${order.orderNumber}`, {
       entityId: id,
       userId: userId || 'system',
       username,
-      newValues: {
-        orderNumber: order.orderNumber,
-        customerId: order.customerId,
-        totalAmount: order.totalAmount,
-      },
+      oldValues: { status: SalesOrderStatus.CANCELLED },
+      newValues: { status: SalesOrderStatus.DRAFT },
     });
 
-    return mapSalesOrderToResponseDto(restoredOrder);
-  }
-
-  async bulkRestore(ids: string[], userId?: string, username?: string): Promise<BulkOperationResponse> {
-    if (!ids || ids.length === 0) {
-      return BulkOperationUtil.createResponse('restored', 'sales order', 0, []);
-    }
-
-    const failedItems = [];
-    let successCount = 0;
-
-    for (const id of ids) {
-      try {
-        await this.restore(id, userId, username);
-        successCount++;
-      } catch (error) {
-        BulkOperationUtil.addFailure(failedItems, id, error.message, 'RESTORE_ERROR');
-      }
-    }
-
-    return BulkOperationUtil.createResponse('restored', 'sales order', successCount, failedItems);
-  }
-
-  async permanentDelete(id: string, userId?: string, username?: string): Promise<void> {
-    const order = await this.salesOrderRepository.findOne({
-      where: { id },
-      relations: { customer: true, items: true },
-      withDeleted: true,
-    });
-
-    ValidationUtil.validateForPermanentDelete(order, 'Sales order', id);
-
-    const isCompleted = order.isFulfilled;
-    const invoices = await this.invoiceRepository.find({
-      where: { salesOrderId: id },
-      withDeleted: true,
-    });
-    const hasPayments = invoices.some((invoice) => Number(invoice.paidAmount) > 0);
-
-    ValidationUtil.validateFinancialEntityDeletion('sales order', hasPayments, false, isCompleted);
-
-    if (invoices.length > 0) {
-      try {
-        for (const invoice of invoices) {
-          await this.auditLogService.log('PERMANENT_DELETE', 'Invoice', `Permanently deleted invoice: ${invoice.invoiceNumber} (cascaded from sales order ${order.orderNumber})`, {
-            entityId: invoice.id,
-            userId: userId || 'system',
-            username,
-            oldValues: {
-              invoiceNumber: invoice.invoiceNumber,
-              salesOrderId: id,
-              totalAmount: invoice.totalAmount,
-              paidAmount: invoice.paidAmount,
-            },
-          });
-        }
-
-        await this.invoiceRepository.delete(invoices.map((invoice) => invoice.id));
-      } catch (error) {
-        throw new ConflictException(
-          'Failed to delete associated invoices. Cannot permanently delete sales order.',
-        );
-      }
-    }
-
-    if (Number(order.paidAmount) > 0 && order.customer) {
-      const customer = order.customer;
-      customer.totalSales = Math.max(0, Number(customer.totalSales) - Number(order.totalAmount));
-      customer.totalOrders = Math.max(0, customer.totalOrders - 1);
-      await this.customerRepository.save(customer);
-    }
-
-    try {
-      await this.stockMovementService.deleteByReference('sales_order', id);
-    } catch (error) {
-      this.logger.error(`Failed to delete stock movements for sales order ${order.orderNumber}: ${error.message}`);
-    }
-
-    try {
-      const paymentRepository = this.salesOrderRepository.manager.getRepository(Payment);
-      const associatedPayments = await paymentRepository.find({
-        where: {
-          customerId: order.customerId,
-          notes: ILike(`%sales order ${order.orderNumber}%`),
-        },
-        withDeleted: true,
-      });
-
-      if (associatedPayments.length > 0) {
-        for (const payment of associatedPayments) {
-          await this.auditLogService.log('PERMANENT_DELETE', 'Payment', `Permanently deleted payment: ${payment.paymentNumber} (cascaded from sales order ${order.orderNumber})`, {
-            entityId: payment.id,
-            userId: userId || 'system',
-            username,
-            oldValues: {
-              paymentNumber: payment.paymentNumber,
-              salesOrderId: id,
-              amount: payment.amount,
-            },
-          });
-        }
-
-        await paymentRepository.delete(associatedPayments.map((payment) => payment.id));
-      }
-    } catch (error) {
-      this.logger.error(`Failed to permanently delete payments for sales order ${order.orderNumber}: ${error.message}`);
-    }
-
-    await this.salesOrderItemRepository.delete({ salesOrderId: id });
-
-    await this.auditLogService.log('PERMANENT_DELETE', 'SalesOrder', `Permanently deleted sales order: ${order.orderNumber}`, {
-      entityId: id,
-      userId: userId || 'system',
-      username,
-      oldValues: {
-        orderNumber: order.orderNumber,
-        customerId: order.customerId,
-        customerName: order.customer?.name,
-        totalAmount: order.totalAmount,
-        paidAmount: order.paidAmount,
-      },
-    });
-
-    await this.salesOrderRepository.delete(id);
-  }
-
-  async bulkPermanentDelete(
-    orderIds: string[],
-    userId?: string,
-    username?: string,
-  ): Promise<BulkOperationResponse> {
-    if (!orderIds || orderIds.length === 0) {
-      return BulkOperationUtil.createResponse('permanently deleted', 'sales order', 0, []);
-    }
-
-    const failedItems = [];
-    let successCount = 0;
-
-    for (const id of orderIds) {
-      try {
-        const order = await this.salesOrderRepository.findOne({
-          where: { id },
-          relations: { customer: true, items: true },
-          withDeleted: true,
-        });
-
-        try {
-          ValidationUtil.validateForPermanentDelete(order, 'Sales order', id);
-        } catch (error) {
-          BulkOperationUtil.addFailure(failedItems, id, error.message, 'VALIDATION_ERROR');
-          continue;
-        }
-
-        const isCompleted = order.isFulfilled;
-        const invoices = await this.invoiceRepository.find({
-          where: { salesOrderId: id },
-          withDeleted: true,
-        });
-        const hasPayments = invoices.some((invoice) => Number(invoice.paidAmount) > 0);
-
-        try {
-          ValidationUtil.validateFinancialEntityDeletion('sales order', hasPayments, false, isCompleted);
-        } catch (error) {
-          BulkOperationUtil.addFailure(failedItems, id, error.message, 'BUSINESS_RULE_ERROR');
-          continue;
-        }
-
-        if (invoices.length > 0) {
-          try {
-            for (const invoice of invoices) {
-              await this.auditLogService.log('PERMANENT_DELETE', 'Invoice', `Permanently deleted invoice: ${invoice.invoiceNumber} (cascaded from sales order ${order.orderNumber})`, {
-                entityId: invoice.id,
-                userId: userId || 'system',
-                username,
-                oldValues: {
-                  invoiceNumber: invoice.invoiceNumber,
-                  salesOrderId: id,
-                  totalAmount: invoice.totalAmount,
-                  paidAmount: invoice.paidAmount,
-                },
-              });
-            }
-
-            await this.invoiceRepository.delete(invoices.map((invoice) => invoice.id));
-          } catch (error) {
-            BulkOperationUtil.addFailure(
-              failedItems,
-              id,
-              `Failed to delete associated invoices: ${error.message}`,
-              'INVOICE_DELETE_ERROR',
-            );
-            continue;
-          }
-        }
-
-        if (Number(order.paidAmount) > 0 && order.customer) {
-          const customer = order.customer;
-          customer.totalSales = Math.max(0, Number(customer.totalSales) - Number(order.totalAmount));
-          customer.totalOrders = Math.max(0, customer.totalOrders - 1);
-          await this.customerRepository.save(customer);
-        }
-
-        try {
-          await this.stockMovementService.deleteByReference('sales_order', id);
-        } catch (error) {
-          this.logger.error(`Failed to delete stock movements for sales order ${order.orderNumber}: ${error.message}`);
-        }
-
-        try {
-          const paymentRepository = this.salesOrderRepository.manager.getRepository(Payment);
-          const associatedPayments = await paymentRepository.find({
-            where: {
-              customerId: order.customerId,
-              notes: ILike(`%sales order ${order.orderNumber}%`),
-            },
-            withDeleted: true,
-          });
-
-          if (associatedPayments.length > 0) {
-            for (const payment of associatedPayments) {
-              await this.auditLogService.log('PERMANENT_DELETE', 'Payment', `Permanently deleted payment: ${payment.paymentNumber} (cascaded from sales order ${order.orderNumber})`, {
-                entityId: payment.id,
-                userId: userId || 'system',
-                username,
-                oldValues: {
-                  paymentNumber: payment.paymentNumber,
-                  salesOrderId: id,
-                  amount: payment.amount,
-                },
-              });
-            }
-
-            await paymentRepository.delete(associatedPayments.map((payment) => payment.id));
-          }
-        } catch (error) {
-          this.logger.error(`Failed to permanently delete payments for sales order ${order.orderNumber}: ${error.message}`);
-        }
-
-        await this.salesOrderItemRepository.delete({ salesOrderId: id });
-
-        await this.auditLogService.log('PERMANENT_DELETE', 'SalesOrder', `Permanently deleted sales order: ${order.orderNumber}`, {
-          entityId: id,
-          userId: userId || 'system',
-          username,
-          oldValues: {
-            orderNumber: order.orderNumber,
-            totalAmount: order.totalAmount,
-            customerId: order.customerId,
-          },
-        });
-
-        await this.salesOrderRepository.delete(id);
-        successCount++;
-      } catch (error) {
-        BulkOperationUtil.addFailure(failedItems, id, error.message, 'UNEXPECTED_ERROR');
-      }
-    }
-
-    return BulkOperationUtil.createResponse(
-      'permanently deleted',
-      'sales order',
-      successCount,
-      failedItems,
-    );
+    return saved;
   }
 }

--- a/backend/src/modules/sales/services/sales-order-payment.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
 import { SalesOrderPaymentService } from './sales-order-payment.service';
 import { SalesOrder, SalesOrderStatus, SalesOrderPaymentStatus } from '../../../database/entities/sales-order.entity';
@@ -26,8 +26,27 @@ describe('SalesOrderPaymentService', () => {
   let paymentRepo: jest.Mocked<Repository<SalesOrderPayment>>;
   let methodRepo: jest.Mocked<Repository<PaymentMethodEntity>>;
   let auditLogService: jest.Mocked<AuditLogService>;
+  let dataSource: jest.Mocked<DataSource>;
+
+  const buildMockManager = (paymentRecordsAfterSave: SalesOrderPayment[] = []): EntityManager => ({
+    getRepository: jest.fn().mockImplementation((entity) => {
+      if (entity === SalesOrderPayment) {
+        return {
+          create: jest.fn().mockImplementation((data) => data),
+          save: jest.fn().mockImplementation((data) => Promise.resolve({ id: 'payment-new', ...data })),
+          find: jest.fn().mockResolvedValue(paymentRecordsAfterSave),
+        };
+      }
+      if (entity === SalesOrder) {
+        return { update: jest.fn().mockResolvedValue(undefined) };
+      }
+      return {};
+    }),
+  } as any);
 
   beforeEach(async () => {
+    dataSource = { transaction: jest.fn() } as any;
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SalesOrderPaymentService,
@@ -35,6 +54,7 @@ describe('SalesOrderPaymentService', () => {
         { provide: getRepositoryToken(SalesOrderPayment), useValue: { find: jest.fn(), create: jest.fn(), save: jest.fn() } },
         { provide: getRepositoryToken(PaymentMethodEntity), useValue: { findOne: jest.fn() } },
         { provide: AuditLogService, useValue: { log: jest.fn() } },
+        { provide: DataSource, useValue: dataSource },
       ],
     }).compile();
 
@@ -45,29 +65,45 @@ describe('SalesOrderPaymentService', () => {
     auditLogService = module.get(AuditLogService);
   });
 
-  describe('recomputePaymentStatus', () => {
+  describe('computePaymentStatus', () => {
     it('returns UNPAID when no payments', () => {
       expect(service.computePaymentStatus([], 1000)).toBe(SalesOrderPaymentStatus.UNPAID);
     });
 
+    it('returns UNPAID when net paid is negative (over-refunded edge case)', () => {
+      const records = [{ amount: -100 }] as SalesOrderPayment[];
+      expect(service.computePaymentStatus(records, 1000)).toBe(SalesOrderPaymentStatus.UNPAID);
+    });
+
     it('returns PARTIAL when net paid < total', () => {
-      const records = [{ amount: 400 } as SalesOrderPayment];
+      const records = [{ amount: 400 }] as SalesOrderPayment[];
       expect(service.computePaymentStatus(records, 1000)).toBe(SalesOrderPaymentStatus.PARTIAL);
     });
 
-    it('returns PAID when net paid = total', () => {
-      const records = [{ amount: 1000 } as SalesOrderPayment];
+    it('returns PAID when net paid = total (exact)', () => {
+      const records = [{ amount: 1000 }] as SalesOrderPayment[];
+      expect(service.computePaymentStatus(records, 1000)).toBe(SalesOrderPaymentStatus.PAID);
+    });
+
+    it('returns PAID for three partial payments totalling the exact amount (floating-point tolerance)', () => {
+      // 333.33 + 333.33 + 333.34 = 1000.00 but floating-point may drift
+      const records = [{ amount: 333.33 }, { amount: 333.33 }, { amount: 333.34 }] as SalesOrderPayment[];
       expect(service.computePaymentStatus(records, 1000)).toBe(SalesOrderPaymentStatus.PAID);
     });
 
     it('returns OVERPAID when net paid > total', () => {
-      const records = [{ amount: 1200 } as SalesOrderPayment];
+      const records = [{ amount: 1200 }] as SalesOrderPayment[];
       expect(service.computePaymentStatus(records, 1000)).toBe(SalesOrderPaymentStatus.OVERPAID);
     });
 
     it('returns UNPAID after full payment + full refund', () => {
       const records = [{ amount: 1000 }, { amount: -1000 }] as SalesOrderPayment[];
       expect(service.computePaymentStatus(records, 1000)).toBe(SalesOrderPaymentStatus.UNPAID);
+    });
+
+    it('returns PARTIAL after partial refund', () => {
+      const records = [{ amount: 1000 }, { amount: -400 }] as SalesOrderPayment[];
+      expect(service.computePaymentStatus(records, 1000)).toBe(SalesOrderPaymentStatus.PARTIAL);
     });
   });
 
@@ -85,7 +121,6 @@ describe('SalesOrderPaymentService', () => {
     });
 
     it('throws BadRequestException for non-positive amount', async () => {
-      orderRepo.findOne.mockResolvedValue(mockOrder());
       await expect(service.recordPayment('order-1', { paymentMethodId: 'method-1', amount: 0, paymentDate: '2026-01-01' }))
         .rejects.toThrow(BadRequestException);
     });
@@ -97,26 +132,54 @@ describe('SalesOrderPaymentService', () => {
         .rejects.toThrow(BadRequestException);
     });
 
-    it('creates payment record and updates paymentStatus', async () => {
+    it('creates payment record inside a transaction and updates paymentStatus', async () => {
       const order = mockOrder();
       orderRepo.findOne.mockResolvedValue(order);
       methodRepo.findOne.mockResolvedValue(mockMethod());
-      paymentRepo.find.mockResolvedValue([]);
-      paymentRepo.create.mockReturnValue({ amount: 1000 } as SalesOrderPayment);
-      paymentRepo.save.mockResolvedValue({ amount: 1000 } as SalesOrderPayment);
-      orderRepo.save.mockResolvedValue({ ...order, paymentStatus: SalesOrderPaymentStatus.PAID } as SalesOrder);
+
+      const mockManager = buildMockManager([{ id: 'payment-new', amount: 1000 }] as SalesOrderPayment[]);
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: (m: EntityManager) => Promise<any>) => cb(mockManager));
 
       await service.recordPayment('order-1', { paymentMethodId: 'method-1', amount: 1000, paymentDate: '2026-01-01' });
 
-      expect(paymentRepo.create).toHaveBeenCalledWith(expect.objectContaining({ amount: 1000, salesOrderId: 'order-1' }));
-      expect(orderRepo.save).toHaveBeenCalledWith(expect.objectContaining({ paymentStatus: SalesOrderPaymentStatus.PAID }));
+      expect(dataSource.transaction).toHaveBeenCalled();
+      expect(auditLogService.log).toHaveBeenCalledWith('CREATE', 'SalesOrderPayment', expect.any(String), expect.objectContaining({ newValues: expect.objectContaining({ amount: 1000 }) }));
+    });
+
+    it('passes userId and username to audit log', async () => {
+      const order = mockOrder();
+      orderRepo.findOne.mockResolvedValue(order);
+      methodRepo.findOne.mockResolvedValue(mockMethod());
+
+      const mockManager = buildMockManager([{ id: 'payment-new', amount: 500 }] as SalesOrderPayment[]);
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: (m: EntityManager) => Promise<any>) => cb(mockManager));
+
+      await service.recordPayment('order-1', { paymentMethodId: 'method-1', amount: 500, paymentDate: '2026-01-01' }, 'user-abc', 'alice');
+
+      expect(auditLogService.log).toHaveBeenCalledWith('CREATE', 'SalesOrderPayment', expect.any(String), expect.objectContaining({ userId: 'user-abc', username: 'alice' }));
     });
   });
 
   describe('recordRefund', () => {
+    it('throws BadRequestException for non-positive amount', async () => {
+      await expect(service.recordRefund('order-1', { paymentMethodId: 'method-1', amount: 0, paymentDate: '2026-01-01' }))
+        .rejects.toThrow(BadRequestException);
+    });
+
+    it('throws NotFoundException when order not found', async () => {
+      orderRepo.findOne.mockResolvedValue(null);
+      await expect(service.recordRefund('order-1', { paymentMethodId: 'method-1', amount: 100, paymentDate: '2026-01-01' }))
+        .rejects.toThrow(NotFoundException);
+    });
+
+    it('throws ConflictException when order is CANCELLED', async () => {
+      orderRepo.findOne.mockResolvedValue(mockOrder({ status: SalesOrderStatus.CANCELLED }));
+      await expect(service.recordRefund('order-1', { paymentMethodId: 'method-1', amount: 100, paymentDate: '2026-01-01' }))
+        .rejects.toThrow(ConflictException);
+    });
+
     it('throws BadRequestException when refund amount exceeds net paid', async () => {
-      const order = mockOrder({ paymentStatus: SalesOrderPaymentStatus.PARTIAL });
-      orderRepo.findOne.mockResolvedValue(order);
+      orderRepo.findOne.mockResolvedValue(mockOrder({ paymentStatus: SalesOrderPaymentStatus.PARTIAL }));
       methodRepo.findOne.mockResolvedValue(mockMethod());
       paymentRepo.find.mockResolvedValue([{ amount: 400 }] as SalesOrderPayment[]);
 
@@ -124,22 +187,41 @@ describe('SalesOrderPaymentService', () => {
         .rejects.toThrow(BadRequestException);
     });
 
-    it('creates negative payment record for refund', async () => {
+    it('creates negative payment record inside a transaction', async () => {
       const order = mockOrder({ paymentStatus: SalesOrderPaymentStatus.PAID });
       orderRepo.findOne.mockResolvedValue(order);
       methodRepo.findOne.mockResolvedValue(mockMethod());
       paymentRepo.find.mockResolvedValue([{ amount: 1000 }] as SalesOrderPayment[]);
-      paymentRepo.create.mockReturnValue({ amount: -400 } as SalesOrderPayment);
-      paymentRepo.save.mockResolvedValue({ amount: -400 } as SalesOrderPayment);
-      orderRepo.save.mockResolvedValue({ ...order, paymentStatus: SalesOrderPaymentStatus.PARTIAL } as SalesOrder);
+
+      const mockManager = buildMockManager([{ amount: 1000 }, { amount: -400 }] as SalesOrderPayment[]);
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: (m: EntityManager) => Promise<any>) => cb(mockManager));
 
       await service.recordRefund('order-1', { paymentMethodId: 'method-1', amount: 400, paymentDate: '2026-01-01' });
 
-      expect(paymentRepo.create).toHaveBeenCalledWith(expect.objectContaining({ amount: -400 }));
+      expect(dataSource.transaction).toHaveBeenCalled();
+      expect(auditLogService.log).toHaveBeenCalledWith('CREATE', 'SalesOrderPayment', expect.any(String), expect.objectContaining({ newValues: expect.objectContaining({ amount: -400 }) }));
+    });
+
+    it('allows refund on FULFILLED orders', async () => {
+      const order = mockOrder({ status: SalesOrderStatus.FULFILLED, paymentStatus: SalesOrderPaymentStatus.PAID });
+      orderRepo.findOne.mockResolvedValue(order);
+      methodRepo.findOne.mockResolvedValue(mockMethod());
+      paymentRepo.find.mockResolvedValue([{ amount: 1000 }] as SalesOrderPayment[]);
+
+      const mockManager = buildMockManager([{ amount: 1000 }, { amount: -1000 }] as SalesOrderPayment[]);
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: (m: EntityManager) => Promise<any>) => cb(mockManager));
+
+      await expect(service.recordRefund('order-1', { paymentMethodId: 'method-1', amount: 1000, paymentDate: '2026-01-01' }))
+        .resolves.not.toThrow();
     });
   });
 
   describe('listPayments', () => {
+    it('throws NotFoundException when order not found', async () => {
+      orderRepo.findOne.mockResolvedValue(null);
+      await expect(service.listPayments('order-1')).rejects.toThrow(NotFoundException);
+    });
+
     it('returns payments ordered by paymentDate', async () => {
       orderRepo.findOne.mockResolvedValue(mockOrder());
       paymentRepo.find.mockResolvedValue([{ id: 'p1', amount: 500 }] as SalesOrderPayment[]);

--- a/backend/src/modules/sales/services/sales-order-payment.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.spec.ts
@@ -1,0 +1,156 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+import { SalesOrderPaymentService } from './sales-order-payment.service';
+import { SalesOrder, SalesOrderStatus, SalesOrderPaymentStatus } from '../../../database/entities/sales-order.entity';
+import { SalesOrderPayment } from '../../../database/entities/sales-order-payment.entity';
+import { PaymentMethodEntity } from '../../../database/entities/payment-method.entity';
+import { AuditLogService } from '../../audit-logs/services';
+
+const mockOrder = (overrides: Partial<SalesOrder> = {}): SalesOrder => ({
+  id: 'order-1',
+  orderNumber: 'SO-000001',
+  status: SalesOrderStatus.DRAFT,
+  paymentStatus: SalesOrderPaymentStatus.UNPAID,
+  totalAmount: 1000,
+  customerId: 'customer-1',
+  ...overrides,
+} as SalesOrder);
+
+const mockMethod = (): PaymentMethodEntity => ({ id: 'method-1', isActive: true } as PaymentMethodEntity);
+
+describe('SalesOrderPaymentService', () => {
+  let service: SalesOrderPaymentService;
+  let orderRepo: jest.Mocked<Repository<SalesOrder>>;
+  let paymentRepo: jest.Mocked<Repository<SalesOrderPayment>>;
+  let methodRepo: jest.Mocked<Repository<PaymentMethodEntity>>;
+  let auditLogService: jest.Mocked<AuditLogService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SalesOrderPaymentService,
+        { provide: getRepositoryToken(SalesOrder), useValue: { findOne: jest.fn(), save: jest.fn() } },
+        { provide: getRepositoryToken(SalesOrderPayment), useValue: { find: jest.fn(), create: jest.fn(), save: jest.fn() } },
+        { provide: getRepositoryToken(PaymentMethodEntity), useValue: { findOne: jest.fn() } },
+        { provide: AuditLogService, useValue: { log: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get(SalesOrderPaymentService);
+    orderRepo = module.get(getRepositoryToken(SalesOrder));
+    paymentRepo = module.get(getRepositoryToken(SalesOrderPayment));
+    methodRepo = module.get(getRepositoryToken(PaymentMethodEntity));
+    auditLogService = module.get(AuditLogService);
+  });
+
+  describe('recomputePaymentStatus', () => {
+    it('returns UNPAID when no payments', () => {
+      expect(service.computePaymentStatus([], 1000)).toBe(SalesOrderPaymentStatus.UNPAID);
+    });
+
+    it('returns PARTIAL when net paid < total', () => {
+      const records = [{ amount: 400 } as SalesOrderPayment];
+      expect(service.computePaymentStatus(records, 1000)).toBe(SalesOrderPaymentStatus.PARTIAL);
+    });
+
+    it('returns PAID when net paid = total', () => {
+      const records = [{ amount: 1000 } as SalesOrderPayment];
+      expect(service.computePaymentStatus(records, 1000)).toBe(SalesOrderPaymentStatus.PAID);
+    });
+
+    it('returns OVERPAID when net paid > total', () => {
+      const records = [{ amount: 1200 } as SalesOrderPayment];
+      expect(service.computePaymentStatus(records, 1000)).toBe(SalesOrderPaymentStatus.OVERPAID);
+    });
+
+    it('returns UNPAID after full payment + full refund', () => {
+      const records = [{ amount: 1000 }, { amount: -1000 }] as SalesOrderPayment[];
+      expect(service.computePaymentStatus(records, 1000)).toBe(SalesOrderPaymentStatus.UNPAID);
+    });
+  });
+
+  describe('recordPayment', () => {
+    it('throws NotFoundException when order not found', async () => {
+      orderRepo.findOne.mockResolvedValue(null);
+      await expect(service.recordPayment('order-1', { paymentMethodId: 'method-1', amount: 100, paymentDate: '2026-01-01' }))
+        .rejects.toThrow(NotFoundException);
+    });
+
+    it('throws ConflictException when order is not DRAFT', async () => {
+      orderRepo.findOne.mockResolvedValue(mockOrder({ status: SalesOrderStatus.FULFILLED }));
+      await expect(service.recordPayment('order-1', { paymentMethodId: 'method-1', amount: 100, paymentDate: '2026-01-01' }))
+        .rejects.toThrow(ConflictException);
+    });
+
+    it('throws BadRequestException for non-positive amount', async () => {
+      orderRepo.findOne.mockResolvedValue(mockOrder());
+      await expect(service.recordPayment('order-1', { paymentMethodId: 'method-1', amount: 0, paymentDate: '2026-01-01' }))
+        .rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when payment method not found', async () => {
+      orderRepo.findOne.mockResolvedValue(mockOrder());
+      methodRepo.findOne.mockResolvedValue(null);
+      await expect(service.recordPayment('order-1', { paymentMethodId: 'method-1', amount: 100, paymentDate: '2026-01-01' }))
+        .rejects.toThrow(BadRequestException);
+    });
+
+    it('creates payment record and updates paymentStatus', async () => {
+      const order = mockOrder();
+      orderRepo.findOne.mockResolvedValue(order);
+      methodRepo.findOne.mockResolvedValue(mockMethod());
+      paymentRepo.find.mockResolvedValue([]);
+      paymentRepo.create.mockReturnValue({ amount: 1000 } as SalesOrderPayment);
+      paymentRepo.save.mockResolvedValue({ amount: 1000 } as SalesOrderPayment);
+      orderRepo.save.mockResolvedValue({ ...order, paymentStatus: SalesOrderPaymentStatus.PAID } as SalesOrder);
+
+      await service.recordPayment('order-1', { paymentMethodId: 'method-1', amount: 1000, paymentDate: '2026-01-01' });
+
+      expect(paymentRepo.create).toHaveBeenCalledWith(expect.objectContaining({ amount: 1000, salesOrderId: 'order-1' }));
+      expect(orderRepo.save).toHaveBeenCalledWith(expect.objectContaining({ paymentStatus: SalesOrderPaymentStatus.PAID }));
+    });
+  });
+
+  describe('recordRefund', () => {
+    it('throws BadRequestException when refund amount exceeds net paid', async () => {
+      const order = mockOrder({ paymentStatus: SalesOrderPaymentStatus.PARTIAL });
+      orderRepo.findOne.mockResolvedValue(order);
+      methodRepo.findOne.mockResolvedValue(mockMethod());
+      paymentRepo.find.mockResolvedValue([{ amount: 400 }] as SalesOrderPayment[]);
+
+      await expect(service.recordRefund('order-1', { paymentMethodId: 'method-1', amount: 500, paymentDate: '2026-01-01' }))
+        .rejects.toThrow(BadRequestException);
+    });
+
+    it('creates negative payment record for refund', async () => {
+      const order = mockOrder({ paymentStatus: SalesOrderPaymentStatus.PAID });
+      orderRepo.findOne.mockResolvedValue(order);
+      methodRepo.findOne.mockResolvedValue(mockMethod());
+      paymentRepo.find.mockResolvedValue([{ amount: 1000 }] as SalesOrderPayment[]);
+      paymentRepo.create.mockReturnValue({ amount: -400 } as SalesOrderPayment);
+      paymentRepo.save.mockResolvedValue({ amount: -400 } as SalesOrderPayment);
+      orderRepo.save.mockResolvedValue({ ...order, paymentStatus: SalesOrderPaymentStatus.PARTIAL } as SalesOrder);
+
+      await service.recordRefund('order-1', { paymentMethodId: 'method-1', amount: 400, paymentDate: '2026-01-01' });
+
+      expect(paymentRepo.create).toHaveBeenCalledWith(expect.objectContaining({ amount: -400 }));
+    });
+  });
+
+  describe('listPayments', () => {
+    it('returns payments ordered by paymentDate', async () => {
+      orderRepo.findOne.mockResolvedValue(mockOrder());
+      paymentRepo.find.mockResolvedValue([{ id: 'p1', amount: 500 }] as SalesOrderPayment[]);
+
+      const result = await service.listPayments('order-1');
+
+      expect(paymentRepo.find).toHaveBeenCalledWith(expect.objectContaining({
+        where: { salesOrderId: 'order-1' },
+        order: { paymentDate: 'ASC' },
+      }));
+      expect(result).toHaveLength(1);
+    });
+  });
+});

--- a/backend/src/modules/sales/services/sales-order-payment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.ts
@@ -5,19 +5,14 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import { SalesOrder, SalesOrderPaymentStatus, SalesOrderStatus } from '../../../database/entities/sales-order.entity';
 import { SalesOrderPayment } from '../../../database/entities/sales-order-payment.entity';
 import { PaymentMethodEntity } from '../../../database/entities/payment-method.entity';
 import { AuditLogService } from '../../audit-logs/services';
+import { RecordPaymentDto } from '../dto/sales-order.dto';
 
-export interface RecordPaymentDto {
-  paymentMethodId: string;
-  amount: number;
-  paymentDate: string;
-  referenceNumber?: string;
-  notes?: string;
-}
+const AMOUNT_TOLERANCE = 0.001;
 
 @Injectable()
 export class SalesOrderPaymentService {
@@ -29,6 +24,7 @@ export class SalesOrderPaymentService {
     @InjectRepository(PaymentMethodEntity)
     private readonly paymentMethodRepository: Repository<PaymentMethodEntity>,
     private readonly auditLogService: AuditLogService,
+    private readonly dataSource: DataSource,
   ) {}
 
   computePaymentStatus(
@@ -38,12 +34,12 @@ export class SalesOrderPaymentService {
     const netPaid = records.reduce((sum, r) => sum + Number(r.amount), 0);
     const total = Number(totalAmount);
     if (netPaid <= 0) return SalesOrderPaymentStatus.UNPAID;
+    if (Math.abs(netPaid - total) < AMOUNT_TOLERANCE) return SalesOrderPaymentStatus.PAID;
     if (netPaid < total) return SalesOrderPaymentStatus.PARTIAL;
-    if (netPaid === total) return SalesOrderPaymentStatus.PAID;
     return SalesOrderPaymentStatus.OVERPAID;
   }
 
-  async recordPayment(orderId: string, dto: RecordPaymentDto): Promise<SalesOrderPayment> {
+  async recordPayment(orderId: string, dto: RecordPaymentDto, userId?: string, username?: string): Promise<SalesOrderPayment> {
     if (dto.amount <= 0) {
       throw new BadRequestException('Payment amount must be positive');
     }
@@ -59,34 +55,40 @@ export class SalesOrderPaymentService {
     });
     if (!method) throw new BadRequestException(`Payment method ${dto.paymentMethodId} not found or inactive`);
 
-    const record = this.salesOrderPaymentRepository.create({
-      salesOrderId: orderId,
-      paymentMethodId: dto.paymentMethodId,
-      amount: dto.amount,
-      paymentDate: dto.paymentDate,
-      referenceNumber: dto.referenceNumber,
-      notes: dto.notes,
+    const saved = await this.dataSource.transaction(async (manager: EntityManager) => {
+      const record = manager.getRepository(SalesOrderPayment).create({
+        salesOrderId: orderId,
+        paymentMethodId: dto.paymentMethodId,
+        amount: dto.amount,
+        paymentDate: dto.paymentDate,
+        referenceNumber: dto.referenceNumber,
+        notes: dto.notes,
+      });
+      const savedRecord = await manager.getRepository(SalesOrderPayment).save(record);
+      await this.updatePaymentStatusInTx(order, manager);
+      return savedRecord;
     });
-    const saved = await this.salesOrderPaymentRepository.save(record);
-
-    await this.updatePaymentStatus(order, saved);
 
     await this.auditLogService.log('CREATE', 'SalesOrderPayment', `Recorded payment for ${order.orderNumber}`, {
       entityId: saved.id,
-      userId: 'system',
+      userId: userId || 'system',
+      username,
       newValues: { amount: dto.amount, paymentMethodId: dto.paymentMethodId },
     });
 
     return saved;
   }
 
-  async recordRefund(orderId: string, dto: RecordPaymentDto): Promise<SalesOrderPayment> {
+  async recordRefund(orderId: string, dto: RecordPaymentDto, userId?: string, username?: string): Promise<SalesOrderPayment> {
     if (dto.amount <= 0) {
       throw new BadRequestException('Refund amount must be positive');
     }
 
     const order = await this.salesOrderRepository.findOne({ where: { id: orderId } });
     if (!order) throw new NotFoundException('Sales order not found');
+    if (order.status === SalesOrderStatus.CANCELLED) {
+      throw new ConflictException('Cannot record a refund on a cancelled order');
+    }
 
     const method = await this.paymentMethodRepository.findOne({
       where: { id: dto.paymentMethodId, isActive: true },
@@ -95,25 +97,28 @@ export class SalesOrderPaymentService {
 
     const existing = await this.salesOrderPaymentRepository.find({ where: { salesOrderId: orderId } });
     const netPaid = existing.reduce((sum, r) => sum + Number(r.amount), 0);
-    if (dto.amount > netPaid) {
-      throw new BadRequestException(`Refund amount (${dto.amount}) exceeds net paid (${netPaid})`);
+    if (dto.amount > netPaid + AMOUNT_TOLERANCE) {
+      throw new BadRequestException(`Refund amount (${dto.amount}) exceeds net paid (${netPaid.toFixed(4)})`);
     }
 
-    const record = this.salesOrderPaymentRepository.create({
-      salesOrderId: orderId,
-      paymentMethodId: dto.paymentMethodId,
-      amount: -dto.amount,
-      paymentDate: dto.paymentDate,
-      referenceNumber: dto.referenceNumber,
-      notes: dto.notes,
+    const saved = await this.dataSource.transaction(async (manager: EntityManager) => {
+      const record = manager.getRepository(SalesOrderPayment).create({
+        salesOrderId: orderId,
+        paymentMethodId: dto.paymentMethodId,
+        amount: -dto.amount,
+        paymentDate: dto.paymentDate,
+        referenceNumber: dto.referenceNumber,
+        notes: dto.notes,
+      });
+      const savedRecord = await manager.getRepository(SalesOrderPayment).save(record);
+      await this.updatePaymentStatusInTx(order, manager);
+      return savedRecord;
     });
-    const saved = await this.salesOrderPaymentRepository.save(record);
-
-    await this.updatePaymentStatus(order, saved);
 
     await this.auditLogService.log('CREATE', 'SalesOrderPayment', `Recorded refund for ${order.orderNumber}`, {
       entityId: saved.id,
-      userId: 'system',
+      userId: userId || 'system',
+      username,
       newValues: { amount: -dto.amount, paymentMethodId: dto.paymentMethodId },
     });
 
@@ -131,12 +136,9 @@ export class SalesOrderPaymentService {
     });
   }
 
-  private async updatePaymentStatus(order: SalesOrder, savedRecord: SalesOrderPayment): Promise<void> {
-    const all = await this.salesOrderPaymentRepository.find({ where: { salesOrderId: order.id } });
-    const records = all.some((record) => record.id === savedRecord.id)
-      ? all
-      : [...all, savedRecord];
-    order.paymentStatus = this.computePaymentStatus(records, order.totalAmount);
-    await this.salesOrderRepository.save(order);
+  private async updatePaymentStatusInTx(order: SalesOrder, manager: EntityManager): Promise<void> {
+    const all = await manager.getRepository(SalesOrderPayment).find({ where: { salesOrderId: order.id } });
+    const newStatus = this.computePaymentStatus(all, order.totalAmount);
+    await manager.getRepository(SalesOrder).update(order.id, { paymentStatus: newStatus });
   }
 }

--- a/backend/src/modules/sales/services/sales-order-payment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.ts
@@ -2,407 +2,141 @@ import {
   BadRequestException,
   ConflictException,
   Injectable,
-  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, Repository } from 'typeorm';
-
-import { Invoice } from '../../../database/entities/invoice.entity';
-import { Payment, PaymentStatus, SettlementStatusEnum } from '../../../database/entities/payment.entity';
+import { Repository } from 'typeorm';
+import { SalesOrder, SalesOrderPaymentStatus, SalesOrderStatus } from '../../../database/entities/sales-order.entity';
+import { SalesOrderPayment } from '../../../database/entities/sales-order-payment.entity';
 import { PaymentMethodEntity } from '../../../database/entities/payment-method.entity';
-import { SalesOrder } from '../../../database/entities/sales-order.entity';
 import { AuditLogService } from '../../audit-logs/services';
-import { AccountingService } from '../../accounting/services/accounting.service';
-import { SettingsService } from '../../settings/settings.service';
-import { SalesOrderResponseDto } from '../dto/sales-order.dto';
+
+export interface RecordPaymentDto {
+  paymentMethodId: string;
+  amount: number;
+  paymentDate: string;
+  referenceNumber?: string;
+  notes?: string;
+}
 
 @Injectable()
 export class SalesOrderPaymentService {
-  private readonly logger = new Logger(SalesOrderPaymentService.name);
-
   constructor(
     @InjectRepository(SalesOrder)
     private readonly salesOrderRepository: Repository<SalesOrder>,
-    private readonly settingsService: SettingsService,
+    @InjectRepository(SalesOrderPayment)
+    private readonly salesOrderPaymentRepository: Repository<SalesOrderPayment>,
+    @InjectRepository(PaymentMethodEntity)
+    private readonly paymentMethodRepository: Repository<PaymentMethodEntity>,
     private readonly auditLogService: AuditLogService,
-    private readonly accountingService: AccountingService,
-    private readonly dataSource: DataSource,
   ) {}
 
-  async recordPayment(
-    id: string,
-    amount: number,
-    paymentMethodId: string | undefined,
-    findOrderById: (id: string) => Promise<SalesOrderResponseDto>,
-  ): Promise<SalesOrderResponseDto> {
-    if (amount < 0) {
+  computePaymentStatus(
+    records: SalesOrderPayment[],
+    totalAmount: number,
+  ): SalesOrderPaymentStatus {
+    const netPaid = records.reduce((sum, r) => sum + Number(r.amount), 0);
+    const total = Number(totalAmount);
+    if (netPaid <= 0) return SalesOrderPaymentStatus.UNPAID;
+    if (netPaid < total) return SalesOrderPaymentStatus.PARTIAL;
+    if (netPaid === total) return SalesOrderPaymentStatus.PAID;
+    return SalesOrderPaymentStatus.OVERPAID;
+  }
+
+  async recordPayment(orderId: string, dto: RecordPaymentDto): Promise<SalesOrderPayment> {
+    if (dto.amount <= 0) {
       throw new BadRequestException('Payment amount must be positive');
     }
 
-    const order = await this.salesOrderRepository.findOne({
-      where: { id },
-      relations: { customer: true, items: { product: true } },
+    const order = await this.salesOrderRepository.findOne({ where: { id: orderId } });
+    if (!order) throw new NotFoundException('Sales order not found');
+    if (order.status !== SalesOrderStatus.DRAFT) {
+      throw new ConflictException('Payments can only be recorded on DRAFT orders');
+    }
+
+    const method = await this.paymentMethodRepository.findOne({
+      where: { id: dto.paymentMethodId, isActive: true },
+    });
+    if (!method) throw new BadRequestException(`Payment method ${dto.paymentMethodId} not found or inactive`);
+
+    const record = this.salesOrderPaymentRepository.create({
+      salesOrderId: orderId,
+      paymentMethodId: dto.paymentMethodId,
+      amount: dto.amount,
+      paymentDate: dto.paymentDate,
+      referenceNumber: dto.referenceNumber,
+      notes: dto.notes,
+    });
+    const saved = await this.salesOrderPaymentRepository.save(record);
+
+    await this.updatePaymentStatus(order, saved);
+
+    await this.auditLogService.log('CREATE', 'SalesOrderPayment', `Recorded payment for ${order.orderNumber}`, {
+      entityId: saved.id,
+      userId: 'system',
+      newValues: { amount: dto.amount, paymentMethodId: dto.paymentMethodId },
     });
 
-    if (!order) {
-      throw new NotFoundException('Sales order not found');
-    }
-
-    if (order.isFulfilled) {
-      throw new ConflictException('Cannot modify payment for fulfilled order');
-    }
-
-    order.paidAmount = Number(amount);
-    const savedOrder = await this.salesOrderRepository.save(order);
-
-    try {
-      const paymentRepository = this.salesOrderRepository.manager.getRepository(Payment);
-      const invoiceRepository = this.salesOrderRepository.manager.getRepository(Invoice);
-      const paymentMethodRepository = this.salesOrderRepository.manager.getRepository(PaymentMethodEntity);
-
-      let selectedMethod = null;
-      if (paymentMethodId) {
-        selectedMethod = await paymentMethodRepository.findOne({
-          where: { id: paymentMethodId, isActive: true },
-        });
-      }
-      if (!selectedMethod) {
-        selectedMethod = await paymentMethodRepository.findOne({
-          where: { code: 'CASH', isActive: true },
-        });
-      }
-      if (!selectedMethod) {
-        this.logger.warn(
-          `No payment method found for order ${order.orderNumber} (requested: ${paymentMethodId || 'none'})`,
-        );
-      }
-
-      const methodSettlementStatus = selectedMethod?.requiresSettlement
-        ? SettlementStatusEnum.PENDING
-        : SettlementStatusEnum.NOT_APPLICABLE;
-
-      const invoice = await invoiceRepository.findOne({
-        where: { salesOrderId: savedOrder.id },
-      });
-
-      if (invoice) {
-        invoice.paidAmount = Number(amount);
-        invoice.calculateTotals();
-        invoice.updateStatus();
-        await invoiceRepository.save(invoice);
-      }
-
-      let existingPayment = null;
-      if (invoice) {
-        existingPayment = await paymentRepository.findOne({
-          where: { invoiceId: invoice.id },
-          withDeleted: true,
-        });
-      }
-
-      if (existingPayment) {
-        if (existingPayment.deletedAt) {
-          await paymentRepository.restore(existingPayment.id);
-          const restoredPayment = await paymentRepository.findOne({
-            where: { id: existingPayment.id },
-          });
-
-          if (restoredPayment) {
-            restoredPayment.isActive = true;
-            await paymentRepository.save(restoredPayment);
-
-            await this.auditLogService.log('RESTORE', 'Payment', `Restored payment: ${restoredPayment.paymentNumber} for sales order ${order.orderNumber}`, {
-              entityId: restoredPayment.id,
-              userId: 'system',
-              newValues: {
-                paymentNumber: restoredPayment.paymentNumber,
-                amount: Number(amount),
-              },
-            });
-
-            Object.assign(existingPayment, restoredPayment);
-          }
-        }
-
-        existingPayment.amount = Number(amount);
-        existingPayment.paymentDate = new Date();
-        existingPayment.notes = `Payment recorded for sales order ${order.orderNumber}${invoice ? ` (Invoice: ${invoice.invoiceNumber})` : ''}`;
-        existingPayment.invoiceId = invoice ? invoice.id : null;
-        existingPayment.paymentMethodId = selectedMethod?.id || existingPayment.paymentMethodId;
-        existingPayment.settlementStatus = selectedMethod
-          ? methodSettlementStatus
-          : existingPayment.settlementStatus;
-        await paymentRepository.save(existingPayment);
-
-        await this.auditLogService.log('UPDATE', 'Payment', `Updated payment: ${existingPayment.paymentNumber} for sales order ${order.orderNumber}`, {
-          entityId: existingPayment.id,
-          userId: 'system',
-          newValues: {
-            paymentNumber: existingPayment.paymentNumber,
-            amount: existingPayment.amount,
-            status: existingPayment.status,
-          },
-        });
-      } else {
-        const paymentNumber = await this.generatePaymentNumber(paymentRepository);
-        const payment = paymentRepository.create({
-          paymentNumber,
-          status: PaymentStatus.COMPLETED,
-          paymentMethodId: selectedMethod?.id,
-          settlementStatus: methodSettlementStatus,
-          paymentDate: new Date(),
-          amount: Number(amount),
-          customerId: order.customerId,
-          invoiceId: invoice ? invoice.id : null,
-          notes: `Payment recorded for sales order ${order.orderNumber}${invoice ? ` (Invoice: ${invoice.invoiceNumber})` : ''}`,
-        });
-
-        await paymentRepository.save(payment);
-
-        await this.auditLogService.log('CREATE', 'Payment', `Created payment: ${payment.paymentNumber} for sales order ${order.orderNumber}`, {
-          entityId: payment.id,
-          userId: 'system',
-          newValues: {
-            paymentNumber: payment.paymentNumber,
-            amount: payment.amount,
-            status: payment.status,
-            paymentMethodId: payment.paymentMethodId,
-          },
-        });
-      }
-    } catch (error) {
-      this.logger.error(`Failed to auto-generate payment for order ${order.orderNumber}: ${error.message}`, error.stack);
-    }
-
-    return findOrderById(savedOrder.id);
+    return saved;
   }
 
-  async recordPayments(
-    id: string,
-    payments: { paymentMethodId: string; amount: number; reference?: string }[],
-    findOrderById: (id: string) => Promise<SalesOrderResponseDto>,
-  ): Promise<SalesOrderResponseDto> {
-    for (const line of payments) {
-      if (line.amount <= 0) {
-        throw new BadRequestException('All payment amounts must be positive');
-      }
+  async recordRefund(orderId: string, dto: RecordPaymentDto): Promise<SalesOrderPayment> {
+    if (dto.amount <= 0) {
+      throw new BadRequestException('Refund amount must be positive');
     }
 
-    const order = await this.salesOrderRepository.findOne({
-      where: { id },
-      relations: { customer: true, items: { product: true } },
+    const order = await this.salesOrderRepository.findOne({ where: { id: orderId } });
+    if (!order) throw new NotFoundException('Sales order not found');
+
+    const method = await this.paymentMethodRepository.findOne({
+      where: { id: dto.paymentMethodId, isActive: true },
+    });
+    if (!method) throw new BadRequestException(`Payment method ${dto.paymentMethodId} not found or inactive`);
+
+    const existing = await this.salesOrderPaymentRepository.find({ where: { salesOrderId: orderId } });
+    const netPaid = existing.reduce((sum, r) => sum + Number(r.amount), 0);
+    if (dto.amount > netPaid) {
+      throw new BadRequestException(`Refund amount (${dto.amount}) exceeds net paid (${netPaid})`);
+    }
+
+    const record = this.salesOrderPaymentRepository.create({
+      salesOrderId: orderId,
+      paymentMethodId: dto.paymentMethodId,
+      amount: -dto.amount,
+      paymentDate: dto.paymentDate,
+      referenceNumber: dto.referenceNumber,
+      notes: dto.notes,
+    });
+    const saved = await this.salesOrderPaymentRepository.save(record);
+
+    await this.updatePaymentStatus(order, saved);
+
+    await this.auditLogService.log('CREATE', 'SalesOrderPayment', `Recorded refund for ${order.orderNumber}`, {
+      entityId: saved.id,
+      userId: 'system',
+      newValues: { amount: -dto.amount, paymentMethodId: dto.paymentMethodId },
     });
 
-    if (!order) {
-      throw new NotFoundException('Sales order not found');
-    }
-
-    if (order.isFulfilled) {
-      throw new ConflictException('Cannot modify payment for fulfilled order');
-    }
-
-    const totalPayment = payments.reduce((sum, payment) => sum + payment.amount, 0);
-    const newPaidAmount = Number(order.paidAmount || 0) + totalPayment;
-
-    await this.dataSource.transaction(async (manager) => {
-      const paymentRepo = manager.getRepository(Payment);
-      const invoiceRepo = manager.getRepository(Invoice);
-      const paymentMethodRepo = manager.getRepository(PaymentMethodEntity);
-      const orderRepo = manager.getRepository(SalesOrder);
-
-      const invoice = await invoiceRepo.findOne({ where: { salesOrderId: order.id } });
-      const softDeletedPayments = invoice
-        ? (await paymentRepo.find({
-            where: { invoiceId: invoice.id },
-            withDeleted: true,
-            order: { paymentDate: 'DESC' },
-          })).filter((record) => record.deletedAt !== null)
-        : [];
-
-      for (let index = 0; index < payments.length; index++) {
-        const line = payments[index];
-        const method = await paymentMethodRepo.findOne({
-          where: { id: line.paymentMethodId, isActive: true },
-        });
-
-        if (!method) {
-          throw new BadRequestException(`Payment method ${line.paymentMethodId} not found or inactive`);
-        }
-
-        const settlementStatus = method.requiresSettlement
-          ? SettlementStatusEnum.PENDING
-          : SettlementStatusEnum.NOT_APPLICABLE;
-
-        const notes = line.reference
-          ? `${line.reference} - Payment for ${order.orderNumber}${invoice ? ` (${invoice.invoiceNumber})` : ''}`
-          : `Payment for ${order.orderNumber}${invoice ? ` (${invoice.invoiceNumber})` : ''}`;
-
-        const existingDeleted = softDeletedPayments[index];
-        let savedPayment: Payment;
-
-        if (existingDeleted) {
-          await paymentRepo.restore(existingDeleted.id);
-          const restoredPayment = await paymentRepo.findOne({ where: { id: existingDeleted.id } });
-          if (!restoredPayment) {
-            throw new NotFoundException(`Payment ${existingDeleted.id} not found after restore`);
-          }
-
-          restoredPayment.isActive = true;
-          restoredPayment.amount = Number(line.amount);
-          restoredPayment.paymentMethodId = method.id;
-          restoredPayment.paymentMethodEntity = method;
-          restoredPayment.settlementStatus = settlementStatus;
-          restoredPayment.paymentDate = new Date();
-          restoredPayment.notes = notes;
-          savedPayment = await paymentRepo.save(restoredPayment);
-
-          await this.auditLogService.log('UPDATE', 'Payment', `Restored and updated payment: ${savedPayment.paymentNumber} for ${order.orderNumber}`, {
-            entityId: savedPayment.id,
-            userId: 'system',
-            newValues: {
-              paymentNumber: savedPayment.paymentNumber,
-              amount: savedPayment.amount,
-              paymentMethodId: method.id,
-            },
-          });
-        } else {
-          const paymentNumber = await this.generatePaymentNumber(paymentRepo);
-          const payment = paymentRepo.create({
-            paymentNumber,
-            status: PaymentStatus.COMPLETED,
-            paymentMethodId: method.id,
-            settlementStatus,
-            paymentDate: new Date(),
-            amount: Number(line.amount),
-            customerId: order.customerId,
-            invoiceId: invoice ? invoice.id : null,
-            notes,
-          });
-
-          savedPayment = await paymentRepo.save(payment);
-
-          await this.auditLogService.log('CREATE', 'Payment', `Created payment: ${paymentNumber} for ${order.orderNumber}`, {
-            entityId: savedPayment.id,
-            userId: 'system',
-            newValues: {
-              paymentNumber,
-              amount: line.amount,
-              paymentMethodId: method.id,
-            },
-          });
-        }
-
-        try {
-          const fullPayment = await paymentRepo.findOne({
-            where: { id: savedPayment.id },
-            relations: { customer: true, paymentMethodEntity: true },
-          });
-          if (fullPayment) {
-            await this.accountingService.postCustomerPaymentEntry(fullPayment, 'system');
-          }
-        } catch (error) {
-          this.logger.error(`Failed to post accounting entry for payment ${savedPayment.paymentNumber}: ${error.message}`);
-        }
-      }
-
-      await orderRepo.update(order.id, { paidAmount: newPaidAmount });
-
-      if (invoice) {
-        invoice.paidAmount = newPaidAmount;
-        invoice.calculateTotals();
-        invoice.updateStatus();
-        await invoiceRepo.save(invoice);
-      }
-    });
-
-    return findOrderById(id);
+    return saved;
   }
 
-  async unpayOrder(
-    id: string,
-    findOrderById: (id: string) => Promise<SalesOrderResponseDto>,
-  ): Promise<SalesOrderResponseDto> {
-    const order = await this.salesOrderRepository.findOne({
-      where: { id },
-      relations: { customer: true, items: { product: true } },
+  async listPayments(orderId: string): Promise<SalesOrderPayment[]> {
+    const order = await this.salesOrderRepository.findOne({ where: { id: orderId } });
+    if (!order) throw new NotFoundException('Sales order not found');
+
+    return this.salesOrderPaymentRepository.find({
+      where: { salesOrderId: orderId },
+      order: { paymentDate: 'ASC' },
+      relations: { paymentMethod: true },
     });
-
-    if (!order) {
-      throw new NotFoundException('Sales order not found');
-    }
-
-    if (order.isFulfilled) {
-      throw new ConflictException('Cannot unpay fulfilled order - order has already been fulfilled');
-    }
-
-    try {
-      const paymentRepository = this.salesOrderRepository.manager.getRepository(Payment);
-      const invoiceRepository = this.salesOrderRepository.manager.getRepository(Invoice);
-
-      const invoice = await invoiceRepository.findOne({
-        where: { salesOrderId: order.id },
-      });
-
-      if (invoice) {
-        const associatedPayments = await paymentRepository.find({
-          where: { invoiceId: invoice.id },
-        });
-
-        if (associatedPayments.length > 0) {
-          for (const payment of associatedPayments) {
-            try {
-              await this.accountingService.reverseSourceEntries('payment', payment.id, 'system');
-              this.logger.log(`Reversed accounting entries for payment ${payment.paymentNumber}`);
-            } catch (error) {
-              this.logger.error(`Failed to reverse JE for payment ${payment.id}: ${error.message}`);
-            }
-
-            await this.auditLogService.log('DELETE', 'Payment', `Soft deleted payment: ${payment.paymentNumber} (unpaid sales order ${order.orderNumber})`, {
-              entityId: payment.id,
-              userId: 'system',
-              oldValues: {
-                paymentNumber: payment.paymentNumber,
-                amount: payment.amount,
-                status: payment.status,
-              },
-            });
-          }
-
-          await paymentRepository.softDelete(associatedPayments.map((payment) => payment.id));
-        }
-
-        invoice.paidAmount = 0;
-        invoice.calculateTotals();
-        invoice.updateStatus();
-        await invoiceRepository.save(invoice);
-      }
-    } catch (error) {
-      this.logger.error(`Failed to unpay order ${order.orderNumber}: ${error.message}`);
-    }
-
-    order.paidAmount = 0;
-    const savedOrder = await this.salesOrderRepository.save(order);
-
-    return findOrderById(savedOrder.id);
   }
 
-  private async generatePaymentNumber(paymentRepository: Repository<Payment>): Promise<string> {
-    try {
-      return await this.settingsService.generateDocumentNumber('Payments');
-    } catch {
-      const allPayments = await paymentRepository.find({
-        select: { paymentNumber: true },
-        withDeleted: true,
-      });
-      let maxNumber = 0;
-      for (const payment of allPayments) {
-        const match = payment.paymentNumber.match(/^PAY-(\d+)$/);
-        if (match) {
-          maxNumber = Math.max(maxNumber, parseInt(match[1], 10));
-        }
-      }
-      return `PAY-${(maxNumber + 1).toString().padStart(6, '0')}`;
-    }
+  private async updatePaymentStatus(order: SalesOrder, savedRecord: SalesOrderPayment): Promise<void> {
+    const all = await this.salesOrderPaymentRepository.find({ where: { salesOrderId: order.id } });
+    const records = all.some((record) => record.id === savedRecord.id)
+      ? all
+      : [...all, savedRecord];
+    order.paymentStatus = this.computePaymentStatus(records, order.totalAmount);
+    await this.salesOrderRepository.save(order);
   }
 }

--- a/backend/src/modules/sales/services/sales-order-query.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-query.service.spec.ts
@@ -1,17 +1,16 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { SalesOrder } from '../../../database/entities/sales-order.entity';
+import { SalesOrder, SalesOrderPaymentStatus, SalesOrderStatus } from '../../../database/entities/sales-order.entity';
 import { Product } from '../../../database/entities/product.entity';
-import { Invoice } from '../../../database/entities/invoice.entity';
-import { Payment } from '../../../database/entities/payment.entity';
 import { Customer } from '../../../database/entities/customer.entity';
-import { SalesOrderItem } from '../../../database/entities/sales-order-item.entity';
+import { SalesOrderPayment } from '../../../database/entities/sales-order-payment.entity';
 import { SalesOrderQueryService } from './sales-order-query.service';
 
 describe('SalesOrderQueryService', () => {
   let service: SalesOrderQueryService;
   let salesOrderRepository: jest.Mocked<Repository<SalesOrder>>;
+  let paymentRepository: jest.Mocked<Repository<SalesOrderPayment>>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -27,21 +26,15 @@ describe('SalesOrderQueryService', () => {
           },
         },
         {
+          provide: getRepositoryToken(SalesOrderPayment),
+          useValue: {
+            find: jest.fn().mockResolvedValue([]),
+          },
+        },
+        {
           provide: getRepositoryToken(Product),
           useValue: {
             findOne: jest.fn(),
-          },
-        },
-        {
-          provide: getRepositoryToken(Invoice),
-          useValue: {
-            find: jest.fn(),
-          },
-        },
-        {
-          provide: getRepositoryToken(Payment),
-          useValue: {
-            find: jest.fn().mockResolvedValue([]),
           },
         },
       ],
@@ -49,195 +42,54 @@ describe('SalesOrderQueryService', () => {
 
     service = module.get(SalesOrderQueryService);
     salesOrderRepository = module.get(getRepositoryToken(SalesOrder));
-  });
-
-  it('returns the previous sequential order when it exists', async () => {
-    salesOrderRepository.findOne.mockResolvedValue({
-      id: 'order-1',
-      orderNumber: 'SO-000001',
-      customerId: 'customer-1',
-      orderDate: new Date('2026-01-01T00:00:00.000Z'),
-      totalAmount: 100,
-      paidAmount: 0,
-      balanceDue: 100,
-      isFulfilled: false,
-      isPaidInFull: false,
-      customer: {
-        id: 'customer-1',
-        name: 'Acme',
-      } as Customer,
-      items: [
-        {
-          id: 'item-1',
-          productId: 'product-1',
-          quantity: 1,
-          unitPrice: 100,
-          totalAmount: 100,
-          product: {
-            id: 'product-1',
-            name: 'Widget',
-          } as Product,
-        } as SalesOrderItem,
-      ],
-    } as SalesOrder);
-
-    const result = await service.findPreviousOrder('SO-000002');
-
-    expect(salesOrderRepository.findOne).toHaveBeenCalledWith({
-      where: { orderNumber: 'SO-000001' },
-      relations: { customer: true, items: { product: true } },
-      withDeleted: true,
-    });
-    expect(result).toMatchObject({
-      id: 'order-1',
-      orderNumber: 'SO-000001',
-      customer: { name: 'Acme' },
-      items: [
-        expect.objectContaining({
-          productId: 'product-1',
-        }),
-      ],
-    });
+    paymentRepository = module.get(getRepositoryToken(SalesOrderPayment));
   });
 
   describe('findById', () => {
-    function makeQueryBuilder(result: SalesOrder | null) {
-      return {
-        leftJoinAndSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockResolvedValue(result),
-      } as any;
-    }
-
-    const baseOrder: SalesOrder = {
+    const baseOrder = {
       id: 'order-1',
       orderNumber: 'SO-000001',
       customerId: 'customer-1',
       orderDate: new Date('2026-01-01'),
+      currency: 'USD',
+      status: SalesOrderStatus.DRAFT,
+      paymentStatus: SalesOrderPaymentStatus.PARTIAL,
+      subtotal: 200,
+      shippingAmount: 0,
       totalAmount: 200,
-      paidAmount: 100,
-      balanceDue: 100,
-      isFulfilled: true,
-      isPaidInFull: false,
-      invoices: [
-        {
-          id: 'invoice-1',
-          invoiceNumber: 'INV-000001',
-          payments: [
-            { id: 'pay-1', paymentNumber: 'PAY-1', amount: 50, paymentDate: new Date(), isActive: true, deletedAt: null } as Payment,
-          ],
-        } as any,
-      ],
       items: [],
       customer: { id: 'customer-1', name: 'Acme' } as Customer,
     } as SalesOrder;
 
-    let paymentRepository: jest.Mocked<Repository<Payment>>;
-
-    beforeEach(() => {
-      paymentRepository = service['paymentRepository'] as jest.Mocked<Repository<Payment>>;
-    });
-
-    it('merges direct payments into dto.payments alongside invoice payments', async () => {
-      salesOrderRepository.createQueryBuilder.mockReturnValue(makeQueryBuilder(baseOrder));
+    it('maps direct sales order payment records onto the response', async () => {
+      salesOrderRepository.findOne.mockResolvedValue(baseOrder);
       paymentRepository.find.mockResolvedValue([
-        { id: 'pay-direct-1', paymentNumber: 'PAY-D1', amount: 50, paymentDate: new Date() } as Payment,
+        {
+          id: 'pay-1',
+          amount: 100,
+          paymentDate: '2026-01-02',
+          paymentMethodId: 'method-1',
+        } as SalesOrderPayment,
       ]);
 
       const result = await service.findById('order-1');
 
-      expect(result.payments).toHaveLength(2);
-      expect(result.payments.map((p) => p.id)).toEqual(expect.arrayContaining(['pay-1', 'pay-direct-1']));
-    });
-
-    it('deduplicates payments that appear in both invoice and direct results', async () => {
-      salesOrderRepository.createQueryBuilder.mockReturnValue(makeQueryBuilder(baseOrder));
-      paymentRepository.find.mockResolvedValue([
-        { id: 'pay-1', paymentNumber: 'PAY-1', amount: 50, paymentDate: new Date() } as Payment,
-      ]);
-
-      const result = await service.findById('order-1');
-
-      expect(result.payments).toHaveLength(1);
-      expect(result.payments[0].id).toBe('pay-1');
-    });
-
-    it('falls back to invoice-only payments when payment repository throws', async () => {
-      salesOrderRepository.createQueryBuilder.mockReturnValue(makeQueryBuilder(baseOrder));
-      paymentRepository.find.mockRejectedValue(new Error('DB error'));
-
-      const result = await service.findById('order-1');
-
-      expect(result.payments).toHaveLength(1);
-      expect(result.payments[0].id).toBe('pay-1');
+      expect(paymentRepository.find).toHaveBeenCalledWith(expect.objectContaining({
+        where: { salesOrderId: 'order-1' },
+        order: { paymentDate: 'ASC' },
+      }));
+      expect(result).toMatchObject({
+        id: 'order-1',
+        status: SalesOrderStatus.DRAFT,
+        paymentStatus: SalesOrderPaymentStatus.PARTIAL,
+        payments: [expect.objectContaining({ id: 'pay-1', amount: 100 })],
+      });
     });
 
     it('throws NotFoundException when order does not exist', async () => {
-      salesOrderRepository.createQueryBuilder.mockReturnValue(makeQueryBuilder(null));
+      salesOrderRepository.findOne.mockResolvedValue(null);
 
       await expect(service.findById('missing')).rejects.toThrow('Sales order not found');
-    });
-  });
-
-  describe('findAll', () => {
-    function makeQueryBuilder() {
-      const qb: any = {
-        leftJoinAndSelect: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        orderBy: jest.fn().mockReturnThis(),
-        skip: jest.fn().mockReturnThis(),
-        take: jest.fn().mockReturnThis(),
-        leftJoin: jest.fn().mockReturnThis(),
-        getMany: jest.fn().mockResolvedValue([]),
-        getRawOne: jest.fn().mockResolvedValue({ count: '0' }),
-      };
-      return qb;
-    }
-
-    it('searches customer name with ILIKE', async () => {
-      const qb = makeQueryBuilder();
-      salesOrderRepository.createQueryBuilder.mockReturnValue(qb);
-
-      await service.findAll({ search: 'Acme' });
-
-      const andWhereCalls: string[] = qb.andWhere.mock.calls.map((c: any[]) => c[0]);
-      const searchCall = andWhereCalls.find(
-        (c) => typeof c === 'string' && c.includes('customer.name ILIKE'),
-      );
-      expect(searchCall).toBeDefined();
-    });
-
-    it('searches product name with ILIKE in main query', async () => {
-      const qb = makeQueryBuilder();
-      salesOrderRepository.createQueryBuilder.mockReturnValue(qb);
-
-      await service.findAll({ search: 'Widget' });
-
-      const andWhereCalls: string[] = qb.andWhere.mock.calls.map((c: any[]) => c[0]);
-      const searchCall = andWhereCalls.find(
-        (c) => typeof c === 'string' && c.includes('product.name ILIKE'),
-      );
-      expect(searchCall).toBeDefined();
-    });
-
-    it('uses EXISTS subquery in count so an order with multiple matching items counts as 1', async () => {
-      const mainQb = makeQueryBuilder();
-      const countQb = makeQueryBuilder();
-      let callCount = 0;
-      salesOrderRepository.createQueryBuilder.mockImplementation(() => {
-        callCount++;
-        return callCount === 1 ? mainQb : countQb;
-      });
-
-      await service.findAll({ search: 'Widget' });
-
-      const countAndWhereCalls: string[] = countQb.andWhere.mock.calls.map((c: any[]) => c[0]);
-      const existsCall = countAndWhereCalls.find(
-        (c) => typeof c === 'string' && c.includes('EXISTS'),
-      );
-      expect(existsCall).toBeDefined();
     });
   });
 });

--- a/backend/src/modules/sales/services/sales-order-query.service.ts
+++ b/backend/src/modules/sales/services/sales-order-query.service.ts
@@ -2,17 +2,14 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
   Between,
-  ILike,
   IsNull,
   LessThanOrEqual,
   MoreThanOrEqual,
   Repository,
 } from 'typeorm';
-import { SalesOrder } from '../../../database/entities/sales-order.entity';
 import { Product } from '../../../database/entities/product.entity';
-import { Invoice } from '../../../database/entities/invoice.entity';
-import { Payment } from '../../../database/entities/payment.entity';
-import { CustomerPrintDto } from '../dto/customer.dto';
+import { SalesOrder, SalesOrderPaymentStatus, SalesOrderStatus } from '../../../database/entities/sales-order.entity';
+import { SalesOrderPayment } from '../../../database/entities/sales-order-payment.entity';
 import { QuerySalesOrdersDto, SalesOrderResponseDto } from '../dto/sales-order.dto';
 import { mapSalesOrderToResponseDto } from './sales-order.mapper';
 
@@ -21,36 +18,11 @@ export class SalesOrderQueryService {
   constructor(
     @InjectRepository(SalesOrder)
     private readonly salesOrderRepository: Repository<SalesOrder>,
+    @InjectRepository(SalesOrderPayment)
+    private readonly salesOrderPaymentRepository: Repository<SalesOrderPayment>,
     @InjectRepository(Product)
     private readonly productRepository: Repository<Product>,
-    @InjectRepository(Invoice)
-    private readonly invoiceRepository: Repository<Invoice>,
-    @InjectRepository(Payment)
-    private readonly paymentRepository: Repository<Payment>,
   ) {}
-
-  async findPreviousOrder(currentOrderNumber: string): Promise<SalesOrderResponseDto | null> {
-    const match = currentOrderNumber.match(/^SO-(\d+)$/);
-    if (!match) {
-      return null;
-    }
-
-    const currentNumber = parseInt(match[1]);
-    if (currentNumber <= 1) {
-      return null;
-    }
-
-    const previousNumber = currentNumber - 1;
-    const previousOrderNumber = `SO-${previousNumber.toString().padStart(6, '0')}`;
-
-    const previousOrder = await this.salesOrderRepository.findOne({
-      where: { orderNumber: previousOrderNumber },
-      relations: { customer: true, items: { product: true } },
-      withDeleted: true,
-    });
-
-    return previousOrder ? mapSalesOrderToResponseDto(previousOrder) : null;
-  }
 
   async findAll(query: QuerySalesOrdersDto) {
     const {
@@ -59,7 +31,7 @@ export class SalesOrderQueryService {
       fromDate,
       toDate,
       paymentStatus,
-      fulfillmentStatus,
+      status,
       sortBy = 'orderNumber',
       sortOrder = 'ASC',
       page = 1,
@@ -75,9 +47,11 @@ export class SalesOrderQueryService {
         'order.id',
         'order.orderNumber',
         'order.orderDate',
+        'order.status',
+        'order.paymentStatus',
+        'order.subtotal',
+        'order.shippingAmount',
         'order.totalAmount',
-        'order.paidAmount',
-        'order.isFulfilled',
         'order.customerId',
         'order.createdAt',
         'order.updatedAt',
@@ -124,35 +98,15 @@ export class SalesOrderQueryService {
     }
 
     if (paymentStatus && paymentStatus !== 'all') {
-      switch (paymentStatus) {
-        case 'unpaid':
-          queryBuilder = queryBuilder.andWhere('(order.paidAmount = 0 OR order.paidAmount IS NULL)');
-          break;
-        case 'partial':
-          queryBuilder = queryBuilder.andWhere(
-            'order.paidAmount > 0 AND order.paidAmount < order.totalAmount',
-          );
-          break;
-        case 'paid':
-          queryBuilder = queryBuilder.andWhere(
-            'order.paidAmount >= order.totalAmount AND order.paidAmount > 0',
-          );
-          break;
-        case 'overpaid':
-          queryBuilder = queryBuilder.andWhere('order.paidAmount > order.totalAmount');
-          break;
-      }
+      queryBuilder = queryBuilder.andWhere('order.paymentStatus = :paymentStatus', {
+        paymentStatus: paymentStatus.toUpperCase(),
+      });
     }
 
-    if (fulfillmentStatus && fulfillmentStatus !== 'all') {
-      switch (fulfillmentStatus) {
-        case 'fulfilled':
-          queryBuilder = queryBuilder.andWhere('order.isFulfilled = true');
-          break;
-        case 'unfulfilled':
-          queryBuilder = queryBuilder.andWhere('order.isFulfilled = false');
-          break;
-      }
+    if (status && status !== 'all') {
+      queryBuilder = queryBuilder.andWhere('order.status = :status', {
+        status: status.toUpperCase(),
+      });
     }
 
     queryBuilder = queryBuilder
@@ -160,102 +114,14 @@ export class SalesOrderQueryService {
       .skip((page - 1) * limit)
       .take(limit);
 
-    const countQuery = this.salesOrderRepository
-      .createQueryBuilder('order')
-      .where('order.deletedAt IS NULL')
-      .select('COUNT(order.id)', 'count')
-      .leftJoin('order.customer', 'customer');
-
-    if (customerId) {
-      countQuery.andWhere('order.customerId = :customerId', { customerId });
-    }
-    if (fromDate) {
-      countQuery.andWhere('order.orderDate >= :fromDate', { fromDate: new Date(fromDate) });
-    }
-    if (toDate) {
-      const endDate = new Date(toDate);
-      endDate.setHours(23, 59, 59, 999);
-      countQuery.andWhere('order.orderDate <= :toDate', { toDate: endDate });
-    }
-    if (search) {
-      countQuery.andWhere(
-        `(order.orderNumber ILIKE :search
-          OR customer.name ILIKE :search
-          OR EXISTS (
-            SELECT 1 FROM sales_order_items i
-            JOIN products p ON p.id = i."productId"
-            WHERE i."salesOrderId" = order.id
-            AND p.name ILIKE :search
-          ))`,
-        { search: `%${search}%` },
-      );
-    }
-
-    if (paymentStatus && paymentStatus !== 'all') {
-      switch (paymentStatus) {
-        case 'unpaid':
-          countQuery.andWhere('(order.paidAmount = 0 OR order.paidAmount IS NULL)');
-          break;
-        case 'partial':
-          countQuery.andWhere('order.paidAmount > 0 AND order.paidAmount < order.totalAmount');
-          break;
-        case 'paid':
-          countQuery.andWhere('order.paidAmount >= order.totalAmount AND order.paidAmount > 0');
-          break;
-        case 'overpaid':
-          countQuery.andWhere('order.paidAmount > order.totalAmount');
-          break;
-      }
-    }
-
-    if (fulfillmentStatus && fulfillmentStatus !== 'all') {
-      switch (fulfillmentStatus) {
-        case 'fulfilled':
-          countQuery.andWhere('order.isFulfilled = true');
-          break;
-        case 'unfulfilled':
-          countQuery.andWhere('order.isFulfilled = false');
-          break;
-      }
-    }
-
-    const { count } = await countQuery.getRawOne();
-    const total = parseInt(count);
-    const orders = await queryBuilder.getMany();
+    const [orders, total] = await queryBuilder.getManyAndCount();
 
     return {
-      data: orders.map((order) => ({
-        id: order.id,
-        orderNumber: order.orderNumber,
-        orderDate: order.orderDate,
-        totalAmount: Number(order.totalAmount),
-        paidAmount: Number(order.paidAmount || 0),
-        balanceDue: Math.max(0, Number(order.totalAmount) - Number(order.paidAmount || 0)),
-        isPaidInFull: Number(order.paidAmount || 0) >= Number(order.totalAmount),
-        isFulfilled: order.isFulfilled,
-        customerId: order.customerId,
-        customer: order.customer,
-        items: order.items,
-        createdAt: order.createdAt,
-        updatedAt: order.updatedAt,
-      })),
+      data: orders.map((order) => mapSalesOrderToResponseDto(order)),
       total,
       page,
       limit,
       totalPages: Math.ceil(total / limit),
-    };
-  }
-
-  async testInvoiceRelations(orderNumber: string): Promise<any> {
-    const order = await this.salesOrderRepository.findOne({
-      where: { orderNumber },
-      relations: { invoices: true, customer: true, items: true },
-    });
-
-    return {
-      order,
-      invoicesCount: order?.invoices?.length || 0,
-      invoices: order?.invoices || null,
     };
   }
 
@@ -269,7 +135,7 @@ export class SalesOrderQueryService {
     } = query;
 
     const findOptions: any = {
-      relations: { customer: true, items: { product: true }, invoices: true },
+      relations: { customer: true, items: { product: true } },
       where: { deletedAt: IsNull() },
       order: { [sortBy]: sortOrder },
     };
@@ -293,74 +159,13 @@ export class SalesOrderQueryService {
     const total = await this.salesOrderRepository.count({ where: findOptions.where });
     const orders = await this.salesOrderRepository.find(findOptions);
 
-    const data = orders.map((order) => {
-      const paidAmount = Number(order.paidAmount || 0);
-      const totalAmount = Number(order.totalAmount);
-      const balanceDue = Math.max(0, totalAmount - paidAmount);
-      const isPaidInFull = paidAmount >= totalAmount;
-
-      return {
-        id: order.id,
-        orderNumber: order.orderNumber,
-        orderDate: order.orderDate,
-        totalAmount,
-        paidAmount,
-        balanceDue,
-        isPaidInFull,
-        isFulfilled: order.isFulfilled || false,
-        fulfilledDate: order.fulfilledDate,
-        canFulfill: isPaidInFull && !order.isFulfilled,
-        canUnfulfill: order.isFulfilled || false,
-        customerId: order.customerId,
-        customer: order.customer
-          ? ({
-              id: order.customer.id,
-              name: order.customer.name,
-              phone: order.customer.phone,
-              streetAddress: order.customer.billingStreetAddress,
-              city: order.customer.billingCity,
-              state: order.customer.billingState,
-              postalCode: order.customer.billingPostalCode,
-              country: order.customer.billingCountry,
-            } satisfies CustomerPrintDto)
-          : null,
-        customerName: order.customer?.name || 'Unknown Customer',
-        items:
-          order.items?.map((item) => ({
-            ...item,
-            product: item.product || null,
-            productId: item.productId,
-          })) || [],
-        itemsCount: order.items?.length || 0,
-        invoices:
-          order.invoices?.map((invoice) => ({
-            id: invoice.id,
-            invoiceNumber: invoice.invoiceNumber,
-            status: invoice.status,
-            invoiceDate: invoice.invoiceDate,
-            shippingAmount: Number(invoice.shippingAmount || 0),
-            totalAmount: Number(invoice.totalAmount),
-            paidAmount: Number(invoice.paidAmount),
-            balanceDue: Number(invoice.balanceDue),
-            customerName: invoice.customer?.name,
-            customerId: invoice.customerId,
-            salesOrderId: invoice.salesOrderId,
-            salesOrder: {
-              id: order.id,
-              orderNumber: order.orderNumber,
-              orderDate: order.orderDate,
-            },
-            orderNumber: order.orderNumber,
-          })) || [],
-        isOverdue: false,
-        notes: order.notes,
-        createdAt: order.createdAt,
-        updatedAt: order.updatedAt,
-      };
-    });
-
     return {
-      data,
+      data: orders.map((order) => ({
+        ...mapSalesOrderToResponseDto(order),
+        customerName: order.customer?.name || 'Unknown Customer',
+        itemsCount: order.items?.length || 0,
+        isOverdue: false,
+      })),
       total,
     };
   }
@@ -373,8 +178,8 @@ export class SalesOrderQueryService {
     const [totalOrders, fulfilledOrders, unfulfilledOrders, thisMonthOrders, thisWeekOrders] =
       await Promise.all([
         this.salesOrderRepository.count(),
-        this.salesOrderRepository.count({ where: { isFulfilled: true } }),
-        this.salesOrderRepository.count({ where: { isFulfilled: false } }),
+        this.salesOrderRepository.count({ where: { status: SalesOrderStatus.FULFILLED } }),
+        this.salesOrderRepository.count({ where: { status: SalesOrderStatus.DRAFT } }),
         this.salesOrderRepository.count({ where: { orderDate: MoreThanOrEqual(thisMonth) } }),
         this.salesOrderRepository.count({ where: { orderDate: MoreThanOrEqual(thisWeek) } }),
       ]);
@@ -406,29 +211,12 @@ export class SalesOrderQueryService {
   }
 
   async findById(id: string): Promise<SalesOrderResponseDto> {
-    const order = await this.salesOrderRepository
-      .createQueryBuilder('salesOrder')
-      .leftJoinAndSelect('salesOrder.customer', 'customer')
-      .leftJoinAndSelect('salesOrder.items', 'items')
-      .leftJoinAndSelect('items.product', 'product')
-      .leftJoinAndSelect('salesOrder.invoices', 'invoices')
-      .leftJoinAndSelect('invoices.payments', 'payments')
-      .leftJoinAndSelect('invoices.items', 'invoiceItems')
-      .leftJoinAndSelect('invoiceItems.product', 'invoiceItemProduct')
-      .where('salesOrder.id = :id', { id })
-      .getOne();
+    const order = await this.salesOrderRepository.findOne({
+      where: { id },
+      relations: { customer: true, items: { product: true } },
+    });
 
-    if (!order) {
-      throw new NotFoundException('Sales order not found');
-    }
-
-    if (order.invoices && order.invoices.length > 0) {
-      order.invoices.forEach((invoice) => {
-        if (invoice.payments && invoice.payments.length > 0) {
-          invoice.payments = invoice.payments.filter((payment) => payment.isActive && !payment.deletedAt);
-        }
-      });
-    }
+    if (!order) throw new NotFoundException('Sales order not found');
 
     if (order.items && order.items.length > 0) {
       for (const item of order.items) {
@@ -438,33 +226,32 @@ export class SalesOrderQueryService {
       }
     }
 
-    try {
-      const directPayments = await this.paymentRepository.find({
-        where: {
-          customerId: order.customerId,
-          notes: ILike(`%sales order ${order.orderNumber}%`),
-          invoiceId: null as any,
-        },
-      });
+    const payments = await this.salesOrderPaymentRepository.find({
+      where: { salesOrderId: id },
+      order: { paymentDate: 'ASC' },
+      relations: { paymentMethod: true },
+    });
 
-      return mapSalesOrderToResponseDto(order, directPayments);
-    } catch (error) {
-      console.error('Failed to fetch direct payments:', error);
-      return mapSalesOrderToResponseDto(order);
-    }
+    return mapSalesOrderToResponseDto(order, payments);
   }
 
   async findByOrderNumber(orderNumber: string): Promise<SalesOrderResponseDto> {
     const order = await this.salesOrderRepository.findOne({
       where: { orderNumber },
-      relations: { customer: true, items: { product: true }, invoices: true },
+      relations: { customer: true, items: { product: true } },
     });
 
     if (!order) {
       throw new NotFoundException('Sales order not found');
     }
 
-    return mapSalesOrderToResponseDto(order);
+    const payments = await this.salesOrderPaymentRepository.find({
+      where: { salesOrderId: order.id },
+      order: { paymentDate: 'ASC' },
+      relations: { paymentMethod: true },
+    });
+
+    return mapSalesOrderToResponseDto(order, payments);
   }
 
   async findOrdersByCustomer(customerId: string, limit: number = 10) {
@@ -480,89 +267,9 @@ export class SalesOrderQueryService {
       orderNumber: order.orderNumber,
       orderDate: order.orderDate,
       totalAmount: Number(order.totalAmount),
+      status: order.status,
+      paymentStatus: order.paymentStatus,
       itemsCount: order.items?.length || 0,
     }));
-  }
-
-  async getOrderInvoices(id: string) {
-    const order = await this.salesOrderRepository.findOne({ where: { id } });
-    if (!order) {
-      throw new NotFoundException('Sales order not found');
-    }
-
-    const invoices = await this.invoiceRepository.find({
-      where: { salesOrderId: id },
-      order: { invoiceDate: 'DESC' },
-    });
-
-    return {
-      orderId: id,
-      orderNumber: order.orderNumber,
-      invoices: invoices.map((invoice) => ({
-        id: invoice.id,
-        invoiceNumber: invoice.invoiceNumber,
-        status: invoice.status,
-        invoiceDate: invoice.invoiceDate,
-        shippingAmount: Number(invoice.shippingAmount || 0),
-        totalAmount: Number(invoice.totalAmount),
-        paidAmount: Number(invoice.paidAmount),
-        balanceDue: Number(invoice.balanceDue),
-        customerName: invoice.customer?.name,
-        customerId: invoice.customerId,
-        salesOrderId: invoice.salesOrderId,
-        salesOrder: {
-          id: order.id,
-          orderNumber: order.orderNumber,
-          orderDate: order.orderDate,
-        },
-        orderNumber: order.orderNumber,
-      })),
-    };
-  }
-
-  async findDeleted(query: QuerySalesOrdersDto = {}): Promise<any> {
-    const {
-      search,
-      customerId,
-      sortBy = 'deletedAt',
-      sortOrder = 'ASC',
-      page = 1,
-      limit = 20,
-    } = query;
-
-    let queryBuilder = this.salesOrderRepository
-      .createQueryBuilder('order')
-      .withDeleted()
-      .leftJoinAndSelect('order.customer', 'customer')
-      .leftJoinAndSelect('order.items', 'items')
-      .where('order.deletedAt IS NOT NULL');
-
-    if (customerId) {
-      queryBuilder = queryBuilder.andWhere('order.customerId = :customerId', { customerId });
-    }
-
-    if (search) {
-      queryBuilder = queryBuilder.andWhere(
-        '(order.orderNumber ILIKE :search OR customer.name ILIKE :search)',
-        { search: `%${search}%` },
-      );
-    }
-
-    queryBuilder = queryBuilder.orderBy(`order.${sortBy}`, sortOrder as 'ASC' | 'DESC');
-    const offset = (page - 1) * limit;
-    queryBuilder = queryBuilder.skip(offset).take(limit);
-
-    const [orders, total] = await queryBuilder.getManyAndCount();
-    const data = orders.map((order) => mapSalesOrderToResponseDto(order));
-
-    return {
-      data,
-      meta: {
-        total,
-        page,
-        limit,
-        totalPages: Math.ceil(total / limit),
-      },
-    };
   }
 }

--- a/backend/src/modules/sales/services/sales-order.mapper.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.mapper.spec.ts
@@ -1,141 +1,49 @@
+import { SalesOrderPaymentStatus, SalesOrderStatus } from '../../../database/entities/sales-order.entity';
 import { mapSalesOrderToResponseDto } from './sales-order.mapper';
 
 describe('mapSalesOrderToResponseDto', () => {
-  it('flattens invoice payments onto the sales order response', () => {
-    const paymentDate = new Date('2026-04-01T00:00:00.000Z');
+  it('maps status, paymentStatus, subtotal, and direct sales order payments', () => {
     const order = {
       id: 'order-1',
       orderNumber: 'SO-001',
       orderDate: new Date('2026-03-31T00:00:00.000Z'),
-      fulfilledDate: null,
-      shippingAmount: 0,
-      totalAmount: 100,
-      paidAmount: 100,
-      isFulfilled: true,
-      isPaidInFull: true,
-      balanceDue: 0,
-      canFulfill: false,
-      canUnfulfill: true,
+      status: SalesOrderStatus.DRAFT,
+      paymentStatus: SalesOrderPaymentStatus.PARTIAL,
+      subtotal: 100,
+      shippingAmount: 10,
+      totalAmount: 110,
       notes: null,
       customerId: 'customer-1',
       customer: null,
       items: [],
-      invoices: [
-        {
-          id: 'invoice-1',
-          invoiceNumber: 'INV-001',
-          status: 'paid',
-          invoiceDate: new Date('2026-04-01T00:00:00.000Z'),
-          shippingAmount: 0,
-          totalAmount: 100,
-          paidAmount: 100,
-          balanceDue: 0,
-          customer: null,
-          customerId: 'customer-1',
-          salesOrderId: 'order-1',
-          payments: [
-            {
-              id: 'payment-1',
-              paymentNumber: 'PAY-001',
-              amount: '100.00',
-              paymentDate,
-            },
-          ],
-          items: [],
-        },
-      ],
       createdAt: new Date('2026-03-31T00:00:00.000Z'),
       updatedAt: new Date('2026-04-01T00:00:00.000Z'),
-      deletedAt: null,
     };
 
-    expect(mapSalesOrderToResponseDto(order as any).payments).toEqual([
+    const payments = [
       {
         id: 'payment-1',
-        paymentNumber: 'PAY-001',
-        amount: 100,
-        paymentDate,
-      },
-    ]);
-  });
-
-  it('merges direct payments into the sales order response payments without duplicates', () => {
-    const invoicePaymentDate = new Date('2026-04-01T00:00:00.000Z');
-    const directPaymentDate = new Date('2026-04-02T00:00:00.000Z');
-    const order = {
-      id: 'order-1',
-      orderNumber: 'SO-001',
-      orderDate: new Date('2026-03-31T00:00:00.000Z'),
-      fulfilledDate: null,
-      shippingAmount: 0,
-      totalAmount: 150,
-      paidAmount: 150,
-      isFulfilled: true,
-      isPaidInFull: true,
-      balanceDue: 0,
-      canFulfill: false,
-      canUnfulfill: true,
-      notes: null,
-      customerId: 'customer-1',
-      customer: null,
-      items: [],
-      invoices: [
-        {
-          id: 'invoice-1',
-          invoiceNumber: 'INV-001',
-          status: 'paid',
-          invoiceDate: new Date('2026-04-01T00:00:00.000Z'),
-          shippingAmount: 0,
-          totalAmount: 100,
-          paidAmount: 100,
-          balanceDue: 0,
-          customer: null,
-          customerId: 'customer-1',
-          salesOrderId: 'order-1',
-          payments: [
-            {
-              id: 'payment-1',
-              paymentNumber: 'PAY-001',
-              amount: '100.00',
-              paymentDate: invoicePaymentDate,
-            },
-          ],
-          items: [],
-        },
-      ],
-      createdAt: new Date('2026-03-31T00:00:00.000Z'),
-      updatedAt: new Date('2026-04-01T00:00:00.000Z'),
-      deletedAt: null,
-    };
-
-    const directPayments = [
-      {
-        id: 'payment-2',
-        paymentNumber: 'PAY-002',
-        amount: '50.00',
-        paymentDate: directPaymentDate,
-      },
-      {
-        id: 'payment-1',
-        paymentNumber: 'PAY-001',
         amount: '100.00',
-        paymentDate: invoicePaymentDate,
+        paymentDate: '2026-04-01',
+        paymentMethodId: 'method-1',
+        referenceNumber: 'REF-1',
       },
     ];
 
-    expect(mapSalesOrderToResponseDto(order as any, directPayments as any).payments).toEqual([
-      {
-        id: 'payment-1',
-        paymentNumber: 'PAY-001',
-        amount: 100,
-        paymentDate: invoicePaymentDate,
-      },
-      {
-        id: 'payment-2',
-        paymentNumber: 'PAY-002',
-        amount: 50,
-        paymentDate: directPaymentDate,
-      },
-    ]);
+    expect(mapSalesOrderToResponseDto(order as any, payments as any)).toMatchObject({
+      id: 'order-1',
+      status: SalesOrderStatus.DRAFT,
+      paymentStatus: SalesOrderPaymentStatus.PARTIAL,
+      subtotal: 100,
+      payments: [
+        {
+          id: 'payment-1',
+          amount: 100,
+          paymentDate: '2026-04-01',
+          paymentMethodId: 'method-1',
+          referenceNumber: 'REF-1',
+        },
+      ],
+    });
   });
 });

--- a/backend/src/modules/sales/services/sales-order.mapper.ts
+++ b/backend/src/modules/sales/services/sales-order.mapper.ts
@@ -1,47 +1,22 @@
 import { DiscountType } from '../../../database/entities/sales-order-item.entity';
 import { SalesOrder } from '../../../database/entities/sales-order.entity';
+import { SalesOrderPayment } from '../../../database/entities/sales-order-payment.entity';
 import { CustomerPrintDto } from '../dto/customer.dto';
 import { SalesOrderResponseDto } from '../dto/sales-order.dto';
 
 export function mapSalesOrderToResponseDto(
   order: SalesOrder,
-  directPayments?: any[],
+  payments: SalesOrderPayment[] = [],
 ): SalesOrderResponseDto {
-  const invoicePayments = (order.invoices ?? []).flatMap(
-    (invoice) =>
-      (invoice.payments ?? []).map((payment) => ({
-        id: payment.id,
-        paymentNumber: payment.paymentNumber,
-        amount: Number(payment.amount),
-        paymentDate: payment.paymentDate,
-      })),
-  );
-
-  const mappedDirectPayments = (directPayments ?? []).map((payment) => ({
-    id: payment.id,
-    paymentNumber: payment.paymentNumber,
-    amount: Number(payment.amount),
-    paymentDate: payment.paymentDate,
-  }));
-
-  const payments = [...invoicePayments, ...mappedDirectPayments].filter(
-    (payment, index, allPayments) =>
-      allPayments.findIndex((candidate) => candidate.id === payment.id) === index,
-  );
-
   return {
     id: order.id,
     orderNumber: order.orderNumber,
     orderDate: order.orderDate,
-    fulfilledDate: order.fulfilledDate,
+    status: order.status,
+    paymentStatus: order.paymentStatus,
+    subtotal: Number(order.subtotal || 0),
     shippingAmount: Number(order.shippingAmount || 0),
     totalAmount: Number(order.totalAmount),
-    paidAmount: Number(order.paidAmount),
-    isFulfilled: order.isFulfilled,
-    isPaidInFull: order.isPaidInFull,
-    balanceDue: order.balanceDue,
-    canFulfill: order.canFulfill,
-    canUnfulfill: order.canUnfulfill,
     notes: order.notes,
     customerId: order.customerId,
     customer: order.customer
@@ -78,58 +53,16 @@ export function mapSalesOrderToResponseDto(
         createdAt: item.createdAt,
         updatedAt: item.updatedAt,
       })) || [],
-    invoices:
-      order.invoices?.map((invoice) => ({
-        id: invoice.id,
-        invoiceNumber: invoice.invoiceNumber,
-        status: invoice.status,
-        invoiceDate: invoice.invoiceDate,
-        shippingAmount: Number(invoice.shippingAmount || 0),
-        totalAmount: Number(invoice.totalAmount),
-        paidAmount: Number(invoice.paidAmount),
-        balanceDue: Number(invoice.balanceDue),
-        customerName: invoice.customer?.name,
-        customerId: invoice.customerId,
-        salesOrderId: invoice.salesOrderId,
-        salesOrder: {
-          id: order.id,
-          orderNumber: order.orderNumber,
-          orderDate: order.orderDate,
-        },
-        orderNumber: order.orderNumber,
-        payments:
-          invoice.payments?.map((payment) => ({
-            id: payment.id,
-            paymentNumber: payment.paymentNumber,
-            paymentDate: payment.paymentDate,
-            amount: Number(payment.amount),
-            paymentMethodId: payment.paymentMethodId,
-            paymentMethod: payment.paymentMethodEntity?.code?.toLowerCase() || 'cash',
-            status: payment.status,
-          })) || [],
-        items:
-          invoice.items?.map((item) => ({
-            id: item.id,
-            lineNumber: item.lineNumber,
-            productId: item.productId,
-            quantity: Number(item.quantity),
-            unitPrice: Number(item.unitPrice),
-            discountType: item.discountType,
-            discountPercent: Number(item.discountPercent || 0),
-            discount: Number(item.discount),
-            totalAmount: Number(item.totalAmount),
-            product: item.product
-              ? {
-                  id: item.product.id,
-                  name: item.product.name,
-                  barcode: item.product.barcode,
-                }
-              : undefined,
-          })) || [],
-      })) || [],
-    payments,
+    payments: payments.map((p) => ({
+      id: p.id,
+      amount: Number(p.amount),
+      paymentDate: p.paymentDate,
+      referenceNumber: p.referenceNumber,
+      notes: p.notes,
+      paymentMethodId: p.paymentMethodId,
+      paymentMethodName: (p.paymentMethod as any)?.name,
+    })),
     createdAt: order.createdAt,
     updatedAt: order.updatedAt,
-    deletedAt: order.deletedAt,
   };
 }

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -1,23 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { getRepositoryToken, getDataSourceToken } from '@nestjs/typeorm';
-import { Repository, DataSource } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { SalesOrderService } from './sales-order.service';
-import { SalesOrder } from '../../../database/entities/sales-order.entity';
+import { SalesOrder, SalesOrderPaymentStatus, SalesOrderStatus } from '../../../database/entities/sales-order.entity';
 import { SalesOrderItem } from '../../../database/entities/sales-order-item.entity';
 import { Customer } from '../../../database/entities/customer.entity';
 import { Product } from '../../../database/entities/product.entity';
 import { Invoice } from '../../../database/entities/invoice.entity';
 import { InvoiceItem } from '../../../database/entities/invoice-item.entity';
-import { User, UserRole } from '../../../database/entities/user.entity';
+import { User } from '../../../database/entities/user.entity';
 import { PriceListItem } from '../../../database/entities/price-list-item.entity';
-import { Payment } from '../../../database/entities/payment.entity';
 import { InventoryIntegrationService } from './inventory-integration.service';
 import { StockMovementService } from '../../../modules/inventory/services/stock-movement.service';
 import { BaseCostCalculatorService } from '../../inventory/services/base-cost-calculator.service';
 import { SettingsService } from '../../settings/settings.service';
 import { AuditLogService } from '../../audit-logs/services';
 import { AccountingService } from '../../accounting/services/accounting.service';
-import { ConflictException, NotFoundException } from '@nestjs/common';
 import { SalesOrderFulfillmentService } from './sales-order-fulfillment.service';
 import { SalesOrderLifecycleService } from './sales-order-lifecycle.service';
 import { SalesOrderPaymentService } from './sales-order-payment.service';
@@ -25,778 +23,101 @@ import { SalesOrderQueryService } from './sales-order-query.service';
 import { CustomerService } from './customer.service';
 
 describe('SalesOrderService', () => {
-  let module: TestingModule;
   let service: SalesOrderService;
-  let salesOrderRepository: jest.Mocked<Repository<SalesOrder>>;
-  let accountingService: jest.Mocked<AccountingService>;
-  let inventoryIntegrationService: jest.Mocked<InventoryIntegrationService>;
-  let stockMovementService: jest.Mocked<StockMovementService>;
-  let baseCostCalculator: jest.Mocked<BaseCostCalculatorService>;
-  let settingsService: jest.Mocked<SettingsService>;
-  let auditLogService: jest.Mocked<AuditLogService>;
-  let dataSource: jest.Mocked<DataSource>;
-  let salesOrderFulfillmentService: jest.Mocked<SalesOrderFulfillmentService>;
   let salesOrderLifecycleService: jest.Mocked<SalesOrderLifecycleService>;
+  let salesOrderPaymentService: jest.Mocked<SalesOrderPaymentService>;
+  let salesOrderFulfillmentService: jest.Mocked<SalesOrderFulfillmentService>;
   let salesOrderQueryService: jest.Mocked<SalesOrderQueryService>;
-  const adminUser = { role: UserRole.ADMIN } as any;
-
-  const createMockSalesOrder = (): Partial<SalesOrder> => ({
-    id: '123e4567-e89b-12d3-a456-426614174000',
-    orderNumber: 'SO-000001',
-    isFulfilled: false,
-    isPaidInFull: true,
-    balanceDue: 0,
-    paidAmount: 1000,
-    totalAmount: 1000,
-    fulfilledDate: null,
-    items: [
-      {
-        id: 'item-1',
-        productId: 'product-1',
-        quantity: 10,
-        product: {
-          id: 'product-1',
-          name: 'Test Product',
-          baseCost: 50,
-        } as Product,
-      } as SalesOrderItem,
-    ],
-    customer: {
-      id: 'customer-1',
-      name: 'Test Customer',
-    } as Customer,
-  });
 
   beforeEach(async () => {
-    dataSource = {
-      transaction: jest.fn(),
-    } as any;
-
-    module = await Test.createTestingModule({
+    const module: TestingModule = await Test.createTestingModule({
       providers: [
         SalesOrderService,
-        SalesOrderFulfillmentService,
-        SalesOrderLifecycleService,
-        SalesOrderPaymentService,
-        SalesOrderQueryService,
-        {
-          provide: getRepositoryToken(SalesOrder),
-          useValue: {
-            findOne: jest.fn(),
-            save: jest.fn(),
-            find: jest.fn(),
-            createQueryBuilder: jest.fn(),
-          },
-        },
-        {
-          provide: getRepositoryToken(SalesOrderItem),
-          useValue: {
-            save: jest.fn(),
-          },
-        },
-        {
-          provide: getRepositoryToken(Customer),
-          useValue: {},
-        },
-        {
-          provide: getRepositoryToken(Product),
-          useValue: {},
-        },
-        {
-          provide: getRepositoryToken(Invoice),
-          useValue: {},
-        },
-        {
-          provide: getRepositoryToken(InvoiceItem),
-          useValue: {},
-        },
-        {
-          provide: getRepositoryToken(User),
-          useValue: {},
-        },
-        {
-          provide: getRepositoryToken(PriceListItem),
-          useValue: {},
-        },
-        {
-          provide: getRepositoryToken(Payment),
-          useValue: {
-            find: jest.fn().mockResolvedValue([]),
-          },
-        },
-        {
-          provide: getDataSourceToken(),
-          useValue: dataSource,
-        },
-        {
-          provide: InventoryIntegrationService,
-          useValue: {
-            adjustStock: jest.fn(),
-          },
-        },
-        {
-          provide: StockMovementService,
-          useValue: {
-            deleteByReference: jest.fn(),
-          },
-        },
-        {
-          provide: BaseCostCalculatorService,
-          useValue: {
-            restoreStock: jest.fn(),
-          },
-        },
-        {
-          provide: SettingsService,
-          useValue: {
-            generateDocumentNumber: jest.fn(),
-          },
-        },
-        {
-          provide: AuditLogService,
-          useValue: {
-            log: jest.fn(),
-          },
-        },
-        {
-          provide: AccountingService,
-          useValue: {
-            postSalesOrderEntry: jest.fn(),
-            postCustomerPaymentEntry: jest.fn(),
-            reverseSourceEntries: jest.fn(),
-          },
-        },
-        {
-          provide: CustomerService,
-          useValue: { updateCustomerMetrics: jest.fn().mockResolvedValue(undefined) },
-        },
+        { provide: getRepositoryToken(SalesOrder), useValue: { findOne: jest.fn(), create: jest.fn(), save: jest.fn(), update: jest.fn(), createQueryBuilder: jest.fn() } },
+        { provide: getRepositoryToken(SalesOrderItem), useValue: { save: jest.fn(), delete: jest.fn(), insert: jest.fn() } },
+        { provide: getRepositoryToken(Customer), useValue: { findOne: jest.fn() } },
+        { provide: getRepositoryToken(Product), useValue: { findOne: jest.fn() } },
+        { provide: getRepositoryToken(Invoice), useValue: { createQueryBuilder: jest.fn(), create: jest.fn(), save: jest.fn(), find: jest.fn() } },
+        { provide: getRepositoryToken(InvoiceItem), useValue: { insert: jest.fn(), delete: jest.fn() } },
+        { provide: getRepositoryToken(User), useValue: {} },
+        { provide: getRepositoryToken(PriceListItem), useValue: { findOne: jest.fn() } },
+        { provide: CustomerService, useValue: { updateCustomerMetrics: jest.fn() } },
+        { provide: InventoryIntegrationService, useValue: { checkAvailability: jest.fn(), reserveStock: jest.fn(), getOrderFulfillmentStatus: jest.fn() } },
+        { provide: StockMovementService, useValue: {} },
+        { provide: BaseCostCalculatorService, useValue: {} },
+        { provide: SettingsService, useValue: { generateDocumentNumber: jest.fn() } },
+        { provide: AuditLogService, useValue: { log: jest.fn() } },
+        { provide: AccountingService, useValue: {} },
+        { provide: SalesOrderFulfillmentService, useValue: { fulfillOrder: jest.fn(), unfulfillOrder: jest.fn() } },
+        { provide: SalesOrderLifecycleService, useValue: { assertEditAllowed: jest.fn(), cancel: jest.fn(), uncancel: jest.fn() } },
+        { provide: SalesOrderPaymentService, useValue: { recordPayment: jest.fn(), recordRefund: jest.fn(), listPayments: jest.fn() } },
+        { provide: SalesOrderQueryService, useValue: { findById: jest.fn(), findAll: jest.fn(), findSummaries: jest.fn(), getDashboardStats: jest.fn(), findByOrderNumber: jest.fn(), findOrdersByCustomer: jest.fn() } },
       ],
     }).compile();
 
-    service = module.get<SalesOrderService>(SalesOrderService);
-    salesOrderRepository = module.get(getRepositoryToken(SalesOrder));
-    accountingService = module.get(AccountingService);
-    inventoryIntegrationService = module.get(InventoryIntegrationService);
-    stockMovementService = module.get(StockMovementService);
-    baseCostCalculator = module.get(BaseCostCalculatorService);
-    settingsService = module.get(SettingsService);
-    auditLogService = module.get(AuditLogService);
-    salesOrderFulfillmentService = module.get(SalesOrderFulfillmentService);
+    service = module.get(SalesOrderService);
     salesOrderLifecycleService = module.get(SalesOrderLifecycleService);
+    salesOrderPaymentService = module.get(SalesOrderPaymentService);
+    salesOrderFulfillmentService = module.get(SalesOrderFulfillmentService);
     salesOrderQueryService = module.get(SalesOrderQueryService);
+    salesOrderQueryService.findById.mockResolvedValue({ id: 'order-1' } as any);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('delegates cancel then reloads the response', async () => {
+    await service.cancel('order-1', 'user-1', 'admin');
+
+    expect(salesOrderLifecycleService.cancel).toHaveBeenCalledWith('order-1', 'user-1', 'admin');
+    expect(salesOrderQueryService.findById).toHaveBeenCalledWith('order-1');
   });
 
-  describe('searchGlobal', () => {
-    function mockSOQuery(order: {
-      id: string;
-      orderNumber: string;
-      customer: { name: string };
-    }) {
-      salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue({
-        leftJoinAndSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        take: jest.fn().mockReturnThis(),
-        getMany: jest.fn().mockResolvedValue([order]),
-      } as any);
-    }
+  it('delegates uncancel then reloads the response', async () => {
+    await service.uncancel('order-1', 'user-1', 'admin');
 
-    it('returns matching sales orders as GlobalSearchResultDto', async () => {
-      const order = {
-        id: 'so-uuid-1',
-        orderNumber: 'SO-000001',
-        customer: { name: 'ABC Trading' },
-        deletedAt: null,
-      };
-      salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue({
-        leftJoinAndSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        take: jest.fn().mockReturnThis(),
-        getMany: jest.fn().mockResolvedValue([order]),
-      } as any);
-
-      const results = await service.searchGlobal('SO-000001', {
-        role: UserRole.SALES_STAFF,
-      } as any);
-
-      expect(results).toHaveLength(1);
-      expect(results[0]).toMatchObject({
-        type: 'transaction',
-        id: 'so-uuid-1',
-        label: 'SO-000001',
-        description: 'ABC Trading',
-        route: '/sales/orders/so-uuid-1/edit',
-      });
-    });
-
-    it('exact orderNumber match scores SCORE_EXACT_CODE + BOOST_TRANSACTION + BOOST_EXACT_MATCH', async () => {
-      mockSOQuery({
-        id: 'so1',
-        orderNumber: 'SO-001',
-        customer: { name: 'Acme' },
-      });
-
-      const results = await service.searchGlobal('SO-001', adminUser);
-
-      expect(results[0].score).toBe(150);
-    });
-
-    it('orderNumber startsWith scores SCORE_STARTSWITH_CODE + BOOST_TRANSACTION', async () => {
-      mockSOQuery({
-        id: 'so1',
-        orderNumber: 'SO-001',
-        customer: { name: 'Acme' },
-      });
-
-      const results = await service.searchGlobal('SO-', adminUser);
-
-      expect(results[0].score).toBe(110);
-    });
-
-    it('contains match scores SCORE_CONTAINS + BOOST_TRANSACTION', async () => {
-      mockSOQuery({
-        id: 'so1',
-        orderNumber: 'SO-001',
-        customer: { name: 'Acme Corp' },
-      });
-
-      const results = await service.searchGlobal('Acme', adminUser);
-
-      expect(results[0].score).toBe(70);
-    });
+    expect(salesOrderLifecycleService.uncancel).toHaveBeenCalledWith('order-1', 'user-1', 'admin');
+    expect(salesOrderQueryService.findById).toHaveBeenCalledWith('order-1');
   });
 
-  describe('fulfillOrder', () => {
-    it('should post accounting entry successfully', async () => {
-      // Arrange
-      const mockSalesOrder = createMockSalesOrder();
-      const orderId = mockSalesOrder.id;
-      const savedOrder = { ...mockSalesOrder, isFulfilled: true, fulfilledDate: new Date() };
+  it('delegates recordPayment then reloads the response', async () => {
+    const dto = { paymentMethodId: 'method-1', amount: 100, paymentDate: '2026-05-26' };
 
-      // Mock the query builder for findById
-      const mockQueryBuilder = {
-        leftJoinAndSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockResolvedValue(savedOrder),
-      };
+    await service.recordPayment('order-1', dto);
 
-      salesOrderRepository.findOne.mockResolvedValue(mockSalesOrder as SalesOrder);
-      salesOrderRepository.save.mockResolvedValue(savedOrder as SalesOrder);
-      salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue(mockQueryBuilder);
-
-      inventoryIntegrationService.adjustStock.mockResolvedValue(undefined);
-      auditLogService.log.mockResolvedValue(undefined);
-      accountingService.postSalesOrderEntry.mockResolvedValue({
-        id: 'journal-1',
-        entryNumber: 'JE-000001',
-      } as any);
-
-      // Act
-      const result = await service.fulfillOrder(orderId);
-
-      // Assert
-      expect(accountingService.postSalesOrderEntry).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: orderId,
-          orderNumber: mockSalesOrder.orderNumber,
-        }),
-        'system',
-        undefined,
-      );
-      expect(result).toBeDefined();
-      expect(salesOrderRepository.save).toHaveBeenCalled();
-    });
-
-    it('should continue fulfillment when accounting post fails', async () => {
-      // Arrange
-      const mockSalesOrder = createMockSalesOrder();
-      const orderId = mockSalesOrder.id;
-      const savedOrder = { ...mockSalesOrder, isFulfilled: true, fulfilledDate: new Date() };
-
-      // Mock the query builder for findById
-      const mockQueryBuilder = {
-        leftJoinAndSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockResolvedValue(savedOrder),
-      };
-
-      salesOrderRepository.findOne.mockResolvedValue(mockSalesOrder as SalesOrder);
-      salesOrderRepository.save.mockResolvedValue(savedOrder as SalesOrder);
-      salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue(mockQueryBuilder);
-
-      inventoryIntegrationService.adjustStock.mockResolvedValue(undefined);
-      auditLogService.log.mockResolvedValue(undefined);
-      accountingService.postSalesOrderEntry.mockRejectedValue(
-        new Error('Account mappings not configured'),
-      );
-
-      // Act
-      const result = await service.fulfillOrder(orderId);
-
-      // Assert
-      expect(accountingService.postSalesOrderEntry).toHaveBeenCalled();
-      expect(result).toBeDefined();
-      expect(salesOrderRepository.save).toHaveBeenCalled();
-      // Should not throw error despite accounting failure
-    });
-
-    it('should load order with relations before posting to accounting', async () => {
-      // Arrange
-      const mockSalesOrder = createMockSalesOrder();
-      const orderId = mockSalesOrder.id;
-      const savedOrder = { ...mockSalesOrder, isFulfilled: true, fulfilledDate: new Date() };
-
-      // Mock the query builder for findById
-      const mockQueryBuilder = {
-        leftJoinAndSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockResolvedValue(savedOrder),
-      };
-
-      salesOrderRepository.findOne.mockResolvedValue(mockSalesOrder as SalesOrder);
-      salesOrderRepository.save.mockResolvedValue(savedOrder as SalesOrder);
-      salesOrderRepository.createQueryBuilder = jest.fn().mockReturnValue(mockQueryBuilder);
-
-      inventoryIntegrationService.adjustStock.mockResolvedValue(undefined);
-      auditLogService.log.mockResolvedValue(undefined);
-      accountingService.postSalesOrderEntry.mockResolvedValue({
-        id: 'journal-1',
-      } as any);
-
-      // Act
-      await service.fulfillOrder(orderId);
-
-      // Assert
-      // Verify findOne was called for the initial load with relations
-      expect(salesOrderRepository.findOne).toHaveBeenCalledWith({
-        where: { id: orderId },
-        relations: { customer: true, items: { product: true } },
-      });
-
-      // Verify the accounting service received the order with customer and items
-      const callArg = accountingService.postSalesOrderEntry.mock.calls[0][0];
-      expect(callArg).toHaveProperty('customer');
-      expect(callArg).toHaveProperty('items');
-      expect(callArg.items).toHaveLength(1);
-      expect(callArg.items[0]).toHaveProperty('product');
-    });
-
-    it('should throw error when order not found', async () => {
-      // Arrange
-      salesOrderRepository.findOne.mockResolvedValue(null);
-
-      // Act & Assert
-      await expect(service.fulfillOrder('non-existent-id')).rejects.toThrow(
-        NotFoundException,
-      );
-    });
-
-    it('should throw error when order is already fulfilled', async () => {
-      // Arrange
-      const mockSalesOrder = createMockSalesOrder();
-      const fulfilledOrder = { ...mockSalesOrder, isFulfilled: true };
-      salesOrderRepository.findOne.mockResolvedValue(fulfilledOrder as SalesOrder);
-
-      // Act & Assert
-      await expect(service.fulfillOrder(mockSalesOrder.id)).rejects.toThrow(
-        ConflictException,
-      );
-    });
-
-    it('should throw error when order is not paid in full', async () => {
-      // Arrange
-      const mockSalesOrder = createMockSalesOrder();
-      const unpaidOrder = { ...mockSalesOrder, isPaidInFull: false, balanceDue: 500 };
-      salesOrderRepository.findOne.mockResolvedValue(unpaidOrder as SalesOrder);
-
-      // Act & Assert
-      await expect(service.fulfillOrder(mockSalesOrder.id)).rejects.toThrow(
-        ConflictException,
-      );
-    });
+    expect(salesOrderPaymentService.recordPayment).toHaveBeenCalledWith('order-1', dto);
+    expect(salesOrderQueryService.findById).toHaveBeenCalledWith('order-1');
   });
 
-  describe('unpayOrder', () => {
-    it('should call reverseSourceEntries for each payment when unpaying', async () => {
-      const mockOrder = { id: 'so-123', orderNumber: 'SO-000026', isFulfilled: false, paidAmount: 500 };
-      const mockInvoice = {
-        id: 'inv-123',
-        salesOrderId: 'so-123',
-        paidAmount: 500,
-        calculateTotals: jest.fn(),
-        updateStatus: jest.fn(),
-      };
-      const mockPayments = [
-        { id: 'pay-1', paymentNumber: 'PAY-001', amount: 300, status: 'COMPLETED' },
-        { id: 'pay-2', paymentNumber: 'PAY-002', amount: 200, status: 'COMPLETED' },
-      ];
+  it('delegates recordRefund then reloads the response', async () => {
+    const dto = { paymentMethodId: 'method-1', amount: 100, paymentDate: '2026-05-26' };
 
-      const paymentRepository = {
-        find: jest.fn().mockResolvedValue(mockPayments),
-        softDelete: jest.fn().mockResolvedValue({}),
-      };
-      const invoiceRepository = {
-        findOne: jest.fn().mockResolvedValue(mockInvoice),
-        save: jest.fn().mockResolvedValue(mockInvoice),
-      };
+    await service.recordRefund('order-1', dto);
 
-      (salesOrderRepository as any).manager = {
-        getRepository: jest.fn()
-          .mockReturnValueOnce(paymentRepository)
-          .mockReturnValueOnce(invoiceRepository),
-      };
-
-      salesOrderRepository.findOne.mockResolvedValue(mockOrder as any);
-      salesOrderRepository.save.mockResolvedValue({ ...mockOrder, paidAmount: 0 } as any);
-      jest.spyOn(service, 'findById').mockResolvedValue({ id: 'so-123' } as any);
-      auditLogService.log.mockResolvedValue(undefined);
-      accountingService.reverseSourceEntries.mockResolvedValue(undefined);
-
-      await service.unpayOrder('so-123');
-
-      expect(accountingService.reverseSourceEntries).toHaveBeenCalledTimes(2);
-      expect(accountingService.reverseSourceEntries).toHaveBeenCalledWith('payment', 'pay-1', 'system');
-      expect(accountingService.reverseSourceEntries).toHaveBeenCalledWith('payment', 'pay-2', 'system');
-      expect(paymentRepository.softDelete).toHaveBeenCalledWith(['pay-1', 'pay-2']);
-    });
-
-    it('should still succeed if accounting reversal fails', async () => {
-      const mockOrder = { id: 'so-123', orderNumber: 'SO-000026', isFulfilled: false, paidAmount: 500 };
-      const mockInvoice = {
-        id: 'inv-123',
-        salesOrderId: 'so-123',
-        paidAmount: 500,
-        calculateTotals: jest.fn(),
-        updateStatus: jest.fn(),
-      };
-      const mockPayments = [
-        { id: 'pay-1', paymentNumber: 'PAY-001', amount: 300, status: 'COMPLETED' },
-      ];
-
-      const paymentRepository = {
-        find: jest.fn().mockResolvedValue(mockPayments),
-        softDelete: jest.fn().mockResolvedValue({}),
-      };
-      const invoiceRepository = {
-        findOne: jest.fn().mockResolvedValue(mockInvoice),
-        save: jest.fn().mockResolvedValue(mockInvoice),
-      };
-
-      (salesOrderRepository as any).manager = {
-        getRepository: jest.fn()
-          .mockReturnValueOnce(paymentRepository)
-          .mockReturnValueOnce(invoiceRepository),
-      };
-
-      salesOrderRepository.findOne.mockResolvedValue(mockOrder as any);
-      salesOrderRepository.save.mockResolvedValue({ ...mockOrder, paidAmount: 0 } as any);
-      jest.spyOn(service, 'findById').mockResolvedValue({ id: 'so-123' } as any);
-      auditLogService.log.mockResolvedValue(undefined);
-      accountingService.reverseSourceEntries.mockRejectedValue(new Error('No open period'));
-
-      await expect(service.unpayOrder('so-123')).resolves.toBeDefined();
-      expect(paymentRepository.softDelete).toHaveBeenCalled();
-    });
+    expect(salesOrderPaymentService.recordRefund).toHaveBeenCalledWith('order-1', dto);
+    expect(salesOrderQueryService.findById).toHaveBeenCalledWith('order-1');
   });
 
-  describe('recordPayments - upsert on re-pay', () => {
-    it('should restore soft-deleted payment instead of creating a new one', async () => {
-      const invoiceId = 'invoice-uuid-1';
-      const softDeletedPaymentId = 'payment-uuid-1';
-      const existingPaymentNumber = 'PAY-000001';
+  it('delegates fulfillOrder then reloads the response', async () => {
+    await service.fulfillOrder('order-1', 'user-1', 'admin');
 
-      const mockOrder = {
-        id: 'order-uuid-1',
-        orderNumber: 'SO-000001',
-        customerId: 'customer-uuid-1',
-        paidAmount: 0,
-        isFulfilled: false,
-      };
-      const mockInvoice = {
-        id: invoiceId,
-        salesOrderId: mockOrder.id,
-        invoiceNumber: 'INV-000001',
-        paidAmount: 0,
-        calculateTotals: jest.fn(),
-        updateStatus: jest.fn(),
-      };
-      const mockPaymentMethod = { id: 'pm-uuid-1', requiresSettlement: false, isActive: true };
-      const softDeletedPayment = {
-        id: softDeletedPaymentId,
-        paymentNumber: existingPaymentNumber,
-        deletedAt: new Date('2026-01-01'),
-        amount: 100,
-        paymentMethodId: 'pm-uuid-old',
-        settlementStatus: 'NOT_APPLICABLE',
-      };
-
-      const paymentRepo = {
-        find: jest.fn().mockResolvedValue([softDeletedPayment]),
-        findOne: jest.fn().mockResolvedValue({ ...softDeletedPayment, deletedAt: null, isActive: true }),
-        create: jest.fn().mockReturnValue({ id: 'new-payment-id' }),
-        save: jest.fn().mockResolvedValue({ ...softDeletedPayment, amount: 150 }),
-        restore: jest.fn().mockResolvedValue(undefined),
-      };
-      const invoiceRepo = {
-        findOne: jest.fn().mockResolvedValue(mockInvoice),
-        save: jest.fn().mockResolvedValue(mockInvoice),
-      };
-      const paymentMethodRepo = {
-        findOne: jest.fn().mockResolvedValue(mockPaymentMethod),
-      };
-      const orderRepo = {
-        update: jest.fn().mockResolvedValue(undefined),
-      };
-
-      dataSource.transaction = jest.fn().mockImplementation(async (cb) =>
-        cb({
-          getRepository: jest.fn((entity) => {
-            if (entity?.name === 'Payment') return paymentRepo;
-            if (entity?.name === 'Invoice') return invoiceRepo;
-            if (entity?.name === 'PaymentMethodEntity') return paymentMethodRepo;
-            if (entity?.name === 'SalesOrder') return orderRepo;
-            return {};
-          }),
-        } as any),
-      ) as any;
-
-      salesOrderRepository.findOne.mockResolvedValue(mockOrder as any);
-      settingsService.generateDocumentNumber.mockResolvedValue('PAY-000002');
-      accountingService.postCustomerPaymentEntry.mockResolvedValue({ id: 'je-1' } as any);
-      auditLogService.log.mockResolvedValue(undefined);
-      jest.spyOn(service, 'findById').mockResolvedValue({ id: mockOrder.id } as any);
-
-      await service.recordPayments(mockOrder.id, [{ paymentMethodId: 'pm-uuid-1', amount: 150 }]);
-
-      expect(paymentRepo.restore).toHaveBeenCalledWith(softDeletedPaymentId);
-      expect(paymentRepo.create).not.toHaveBeenCalled();
-    });
-
-    it('should create a new payment when no soft-deleted payments exist', async () => {
-      const mockOrder = {
-        id: 'order-uuid-1',
-        orderNumber: 'SO-000001',
-        customerId: 'customer-uuid-1',
-        paidAmount: 0,
-        isFulfilled: false,
-      };
-      const mockInvoice = {
-        id: 'invoice-uuid-1',
-        salesOrderId: mockOrder.id,
-        invoiceNumber: 'INV-000001',
-        paidAmount: 0,
-        calculateTotals: jest.fn(),
-        updateStatus: jest.fn(),
-      };
-      const mockPaymentMethod = { id: 'pm-uuid-1', requiresSettlement: false, isActive: true };
-
-      const paymentRepo = {
-        find: jest.fn().mockResolvedValue([]),
-        findOne: jest.fn().mockResolvedValue({ id: 'new-payment' }),
-        create: jest.fn().mockReturnValue({ id: 'new-payment', paymentNumber: 'PAY-000002' }),
-        save: jest.fn().mockResolvedValue({ id: 'new-payment', paymentNumber: 'PAY-000002' }),
-        restore: jest.fn().mockResolvedValue(undefined),
-      };
-      const invoiceRepo = {
-        findOne: jest.fn().mockResolvedValue(mockInvoice),
-        save: jest.fn().mockResolvedValue(mockInvoice),
-      };
-      const paymentMethodRepo = {
-        findOne: jest.fn().mockResolvedValue(mockPaymentMethod),
-      };
-      const orderRepo = {
-        update: jest.fn().mockResolvedValue(undefined),
-      };
-
-      dataSource.transaction = jest.fn().mockImplementation(async (cb) =>
-        cb({
-          getRepository: jest.fn((entity) => {
-            if (entity?.name === 'Payment') return paymentRepo;
-            if (entity?.name === 'Invoice') return invoiceRepo;
-            if (entity?.name === 'PaymentMethodEntity') return paymentMethodRepo;
-            if (entity?.name === 'SalesOrder') return orderRepo;
-            return {};
-          }),
-        } as any),
-      ) as any;
-
-      salesOrderRepository.findOne.mockResolvedValue(mockOrder as any);
-      settingsService.generateDocumentNumber.mockResolvedValue('PAY-000002');
-      accountingService.postCustomerPaymentEntry.mockResolvedValue({ id: 'je-1' } as any);
-      auditLogService.log.mockResolvedValue(undefined);
-      jest.spyOn(service, 'findById').mockResolvedValue({ id: mockOrder.id } as any);
-
-      await service.recordPayments(mockOrder.id, [{ paymentMethodId: 'pm-uuid-1', amount: 150 }]);
-
-      expect(paymentRepo.create).toHaveBeenCalled();
-      expect(paymentRepo.restore).not.toHaveBeenCalled();
-    });
+    expect(salesOrderFulfillmentService.fulfillOrder).toHaveBeenCalledWith('order-1', 'user-1', 'admin');
+    expect(salesOrderQueryService.findById).toHaveBeenCalledWith('order-1');
   });
 
-  describe('unfulfillOrder', () => {
-    it('calls updateCustomerMetrics with the order customerId after unfulfillment', async () => {
-      const mockOrder = { id: 'o1', customerId: 'c1' } as SalesOrder;
-      salesOrderFulfillmentService.unfulfillOrder = jest.fn().mockResolvedValue(mockOrder);
-      salesOrderQueryService.findById = jest.fn().mockResolvedValue({ id: 'o1' } as any);
-      const customerService = module.get(CustomerService);
+  it('delegates unfulfillOrder then reloads the response', async () => {
+    await service.unfulfillOrder('order-1', 'user-1', 'admin');
 
-      await service.unfulfillOrder('o1');
-
-      expect(customerService.updateCustomerMetrics).toHaveBeenCalledWith('c1');
-    });
-
-    it('should call reverseSourceEntries with sales_order sourceType when unfulfilling', async () => {
-      const mockOrder = {
-        id: 'so-123',
-        orderNumber: 'SO-000026',
-        isFulfilled: true,
-        items: [{ productId: 'prod-1', quantity: 5, product: { id: 'prod-1' } }],
-      };
-
-      salesOrderRepository.findOne.mockResolvedValue(mockOrder as any);
-      salesOrderRepository.save.mockResolvedValue({ ...mockOrder, isFulfilled: false } as any);
-      jest.spyOn(service, 'findById').mockResolvedValue({ id: 'so-123' } as any);
-      baseCostCalculator.restoreStock.mockResolvedValue(undefined);
-      stockMovementService.deleteByReference.mockResolvedValue({ deletedCount: 1 } as any);
-      auditLogService.log.mockResolvedValue(undefined);
-      accountingService.reverseSourceEntries.mockResolvedValue(undefined);
-
-      await service.unfulfillOrder('so-123');
-
-      expect(accountingService.reverseSourceEntries).toHaveBeenCalledWith(
-        'sales_order',
-        'so-123',
-        'system',
-      );
-    });
-
-    it('should still succeed if accounting reversal fails', async () => {
-      const mockOrder = {
-        id: 'so-123',
-        orderNumber: 'SO-000026',
-        isFulfilled: true,
-        items: [{ productId: 'prod-1', quantity: 5, product: { id: 'prod-1' } }],
-      };
-
-      salesOrderRepository.findOne.mockResolvedValue(mockOrder as any);
-      salesOrderRepository.save.mockResolvedValue({ ...mockOrder, isFulfilled: false } as any);
-      jest.spyOn(service, 'findById').mockResolvedValue({ id: 'so-123' } as any);
-      baseCostCalculator.restoreStock.mockResolvedValue(undefined);
-      stockMovementService.deleteByReference.mockResolvedValue({ deletedCount: 1 } as any);
-      auditLogService.log.mockResolvedValue(undefined);
-      accountingService.reverseSourceEntries.mockRejectedValue(new Error('No open period'));
-
-      await expect(service.unfulfillOrder('so-123')).resolves.toBeDefined();
-    });
+    expect(salesOrderFulfillmentService.unfulfillOrder).toHaveBeenCalledWith('order-1', 'user-1', 'admin');
+    expect(salesOrderQueryService.findById).toHaveBeenCalledWith('order-1');
   });
 
-  describe('fulfillOrder calls updateCustomerMetrics', () => {
-    it('calls updateCustomerMetrics with the order customerId after fulfillment', async () => {
-      const mockOrder = { id: 'o1', customerId: 'c1' } as SalesOrder;
-      salesOrderFulfillmentService.fulfillOrder = jest.fn().mockResolvedValue(mockOrder);
-      salesOrderQueryService.findById = jest.fn().mockResolvedValue({ id: 'o1' } as any);
-      const customerService = module.get(CustomerService);
+  it('uses status/paymentStatus enum fields in mock orders', () => {
+    const order = {
+      status: SalesOrderStatus.DRAFT,
+      paymentStatus: SalesOrderPaymentStatus.PAID,
+      subtotal: 1000,
+      totalAmount: 1000,
+    } as Partial<SalesOrder>;
 
-      await service.fulfillOrder('o1', 'user1', 'user1');
-
-      expect(customerService.updateCustomerMetrics).toHaveBeenCalledWith('c1');
-    });
-  });
-
-  describe('delete calls updateCustomerMetrics', () => {
-    it('calls updateCustomerMetrics with the order customerId after delete', async () => {
-      salesOrderRepository.findOne.mockResolvedValue({ id: 'o1', customerId: 'c1' } as SalesOrder);
-      salesOrderLifecycleService.delete = jest.fn().mockResolvedValue({
-        deletedOrderNumber: 'SO-000001',
-        previousOrder: null,
-      });
-      const customerService = module.get(CustomerService);
-
-      await service.delete('o1');
-
-      expect(customerService.updateCustomerMetrics).toHaveBeenCalledWith('c1');
-    });
-  });
-
-  describe('restore calls updateCustomerMetrics', () => {
-    it('calls updateCustomerMetrics with the order customerId after restore', async () => {
-      salesOrderLifecycleService.restore = jest.fn().mockResolvedValue({
-        id: 'o1',
-        customerId: 'c1',
-      } as SalesOrder);
-      const customerService = module.get(CustomerService);
-
-      await service.restore('o1');
-
-      expect(customerService.updateCustomerMetrics).toHaveBeenCalledWith('c1');
-    });
-  });
-
-  describe('permanentDelete calls updateCustomerMetrics', () => {
-    it('calls updateCustomerMetrics with the order customerId after permanent delete', async () => {
-      salesOrderRepository.findOne.mockResolvedValue({ id: 'o1', customerId: 'c1' } as SalesOrder);
-      salesOrderLifecycleService.permanentDelete = jest.fn().mockResolvedValue(undefined);
-      const customerService = module.get(CustomerService);
-
-      await service.permanentDelete('o1');
-
-      expect(customerService.updateCustomerMetrics).toHaveBeenCalledWith('c1');
-    });
-  });
-
-  describe('create does NOT call updateCustomerSalesMetrics', () => {
-    it('does not update customer metrics when an order is created', async () => {
-      const customerService = module.get(CustomerService);
-
-      try {
-        await service.create({ customerId: 'nonexistent', items: [], shippingAmount: 0 });
-      } catch {}
-
-      expect(customerService.updateCustomerMetrics).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('bulkRestore calls updateCustomerMetrics per unique customer', () => {
-    it('calls updateCustomerMetrics for each unique customerId in the batch', async () => {
-      salesOrderRepository.find = jest.fn().mockResolvedValue([
-        { id: 'o1', customerId: 'c1' } as SalesOrder,
-        { id: 'o2', customerId: 'c2' } as SalesOrder,
-        { id: 'o3', customerId: 'c1' } as SalesOrder, // duplicate customer
-      ]);
-      salesOrderLifecycleService.bulkRestore = jest.fn().mockResolvedValue({
-        success: 3, failed: [],
-      });
-      const customerService = module.get(CustomerService);
-
-      await service.bulkRestore(['o1', 'o2', 'o3']);
-
-      expect(customerService.updateCustomerMetrics).toHaveBeenCalledWith('c1');
-      expect(customerService.updateCustomerMetrics).toHaveBeenCalledWith('c2');
-      expect(customerService.updateCustomerMetrics).toHaveBeenCalledTimes(2); // deduplicated
-    });
-  });
-
-  describe('bulkPermanentDelete calls updateCustomerMetrics per unique customer', () => {
-    it('calls updateCustomerMetrics for each unique customerId in the batch', async () => {
-      salesOrderRepository.find = jest.fn().mockResolvedValue([
-        { id: 'o1', customerId: 'c1' } as SalesOrder,
-        { id: 'o2', customerId: 'c2' } as SalesOrder,
-      ]);
-      salesOrderLifecycleService.bulkPermanentDelete = jest.fn().mockResolvedValue({
-        success: 2, failed: [],
-      });
-      const customerService = module.get(CustomerService);
-
-      await service.bulkPermanentDelete(['o1', 'o2']);
-
-      expect(customerService.updateCustomerMetrics).toHaveBeenCalledWith('c1');
-      expect(customerService.updateCustomerMetrics).toHaveBeenCalledWith('c2');
-      expect(customerService.updateCustomerMetrics).toHaveBeenCalledTimes(2);
-    });
+    expect(order.status).toBe(SalesOrderStatus.DRAFT);
+    expect(order.paymentStatus).toBe(SalesOrderPaymentStatus.PAID);
   });
 });

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -80,18 +80,18 @@ describe('SalesOrderService', () => {
   it('delegates recordPayment then reloads the response', async () => {
     const dto = { paymentMethodId: 'method-1', amount: 100, paymentDate: '2026-05-26' };
 
-    await service.recordPayment('order-1', dto);
+    await service.recordPayment('order-1', dto, 'user-1', 'admin');
 
-    expect(salesOrderPaymentService.recordPayment).toHaveBeenCalledWith('order-1', dto);
+    expect(salesOrderPaymentService.recordPayment).toHaveBeenCalledWith('order-1', dto, 'user-1', 'admin');
     expect(salesOrderQueryService.findById).toHaveBeenCalledWith('order-1');
   });
 
   it('delegates recordRefund then reloads the response', async () => {
     const dto = { paymentMethodId: 'method-1', amount: 100, paymentDate: '2026-05-26' };
 
-    await service.recordRefund('order-1', dto);
+    await service.recordRefund('order-1', dto, 'user-1', 'admin');
 
-    expect(salesOrderPaymentService.recordRefund).toHaveBeenCalledWith('order-1', dto);
+    expect(salesOrderPaymentService.recordRefund).toHaveBeenCalledWith('order-1', dto, 'user-1', 'admin');
     expect(salesOrderQueryService.findById).toHaveBeenCalledWith('order-1');
   });
 

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -551,11 +551,6 @@ export class SalesOrderService extends BaseCrudService<
       await this.salesOrderRepository.update(id, updateData);
     }
 
-    // Keep child documents aligned with order item changes without blocking header-only edits.
-    if (items && items.length > 0) {
-      await this.updateAssociatedInvoices(id);
-    }
-
     // Log audit trail for update
     if (Object.keys(updateData).length > 0) {
       await this.auditLogService.log(
@@ -708,93 +703,6 @@ export class SalesOrderService extends BaseCrudService<
     return processedItems;
   }
 
-  async updateAssociatedInvoices(salesOrderId: string): Promise<void> {
-    try {
-      // Find the updated sales order with all relations
-      const updatedOrder = await this.salesOrderRepository.findOne({
-        where: { id: salesOrderId },
-        relations: { customer: true, items: { product: true } }
-      });
-
-      if (!updatedOrder) {
-        console.warn(`Sales order ${salesOrderId} not found for invoice update`);
-        return;
-      }
-
-      // Find all invoices associated with this sales order
-      const invoices = await this.invoiceRepository.find({
-        where: { salesOrderId }
-      });
-
-      if (invoices.length === 0) {
-        console.log(`No invoices found for sales order ${updatedOrder.orderNumber}`);
-        return;
-      }
-
-      // Update each invoice with the latest order data
-      for (const invoice of invoices) {
-        // Skip fully paid invoices - they shouldn't be modified
-        if (invoice.status === 'paid' && Number(invoice.balanceDue) <= 0) {
-          console.log(`⏭️  Skipping paid invoice ${invoice.invoiceNumber}`);
-          continue;
-        }
-
-        // Update customer information if changed
-        if (updatedOrder.customer) {
-          invoice.customerId = updatedOrder.customerId;
-        }
-
-        // Sync invoice items from sales order items
-        if (updatedOrder.items && updatedOrder.items.length > 0) {
-          // Delete existing invoice items
-          await this.invoiceItemRepository.delete({ invoiceId: invoice.id });
-
-          // Create new invoice items from sales order
-          const invoiceItemsData = updatedOrder.items.map(soItem => ({
-            invoiceId: invoice.id,
-            lineNumber: soItem.lineNumber,
-            productId: soItem.productId,
-            quantity: Number(soItem.quantity),
-            unitPrice: Number(soItem.unitPrice),
-            discountType: soItem.discountType,
-            discountPercent: Number(soItem.discountPercent || 0),
-            discount: Number(soItem.discountAmount),
-            totalAmount: Number(soItem.totalAmount),
-          }));
-
-          // Insert all items
-          await this.invoiceItemRepository.insert(invoiceItemsData);
-
-          // Update total amount from order (items + shipping)
-          const newSubtotal = updatedOrder.items.reduce((sum, item) =>
-            sum + Number(item.totalAmount), 0);
-          const shippingAmount = Number(updatedOrder.shippingAmount || 0);
-          invoice.totalAmount = newSubtotal + shippingAmount;
-        }
-
-        // Sync notes from sales order
-        invoice.notes = updatedOrder.notes;
-
-        // Preserve existing paidAmount and recalculate balance due
-        const currentPaidAmount = Number(invoice.paidAmount);
-        invoice.balanceDue = Number(invoice.totalAmount) - currentPaidAmount;
-
-        // Update invoice status based on payment status
-        invoice.updateStatus();
-
-        // Save the updated invoice
-        await this.invoiceRepository.save(invoice);
-
-        console.log(`✅ Updated invoice ${invoice.invoiceNumber} (including items) for sales order ${updatedOrder.orderNumber}`);
-      }
-
-      console.log(`✅ Updated ${invoices.length} invoice(s) for sales order ${updatedOrder.orderNumber}`);
-    } catch (error) {
-      console.error(`⚠️ Failed to update associated invoices for sales order ${salesOrderId}:`, error.message);
-      // Don't throw error - sales order update should still succeed even if invoice update fails
-    }
-  }
-
   async cancel(id: string, userId?: string, username?: string): Promise<SalesOrderResponseDto> {
     await this.salesOrderLifecycleService.cancel(id, userId, username);
     return this.salesOrderQueryService.findById(id);
@@ -805,13 +713,13 @@ export class SalesOrderService extends BaseCrudService<
     return this.salesOrderQueryService.findById(id);
   }
 
-  async recordPayment(orderId: string, dto: RecordPaymentDto): Promise<SalesOrderResponseDto> {
-    await this.salesOrderPaymentService.recordPayment(orderId, dto);
+  async recordPayment(orderId: string, dto: RecordPaymentDto, userId?: string, username?: string): Promise<SalesOrderResponseDto> {
+    await this.salesOrderPaymentService.recordPayment(orderId, dto, userId, username);
     return this.salesOrderQueryService.findById(orderId);
   }
 
-  async recordRefund(orderId: string, dto: RecordRefundDto): Promise<SalesOrderResponseDto> {
-    await this.salesOrderPaymentService.recordRefund(orderId, dto);
+  async recordRefund(orderId: string, dto: RecordRefundDto, userId?: string, username?: string): Promise<SalesOrderResponseDto> {
+    await this.salesOrderPaymentService.recordRefund(orderId, dto, userId, username);
     return this.salesOrderQueryService.findById(orderId);
   }
 

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -21,6 +21,8 @@ import {
   UpdateSalesOrderDto,
   QuerySalesOrdersDto,
   SalesOrderResponseDto,
+  RecordPaymentDto,
+  RecordRefundDto,
 } from '../dto/sales-order.dto';
 import { GlobalSearchResultDto } from '../../search/dto/global-search-result.dto';
 import { canSearchSalesOrders } from '../../search/search.permissions';
@@ -165,10 +167,6 @@ export class SalesOrderService extends BaseCrudService<
     }
   }
 
-  private async findPreviousOrder(currentOrderNumber: string): Promise<SalesOrderResponseDto | null> {
-    return this.salesOrderQueryService.findPreviousOrder(currentOrderNumber);
-  }
-
   async create(
     createSalesOrderDto: CreateSalesOrderDto,
     userId?: string,
@@ -223,6 +221,7 @@ export class SalesOrderService extends BaseCrudService<
           orderNumber,
           customerId,
           orderDate: new Date(),
+          subtotal,
           shippingAmount,
           totalAmount,
         });
@@ -436,10 +435,6 @@ export class SalesOrderService extends BaseCrudService<
     };
   }
 
-  async testInvoiceRelations(orderNumber: string): Promise<any> {
-    return this.salesOrderQueryService.testInvoiceRelations(orderNumber);
-  }
-
   async findSummaries(query: QuerySalesOrdersDto = {}): Promise<any> {
     return this.salesOrderQueryService.findSummaries(query);
   }
@@ -462,6 +457,8 @@ export class SalesOrderService extends BaseCrudService<
     userId?: string,
     username?: string,
   ): Promise<SalesOrderResponseDto> {
+    await this.salesOrderLifecycleService.assertEditAllowed(id);
+
     const order = await this.salesOrderRepository.findOne({
       where: { id }
     });
@@ -470,10 +467,6 @@ export class SalesOrderService extends BaseCrudService<
     }
 
     const { items, customerId, notes } = updateSalesOrderDto;
-
-    if (items) {
-      await this.salesOrderLifecycleService.assertItemsNotLocked(id);
-    }
 
     // Prepare update data for the sales order
     const updateData: any = {};
@@ -543,6 +536,7 @@ export class SalesOrderService extends BaseCrudService<
 
       // Add shipping and total amount to update data
       updateData.shippingAmount = shippingAmount;
+      updateData.subtotal = subtotal;
       updateData.totalAmount = totalAmount;
     } else if (updateSalesOrderDto.shippingAmount !== undefined) {
       // If only shipping is being updated (no items), recalculate total
@@ -557,14 +551,9 @@ export class SalesOrderService extends BaseCrudService<
       await this.salesOrderRepository.update(id, updateData);
     }
 
-    // Keep child documents aligned with order changes without blocking header-only edits.
+    // Keep child documents aligned with order item changes without blocking header-only edits.
     if (items && items.length > 0) {
       await this.updateAssociatedInvoices(id);
-    } else if (customerId !== undefined || notes !== undefined) {
-      const refreshedOrder = await this.salesOrderRepository.findOne({ where: { id } });
-      if (refreshedOrder) {
-        await this.salesOrderLifecycleService.syncChildHeaderFromSalesOrder(refreshedOrder);
-      }
     }
 
     // Log audit trail for update
@@ -584,28 +573,6 @@ export class SalesOrderService extends BaseCrudService<
     }
 
     return this.findById(id);
-  }
-
-  async delete(
-    id: string,
-    userId?: string,
-    username?: string,
-  ): Promise<{ deletedOrderNumber: string; previousOrder: SalesOrderResponseDto | null }> {
-    const order = await this.salesOrderRepository.findOne({ where: { id } });
-    const customerId = order?.customerId;
-
-    const result = await this.salesOrderLifecycleService.delete(
-      id,
-      userId,
-      username,
-      this.findPreviousOrder.bind(this),
-    );
-
-    if (customerId) {
-      await this.triggerMetricUpdate(customerId, `delete ${id}`);
-    }
-
-    return result;
   }
 
   async duplicateOrder(id: string, userId: string): Promise<SalesOrderResponseDto> {
@@ -656,36 +623,6 @@ export class SalesOrderService extends BaseCrudService<
 
   async findOrdersByCustomer(customerId: string, limit: number = 10) {
     return this.salesOrderQueryService.findOrdersByCustomer(customerId, limit);
-  }
-
-  async getOrderInvoices(id: string) {
-    return this.salesOrderQueryService.getOrderInvoices(id);
-  }
-
-  async createInvoiceFromOrder(id: string) {
-    const order = await this.salesOrderRepository.findOne({
-      where: { id },
-      relations: { customer: true, items: { product: true } },
-    });
-
-    if (!order) {
-      throw new NotFoundException('Sales order not found');
-    }
-
-    const invoiceNumber = await this.generateInvoiceNumber();
-    const invoiceData = Invoice.fromSalesOrder(order);
-    const invoice = this.invoiceRepository.create({ ...invoiceData, invoiceNumber });
-
-    // lineItems removed from invoice model
-
-    const savedInvoice = await this.invoiceRepository.save(invoice);
-
-    return {
-      invoiceId: savedInvoice.id,
-      invoiceNumber: savedInvoice.invoiceNumber,
-      orderId: id,
-      orderNumber: order.orderNumber,
-    };
   }
 
   // Helper methods
@@ -769,65 +706,6 @@ export class SalesOrderService extends BaseCrudService<
 
     console.log('Processed items from validateAndProcessItems:', JSON.stringify(processedItems, null, 2));
     return processedItems;
-  }
-
-
-  async findDeleted(query: QuerySalesOrdersDto = {}): Promise<any> {
-    return this.salesOrderQueryService.findDeleted(query);
-  }
-
-  async restore(id: string, userId?: string, username?: string): Promise<SalesOrderResponseDto> {
-    const restoredOrder = await this.salesOrderLifecycleService.restore(id, userId, username);
-    await this.triggerMetricUpdate(restoredOrder.customerId, `restore ${id}`);
-    return restoredOrder;
-  }
-
-  async bulkRestore(ids: string[], userId?: string, username?: string): Promise<BulkOperationResponse> {
-    const orders = ids.length > 0
-      ? await this.salesOrderRepository.find({ where: ids.map(id => ({ id })), withDeleted: true })
-      : [];
-    const customerIds = [...new Set(orders.map(o => o.customerId).filter(Boolean))];
-
-    const result = await this.salesOrderLifecycleService.bulkRestore(ids, userId, username);
-
-    for (const customerId of customerIds) {
-      await this.triggerMetricUpdate(customerId, `bulkRestore`);
-    }
-
-    return result;
-  }
-
-  async permanentDelete(id: string, userId?: string, username?: string): Promise<void> {
-    const order = await this.salesOrderRepository.findOne({
-      where: { id },
-      withDeleted: true,
-    });
-    const customerId = order?.customerId;
-
-    await this.salesOrderLifecycleService.permanentDelete(id, userId, username);
-
-    if (customerId) {
-      await this.triggerMetricUpdate(customerId, `permanentDelete ${id}`);
-    }
-  }
-
-  async bulkPermanentDelete(
-    orderIds: string[],
-    userId?: string,
-    username?: string,
-  ): Promise<BulkOperationResponse> {
-    const orders = orderIds.length > 0
-      ? await this.salesOrderRepository.find({ where: orderIds.map(id => ({ id })), withDeleted: true })
-      : [];
-    const customerIds = [...new Set(orders.map(o => o.customerId).filter(Boolean))];
-
-    const result = await this.salesOrderLifecycleService.bulkPermanentDelete(orderIds, userId, username);
-
-    for (const customerId of customerIds) {
-      await this.triggerMetricUpdate(customerId, `bulkPermanentDelete`);
-    }
-
-    return result;
   }
 
   async updateAssociatedInvoices(salesOrderId: string): Promise<void> {
@@ -917,41 +795,38 @@ export class SalesOrderService extends BaseCrudService<
     }
   }
 
-  async recordPayment(id: string, amount: number, paymentMethodId?: string): Promise<SalesOrderResponseDto> {
-    return this.salesOrderPaymentService.recordPayment(
-      id,
-      amount,
-      paymentMethodId,
-      this.findById.bind(this),
-    );
+  async cancel(id: string, userId?: string, username?: string): Promise<SalesOrderResponseDto> {
+    await this.salesOrderLifecycleService.cancel(id, userId, username);
+    return this.salesOrderQueryService.findById(id);
   }
 
-  async recordPayments(id: string, payments: { paymentMethodId: string; amount: number; reference?: string }[]): Promise<SalesOrderResponseDto> {
-    return this.salesOrderPaymentService.recordPayments(
-      id,
-      payments,
-      this.findById.bind(this),
-    );
+  async uncancel(id: string, userId?: string, username?: string): Promise<SalesOrderResponseDto> {
+    await this.salesOrderLifecycleService.uncancel(id, userId, username);
+    return this.salesOrderQueryService.findById(id);
   }
 
-  async unpayOrder(id: string): Promise<SalesOrderResponseDto> {
-    return this.salesOrderPaymentService.unpayOrder(id, this.findById.bind(this));
+  async recordPayment(orderId: string, dto: RecordPaymentDto): Promise<SalesOrderResponseDto> {
+    await this.salesOrderPaymentService.recordPayment(orderId, dto);
+    return this.salesOrderQueryService.findById(orderId);
+  }
+
+  async recordRefund(orderId: string, dto: RecordRefundDto): Promise<SalesOrderResponseDto> {
+    await this.salesOrderPaymentService.recordRefund(orderId, dto);
+    return this.salesOrderQueryService.findById(orderId);
+  }
+
+  async listPayments(orderId: string) {
+    return this.salesOrderPaymentService.listPayments(orderId);
   }
 
   async fulfillOrder(id: string, userId?: string, username?: string): Promise<SalesOrderResponseDto> {
-    const savedOrder = await this.salesOrderFulfillmentService.fulfillOrder(
-      id,
-      userId,
-      username,
-    );
-    await this.triggerMetricUpdate(savedOrder.customerId, `fulfillOrder ${id}`);
-    return this.findById(savedOrder.id);
+    await this.salesOrderFulfillmentService.fulfillOrder(id, userId, username);
+    return this.salesOrderQueryService.findById(id);
   }
 
-  async unfulfillOrder(id: string): Promise<SalesOrderResponseDto> {
-    const savedOrder = await this.salesOrderFulfillmentService.unfulfillOrder(id);
-    await this.triggerMetricUpdate(savedOrder.customerId, `unfulfillOrder ${id}`);
-    return this.findById(savedOrder.id);
+  async unfulfillOrder(id: string, userId?: string, username?: string): Promise<SalesOrderResponseDto> {
+    await this.salesOrderFulfillmentService.unfulfillOrder(id, userId, username);
+    return this.salesOrderQueryService.findById(id);
   }
 
 

--- a/backend/test/e2e/accounting-auto-posting.e2e-spec.ts
+++ b/backend/test/e2e/accounting-auto-posting.e2e-spec.ts
@@ -339,8 +339,8 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
       const fulfilledOrder = await salesOrderService.fulfillOrder(savedOrder.id);
 
       // Verify order is fulfilled
-      expect(fulfilledOrder.isFulfilled).toBe(true);
-      expect(fulfilledOrder.fulfilledDate).toBeTruthy();
+      expect(fulfilledOrder.status).toBe('FULFILLED');
+      expect(fulfilledOrder.updatedAt).toBeTruthy();
 
       // Verify journal entry was created
       const journalEntries = await journalEntryRepo.find({
@@ -435,7 +435,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
 
       // Fulfillment should succeed
       const fulfilledOrder = await salesOrderService.fulfillOrder(savedOrder.id);
-      expect(fulfilledOrder.isFulfilled).toBe(true);
+      expect(fulfilledOrder.status).toBe('FULFILLED');
 
       // But no journal entry should be created
       const journalEntries = await journalEntryRepo.find({
@@ -467,7 +467,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
 
       // Fulfillment should succeed (business transaction)
       const fulfilledOrder = await salesOrderService.fulfillOrder(savedOrder.id);
-      expect(fulfilledOrder.isFulfilled).toBe(true);
+      expect(fulfilledOrder.status).toBe('FULFILLED');
 
       // Current behavior posts using active posting period.
       const journalEntries = await journalEntryRepo.find({
@@ -1136,7 +1136,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
 
       // Business transaction should succeed
       const fulfilledOrder = await salesOrderService.fulfillOrder(savedOrder.id);
-      expect(fulfilledOrder.isFulfilled).toBe(true);
+      expect(fulfilledOrder.status).toBe('FULFILLED');
 
       // Current behavior posts using active posting period.
       const journalEntries = await journalEntryRepo.find({
@@ -1207,7 +1207,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
 
       // Fulfillment succeeds but accounting fails silently
       const fulfilledOrder = await salesOrderService.fulfillOrder(savedOrder.id);
-      expect(fulfilledOrder.isFulfilled).toBe(true);
+      expect(fulfilledOrder.status).toBe('FULFILLED');
 
       // No journal entry created
       const journalEntries = await journalEntryRepo.find({

--- a/backend/test/e2e/accounting-auto-posting.e2e-spec.ts
+++ b/backend/test/e2e/accounting-auto-posting.e2e-spec.ts
@@ -12,7 +12,7 @@ import { Customer } from '../../src/database/entities/customer.entity';
 import { Supplier } from '../../src/database/entities/supplier.entity';
 import { Category } from '../../src/database/entities/category.entity';
 import { Product } from '../../src/database/entities/product.entity';
-import { SalesOrder } from '../../src/database/entities/sales-order.entity';
+import { SalesOrder, SalesOrderPaymentStatus } from '../../src/database/entities/sales-order.entity';
 import { SalesOrderItem } from '../../src/database/entities/sales-order-item.entity';
 import { Payment } from '../../src/database/entities/payment.entity';
 import { PurchaseOrder } from '../../src/database/entities/purchase-order.entity';
@@ -319,7 +319,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
         customerId: testCustomer.id,
         orderDate: new Date('2026-02-15'),
         totalAmount: 1000.00,
-        paidAmount: 1000.00,
+        paymentStatus: SalesOrderPaymentStatus.PAID,
       } as any);
       const savedOrder = await salesOrderRepo.save(salesOrder) as unknown as SalesOrder;
 
@@ -381,7 +381,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
         customerId: testCustomer.id,
         orderDate: new Date('2026-02-15'),
         totalAmount: 1000.00,
-        paidAmount: 1000.00,
+        paymentStatus: SalesOrderPaymentStatus.PAID,
       } as any);
       const savedOrder = await salesOrderRepo.save(salesOrder) as unknown as SalesOrder;
 
@@ -418,7 +418,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
         customerId: testCustomer.id,
         orderDate: new Date('2026-02-15'),
         totalAmount: 1000.00,
-        paidAmount: 1000.00,
+        paymentStatus: SalesOrderPaymentStatus.PAID,
       } as any);
       const savedOrder = await salesOrderRepo.save(salesOrder) as unknown as SalesOrder;
 
@@ -450,7 +450,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
         customerId: testCustomer.id,
         orderDate: new Date('2026-01-15'), // Closed period
         totalAmount: 1000.00,
-        paidAmount: 1000.00,
+        paymentStatus: SalesOrderPaymentStatus.PAID,
       } as any);
       const savedOrder = await salesOrderRepo.save(salesOrder) as unknown as SalesOrder;
 
@@ -1119,7 +1119,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
         customerId: testCustomer.id,
         orderDate: new Date('2026-01-15'),
         totalAmount: 1000.00,
-        paidAmount: 1000.00,
+        paymentStatus: SalesOrderPaymentStatus.PAID,
       } as any);
       const savedOrder = await salesOrderRepo.save(salesOrder) as unknown as SalesOrder;
 
@@ -1151,7 +1151,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
         customerId: testCustomer.id,
         orderDate: new Date('2026-02-15'), // Open period
         totalAmount: 1000.00,
-        paidAmount: 1000.00,
+        paymentStatus: SalesOrderPaymentStatus.PAID,
       } as any);
       const savedOrder = await salesOrderRepo.save(salesOrder) as unknown as SalesOrder;
 
@@ -1190,7 +1190,7 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
         customerId: testCustomer.id,
         orderDate: new Date('2026-02-15'),
         totalAmount: 1000.00,
-        paidAmount: 1000.00,
+        paymentStatus: SalesOrderPaymentStatus.PAID,
       } as any);
       const savedOrder = await salesOrderRepo.save(salesOrder) as unknown as SalesOrder;
 

--- a/backend/test/e2e/sales.e2e-spec.ts
+++ b/backend/test/e2e/sales.e2e-spec.ts
@@ -145,14 +145,14 @@ describe('Sales (e2e)', () => {
       expect(res.body.id).toBe(salesOrderId);
     });
 
-    it('GET /sales-orders/:id/fulfillment-status — returns fulfillment status', async () => {
+    it('GET /sales-orders/:id — order starts as DRAFT/UNPAID', async () => {
       const res = await request(app.getHttpServer())
-        .get(`/sales-orders/${salesOrderId}/fulfillment-status`)
+        .get(`/sales-orders/${salesOrderId}`)
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 
-      expect(res.body).toHaveProperty('orderId', salesOrderId);
-      expect(res.body).toHaveProperty('totalItems');
+      expect(res.body.status).toBe('DRAFT');
+      expect(res.body.paymentStatus).toBe('UNPAID');
     });
 
     it('PUT /sales-orders/:id — updates the sales order notes', async () => {
@@ -184,47 +184,32 @@ describe('Sales (e2e)', () => {
   // ─── Payment flow ─────────────────────────────────────────────────────────
 
   describe('Payment flow', () => {
-    it('POST /sales-orders/:id/record-payment — records a payment', async () => {
-      const res = await request(app.getHttpServer())
-        .post(`/sales-orders/${salesOrderId}/record-payment`)
+    it('POST /sales-orders/:id/payments — records a partial payment', async () => {
+      await request(app.getHttpServer())
+        .post(`/sales-orders/${salesOrderId}/payments`)
         .set('Authorization', `Bearer ${accessToken}`)
-        .send({ amount: 300, paymentMethodId })
-        .expect(201);
-
-      const order = res.body.data ?? res.body;
-      expect(Number(order.paidAmount)).toBe(300);
+        .send({ amount: 100, paymentMethodId, paymentDate: '2026-05-26' })
+        .expect(200);
     });
 
-    it('GET /sales-orders/:id — paidAmount reflects the payment', async () => {
+    it('GET /sales-orders/:id/payments — lists payments', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/sales-orders/${salesOrderId}/payments`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      const payments: any[] = res.body.data ?? res.body;
+      expect(payments.length).toBeGreaterThan(0);
+      expect(Number(payments[0].amount)).toBe(100);
+    });
+
+    it('GET /sales-orders/:id — paymentStatus is PARTIAL after partial payment', async () => {
       const res = await request(app.getHttpServer())
         .get(`/sales-orders/${salesOrderId}`)
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 
-      expect(Number(res.body.paidAmount)).toBe(300);
-    });
-  });
-
-  // ─── Invoice ──────────────────────────────────────────────────────────────
-  describe('Invoice', () => {
-    it('POST /sales-orders/:id/create-invoice — creates an invoice', async () => {
-      const res = await request(app.getHttpServer())
-        .post(`/sales-orders/${salesOrderId}/create-invoice`)
-        .set('Authorization', `Bearer ${accessToken}`)
-        .expect(201);
-
-      expect(res.body).toHaveProperty('invoiceId');
-      expect(res.body).toHaveProperty('invoiceNumber');
-    });
-
-    it('GET /sales-orders/:id/invoices — lists invoices for the order', async () => {
-      const res = await request(app.getHttpServer())
-        .get(`/sales-orders/${salesOrderId}/invoices`)
-        .set('Authorization', `Bearer ${accessToken}`)
-        .expect(200);
-
-      expect(res.body).toHaveProperty('invoices');
-      expect(res.body.invoices.length).toBeGreaterThan(0);
+      expect(res.body.paymentStatus).toBe('PARTIAL');
     });
   });
 


### PR DESCRIPTION
Closes #676

## Summary

- Replaces `isFulfilled` (boolean) + `paidAmount` (number) columns with explicit `status` (`DRAFT`/`FULFILLED`/`CANCELLED`) and `paymentStatus` (`UNPAID`/`PARTIAL`/`PAID`/`OVERPAID`) enums on `SalesOrder`
- Introduces `SalesOrderPayment` entity (`sales_order_payments` table) — positive records for payments, negative for refunds — replacing Invoice-routed payment tracking entirely
- Removes all soft-delete infrastructure (delete, restore, bulk-restore, permanent-delete endpoints); cancelled orders remain visible
- Keeps backward-compat getters (`isFulfilled`, `fulfilledDate`, `paidAmount`, `isPaidInFull`, `balanceDue`, `canFulfill`, `canUnfulfill`) on the entity with `@deprecated` JSDoc — still consumed by analytics, accounting, and invoice services

## New endpoints

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/:id/fulfill` | DRAFT+PAID → FULFILLED |
| `POST` | `/:id/unfulfill` | FULFILLED → DRAFT |
| `POST` | `/:id/cancel` | DRAFT+UNPAID → CANCELLED |
| `POST` | `/:id/uncancel` | CANCELLED → DRAFT |
| `GET` | `/:id/payments` | List payment records |
| `POST` | `/:id/payments` | Record a payment |
| `POST` | `/:id/refunds` | Record a refund (negative payment) |

## Removed endpoints

`DELETE /:id`, `DELETE /:id/permanent`, `POST /:id/restore`, `POST /bulk-restore`, `POST /bulk-permanent-delete`, `GET /deleted`, `POST /:id/record-payment`, `POST /record-payments`, `POST /:id/unpay`, `GET /:id/test-invoices`

## Business rules

- Payments only on `DRAFT` orders; refunds on `DRAFT` or `FULFILLED` (not `CANCELLED`)
- Edit (create/update items) requires `status=DRAFT` AND `paymentStatus=UNPAID`
- Fulfill requires `paymentStatus=PAID` (OVERPAID is intentionally blocked per spec)
- Payment status computed atomically inside a `DataSource.transaction()` from the running sum of all `SalesOrderPayment.amount` records
- Floating-point tolerance `0.001` for PAID detection

## Migration

- Backfills `status` from `isFulfilled`, `paymentStatus` from `paidAmount` vs `totalAmount`, `subtotal` from `totalAmount - shippingAmount`
- Drops `isFulfilled`, `fulfilledDate`, `paidAmount` columns after backfill
- Creates `sales_order_payments` table with FK constraints and indexes

## Test plan

- [x] `cd backend && npx jest src/modules/sales --no-coverage` — 135 tests, all pass
- [x] `cd backend && npm run test --no-coverage` — 1058 tests, all pass
- [x] `cd backend && npx tsc --noEmit --pretty false -p tsconfig.json` — zero errors
- [x] Migration revert (`npm run migration:revert`) then re-run (`npm run migration:run`) cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)