### PR TITLE
feat(sales): Sales Order Edit Form — issue #672

### DIFF
--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -279,6 +279,7 @@ const CreateSalesOrderPage: React.FC = () => {
   useEffect(() => {
     if (isEditMode && orderNumber) {
       setLoadingOrder(true)
+      setLoadError(null)
       triggerGetSalesOrderByNumber(orderNumber)
         .unwrap()
         .then((order: any) => {
@@ -296,7 +297,9 @@ const CreateSalesOrderPage: React.FC = () => {
   }, [isEditMode, orderNumber])
 
   useEffect(() => {
-    if (!orderToLoad || !products.length) return
+    if (!orderToLoad) return
+    const needsProducts = orderToLoad.items?.some((i: any) => i.product)
+    if (needsProducts && !products.length) return
     reset({
       customerId: orderToLoad.customerId || orderToLoad.customer?.id || '',
       orderDate: orderToLoad.orderDate
@@ -399,7 +402,16 @@ const CreateSalesOrderPage: React.FC = () => {
   }
 
   if (loadError) {
-    return <Alert severity="error">{loadError}</Alert>
+    return (
+      <>
+        <PageHeader
+          variant="workflow"
+          title="Edit Sales Order"
+          backAction={() => navigate('/sales/orders')}
+        />
+        <Alert severity="error">{loadError}</Alert>
+      </>
+    )
   }
 
   return (

--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   Card,
   CardContent,
+  CircularProgress,
   Grid,
   IconButton,
   MenuItem,
@@ -163,6 +164,7 @@ const CreateSalesOrderPage: React.FC = () => {
   const { currency } = useCurrency()
 
   const [loadingOrder, setLoadingOrder] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [orderToLoad, setOrderToLoad] = useState<any>(null)
   const [editingOrderId, setEditingOrderId] = useState<string | null>(null)
   const [selectedCustomer, setSelectedCustomer] = useState<any>(null)
@@ -287,7 +289,7 @@ const CreateSalesOrderPage: React.FC = () => {
           setOrderToLoad(order)
         })
         .catch((err: any) => {
-          showError(err?.data?.message || err?.response?.data?.message || 'Failed to load sales order')
+          setLoadError(err?.data?.message || err?.response?.data?.message || 'Failed to load sales order')
           setLoadingOrder(false)
         })
     }
@@ -391,9 +393,13 @@ const CreateSalesOrderPage: React.FC = () => {
   if (loadingOrder) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', pt: 10 }}>
-        <Typography>Loading sales order...</Typography>
+        <CircularProgress />
       </Box>
     )
+  }
+
+  if (loadError) {
+    return <Alert severity="error">{loadError}</Alert>
   }
 
   return (
@@ -701,8 +707,8 @@ const CreateSalesOrderPage: React.FC = () => {
 
       <ConfirmationDialog
         open={showDiscardDialog}
-        title="Discard this order?"
-        message="You will lose all entered data."
+        title="Discard changes?"
+        message="You have unsaved changes. Are you sure you want to leave without saving?"
         confirmText="Discard"
         cancelText="Keep editing"
         severity="warning"

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -586,7 +586,7 @@ describe('CreateSalesOrderPage — edit mode', { timeout: 60000 }, () => {
     )
 
     await waitFor(() => {
-      expect(document.querySelector('.MuiCircularProgress-root')).toBeInTheDocument()
+      expect(screen.getByRole('progressbar')).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -541,3 +541,209 @@ describe('CreateSalesOrderPage — new features', () => {
     })
   })
 })
+
+describe('CreateSalesOrderPage — edit mode', { timeout: 60000 }, () => {
+  const existingOrder = {
+    id: 'order-id-1',
+    orderNumber: 'SO-26-001',
+    customerId: 'customer-1',
+    orderDate: '2026-03-15T00:00:00.000Z',
+    shippingAmount: 25,
+    notes: 'Handle with care',
+    items: [
+      {
+        productId: 'product-1',
+        quantity: 3,
+        unitPrice: 11,
+        discountType: 'percentage',
+        discountValue: 0,
+        discountPercent: 0,
+        discountAmount: 0,
+        totalPrice: 33,
+        totalAmount: 33,
+        product: { id: 'product-1', name: 'Alpha Widget', basePrice: 11 },
+      },
+    ],
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockParams.mockReturnValue({ orderNumber: 'SO-26-001' })
+    customersResponse.data.data = [{ id: 'customer-1', name: 'Test Customer' }]
+    mockGet.mockResolvedValue({ data: [] })
+    mockGetDocumentNumberSettings.mockReturnValue({ data: { configurations: [] }, isLoading: false })
+  })
+
+  it('shows CircularProgress while loading the order', async () => {
+    mockFetchSalesOrder.mockReturnValue({
+      unwrap: vi.fn(() => new Promise(() => {})), // never resolves
+    })
+
+    render(
+      <BrowserRouter>
+        <CreateSalesOrderPage />
+      </BrowserRouter>,
+    )
+
+    await waitFor(() => {
+      expect(document.querySelector('.MuiCircularProgress-root')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error Alert when order load fails', async () => {
+    mockFetchSalesOrder.mockReturnValue({
+      unwrap: vi.fn().mockRejectedValue({ data: { message: 'Order not found' } }),
+    })
+
+    render(
+      <BrowserRouter>
+        <CreateSalesOrderPage />
+      </BrowserRouter>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+      expect(screen.getByText('Order not found')).toBeInTheDocument()
+    })
+  })
+
+  it('pre-fills all 4 sections with existing order data', async () => {
+    mockFetchSalesOrder.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue(existingOrder),
+    })
+
+    render(
+      <BrowserRouter>
+        <CreateSalesOrderPage />
+      </BrowserRouter>,
+    )
+
+    // Section 1 — Order Info
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('SO-26-001')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('2026-03-15')).toBeInTheDocument()
+      expect(screen.getByRole('combobox', { name: /customer/i })).toHaveValue('Test Customer')
+    })
+
+    // Section 2 — Line Items
+    await waitFor(() => {
+      const productInput = screen.getByPlaceholderText('Search by name or barcode...')
+      expect(productInput).toHaveValue('Alpha Widget')
+    })
+
+    // Section 3 — Shipping
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('25.00')).toBeInTheDocument()
+    })
+
+    // Section 4 — Notes
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Handle with care')).toBeInTheDocument()
+    })
+  })
+
+  it('save calls updateSalesOrder and redirects to list', async () => {
+    mockFetchSalesOrder.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue(existingOrder),
+    })
+    mockUpdateSalesOrder.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({ id: 'order-id-1', orderNumber: 'SO-26-001' }),
+    })
+
+    render(
+      <BrowserRouter>
+        <CreateSalesOrderPage />
+      </BrowserRouter>,
+    )
+
+    // Wait for form to pre-fill
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: /customer/i })).toHaveValue('Test Customer')
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /update order/i })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /update order/i }))
+
+    await waitFor(() => {
+      expect(mockUpdateSalesOrder).toHaveBeenCalled()
+      expect(mockNavigate).toHaveBeenCalledWith('/sales/orders?highlight=order-id-1')
+    })
+  })
+
+  it('cancel with unsaved changes shows Discard changes dialog', async () => {
+    const user = userEvent.setup()
+    mockFetchSalesOrder.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue(existingOrder),
+    })
+
+    render(
+      <BrowserRouter>
+        <CreateSalesOrderPage />
+      </BrowserRouter>,
+    )
+
+    // Wait for pre-fill
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('2026-03-15')).toBeInTheDocument()
+    })
+
+    // Dirty the form
+    const dateInput = screen.getByLabelText(/order date/i)
+    await user.clear(dateInput)
+    await user.type(dateInput, '2026-04-01')
+
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/discard changes/i)).toBeInTheDocument()
+    })
+  })
+
+  it('cancel without changes navigates immediately without dialog', async () => {
+    const user = userEvent.setup()
+    mockFetchSalesOrder.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue(existingOrder),
+    })
+
+    render(
+      <BrowserRouter>
+        <CreateSalesOrderPage />
+      </BrowserRouter>,
+    )
+
+    // Wait for pre-fill to complete
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: /customer/i })).toHaveValue('Test Customer')
+    })
+
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }))
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/sales/orders')
+    })
+    expect(screen.queryByText(/discard changes/i)).not.toBeInTheDocument()
+  })
+
+  it('create mode cancel also shows unified Discard changes dialog', async () => {
+    const user = userEvent.setup()
+    mockParams.mockReturnValue({}) // create mode — no orderNumber
+
+    render(
+      <BrowserRouter>
+        <CreateSalesOrderPage />
+      </BrowserRouter>,
+    )
+
+    const dateInput = screen.getByLabelText(/order date/i)
+    await user.clear(dateInput)
+    await user.type(dateInput, '2025-01-01')
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/discard changes/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -445,7 +445,7 @@ describe('CreateSalesOrderPage — new features', () => {
     await user.click(screen.getByRole('button', { name: /^cancel$/i }))
 
     await waitFor(() => {
-      expect(screen.getByText(/discard this order/i)).toBeInTheDocument()
+      expect(screen.getByText(/discard changes/i)).toBeInTheDocument()
     })
   })
 
@@ -462,7 +462,7 @@ describe('CreateSalesOrderPage — new features', () => {
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/sales/orders')
     })
-    expect(screen.queryByText(/discard this order/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/discard changes/i)).not.toBeInTheDocument()
   })
 
   it('shows customer validation error when submitting without a customer', async () => {


### PR DESCRIPTION
## Summary

- Closes #672
- `CreateSalesOrderPage` already implemented edit mode; this PR closes the UX gaps and adds full edit-mode test coverage to match the Customer/Supplier form pattern

## Changes

- **Loading state**: replaced plain `<Typography>` with `<CircularProgress />` during order fetch
- **Load error state**: added `loadError` state that renders an `<Alert>` with a back button (via `PageHeader`) instead of silently calling `showError` and leaving the user stranded
- **Discard dialog copy**: unified to "Discard changes?" / "You have unsaved changes…" for both create and edit mode, matching Customer/Supplier forms and the issue spec
- **Infinite spinner guard**: fixed second `useEffect` so orders with no line items (no products to seed) don't block `setLoadingOrder(false)` forever
- **`loadError` reset**: `setLoadError(null)` now called at the start of each fetch so stale errors don't persist if `orderNumber` param changes on the same mount
- **Tests**: updated 2 existing assertions to match new dialog copy; added `describe('edit mode')` block with 7 tests covering spinner, error Alert, pre-fill, save+redirect, cancel with/without changes

## Test Plan

- [x] `cd frontend && npx vitest run src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx` → 21 passed
- [x] `cd frontend && npm run type-check` → exit 0
- [x] Navigate to a Draft sales order → Edit → form pre-fills correctly
- [ ] Edit form → Cancel with changes → "Discard changes?" dialog appears
- [ ] Edit form → Save → redirects to orders list with highlight
- [ ] Edit form → invalid order number in URL → error Alert shown with back button

🤖 Generated with [Claude Code](https://claude.com/claude-code)