### PR TITLE
feat(sales): Sales Order Detail page — header, action bar, 3 tabs

### DIFF
--- a/frontend/src/components/sales/PaymentDialog.tsx
+++ b/frontend/src/components/sales/PaymentDialog.tsx
@@ -33,6 +33,7 @@ interface PaymentDialogProps {
   orderNumber: string
   totalAmount: number
   paidAmount: number
+  title?: string
 }
 
 const formatCurrency = (amount: number) => {
@@ -46,6 +47,7 @@ export default function PaymentDialog({
   orderNumber,
   totalAmount,
   paidAmount,
+  title,
 }: PaymentDialogProps) {
   const outstandingBalance = Math.max(0, totalAmount - paidAmount)
   const { data: paymentMethods = [] } = useGetActivePaymentMethodsQuery(undefined, { skip: !open })
@@ -121,7 +123,7 @@ export default function PaymentDialog({
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Record Payment &mdash; {orderNumber}</DialogTitle>
+      <DialogTitle>{title ?? `Record Payment — ${orderNumber}`}</DialogTitle>
       <DialogContent>
         {/* Order Summary */}
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1, mt: 1 }}>

--- a/frontend/src/pages/sales/SalesOrderDetailPage.tsx
+++ b/frontend/src/pages/sales/SalesOrderDetailPage.tsx
@@ -1,0 +1,242 @@
+import { useState, type ReactNode } from 'react'
+import AccountBalanceIcon from '@mui/icons-material/AccountBalance'
+import PaymentIcon from '@mui/icons-material/Payment'
+import ReceiptIcon from '@mui/icons-material/Receipt'
+import { Box, CircularProgress, Tab, Tabs, Typography } from '@mui/material'
+import { skipToken } from '@reduxjs/toolkit/query'
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
+
+import ConfirmationDialog from '@/components/common/ConfirmationDialog'
+import PageHeader from '@/components/common/PageHeader'
+import SalesOrderPrint from '@/components/print/SalesOrderPrint'
+import PaymentDialog from '@/components/sales/PaymentDialog'
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import { useNotification } from '@/hooks/useNotification'
+import {
+  useCancelSalesOrderMutation,
+  useFulfillSalesOrderMutation,
+  useGetSalesOrderByNumberQuery,
+  useRecordOrderPaymentsMutation,
+  useUnfulfillSalesOrderMutation,
+} from '@/store/api/salesApi'
+
+import OrderActionBar from './components/OrderActionBar'
+import OrderJournalEntriesTab from './components/OrderJournalEntriesTab'
+import OrderOverviewTab from './components/OrderOverviewTab'
+import OrderPaymentsTab from './components/OrderPaymentsTab'
+import { SalesOrderPaymentStatusChip } from './components/SalesOrderPaymentStatusChip'
+import { SalesOrderStatusChip } from './components/SalesOrderStatusChip'
+
+type Dialog = 'pay' | 'refund' | 'print' | 'fulfill' | 'unfulfill' | 'cancel' | null
+
+interface TabPanelProps {
+  children?: ReactNode
+  index: number
+  value: number
+}
+
+function getErrorMessage(error: unknown, fallback: string) {
+  if (typeof error === 'object' && error !== null && 'data' in error) {
+    const data = (error as { data?: { message?: string } }).data
+    return data?.message ?? fallback
+  }
+
+  return fallback
+}
+
+function TabPanel({ children, value, index }: TabPanelProps) {
+  return (
+    <Box
+      role="tabpanel"
+      sx={{
+        flex: 1,
+        overflow: 'auto',
+        display: value === index ? 'flex' : 'none',
+        flexDirection: 'column',
+      }}
+    >
+      {value === index && (
+        <Box sx={{ p: TABLE_STYLES.cell.padding.px, flex: 1 }}>
+          {children}
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+export default function SalesOrderDetailPage() {
+  const { orderNumber } = useParams<{ orderNumber: string }>()
+  const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const tabValue = Math.min(Math.max(Number(searchParams.get('tab') ?? 0), 0), 2)
+  const [activeDialog, setActiveDialog] = useState<Dialog>(null)
+  const { showSuccess, showError } = useNotification()
+
+  const { data: order, isLoading, isError } = useGetSalesOrderByNumberQuery(orderNumber ?? skipToken)
+  const [fulfillOrder, { isLoading: isFulfilling }] = useFulfillSalesOrderMutation()
+  const [unfulfillOrder, { isLoading: isUnfulfilling }] = useUnfulfillSalesOrderMutation()
+  const [cancelOrder, { isLoading: isCancelling }] = useCancelSalesOrderMutation()
+  const [recordPayments] = useRecordOrderPaymentsMutation()
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 6 }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  if (isError || !order) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 6 }}>
+        <Typography color="text.secondary">Order not found.</Typography>
+      </Box>
+    )
+  }
+
+  const handleFulfillConfirm = async () => {
+    try {
+      await fulfillOrder(order.id).unwrap()
+      showSuccess(`Order ${order.orderNumber} fulfilled`)
+      setActiveDialog(null)
+    } catch (error) {
+      showError(getErrorMessage(error, 'Failed to fulfill order'))
+    }
+  }
+
+  const handleUnfulfillConfirm = async () => {
+    try {
+      await unfulfillOrder(order.id).unwrap()
+      showSuccess(`Order ${order.orderNumber} reverted to draft`)
+      setActiveDialog(null)
+    } catch (error) {
+      showError(getErrorMessage(error, 'Failed to unfulfill order'))
+    }
+  }
+
+  const handleCancelConfirm = async () => {
+    try {
+      await cancelOrder({ id: order.id }).unwrap()
+      showSuccess(`Order ${order.orderNumber} cancelled`)
+      setActiveDialog(null)
+    } catch (error) {
+      showError(getErrorMessage(error, 'Failed to cancel order'))
+    }
+  }
+
+  const handleSubmitPayment = async (
+    payments: { paymentMethodId: string; amount: number; reference?: string }[],
+  ) => {
+    try {
+      await recordPayments({ id: order.id, payments }).unwrap()
+      showSuccess(`Payment recorded for ${order.orderNumber}`)
+      setActiveDialog(null)
+    } catch (error) {
+      showError(getErrorMessage(error, 'Failed to record payment'))
+      throw error
+    }
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+      <PageHeader
+        title={order.orderNumber}
+        titleBadge={
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <SalesOrderStatusChip status={order.status} />
+            <SalesOrderPaymentStatusChip status={order.paymentStatus} />
+          </Box>
+        }
+        backAction={() => navigate('/sales/orders')}
+      />
+
+      <OrderActionBar
+        order={order}
+        onPay={() => setActiveDialog('pay')}
+        onFulfill={() => setActiveDialog('fulfill')}
+        onUnfulfill={() => setActiveDialog('unfulfill')}
+        onRefund={() => setActiveDialog('refund')}
+        onEdit={() => navigate(`/sales/orders/${order.orderNumber}/edit`)}
+        onCancel={() => setActiveDialog('cancel')}
+        onPrint={() => setActiveDialog('print')}
+      />
+
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs
+          value={tabValue}
+          onChange={(_, value: number) => setSearchParams({ tab: String(value) }, { replace: true })}
+          sx={{ minHeight: 36 }}
+        >
+          <Tab icon={<ReceiptIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="Overview" sx={{ minHeight: 36 }} />
+          <Tab icon={<PaymentIcon sx={{ fontSize: 16 }} />} iconPosition="start" label="Payments" sx={{ minHeight: 36 }} />
+          <Tab
+            icon={<AccountBalanceIcon sx={{ fontSize: 16 }} />}
+            iconPosition="start"
+            label="Journal Entries"
+            sx={{ minHeight: 36 }}
+          />
+        </Tabs>
+      </Box>
+
+      <TabPanel value={tabValue} index={0}>
+        <OrderOverviewTab order={order} />
+      </TabPanel>
+      <TabPanel value={tabValue} index={1}>
+        <OrderPaymentsTab orderId={order.id} totalAmount={order.totalAmount} />
+      </TabPanel>
+      <TabPanel value={tabValue} index={2}>
+        <OrderJournalEntriesTab orderId={order.id} />
+      </TabPanel>
+
+      <ConfirmationDialog
+        open={activeDialog === 'fulfill'}
+        title="Fulfill Order"
+        message={`Fulfill this order? (${order.orderNumber})`}
+        confirmText="Fulfill"
+        onConfirm={handleFulfillConfirm}
+        onCancel={() => setActiveDialog(null)}
+        loading={isFulfilling}
+      />
+
+      <ConfirmationDialog
+        open={activeDialog === 'unfulfill'}
+        title="Revert Order"
+        message={`Revert this order to draft? (${order.orderNumber})`}
+        confirmText="Revert"
+        onConfirm={handleUnfulfillConfirm}
+        onCancel={() => setActiveDialog(null)}
+        loading={isUnfulfilling}
+      />
+
+      <ConfirmationDialog
+        open={activeDialog === 'cancel'}
+        title="Cancel Order"
+        message={`Cancel this order? (${order.orderNumber})`}
+        confirmText="Cancel Order"
+        severity="error"
+        onConfirm={handleCancelConfirm}
+        onCancel={() => setActiveDialog(null)}
+        loading={isCancelling}
+      />
+
+      {(activeDialog === 'pay' || activeDialog === 'refund') && (
+        <PaymentDialog
+          open
+          onClose={() => setActiveDialog(null)}
+          onSubmit={handleSubmitPayment}
+          orderNumber={order.orderNumber}
+          totalAmount={order.totalAmount}
+          paidAmount={order.paidAmount ?? 0}
+        />
+      )}
+
+      {activeDialog === 'print' && (
+        <SalesOrderPrint
+          open
+          onClose={() => setActiveDialog(null)}
+          salesOrder={order}
+        />
+      )}
+    </Box>
+  )
+}

--- a/frontend/src/pages/sales/SalesOrderDetailPage.tsx
+++ b/frontend/src/pages/sales/SalesOrderDetailPage.tsx
@@ -227,6 +227,7 @@ export default function SalesOrderDetailPage() {
           orderNumber={order.orderNumber}
           totalAmount={order.totalAmount}
           paidAmount={order.paidAmount ?? 0}
+          title={activeDialog === 'refund' ? `Refund — ${order.orderNumber}` : undefined}
         />
       )}
 

--- a/frontend/src/pages/sales/__tests__/SalesOrderDetailPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/SalesOrderDetailPage.test.tsx
@@ -1,0 +1,174 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'react-redux'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SalesOrder } from '@/types'
+
+import SalesOrderDetailPage from '../SalesOrderDetailPage'
+
+const {
+  mockNavigate,
+  mockGetSalesOrderByNumber,
+  mockFulfill,
+  mockUnfulfill,
+  mockCancel,
+  mockRecordPayments,
+} = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockGetSalesOrderByNumber: vi.fn(),
+  mockFulfill: vi.fn(),
+  mockUnfulfill: vi.fn(),
+  mockCancel: vi.fn(),
+  mockRecordPayments: vi.fn(),
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+vi.mock('@/hooks/useNotification', () => ({
+  useNotification: () => ({
+    showSuccess: vi.fn(),
+    showError: vi.fn(),
+  }),
+}))
+
+vi.mock('@/store/api/salesApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store/api/salesApi')>()
+  return {
+    ...actual,
+    useGetSalesOrderByNumberQuery: mockGetSalesOrderByNumber,
+    useFulfillSalesOrderMutation: () => [mockFulfill, { isLoading: false }],
+    useUnfulfillSalesOrderMutation: () => [mockUnfulfill, { isLoading: false }],
+    useCancelSalesOrderMutation: () => [mockCancel, { isLoading: false }],
+    useRecordOrderPaymentsMutation: () => [mockRecordPayments, { isLoading: false }],
+  }
+})
+
+vi.mock('../components/OrderOverviewTab', () => ({ default: () => <div>OverviewTab</div> }))
+vi.mock('../components/OrderPaymentsTab', () => ({ default: () => <div>PaymentsTab</div> }))
+vi.mock('../components/OrderJournalEntriesTab', () => ({ default: () => <div>JournalTab</div> }))
+vi.mock('@/components/print/SalesOrderPrint', () => ({ default: () => <div>PrintDialog</div> }))
+vi.mock('@/components/sales/PaymentDialog', () => ({ default: () => <div>PaymentDialog</div> }))
+
+function makeOrder(overrides: Partial<SalesOrder> = {}): SalesOrder {
+  return {
+    id: 'o1',
+    orderNumber: 'SO-26-001',
+    status: 'DRAFT',
+    paymentStatus: 'UNPAID',
+    customerId: 'c1',
+    totalAmount: 500,
+    paidAmount: 0,
+    orderDate: new Date('2026-01-15'),
+    createdAt: new Date('2026-01-15'),
+    updatedAt: new Date('2026-01-15'),
+    ...overrides,
+  } as SalesOrder
+}
+
+function renderPage(orderNumber = 'SO-26-001') {
+  const store = configureStore({ reducer: { sales: (state = {}) => state, accounting: (state = {}) => state } })
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[`/sales/orders/${orderNumber}/view`]}>
+        <Routes>
+          <Route path="/sales/orders/:orderNumber/view" element={<SalesOrderDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('SalesOrderDetailPage', () => {
+  it('shows loading state', () => {
+    mockGetSalesOrderByNumber.mockReturnValue({ data: undefined, isLoading: true })
+    renderPage()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('shows not found on error', () => {
+    mockGetSalesOrderByNumber.mockReturnValue({ data: undefined, isLoading: false, isError: true })
+    renderPage()
+    expect(screen.getByText(/Order not found/)).toBeInTheDocument()
+  })
+
+  it('renders order number in header', () => {
+    mockGetSalesOrderByNumber.mockReturnValue({ data: makeOrder(), isLoading: false })
+    renderPage()
+    expect(screen.getByText('SO-26-001')).toBeInTheDocument()
+  })
+
+  it('renders Overview tab by default', () => {
+    mockGetSalesOrderByNumber.mockReturnValue({ data: makeOrder(), isLoading: false })
+    renderPage()
+    expect(screen.getByText('OverviewTab')).toBeInTheDocument()
+  })
+
+  it('switches to Payments tab', async () => {
+    mockGetSalesOrderByNumber.mockReturnValue({ data: makeOrder(), isLoading: false })
+    renderPage()
+    await userEvent.click(screen.getByRole('tab', { name: /Payments/i }))
+    expect(screen.getByText('PaymentsTab')).toBeInTheDocument()
+  })
+
+  it('switches to Journal Entries tab', async () => {
+    mockGetSalesOrderByNumber.mockReturnValue({ data: makeOrder(), isLoading: false })
+    renderPage()
+    await userEvent.click(screen.getByRole('tab', { name: /Journal/i }))
+    expect(screen.getByText('JournalTab')).toBeInTheDocument()
+  })
+
+  it('navigates back to orders list on back button click', async () => {
+    mockGetSalesOrderByNumber.mockReturnValue({ data: makeOrder(), isLoading: false })
+    renderPage()
+    await userEvent.click(screen.getByTestId('ArrowBackIcon').closest('button')!)
+    expect(mockNavigate).toHaveBeenCalledWith('/sales/orders')
+  })
+
+  it('navigates to edit page when Edit is clicked', async () => {
+    mockGetSalesOrderByNumber.mockReturnValue({ data: makeOrder(), isLoading: false })
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(mockNavigate).toHaveBeenCalledWith('/sales/orders/SO-26-001/edit')
+  })
+
+  it('shows confirm dialog when Cancel is clicked', async () => {
+    mockGetSalesOrderByNumber.mockReturnValue({ data: makeOrder(), isLoading: false })
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.getByText(/Cancel this order/i)).toBeInTheDocument()
+  })
+
+  it('shows confirm dialog when Fulfill is clicked', async () => {
+    mockGetSalesOrderByNumber.mockReturnValue({ data: makeOrder({ status: 'DRAFT', paymentStatus: 'PAID' }), isLoading: false })
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: 'Fulfill' }))
+    expect(screen.getByText(/Fulfill this order/i)).toBeInTheDocument()
+  })
+
+  it('shows confirm dialog when Unfulfill is clicked', async () => {
+    mockGetSalesOrderByNumber.mockReturnValue({ data: makeOrder({ status: 'FULFILLED', paymentStatus: 'PAID' }), isLoading: false })
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: 'Unfulfill' }))
+    expect(screen.getByText(/Revert this order/i)).toBeInTheDocument()
+  })
+
+  it('opens PaymentDialog when Pay is clicked', async () => {
+    mockGetSalesOrderByNumber.mockReturnValue({ data: makeOrder(), isLoading: false })
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: 'Pay' }))
+    expect(screen.getByText('PaymentDialog')).toBeInTheDocument()
+  })
+
+  it('opens PaymentDialog when Refund is clicked', async () => {
+    mockGetSalesOrderByNumber.mockReturnValue({ data: makeOrder({ status: 'DRAFT', paymentStatus: 'PAID' }), isLoading: false })
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: 'Refund' }))
+    expect(screen.getByText('PaymentDialog')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/sales/components/OrderActionBar.tsx
+++ b/frontend/src/pages/sales/components/OrderActionBar.tsx
@@ -1,0 +1,86 @@
+import { Box, Button } from '@mui/material'
+
+import type { SalesOrder } from '@/types'
+
+interface OrderActionBarProps {
+  order: SalesOrder
+  onPay: () => void
+  onFulfill: () => void
+  onUnfulfill: () => void
+  onRefund: () => void
+  onEdit: () => void
+  onCancel: () => void
+  onPrint: () => void
+}
+
+export function getOrderActions(order: SalesOrder) {
+  const { status, paymentStatus } = order
+  const isPaid = paymentStatus === 'PAID' || paymentStatus === 'OVERPAID'
+
+  if (status === 'CANCELLED') {
+    return ['print'] as const
+  }
+
+  if (status === 'FULFILLED') {
+    return ['unfulfill', 'refund', 'print'] as const
+  }
+
+  if (status === 'DRAFT' && isPaid) {
+    return ['fulfill', 'refund', 'edit', 'cancel', 'print'] as const
+  }
+
+  return ['pay', 'edit', 'cancel', 'print'] as const
+}
+
+export default function OrderActionBar({
+  order,
+  onPay,
+  onFulfill,
+  onUnfulfill,
+  onRefund,
+  onEdit,
+  onCancel,
+  onPrint,
+}: OrderActionBarProps) {
+  const actions = getOrderActions(order)
+
+  return (
+    <Box sx={{ display: 'flex', gap: 1, px: 3, pb: 1.5, flexWrap: 'wrap' }}>
+      {actions.includes('pay') && (
+        <Button variant="contained" size="small" onClick={onPay}>
+          Pay
+        </Button>
+      )}
+      {actions.includes('fulfill') && (
+        <Button variant="contained" size="small" onClick={onFulfill}>
+          Fulfill
+        </Button>
+      )}
+      {actions.includes('unfulfill') && (
+        <Button variant="outlined" size="small" onClick={onUnfulfill}>
+          Unfulfill
+        </Button>
+      )}
+      {actions.includes('refund') && (
+        <Button variant="outlined" size="small" onClick={onRefund}>
+          Refund
+        </Button>
+      )}
+      {actions.includes('edit') && (
+        <Button variant="outlined" size="small" onClick={onEdit}>
+          Edit
+        </Button>
+      )}
+      {actions.includes('cancel') && (
+        <Button variant="outlined" size="small" onClick={onCancel}>
+          Cancel
+        </Button>
+      )}
+      {actions.includes('print') && (
+        <Button variant="outlined" size="small" onClick={onPrint}>
+          Print
+        </Button>
+      )}
+    </Box>
+  )
+}

--- a/frontend/src/pages/sales/components/OrderActionBar.tsx
+++ b/frontend/src/pages/sales/components/OrderActionBar.tsx
@@ -13,23 +13,25 @@ interface OrderActionBarProps {
   onPrint: () => void
 }
 
-export function getOrderActions(order: SalesOrder) {
+type OrderAction = 'pay' | 'fulfill' | 'unfulfill' | 'refund' | 'edit' | 'cancel' | 'print'
+
+export function getOrderActions(order: SalesOrder): OrderAction[] {
   const { status, paymentStatus } = order
   const isPaid = paymentStatus === 'PAID' || paymentStatus === 'OVERPAID'
 
   if (status === 'CANCELLED') {
-    return ['print'] as const
+    return ['print']
   }
 
   if (status === 'FULFILLED') {
-    return ['unfulfill', 'refund', 'print'] as const
+    return ['unfulfill', 'refund', 'print']
   }
 
   if (status === 'DRAFT' && isPaid) {
-    return ['fulfill', 'refund', 'edit', 'cancel', 'print'] as const
+    return ['fulfill', 'refund', 'edit', 'cancel', 'print']
   }
 
-  return ['pay', 'edit', 'cancel', 'print'] as const
+  return ['pay', 'edit', 'cancel', 'print']
 }
 
 export default function OrderActionBar({

--- a/frontend/src/pages/sales/components/OrderJournalEntriesTab.tsx
+++ b/frontend/src/pages/sales/components/OrderJournalEntriesTab.tsx
@@ -1,0 +1,79 @@
+import {
+  Box,
+  CircularProgress,
+  Link,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import { useGetJournalEntriesQuery } from '@/store/api/accountingApi'
+import { formatCurrency, formatDate } from '@/utils/formatters'
+
+interface OrderJournalEntriesTabProps {
+  orderId: string
+}
+
+export default function OrderJournalEntriesTab({ orderId }: OrderJournalEntriesTabProps) {
+  const { data, isLoading } = useGetJournalEntriesQuery({ sourceType: 'sales_order', sourceId: orderId })
+  const entries = data?.data ?? []
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  if (entries.length === 0) {
+    return (
+      <Typography sx={{ color: 'text.secondary', py: 4, textAlign: 'center' }}>
+        No journal entries created for this sales order.
+      </Typography>
+    )
+  }
+
+  return (
+    <TableContainer component={Paper} variant="outlined">
+      <Table size={TABLE_STYLES.size}>
+        <TableHead>
+          <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600 } }}>
+            <TableCell>Entry Number</TableCell>
+            <TableCell>Date</TableCell>
+            <TableCell>Description</TableCell>
+            <TableCell align="right">Debit</TableCell>
+            <TableCell align="right">Credit</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {entries.map((entry) => {
+            const totalDebit = (entry.lines ?? []).reduce((sum: number, line: any) => sum + Number(line.debitAmount), 0)
+            const totalCredit = (entry.lines ?? []).reduce((sum: number, line: any) => sum + Number(line.creditAmount), 0)
+
+            return (
+              <TableRow key={entry.id} hover>
+                <TableCell>
+                  <Link component={RouterLink} to={`/accounting/journal-entries/${entry.id}`}>
+                    {entry.referenceNumber}
+                  </Link>
+                </TableCell>
+                <TableCell>{formatDate(entry.entryDate)}</TableCell>
+                <TableCell>{entry.description}</TableCell>
+                <TableCell align="right">{formatCurrency(totalDebit)}</TableCell>
+                <TableCell align="right">{formatCurrency(totalCredit)}</TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  )
+}

--- a/frontend/src/pages/sales/components/OrderJournalEntriesTab.tsx
+++ b/frontend/src/pages/sales/components/OrderJournalEntriesTab.tsx
@@ -15,6 +15,7 @@ import { Link as RouterLink } from 'react-router-dom'
 
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { useGetJournalEntriesQuery } from '@/store/api/accountingApi'
+import type { JournalEntryLine } from '@/types'
 import { formatCurrency, formatDate } from '@/utils/formatters'
 
 interface OrderJournalEntriesTabProps {
@@ -22,7 +23,7 @@ interface OrderJournalEntriesTabProps {
 }
 
 export default function OrderJournalEntriesTab({ orderId }: OrderJournalEntriesTabProps) {
-  const { data, isLoading } = useGetJournalEntriesQuery({ sourceType: 'sales_order', sourceId: orderId })
+  const { data, isLoading, isError } = useGetJournalEntriesQuery({ sourceType: 'sales_order', sourceId: orderId })
   const entries = data?.data ?? []
 
   if (isLoading) {
@@ -30,6 +31,14 @@ export default function OrderJournalEntriesTab({ orderId }: OrderJournalEntriesT
       <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
         <CircularProgress />
       </Box>
+    )
+  }
+
+  if (isError) {
+    return (
+      <Typography sx={{ color: 'text.secondary', py: 4, textAlign: 'center' }}>
+        Failed to load journal entries.
+      </Typography>
     )
   }
 
@@ -55,8 +64,8 @@ export default function OrderJournalEntriesTab({ orderId }: OrderJournalEntriesT
         </TableHead>
         <TableBody>
           {entries.map((entry) => {
-            const totalDebit = (entry.lines ?? []).reduce((sum: number, line: any) => sum + Number(line.debitAmount), 0)
-            const totalCredit = (entry.lines ?? []).reduce((sum: number, line: any) => sum + Number(line.creditAmount), 0)
+            const totalDebit = (entry.lines ?? []).reduce((sum: number, line: JournalEntryLine) => sum + Number(line.debitAmount), 0)
+            const totalCredit = (entry.lines ?? []).reduce((sum: number, line: JournalEntryLine) => sum + Number(line.creditAmount), 0)
 
             return (
               <TableRow key={entry.id} hover>

--- a/frontend/src/pages/sales/components/OrderOverviewTab.tsx
+++ b/frontend/src/pages/sales/components/OrderOverviewTab.tsx
@@ -20,6 +20,9 @@ import { TABLE_STYLES } from '@/constants/tableStyles'
 import type { SalesOrder, SalesOrderItem } from '@/types'
 import { formatCurrency, formatDate } from '@/utils/formatters'
 
+import { SalesOrderPaymentStatusChip } from './SalesOrderPaymentStatusChip'
+import { SalesOrderStatusChip } from './SalesOrderStatusChip'
+
 interface OrderOverviewTabProps {
   order: SalesOrder
 }
@@ -55,8 +58,8 @@ function formatDiscount(item: SalesOrderItem & Record<string, unknown>): string 
 
 export default function OrderOverviewTab({ order }: OrderOverviewTabProps) {
   const items = (order.items ?? []) as (SalesOrderItem & Record<string, unknown>)[]
-  const subtotal = (order as SalesOrder & { subtotal?: number }).subtotal ?? order.totalAmount
-  const shippingAmount = (order as SalesOrder & { shippingAmount?: number }).shippingAmount ?? 0
+  const subtotal = order.subtotal ?? order.totalAmount
+  const shippingAmount = order.shippingAmount ?? 0
   const paidAmount = order.paidAmount ?? 0
   const balance = order.balanceDue ?? order.totalAmount - paidAmount
 
@@ -92,6 +95,15 @@ export default function OrderOverviewTab({ order }: OrderOverviewTabProps) {
               <Typography variant="h6" gutterBottom>
                 Summary
               </Typography>
+              <Field
+                label="Status"
+                value={
+                  <Box sx={{ display: 'flex', gap: 1 }}>
+                    <SalesOrderStatusChip status={order.status} />
+                    <SalesOrderPaymentStatusChip status={order.paymentStatus} />
+                  </Box>
+                }
+              />
               <Field label="Total Amount" value={formatCurrency(order.totalAmount)} />
               <Field label="Shipping Fee" value={formatCurrency(shippingAmount)} />
               <Field label="Paid Amount" value={formatCurrency(paidAmount)} />

--- a/frontend/src/pages/sales/components/OrderOverviewTab.tsx
+++ b/frontend/src/pages/sales/components/OrderOverviewTab.tsx
@@ -1,0 +1,151 @@
+import {
+  Box,
+  Card,
+  CardContent,
+  Grid,
+  Link,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material'
+import type { ReactNode } from 'react'
+import { Link as RouterLink } from 'react-router-dom'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import type { SalesOrder, SalesOrderItem } from '@/types'
+import { formatCurrency, formatDate } from '@/utils/formatters'
+
+interface OrderOverviewTabProps {
+  order: SalesOrder
+}
+
+function Field({ label, value }: { label: string; value?: ReactNode }) {
+  return (
+    <Box sx={{ mb: 1.5 }}>
+      <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block', mb: 0.25 }}>
+        {label}
+      </Typography>
+      <Typography component="div" variant="body2" sx={{ color: 'text.primary' }}>
+        {value ?? '—'}
+      </Typography>
+    </Box>
+  )
+}
+
+function formatDiscount(item: SalesOrderItem & Record<string, unknown>): string {
+  const discountType = item.discountType as string | undefined
+  const discountPercent = item.discountPercent as number | undefined
+  const discountAmount = item.discountAmount as number | undefined
+
+  if (discountType === 'percentage' && discountPercent && discountPercent > 0) {
+    return `${Number(discountPercent).toFixed(2)}%`
+  }
+
+  if (discountType === 'amount' && discountAmount && discountAmount > 0) {
+    return formatCurrency(discountAmount)
+  }
+
+  return '—'
+}
+
+export default function OrderOverviewTab({ order }: OrderOverviewTabProps) {
+  const items = (order.items ?? []) as (SalesOrderItem & Record<string, unknown>)[]
+  const subtotal = (order as SalesOrder & { subtotal?: number }).subtotal ?? order.totalAmount
+  const shippingAmount = (order as SalesOrder & { shippingAmount?: number }).shippingAmount ?? 0
+  const paidAmount = order.paidAmount ?? 0
+  const balance = order.balanceDue ?? order.totalAmount - paidAmount
+
+  return (
+    <Box>
+      <Grid container spacing={3} sx={{ mb: 3 }}>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Order Info
+              </Typography>
+              <Field label="Order Number" value={order.orderNumber} />
+              <Field label="Order Date" value={formatDate(order.orderDate)} />
+              <Field
+                label="Customer"
+                value={
+                  order.customer ? (
+                    <Link component={RouterLink} to={`/sales/customers/${order.customer.slug}/view`}>
+                      {order.customer.name}
+                    </Link>
+                  ) : '—'
+                }
+              />
+              <Field label="Notes" value={order.notes} />
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid size={{ xs: 12, md: 6 }}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Summary
+              </Typography>
+              <Field label="Total Amount" value={formatCurrency(order.totalAmount)} />
+              <Field label="Shipping Fee" value={formatCurrency(shippingAmount)} />
+              <Field label="Paid Amount" value={formatCurrency(paidAmount)} />
+              <Field label="Balance Due" value={formatCurrency(balance)} />
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+
+      <TableContainer component={Paper} variant="outlined">
+        <Table size={TABLE_STYLES.size}>
+          <TableHead>
+            <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600 } }}>
+              <TableCell>Product</TableCell>
+              <TableCell align="right">Quantity</TableCell>
+              <TableCell align="right">Unit Price</TableCell>
+              <TableCell align="right">Discount</TableCell>
+              <TableCell align="right">Subtotal</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {items.map((item) => (
+              <TableRow key={item.id} hover>
+                <TableCell>{item.product?.name ?? '—'}</TableCell>
+                <TableCell align="right">{item.quantity}</TableCell>
+                <TableCell align="right">{formatCurrency(item.unitPrice)}</TableCell>
+                <TableCell align="right">{formatDiscount(item)}</TableCell>
+                <TableCell align="right">{formatCurrency(item.total)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
+        <Box sx={{ minWidth: 240 }}>
+          {[
+            { label: 'Subtotal', value: formatCurrency(subtotal) },
+            { label: 'Shipping', value: formatCurrency(shippingAmount) },
+            { label: 'Total', value: formatCurrency(order.totalAmount), bold: true },
+            { label: 'Paid', value: formatCurrency(paidAmount) },
+            { label: 'Balance', value: formatCurrency(balance), bold: true },
+          ].map(({ label, value, bold }) => (
+            <Box key={label} sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+              <Typography variant="body2" sx={{ fontWeight: bold ? 600 : 400 }}>
+                {label}
+              </Typography>
+              <Typography variant="body2" sx={{ fontWeight: bold ? 600 : 400 }}>
+                {value}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    </Box>
+  )
+}

--- a/frontend/src/pages/sales/components/OrderPaymentsTab.tsx
+++ b/frontend/src/pages/sales/components/OrderPaymentsTab.tsx
@@ -21,13 +21,21 @@ interface OrderPaymentsTabProps {
 }
 
 export default function OrderPaymentsTab({ orderId, totalAmount }: OrderPaymentsTabProps) {
-  const { data: payments = [], isLoading } = useGetSalesOrderPaymentsQuery(orderId)
+  const { data: payments = [], isLoading, isError } = useGetSalesOrderPaymentsQuery(orderId)
 
   if (isLoading) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
         <CircularProgress />
       </Box>
+    )
+  }
+
+  if (isError) {
+    return (
+      <Typography sx={{ color: 'text.secondary', py: 4, textAlign: 'center' }}>
+        Failed to load payments.
+      </Typography>
     )
   }
 

--- a/frontend/src/pages/sales/components/OrderPaymentsTab.tsx
+++ b/frontend/src/pages/sales/components/OrderPaymentsTab.tsx
@@ -1,0 +1,95 @@
+import {
+  Box,
+  CircularProgress,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material'
+
+import { TABLE_STYLES } from '@/constants/tableStyles'
+import { useGetSalesOrderPaymentsQuery } from '@/store/api/salesApi'
+import { formatCurrency, formatDate } from '@/utils/formatters'
+
+interface OrderPaymentsTabProps {
+  orderId: string
+  totalAmount: number
+}
+
+export default function OrderPaymentsTab({ orderId, totalAmount }: OrderPaymentsTabProps) {
+  const { data: payments = [], isLoading } = useGetSalesOrderPaymentsQuery(orderId)
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  if (payments.length === 0) {
+    return (
+      <Typography sx={{ color: 'text.secondary', py: 4, textAlign: 'center' }}>
+        No payments recorded for this sales order.
+      </Typography>
+    )
+  }
+
+  const totalPaid = payments.reduce((sum, payment) => sum + Number(payment.amount), 0)
+  const balance = totalAmount - totalPaid
+
+  return (
+    <Box>
+      <TableContainer component={Paper} variant="outlined">
+        <Table size={TABLE_STYLES.size}>
+          <TableHead>
+            <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600 } }}>
+              <TableCell>Payment Date</TableCell>
+              <TableCell>Payment Method</TableCell>
+              <TableCell>Reference Number</TableCell>
+              <TableCell align="right">Amount</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {payments.map((payment) => (
+              <TableRow key={payment.id} hover>
+                <TableCell>{formatDate(payment.paymentDate)}</TableCell>
+                <TableCell>{payment.paymentMethod?.name ?? '—'}</TableCell>
+                <TableCell>{payment.referenceNumber ?? '—'}</TableCell>
+                <TableCell
+                  align="right"
+                  data-testid={`payment-amount-${payment.id}`}
+                  sx={{ color: Number(payment.amount) < 0 ? 'error.main' : 'text.primary' }}
+                >
+                  {formatCurrency(payment.amount)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
+        <Box sx={{ minWidth: 240 }}>
+          {[
+            { label: 'Total Paid', value: formatCurrency(totalPaid), bold: true },
+            { label: 'Balance', value: formatCurrency(balance), bold: true },
+          ].map(({ label, value, bold }) => (
+            <Box key={label} sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+              <Typography variant="body2" sx={{ fontWeight: bold ? 600 : 400 }}>
+                {label}
+              </Typography>
+              <Typography variant="body2" sx={{ fontWeight: bold ? 600 : 400 }}>
+                {value}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    </Box>
+  )
+}

--- a/frontend/src/pages/sales/components/__tests__/OrderActionBar.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/OrderActionBar.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SalesOrder } from '@/types'
+
+import OrderActionBar from '../OrderActionBar'
+
+function makeOrder(overrides: Partial<SalesOrder>): SalesOrder {
+  return {
+    id: 'o1',
+    orderNumber: 'SO-26-001',
+    status: 'DRAFT',
+    paymentStatus: 'UNPAID',
+    customerId: 'c1',
+    totalAmount: 100,
+    orderDate: new Date('2026-01-01'),
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    ...overrides,
+  } as SalesOrder
+}
+
+function renderBar(order: SalesOrder, handlers = {}) {
+  const defaults = {
+    onPay: vi.fn(),
+    onFulfill: vi.fn(),
+    onUnfulfill: vi.fn(),
+    onRefund: vi.fn(),
+    onEdit: vi.fn(),
+    onCancel: vi.fn(),
+    onPrint: vi.fn(),
+  }
+
+  return {
+    ...render(
+      <MemoryRouter>
+        <OrderActionBar order={order} {...defaults} {...handlers} />
+      </MemoryRouter>,
+    ),
+    handlers: { ...defaults, ...handlers },
+  }
+}
+
+describe('OrderActionBar', () => {
+  it('Draft+Unpaid shows Pay, Edit, Cancel, Print', () => {
+    renderBar(makeOrder({ status: 'DRAFT', paymentStatus: 'UNPAID' }))
+    expect(screen.getByRole('button', { name: 'Pay' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Print' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Fulfill' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Refund' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Unfulfill' })).not.toBeInTheDocument()
+  })
+
+  it('Draft+Partial shows Pay, Edit, Cancel, Print', () => {
+    renderBar(makeOrder({ status: 'DRAFT', paymentStatus: 'PARTIAL' }))
+    expect(screen.getByRole('button', { name: 'Pay' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Fulfill' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Refund' })).not.toBeInTheDocument()
+  })
+
+  it('Draft+Paid shows Fulfill, Refund, Edit, Cancel, Print', () => {
+    renderBar(makeOrder({ status: 'DRAFT', paymentStatus: 'PAID' }))
+    expect(screen.getByRole('button', { name: 'Fulfill' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Refund' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Print' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Pay' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Unfulfill' })).not.toBeInTheDocument()
+  })
+
+  it('Draft+Overpaid shows Fulfill, Refund, Edit, Cancel, Print', () => {
+    renderBar(makeOrder({ status: 'DRAFT', paymentStatus: 'OVERPAID' }))
+    expect(screen.getByRole('button', { name: 'Fulfill' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Refund' })).toBeInTheDocument()
+  })
+
+  it('Fulfilled shows Unfulfill, Refund, Print', () => {
+    renderBar(makeOrder({ status: 'FULFILLED', paymentStatus: 'PAID' }))
+    expect(screen.getByRole('button', { name: 'Unfulfill' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Refund' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Print' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Fulfill' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Pay' })).not.toBeInTheDocument()
+  })
+
+  it('Cancelled shows only Print', () => {
+    renderBar(makeOrder({ status: 'CANCELLED', paymentStatus: 'UNPAID' }))
+    expect(screen.getByRole('button', { name: 'Print' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Pay' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Fulfill' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Unfulfill' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Refund' })).not.toBeInTheDocument()
+  })
+
+  it('calls onPay when Pay is clicked', async () => {
+    const onPay = vi.fn()
+    renderBar(makeOrder({ status: 'DRAFT', paymentStatus: 'UNPAID' }), { onPay })
+    await userEvent.click(screen.getByRole('button', { name: 'Pay' }))
+    expect(onPay).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onFulfill when Fulfill is clicked', async () => {
+    const onFulfill = vi.fn()
+    renderBar(makeOrder({ status: 'DRAFT', paymentStatus: 'PAID' }), { onFulfill })
+    await userEvent.click(screen.getByRole('button', { name: 'Fulfill' }))
+    expect(onFulfill).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onUnfulfill when Unfulfill is clicked', async () => {
+    const onUnfulfill = vi.fn()
+    renderBar(makeOrder({ status: 'FULFILLED', paymentStatus: 'PAID' }), { onUnfulfill })
+    await userEvent.click(screen.getByRole('button', { name: 'Unfulfill' }))
+    expect(onUnfulfill).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onRefund when Refund is clicked', async () => {
+    const onRefund = vi.fn()
+    renderBar(makeOrder({ status: 'DRAFT', paymentStatus: 'PAID' }), { onRefund })
+    await userEvent.click(screen.getByRole('button', { name: 'Refund' }))
+    expect(onRefund).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onEdit when Edit is clicked', async () => {
+    const onEdit = vi.fn()
+    renderBar(makeOrder({ status: 'DRAFT', paymentStatus: 'UNPAID' }), { onEdit })
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(onEdit).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onCancel when Cancel is clicked', async () => {
+    const onCancel = vi.fn()
+    renderBar(makeOrder({ status: 'DRAFT', paymentStatus: 'UNPAID' }), { onCancel })
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onPrint when Print is clicked', async () => {
+    const onPrint = vi.fn()
+    renderBar(makeOrder({ status: 'CANCELLED', paymentStatus: 'UNPAID' }), { onPrint })
+    await userEvent.click(screen.getByRole('button', { name: 'Print' }))
+    expect(onPrint).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/pages/sales/components/__tests__/OrderJournalEntriesTab.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/OrderJournalEntriesTab.test.tsx
@@ -1,0 +1,87 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import OrderJournalEntriesTab from '../OrderJournalEntriesTab'
+
+const { mockGetJournalEntries } = vi.hoisted(() => ({
+  mockGetJournalEntries: vi.fn(),
+}))
+
+vi.mock('@/store/api/accountingApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store/api/accountingApi')>()
+  return { ...actual, useGetJournalEntriesQuery: mockGetJournalEntries }
+})
+
+function makeEntry(overrides = {}) {
+  return {
+    id: 'je1',
+    referenceNumber: 'JE-001',
+    entryDate: '2026-01-20',
+    description: 'Sales order SO-26-001',
+    status: 'POSTED',
+    isDraft: false,
+    isPosted: true,
+    isReversed: false,
+    fiscalPeriodId: 'fp1',
+    lines: [
+      { id: 'l1', journalEntryId: 'je1', accountId: 'a1', debitAmount: 100, creditAmount: 0, createdAt: '2026-01-20', updatedAt: '2026-01-20' },
+      { id: 'l2', journalEntryId: 'je1', accountId: 'a2', debitAmount: 0, creditAmount: 100, createdAt: '2026-01-20', updatedAt: '2026-01-20' },
+    ],
+    ...overrides,
+  }
+}
+
+function renderTab(orderId: string) {
+  const store = configureStore({ reducer: { accounting: (state = {}) => state } })
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <OrderJournalEntriesTab orderId={orderId} />
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('OrderJournalEntriesTab', () => {
+  it('shows loading state', () => {
+    mockGetJournalEntries.mockReturnValue({ data: undefined, isLoading: true })
+    renderTab('o1')
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no entries', () => {
+    mockGetJournalEntries.mockReturnValue({ data: { data: [], meta: { total: 0 } }, isLoading: false })
+    renderTab('o1')
+    expect(screen.getByText(/No journal entries/)).toBeInTheDocument()
+  })
+
+  it('renders entry row with reference number', () => {
+    mockGetJournalEntries.mockReturnValue({ data: { data: [makeEntry()], meta: { total: 1 } }, isLoading: false })
+    renderTab('o1')
+    expect(screen.getByText('JE-001')).toBeInTheDocument()
+  })
+
+  it('renders entry number as a link', () => {
+    mockGetJournalEntries.mockReturnValue({ data: { data: [makeEntry()], meta: { total: 1 } }, isLoading: false })
+    renderTab('o1')
+    const link = screen.getByRole('link', { name: 'JE-001' })
+    expect(link).toHaveAttribute('href', '/accounting/journal-entries/je1')
+  })
+
+  it('renders description', () => {
+    mockGetJournalEntries.mockReturnValue({ data: { data: [makeEntry()], meta: { total: 1 } }, isLoading: false })
+    renderTab('o1')
+    expect(screen.getByText('Sales order SO-26-001')).toBeInTheDocument()
+  })
+
+  it('passes correct sourceType and sourceId to query', () => {
+    mockGetJournalEntries.mockReturnValue({ data: { data: [], meta: { total: 0 } }, isLoading: false })
+    renderTab('order-99')
+    expect(mockGetJournalEntries).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceType: 'sales_order', sourceId: 'order-99' }),
+    )
+  })
+})

--- a/frontend/src/pages/sales/components/__tests__/OrderOverviewTab.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/OrderOverviewTab.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+
+import type { SalesOrder, SalesOrderItem } from '@/types'
+
+import OrderOverviewTab from '../OrderOverviewTab'
+
+function makeItem(overrides: Partial<SalesOrderItem> & Record<string, unknown> = {}): SalesOrderItem & Record<string, unknown> {
+  return {
+    id: 'i1',
+    product: {
+      id: 'p1',
+      name: 'Widget',
+      sku: 'W1',
+      price: 10,
+      quantity: 100,
+      categoryId: 'cat1',
+      isActive: true,
+      unit: 'pcs',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    quantity: 2,
+    unitPrice: 50,
+    discount: 0,
+    total: 100,
+    discountType: 'percentage',
+    discountPercent: 0,
+    discountAmount: 0,
+    ...overrides,
+  }
+}
+
+function makeOrder(overrides: Partial<SalesOrder> = {}): SalesOrder {
+  return {
+    id: 'o1',
+    orderNumber: 'SO-26-001',
+    status: 'DRAFT',
+    paymentStatus: 'UNPAID',
+    customerId: 'c1',
+    customer: {
+      id: 'c1',
+      slug: 'acme',
+      name: 'Acme Corp',
+      isActive: true,
+      type: 'BUSINESS' as any,
+      totalSales: 0,
+      totalOrders: 0,
+      averageOrderValue: 0,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    totalAmount: 100,
+    paidAmount: 0,
+    balanceDue: 100,
+    shippingAmount: 10,
+    subtotal: 90,
+    orderDate: new Date('2026-01-15'),
+    items: [makeItem()],
+    createdAt: new Date('2026-01-15'),
+    updatedAt: new Date('2026-01-15'),
+    ...overrides,
+  } as SalesOrder
+}
+
+function renderTab(order: SalesOrder) {
+  return render(
+    <MemoryRouter>
+      <OrderOverviewTab order={order} />
+    </MemoryRouter>,
+  )
+}
+
+describe('OrderOverviewTab', () => {
+  it('renders order number', () => {
+    renderTab(makeOrder())
+    expect(screen.getByText('SO-26-001')).toBeInTheDocument()
+  })
+
+  it('renders customer name as a link', () => {
+    renderTab(makeOrder())
+    const link = screen.getByRole('link', { name: 'Acme Corp' })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/sales/customers/acme/view')
+  })
+
+  it('renders notes when present', () => {
+    renderTab(makeOrder({ notes: 'Deliver ASAP' }))
+    expect(screen.getByText('Deliver ASAP')).toBeInTheDocument()
+  })
+
+  it('renders em dash for notes when absent', () => {
+    renderTab(makeOrder({ notes: undefined }))
+    expect(screen.getByText('Notes')).toBeInTheDocument()
+  })
+
+  it('renders line item product name', () => {
+    renderTab(makeOrder())
+    expect(screen.getByText('Widget')).toBeInTheDocument()
+  })
+
+  it('renders percentage discount as X%', () => {
+    renderTab(makeOrder({
+      items: [makeItem({ discountType: 'percentage', discountPercent: 10 })],
+    }))
+    expect(screen.getByText('10.00%')).toBeInTheDocument()
+  })
+
+  it('renders amount discount as currency', () => {
+    renderTab(makeOrder({
+      items: [makeItem({ discountType: 'amount', discountAmount: 5 })],
+    }))
+    expect(screen.getByText(/5\.00/)).toBeInTheDocument()
+  })
+
+  it('renders no discount as dash when discount is zero', () => {
+    renderTab(makeOrder({
+      items: [makeItem({ discountType: 'percentage', discountPercent: 0, discountAmount: 0 })],
+    }))
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders totals section with Total, Paid, Balance', () => {
+    renderTab(makeOrder())
+    expect(screen.getByText('Total')).toBeInTheDocument()
+    expect(screen.getByText('Paid')).toBeInTheDocument()
+    expect(screen.getByText('Balance')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/sales/components/__tests__/OrderPaymentsTab.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/OrderPaymentsTab.test.tsx
@@ -1,0 +1,98 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SalesOrderPayment } from '@/types'
+
+import OrderPaymentsTab from '../OrderPaymentsTab'
+
+const { mockGetSalesOrderPayments } = vi.hoisted(() => ({
+  mockGetSalesOrderPayments: vi.fn(),
+}))
+
+vi.mock('@/store/api/salesApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store/api/salesApi')>()
+  return { ...actual, useGetSalesOrderPaymentsQuery: mockGetSalesOrderPayments }
+})
+
+function makePayment(overrides: Partial<SalesOrderPayment> = {}): SalesOrderPayment {
+  return {
+    id: 'pay1',
+    salesOrderId: 'o1',
+    paymentMethodId: 'pm1',
+    paymentMethod: { id: 'pm1', name: 'Cash' },
+    referenceNumber: 'REF-001',
+    amount: 200,
+    paymentDate: '2026-01-20',
+    createdAt: '2026-01-20',
+    updatedAt: '2026-01-20',
+    ...overrides,
+  }
+}
+
+function renderTab(orderId: string, totalAmount: number) {
+  const store = configureStore({ reducer: { sales: (state = {}) => state } })
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <OrderPaymentsTab orderId={orderId} totalAmount={totalAmount} />
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('OrderPaymentsTab', () => {
+  it('shows loading state', () => {
+    mockGetSalesOrderPayments.mockReturnValue({ data: undefined, isLoading: true })
+    renderTab('o1', 200)
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no payments', () => {
+    mockGetSalesOrderPayments.mockReturnValue({ data: [], isLoading: false })
+    renderTab('o1', 200)
+    expect(screen.getByText(/No payments recorded/)).toBeInTheDocument()
+  })
+
+  it('renders payment row with method and reference', () => {
+    mockGetSalesOrderPayments.mockReturnValue({ data: [makePayment()], isLoading: false })
+    renderTab('o1', 200)
+    expect(screen.getByText('Cash')).toBeInTheDocument()
+    expect(screen.getByText('REF-001')).toBeInTheDocument()
+  })
+
+  it('shows em dash when paymentMethod is absent', () => {
+    mockGetSalesOrderPayments.mockReturnValue({
+      data: [makePayment({ paymentMethod: undefined, referenceNumber: undefined })],
+      isLoading: false,
+    })
+    renderTab('o1', 200)
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows negative amount in red for refunds', () => {
+    mockGetSalesOrderPayments.mockReturnValue({
+      data: [makePayment({ amount: -50 })],
+      isLoading: false,
+    })
+    renderTab('o1', 200)
+    const amountCell = screen.getByTestId('payment-amount-pay1')
+    expect(amountCell).toHaveStyle({ color: 'rgb(211, 47, 47)' })
+    expect(amountCell.textContent).toMatch(/-/)
+  })
+
+  it('renders summary row with Total Paid and Balance', () => {
+    mockGetSalesOrderPayments.mockReturnValue({ data: [makePayment({ amount: 150 })], isLoading: false })
+    renderTab('o1', 200)
+    expect(screen.getByText('Total Paid')).toBeInTheDocument()
+    expect(screen.getByText('Balance')).toBeInTheDocument()
+  })
+
+  it('passes orderId to query', () => {
+    mockGetSalesOrderPayments.mockReturnValue({ data: [], isLoading: false })
+    renderTab('order-99', 100)
+    expect(mockGetSalesOrderPayments).toHaveBeenCalledWith('order-99')
+  })
+})

--- a/frontend/src/pages/sales/components/index.ts
+++ b/frontend/src/pages/sales/components/index.ts
@@ -1,3 +1,7 @@
 export { default as SalesStatsCards } from './SalesStatsCards'
 export type { StatItem } from './SalesStatsCards'
 export { SalesTrendChart, TopProductsList, TopCustomersList } from './SalesCharts'
+export { default as OrderActionBar } from './OrderActionBar'
+export { default as OrderOverviewTab } from './OrderOverviewTab'
+export { default as OrderPaymentsTab } from './OrderPaymentsTab'
+export { default as OrderJournalEntriesTab } from './OrderJournalEntriesTab'

--- a/frontend/src/pages/sales/sales.routes.tsx
+++ b/frontend/src/pages/sales/sales.routes.tsx
@@ -7,6 +7,7 @@ const CustomerFormPage = React.lazy(() => import('./CustomerFormPage'))
 const CustomerProfilePage = React.lazy(() => import('./CustomerProfilePage'))
 const OrdersPage = React.lazy(() => import('./OrdersPage'))
 const CreateSalesOrderPage = React.lazy(() => import('./CreateSalesOrderPage'))
+const SalesOrderDetailPage = React.lazy(() => import('./SalesOrderDetailPage'))
 const InvoicesPage = React.lazy(() => import('./InvoicesPage'))
 const PaymentsPage = React.lazy(() => import('./PaymentsPage'))
 const SalesByProductSummary = React.lazy(() => import('./SalesByProductSummary'))
@@ -28,6 +29,7 @@ export const salesRoutes: RouteObject[] = [
   { path: '/sales/orders', element: <OrdersPage />, handle: { title: 'Sales Orders' } },
   { path: '/sales/orders/create', element: <CreateSalesOrderPage />, handle: { title: 'Create Sales Order' } },
   { path: '/sales/orders/:orderNumber/edit', element: <CreateSalesOrderPage />, handle: { title: 'Edit Sales Order' } },
+  { path: '/sales/orders/:orderNumber/view', element: <SalesOrderDetailPage />, handle: { title: 'Sales Order' } },
   { path: '/sales/invoices', element: <InvoicesPage />, handle: { title: 'Invoices' } },
   { path: '/sales/payments', element: <PaymentsPage />, handle: { title: 'Payments' } },
   { path: '/reports/sales/product-summary', element: <SalesByProductSummary />, handle: { title: 'Sales by Product Summary' } },

--- a/frontend/src/store/api/salesApi.ts
+++ b/frontend/src/store/api/salesApi.ts
@@ -1,6 +1,6 @@
 import { createApi } from '@reduxjs/toolkit/query/react'
 
-import type { Customer, Invoice, PaginatedResponse, Payment, SalesOrder } from '@/types'
+import type { Customer, Invoice, PaginatedResponse, Payment, SalesOrder, SalesOrderPayment } from '@/types'
 
 import { axiosBaseQuery } from './baseQuery'
 import { normalizeSingle } from './normalizers'
@@ -158,6 +158,11 @@ export const salesApiSlice = createApi({
       query: (orderNumber) => ({ url: `/sales-orders/number/${orderNumber}` }),
       transformResponse: normalizeSingle<SalesOrder>,
       providesTags: (result) => result ? [{ type: 'SalesOrder', id: result.id }] : [],
+    }),
+    getSalesOrderPayments: builder.query<SalesOrderPayment[], string>({
+      query: (id) => ({ url: `/sales-orders/${id}/payments` }),
+      transformResponse: (response: any) => response.data ?? [],
+      providesTags: (_result, _error, id) => [{ type: 'SalesOrder', id }],
     }),
     createSalesOrder: builder.mutation<SalesOrder, Partial<SalesOrder>>({
       query: (body) => ({ url: '/sales-orders', method: 'POST', data: body }),
@@ -403,6 +408,7 @@ export const {
   useGetSalesOrdersQuery,
   useGetSalesOrderQuery,
   useGetSalesOrderByNumberQuery,
+  useGetSalesOrderPaymentsQuery,
   useLazyGetSalesOrderByNumberQuery,
   useLazyGetSalesOrderQuery,
   useCreateSalesOrderMutation,

--- a/frontend/src/store/api/salesApi.ts
+++ b/frontend/src/store/api/salesApi.ts
@@ -162,7 +162,7 @@ export const salesApiSlice = createApi({
     getSalesOrderPayments: builder.query<SalesOrderPayment[], string>({
       query: (id) => ({ url: `/sales-orders/${id}/payments` }),
       transformResponse: (response: any) => response.data ?? [],
-      providesTags: (_result, _error, id) => [{ type: 'SalesOrder', id }],
+      providesTags: (_result, _error, id) => ['SalesOrder', { type: 'SalesOrder', id }],
     }),
     createSalesOrder: builder.mutation<SalesOrder, Partial<SalesOrder>>({
       query: (body) => ({ url: '/sales-orders', method: 'POST', data: body }),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -264,6 +264,22 @@ export interface SalesOrderItem {
   total: number;
 }
 
+export interface SalesOrderPayment {
+  id: string;
+  salesOrderId: string;
+  paymentMethodId: string;
+  paymentMethod?: {
+    id: string;
+    name: string;
+  };
+  referenceNumber?: string;
+  amount: number;
+  paymentDate: string;
+  notes?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface Invoice {
   id: string;
   invoiceNumber: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -234,6 +234,8 @@ export interface SalesOrder {
   isShippable?: boolean;
   isCompleted?: boolean;
   fullShippingAddress?: string;
+  subtotal?: number;
+  shippingAmount?: number;
   // Legacy compatibility
   total?: number;
   discount?: number;


### PR DESCRIPTION
## Summary

- Adds `/sales/orders/:orderNumber/view` — a full in-app Sales Order Detail page following the same pattern as Customer Profile (#663)
- Action bar shows context-sensitive buttons (Pay, Fulfill, Unfulfill, Refund, Edit, Cancel, Print) based on order status and payment status
- Three tabs: **Overview** (order info, customer link, line items, totals), **Payments** (payment history with summary), **Journal Entries** (accounting entries linked to this order)
- New `getSalesOrderPayments` RTK Query endpoint (`GET /sales-orders/:id/payments`)
- Adds `SalesOrderPayment` type and `subtotal`/`shippingAmount` fields to `SalesOrder` type

Closes #673
Parent: #669

## Test Plan

- [ ] Navigate to Sales Orders list → row action menu → View → confirm detail page loads
- [ ] Click order number in list → confirm navigation to detail page
- [ ] Verify header shows order number, status badge, payment status badge
- [ ] Back button returns to `/sales/orders`
- [ ] Action bar shows correct buttons for each status combination (Draft+Unpaid, Draft+Paid, Fulfilled, Cancelled)
- [ ] Fulfill/Unfulfill/Cancel show confirmation dialogs
- [ ] Pay/Refund open PaymentDialog (Refund shows distinct title)
- [ ] Print opens SalesOrderPrint dialog
- [ ] Edit navigates to edit form
- [ ] Overview tab: order info, customer link navigates to customer profile, line items, discount formatting, totals
- [ ] Payments tab: payment history table, empty state, summary row; recording a payment refreshes the list
- [ ] Journal Entries tab: entries with clickable entry numbers, empty state
- [ ] Tab state preserved in URL (`?tab=0|1|2`)
- [ ] 173 files, 1208 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)