### PR TITLE
fix(sales): fix PaymentDialog discard confirmation edge cases

### DIFF
--- a/frontend/src/components/sales/PaymentDialog.tsx
+++ b/frontend/src/components/sales/PaymentDialog.tsx
@@ -54,12 +54,18 @@ export default function PaymentDialog({
   const [lines, setLines] = useState<PaymentLine[]>([])
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [confirmDiscard, setConfirmDiscard] = useState(false)
+
+  const isDirty = lines.some(
+    (l) => (l.amount !== '' && l.amount !== 0) || l.reference !== '',
+  )
 
   // Reset state and initialize first line when dialog opens or payment methods load
   useEffect(() => {
     if (!open) return
     setError(null)
     setSubmitting(false)
+    setConfirmDiscard(false)
     const cashMethod = paymentMethods.find((m) => m.code === 'CASH')
     setLines([{
       paymentMethodId: cashMethod?.id || paymentMethods[0]?.id || '',
@@ -241,7 +247,18 @@ export default function PaymentDialog({
         )}
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} disabled={submitting}>Cancel</Button>
+        <Button
+          onClick={() => {
+            if (isDirty) {
+              setConfirmDiscard(true)
+            } else {
+              onClose()
+            }
+          }}
+          disabled={submitting}
+        >
+          Cancel
+        </Button>
         <Button
           variant="contained"
           onClick={handleSubmit}
@@ -251,6 +268,17 @@ export default function PaymentDialog({
           {submitting ? 'Recording...' : 'Record Payment'}
         </Button>
       </DialogActions>
+      <Dialog
+        open={confirmDiscard}
+        onClose={() => setConfirmDiscard(false)}
+        transitionDuration={0}
+      >
+        <DialogTitle>Discard this payment?</DialogTitle>
+        <DialogActions>
+          <Button onClick={() => setConfirmDiscard(false)}>Keep Editing</Button>
+          <Button color="error" onClick={onClose}>Discard</Button>
+        </DialogActions>
+      </Dialog>
     </Dialog>
   );
 }

--- a/frontend/src/components/sales/PaymentDialog.tsx
+++ b/frontend/src/components/sales/PaymentDialog.tsx
@@ -55,29 +55,34 @@ export default function PaymentDialog({
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [confirmDiscard, setConfirmDiscard] = useState(false)
+  const [userHasEdited, setUserHasEdited] = useState(false)
 
-  const isDirty = lines.some(
-    (l) => (l.amount !== '' && l.amount !== 0) || l.reference !== '',
-  )
-
-  // Reset state and initialize first line when dialog opens or payment methods load
+  // Reset all state when the dialog opens
   useEffect(() => {
     if (!open) return
     setError(null)
     setSubmitting(false)
     setConfirmDiscard(false)
+    setUserHasEdited(false)
+    setLines([])
+  }, [open])
+
+  // Seed the first line once payment methods are available (only when lines are empty)
+  useEffect(() => {
+    if (!open || lines.length > 0) return
     const cashMethod = paymentMethods.find((m) => m.code === 'CASH')
     setLines([{
       paymentMethodId: cashMethod?.id || paymentMethods[0]?.id || '',
       amount: outstandingBalance > 0 ? outstandingBalance : '',
       reference: '',
     }])
-  }, [open, paymentMethods])
+  }, [open, paymentMethods, lines.length])
 
   const totalEntered = lines.reduce((sum, l) => sum + (typeof l.amount === 'number' ? l.amount : parseFloat(l.amount as string) || 0), 0)
   const remaining = outstandingBalance - totalEntered
 
   const updateLine = useCallback((index: number, field: keyof PaymentLine, value: any) => {
+    setUserHasEdited(true)
     setLines(prev => {
       const updated = [...prev]
       updated[index] = { ...updated[index], [field]: value }
@@ -86,6 +91,7 @@ export default function PaymentDialog({
   }, [])
 
   const addLine = useCallback(() => {
+    setUserHasEdited(true)
     const cashMethod = paymentMethods.find((m) => m.code === 'CASH')
     setLines(prev => [...prev, {
       paymentMethodId: cashMethod?.id || paymentMethods[0]?.id || '',
@@ -95,6 +101,7 @@ export default function PaymentDialog({
   }, [paymentMethods, remaining])
 
   const removeLine = useCallback((index: number) => {
+    setUserHasEdited(true)
     setLines(prev => prev.length > 1 ? prev.filter((_, i) => i !== index) : prev)
   }, [])
 
@@ -127,8 +134,16 @@ export default function PaymentDialog({
 
   const isOverpaying = totalEntered > outstandingBalance && outstandingBalance > 0
 
+  const handleRequestClose = () => {
+    if (userHasEdited) {
+      setConfirmDiscard(true)
+    } else {
+      onClose()
+    }
+  }
+
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={handleRequestClose} maxWidth="sm" fullWidth>
       <DialogTitle>{title ?? `Record Payment — ${orderNumber}`}</DialogTitle>
       <DialogContent>
         {/* Order Summary */}
@@ -247,16 +262,7 @@ export default function PaymentDialog({
         )}
       </DialogContent>
       <DialogActions>
-        <Button
-          onClick={() => {
-            if (isDirty) {
-              setConfirmDiscard(true)
-            } else {
-              onClose()
-            }
-          }}
-          disabled={submitting}
-        >
+        <Button onClick={handleRequestClose} disabled={submitting}>
           Cancel
         </Button>
         <Button

--- a/frontend/src/components/sales/__tests__/PaymentDialog.test.tsx
+++ b/frontend/src/components/sales/__tests__/PaymentDialog.test.tsx
@@ -97,6 +97,9 @@ describe('PaymentDialog', () => {
 
   it('Cancel with data shows discard confirmation', async () => {
     renderDialog({ totalAmount: 1000, paidAmount: 0 })
+    const amountInput = screen.getByPlaceholderText('Amount')
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '300')
     await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
     expect(screen.getByText('Discard this payment?')).toBeInTheDocument()
   })
@@ -104,6 +107,8 @@ describe('PaymentDialog', () => {
   it('clicking Discard in confirmation calls onClose', async () => {
     const onClose = vi.fn()
     renderDialog({ totalAmount: 1000, paidAmount: 0, onClose })
+    await userEvent.clear(screen.getByPlaceholderText('Amount'))
+    await userEvent.type(screen.getByPlaceholderText('Amount'), '100')
     await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
     await userEvent.click(screen.getByRole('button', { name: /^discard$/i }))
     expect(onClose).toHaveBeenCalledOnce()
@@ -112,9 +117,53 @@ describe('PaymentDialog', () => {
   it('clicking Keep Editing dismisses confirmation and keeps dialog open', async () => {
     const onClose = vi.fn()
     renderDialog({ totalAmount: 1000, paidAmount: 0, onClose })
+    await userEvent.clear(screen.getByPlaceholderText('Amount'))
+    await userEvent.type(screen.getByPlaceholderText('Amount'), '100')
     await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
     await userEvent.click(screen.getByRole('button', { name: /keep editing/i }))
     expect(onClose).not.toHaveBeenCalled()
+    expect(screen.queryByText('Discard this payment?')).not.toBeInTheDocument()
+  })
+
+  it('Cancel on untouched dialog (pre-filled amount) closes without confirmation', async () => {
+    // F2: pre-filled outstandingBalance must not count as user input
+    const onClose = vi.fn()
+    renderDialog({ totalAmount: 1000, paidAmount: 0, onClose })
+    // Do NOT interact with any field — just cancel immediately
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(screen.queryByText('Discard this payment?')).not.toBeInTheDocument()
+  })
+
+  it('Cancel after editing an amount shows discard confirmation', async () => {
+    // F2: confirmation only shown after actual user interaction
+    renderDialog({ totalAmount: 1000, paidAmount: 0 })
+    const amountInput = screen.getByPlaceholderText('Amount')
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '200')
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(screen.getByText('Discard this payment?')).toBeInTheDocument()
+  })
+
+  it('Escape / backdrop on outer dialog shows discard confirmation when user has edited', async () => {
+    // F1: backdrop/Escape must go through same dirty guard as Cancel button
+    const onClose = vi.fn()
+    renderDialog({ totalAmount: 1000, paidAmount: 0, onClose })
+    const amountInput = screen.getByPlaceholderText('Amount')
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '200')
+    // Pressing Escape triggers the outer Dialog's onClose
+    await userEvent.keyboard('{Escape}')
+    expect(onClose).not.toHaveBeenCalled()
+    expect(screen.getByText('Discard this payment?')).toBeInTheDocument()
+  })
+
+  it('Escape on untouched dialog closes immediately without confirmation', async () => {
+    // F1: backdrop/Escape on clean dialog should close directly
+    const onClose = vi.fn()
+    renderDialog({ totalAmount: 1000, paidAmount: 0, onClose })
+    await userEvent.keyboard('{Escape}')
+    expect(onClose).toHaveBeenCalledOnce()
     expect(screen.queryByText('Discard this payment?')).not.toBeInTheDocument()
   })
 

--- a/frontend/src/components/sales/__tests__/PaymentDialog.test.tsx
+++ b/frontend/src/components/sales/__tests__/PaymentDialog.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ComponentProps } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import PaymentDialog from '../PaymentDialog'
+
+const { mockUseGetActivePaymentMethodsQuery } = vi.hoisted(() => ({
+  mockUseGetActivePaymentMethodsQuery: vi.fn(),
+}))
+
+vi.mock('@/store/api/paymentMethodsApi', () => ({
+  useGetActivePaymentMethodsQuery: mockUseGetActivePaymentMethodsQuery,
+}))
+
+const paymentMethods = [
+  { id: 'pm-1', name: 'Cash', code: 'CASH', isActive: true },
+  { id: 'pm-2', name: 'Bank Transfer', code: 'BANK', isActive: true },
+]
+
+function renderDialog(props: Partial<ComponentProps<typeof PaymentDialog>> = {}) {
+  const defaults = {
+    open: true,
+    onClose: vi.fn(),
+    onSubmit: vi.fn().mockResolvedValue(undefined),
+    orderNumber: 'SO-26-001',
+    totalAmount: 1000,
+    paidAmount: 0,
+  }
+  return render(<PaymentDialog {...defaults} {...props} />)
+}
+
+beforeEach(() => {
+  mockUseGetActivePaymentMethodsQuery.mockReturnValue({ data: paymentMethods })
+})
+
+describe('PaymentDialog', () => {
+  it('displays order total and remaining balance', () => {
+    renderDialog({ totalAmount: 1000, paidAmount: 200 })
+    expect(screen.getByText('Order Total')).toBeInTheDocument()
+    expect(screen.getByText('Outstanding Balance')).toBeInTheDocument()
+  })
+
+  it('populates payment method dropdown with methods from API', async () => {
+    renderDialog()
+    expect(screen.getByText('Cash')).toBeInTheDocument()
+  })
+
+  it('adds a payment row when Add Payment Line is clicked', async () => {
+    renderDialog()
+    const addButton = screen.getByRole('button', { name: /add payment line/i })
+    await userEvent.click(addButton)
+    expect(screen.getAllByPlaceholderText('Amount')).toHaveLength(2)
+  })
+
+  it('removes a payment row when x is clicked', async () => {
+    renderDialog()
+    const addButton = screen.getByRole('button', { name: /add payment line/i })
+    await userEvent.click(addButton)
+    expect(screen.getAllByPlaceholderText('Amount')).toHaveLength(2)
+    const removeButtons = screen.getAllByRole('button', { name: '' }).filter(
+      (btn) => btn.querySelector('svg[data-testid="DeleteIcon"]'),
+    )
+    await userEvent.click(removeButtons[0])
+    expect(screen.getAllByPlaceholderText('Amount')).toHaveLength(1)
+  })
+
+  it('disables the remove button when only one row remains', () => {
+    renderDialog()
+    const removeButtons = screen.getAllByRole('button').filter(
+      (btn) => btn.querySelector('svg[data-testid="DeleteIcon"]'),
+    )
+    expect(removeButtons[0]).toBeDisabled()
+  })
+
+  it('Record Payment button is disabled when total entered is 0', () => {
+    renderDialog({ totalAmount: 1000, paidAmount: 1000 })
+    const recordBtn = screen.getByRole('button', { name: /record payment/i })
+    expect(recordBtn).toBeDisabled()
+  })
+
+  it('Record Payment button is enabled when total entered is > 0', async () => {
+    renderDialog({ totalAmount: 1000, paidAmount: 1000 })
+    const amountInput = screen.getByPlaceholderText('Amount')
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '50')
+    expect(screen.getByRole('button', { name: /record payment/i })).toBeEnabled()
+  })
+
+  it('Cancel with no data closes immediately without confirmation', async () => {
+    const onClose = vi.fn()
+    renderDialog({ totalAmount: 1000, paidAmount: 1000, onClose })
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(screen.queryByText('Discard this payment?')).not.toBeInTheDocument()
+  })
+
+  it('Cancel with data shows discard confirmation', async () => {
+    renderDialog({ totalAmount: 1000, paidAmount: 0 })
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(screen.getByText('Discard this payment?')).toBeInTheDocument()
+  })
+
+  it('clicking Discard in confirmation calls onClose', async () => {
+    const onClose = vi.fn()
+    renderDialog({ totalAmount: 1000, paidAmount: 0, onClose })
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    await userEvent.click(screen.getByRole('button', { name: /^discard$/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('clicking Keep Editing dismisses confirmation and keeps dialog open', async () => {
+    const onClose = vi.fn()
+    renderDialog({ totalAmount: 1000, paidAmount: 0, onClose })
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    await userEvent.click(screen.getByRole('button', { name: /keep editing/i }))
+    expect(onClose).not.toHaveBeenCalled()
+    expect(screen.queryByText('Discard this payment?')).not.toBeInTheDocument()
+  })
+
+  it('submit success calls onSubmit with correct lines and closes dialog', async () => {
+    const onClose = vi.fn()
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    renderDialog({ totalAmount: 500, paidAmount: 0, onClose, onSubmit })
+    const amountInput = screen.getByPlaceholderText('Amount')
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '500')
+    await userEvent.click(screen.getByRole('button', { name: /record payment/i }))
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce())
+    expect(onSubmit).toHaveBeenCalledWith([
+      expect.objectContaining({ paymentMethodId: 'pm-1', amount: 500 }),
+    ])
+  })
+
+  it('submit error shows error alert and does not close dialog', async () => {
+    const onClose = vi.fn()
+    const onSubmit = vi.fn().mockRejectedValue({ message: 'Server error' })
+    renderDialog({ totalAmount: 500, paidAmount: 0, onClose, onSubmit })
+    const amountInput = screen.getByPlaceholderText('Amount')
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '500')
+    await userEvent.click(screen.getByRole('button', { name: /record payment/i }))
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('shows overpayment warning when total exceeds outstanding balance', async () => {
+    renderDialog({ totalAmount: 500, paidAmount: 0 })
+    const amountInput = screen.getByPlaceholderText('Amount')
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '600')
+    expect(screen.getByText(/exceeds outstanding balance/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to #674 — three edge cases found during code review of the discard confirmation:

- **Backdrop/Escape bypass:** Clicking the MUI dialog backdrop or pressing Escape called `onClose` directly, skipping the dirty check entirely. Fixed by routing all close paths through a shared `handleRequestClose` function.
- **Spurious confirmation on untouched dialog:** Pre-filled outstanding balance made `isDirty=true` immediately on open, so clicking Cancel right away showed "Discard this payment?" even though the user hadn't touched anything. Fixed by replacing the value-based `isDirty` check with an explicit `userHasEdited` boolean, set only on actual user interaction (`updateLine`, `addLine`, `removeLine`).
- **Background refetch wiping user input:** The `useEffect` depended on `[open, paymentMethods]`, so an RTK Query cache invalidation mid-session would re-run the effect and reset all user-entered lines. Fixed by splitting into two effects: one that resets on `open` change, and one that seeds the first line only when `lines` is empty.

## Test Plan

- [ ] 18 PaymentDialog tests pass (4 new tests covering the fixed cases)
- [ ] 174/174 frontend test files pass
- [ ] Type-check and lint clean