### PR TITLE
feat(sales): Refund Dialog — multi-method refunds on Sales Orders (closes #675)

### DIFF
--- a/backend/src/modules/sales/controllers/sales-order.controller.ts
+++ b/backend/src/modules/sales/controllers/sales-order.controller.ts
@@ -26,6 +26,7 @@ import {
   SalesOrderSummaryDto,
   RecordPaymentDto,
   RecordRefundDto,
+  RecordRefundsDto,
 } from '../dto/sales-order.dto';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 
@@ -184,17 +185,15 @@ export class SalesOrderController {
   }
 
   @Post(':id/refunds')
-  @ApiOperation({ summary: 'Record a refund (creates negative payment record)' })
-  @ApiParam({ name: 'id', type: 'string' })
-  @HttpCode(HttpStatus.OK)
-  async recordRefund(
+  @ApiOperation({ summary: 'Record one or more refunds (creates negative payment records)' })
+  async recordRefunds(
     @Param('id', ParseUUIDPipe) id: string,
-    @Body() dto: RecordRefundDto,
+    @Body() dto: RecordRefundsDto,
     @CurrentUser('userId') userId: string,
     @CurrentUser('username') username: string,
   ) {
-    const data = await this.salesOrderService.recordRefund(id, dto, userId, username);
-    return { data };
+    const data = await this.salesOrderService.recordRefunds(id, dto.refunds, userId, username)
+    return { data }
   }
 
   @Post(':id/duplicate')

--- a/backend/src/modules/sales/dto/sales-order.dto.ts
+++ b/backend/src/modules/sales/dto/sales-order.dto.ts
@@ -328,3 +328,10 @@ export class RecordPaymentDto {
 }
 
 export class RecordRefundDto extends RecordPaymentDto {}
+
+export class RecordRefundsDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => RecordRefundDto)
+  refunds: RecordRefundDto[]
+}

--- a/backend/src/modules/sales/services/sales-order-payment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.ts
@@ -126,12 +126,59 @@ export class SalesOrderPaymentService {
   }
 
   async recordRefunds(orderId: string, dtos: RecordPaymentDto[], userId?: string, username?: string): Promise<SalesOrderPayment[]> {
-    const results: SalesOrderPayment[] = []
+    if (dtos.length === 0) return [];
+
     for (const dto of dtos) {
-      const saved = await this.recordRefund(orderId, dto, userId, username)
-      results.push(saved)
+      if (dto.amount <= 0) throw new BadRequestException('Refund amount must be positive');
     }
-    return results
+
+    const order = await this.salesOrderRepository.findOne({ where: { id: orderId } });
+    if (!order) throw new NotFoundException('Sales order not found');
+    if (order.status === SalesOrderStatus.CANCELLED) {
+      throw new ConflictException('Cannot record a refund on a cancelled order');
+    }
+
+    for (const dto of dtos) {
+      const method = await this.paymentMethodRepository.findOne({
+        where: { id: dto.paymentMethodId, isActive: true },
+      });
+      if (!method) throw new BadRequestException(`Payment method ${dto.paymentMethodId} not found or inactive`);
+    }
+
+    const existing = await this.salesOrderPaymentRepository.find({ where: { salesOrderId: orderId } });
+    const netPaid = existing.reduce((sum, r) => sum + Number(r.amount), 0);
+    const totalRefundAmount = dtos.reduce((sum, dto) => sum + dto.amount, 0);
+    if (totalRefundAmount > netPaid + AMOUNT_TOLERANCE) {
+      throw new BadRequestException(`Total refund amount (${totalRefundAmount}) exceeds net paid (${netPaid.toFixed(4)})`);
+    }
+
+    const results = await this.dataSource.transaction(async (manager: EntityManager) => {
+      const saved: SalesOrderPayment[] = [];
+      for (const dto of dtos) {
+        const record = manager.getRepository(SalesOrderPayment).create({
+          salesOrderId: orderId,
+          paymentMethodId: dto.paymentMethodId,
+          amount: -dto.amount,
+          paymentDate: dto.paymentDate,
+          referenceNumber: dto.referenceNumber,
+          notes: dto.notes,
+        });
+        saved.push(await manager.getRepository(SalesOrderPayment).save(record));
+      }
+      await this.updatePaymentStatusInTx(order, manager);
+      return saved;
+    });
+
+    for (const saved of results) {
+      await this.auditLogService.log('CREATE', 'SalesOrderPayment', `Recorded refund for ${order.orderNumber}`, {
+        entityId: saved.id,
+        userId: userId || 'system',
+        username,
+        newValues: { amount: saved.amount, paymentMethodId: saved.paymentMethodId },
+      });
+    }
+
+    return results;
   }
 
   async listPayments(orderId: string): Promise<SalesOrderPayment[]> {

--- a/backend/src/modules/sales/services/sales-order-payment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.ts
@@ -125,6 +125,15 @@ export class SalesOrderPaymentService {
     return saved;
   }
 
+  async recordRefunds(orderId: string, dtos: RecordPaymentDto[], userId?: string, username?: string): Promise<SalesOrderPayment[]> {
+    const results: SalesOrderPayment[] = []
+    for (const dto of dtos) {
+      const saved = await this.recordRefund(orderId, dto, userId, username)
+      results.push(saved)
+    }
+    return results
+  }
+
   async listPayments(orderId: string): Promise<SalesOrderPayment[]> {
     const order = await this.salesOrderRepository.findOne({ where: { id: orderId } });
     if (!order) throw new NotFoundException('Sales order not found');

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -723,6 +723,10 @@ export class SalesOrderService extends BaseCrudService<
     return this.salesOrderQueryService.findById(orderId);
   }
 
+  async recordRefunds(orderId: string, dtos: RecordPaymentDto[], userId?: string, username?: string) {
+    return this.salesOrderPaymentService.recordRefunds(orderId, dtos, userId, username)
+  }
+
   async listPayments(orderId: string) {
     return this.salesOrderPaymentService.listPayments(orderId);
   }

--- a/frontend/src/components/sales/RefundDialog.tsx
+++ b/frontend/src/components/sales/RefundDialog.tsx
@@ -77,14 +77,14 @@ export default function RefundDialog({
   }, [open])
 
   useEffect(() => {
-    if (!open || lines.length > 0 || paymentMethods.length === 0) return
+    if (!open || lines.length > 0 || paymentMethods.length === 0 || loadingPayments) return
     const cashMethod = paymentMethods.find((m) => m.code === 'CASH')
     setLines([{
       paymentMethodId: cashMethod?.id || paymentMethods[0]?.id || '',
       amount: availableForRefund > 0 ? availableForRefund : '',
       reference: '',
     }])
-  }, [open, paymentMethods, lines.length, availableForRefund])
+  }, [open, paymentMethods, lines.length, availableForRefund, loadingPayments])
 
   const totalEntered = lines.reduce(
     (sum, l) => sum + (typeof l.amount === 'number' ? l.amount : parseFloat(l.amount as string) || 0),

--- a/frontend/src/components/sales/RefundDialog.tsx
+++ b/frontend/src/components/sales/RefundDialog.tsx
@@ -1,0 +1,310 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  Typography,
+  TextField,
+  Select,
+  MenuItem,
+  FormControl,
+  IconButton,
+  Divider,
+  Alert,
+  CircularProgress,
+} from '@mui/material'
+import { default as DeleteIcon } from '@mui/icons-material/Delete'
+import { default as AddIcon } from '@mui/icons-material/Add'
+import { useGetActivePaymentMethodsQuery } from '@/store/api/paymentMethodsApi'
+import { useGetSalesOrderPaymentsQuery } from '@/store/api/salesApi'
+
+interface RefundLine {
+  paymentMethodId: string
+  amount: number | string
+  reference: string
+}
+
+interface RefundDialogProps {
+  open: boolean
+  onClose: () => void
+  onSubmit: (refunds: { paymentMethodId: string; amount: number; reference?: string }[]) => Promise<void>
+  orderId: string
+  orderNumber: string
+}
+
+const formatCurrency = (amount: number) =>
+  new Intl.NumberFormat('en-MY', { style: 'currency', currency: 'MYR' }).format(amount)
+
+export default function RefundDialog({
+  open,
+  onClose,
+  onSubmit,
+  orderId,
+  orderNumber,
+}: RefundDialogProps) {
+  const { data: paymentMethods = [] } = useGetActivePaymentMethodsQuery(undefined, { skip: !open })
+  const { data: paymentRecords = [], isLoading: loadingPayments } = useGetSalesOrderPaymentsQuery(
+    orderId,
+    { skip: !open },
+  )
+
+  const totalPaid = paymentRecords
+    .filter((r) => Number(r.amount) > 0)
+    .reduce((sum, r) => sum + Number(r.amount), 0)
+
+  const alreadyRefunded = paymentRecords
+    .filter((r) => Number(r.amount) < 0)
+    .reduce((sum, r) => sum + Math.abs(Number(r.amount)), 0)
+
+  const availableForRefund = Math.max(0, totalPaid - alreadyRefunded)
+
+  const [lines, setLines] = useState<RefundLine[]>([])
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [confirmDiscard, setConfirmDiscard] = useState(false)
+  const [userHasEdited, setUserHasEdited] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    setError(null)
+    setSubmitting(false)
+    setConfirmDiscard(false)
+    setUserHasEdited(false)
+    setLines([])
+  }, [open])
+
+  useEffect(() => {
+    if (!open || lines.length > 0 || paymentMethods.length === 0) return
+    const cashMethod = paymentMethods.find((m) => m.code === 'CASH')
+    setLines([{
+      paymentMethodId: cashMethod?.id || paymentMethods[0]?.id || '',
+      amount: availableForRefund > 0 ? availableForRefund : '',
+      reference: '',
+    }])
+  }, [open, paymentMethods, lines.length, availableForRefund])
+
+  const totalEntered = lines.reduce(
+    (sum, l) => sum + (typeof l.amount === 'number' ? l.amount : parseFloat(l.amount as string) || 0),
+    0,
+  )
+  const remainingAfterRefund = availableForRefund - totalEntered
+  const exceedsAvailable = totalEntered > availableForRefund
+
+  const updateLine = useCallback((index: number, field: keyof RefundLine, value: any) => {
+    setUserHasEdited(true)
+    setLines((prev) => {
+      const updated = [...prev]
+      updated[index] = { ...updated[index], [field]: value }
+      return updated
+    })
+  }, [])
+
+  const addLine = useCallback(() => {
+    setUserHasEdited(true)
+    const cashMethod = paymentMethods.find((m) => m.code === 'CASH')
+    setLines((prev) => [
+      ...prev,
+      {
+        paymentMethodId: cashMethod?.id || paymentMethods[0]?.id || '',
+        amount: remainingAfterRefund > 0 ? remainingAfterRefund : '',
+        reference: '',
+      },
+    ])
+  }, [paymentMethods, remainingAfterRefund])
+
+  const removeLine = useCallback((index: number) => {
+    setUserHasEdited(true)
+    setLines((prev) => (prev.length > 1 ? prev.filter((_, i) => i !== index) : prev))
+  }, [])
+
+  const handleSubmit = async () => {
+    setError(null)
+    const validLines = lines.filter((l) => {
+      const amt = typeof l.amount === 'number' ? l.amount : parseFloat(l.amount as string)
+      return l.paymentMethodId && amt > 0
+    })
+    if (validLines.length === 0) {
+      setError('At least one refund line with a valid amount is required.')
+      return
+    }
+    if (totalEntered > availableForRefund) {
+      setError(`Total refund (${formatCurrency(totalEntered)}) exceeds available for refund (${formatCurrency(availableForRefund)}).`)
+      return
+    }
+    setSubmitting(true)
+    try {
+      await onSubmit(
+        validLines.map((l) => ({
+          paymentMethodId: l.paymentMethodId,
+          amount: typeof l.amount === 'number' ? l.amount : parseFloat(l.amount as string),
+          reference: l.reference || undefined,
+        })),
+      )
+      onClose()
+    } catch (err: any) {
+      setError(err?.response?.data?.message || err?.message || 'Failed to record refund.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleRequestClose = () => {
+    if (userHasEdited) {
+      setConfirmDiscard(true)
+    } else {
+      onClose()
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={handleRequestClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Refund — {orderNumber}</DialogTitle>
+      <DialogContent>
+        {loadingPayments ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
+            <CircularProgress size={24} />
+          </Box>
+        ) : (
+          <>
+            {/* Refund Summary */}
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1, mt: 1 }}>
+              <Typography variant="body2" sx={{ color: 'text.secondary' }}>Total Paid</Typography>
+              <Typography variant="body2">{formatCurrency(totalPaid)}</Typography>
+            </Box>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+              <Typography variant="body2" sx={{ color: 'text.secondary' }}>Already Refunded</Typography>
+              <Typography variant="body2">{formatCurrency(alreadyRefunded)}</Typography>
+            </Box>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
+              <Typography variant="body2" sx={{ fontWeight: 'bold' }}>Available for Refund</Typography>
+              <Typography variant="body2" sx={{ fontWeight: 'bold' }}>{formatCurrency(availableForRefund)}</Typography>
+            </Box>
+
+            <Divider sx={{ mb: 2 }} />
+
+            {/* Refund Lines */}
+            {lines.map((line, index) => (
+              <Box key={index} sx={{ display: 'flex', gap: 1, mb: 1.5, alignItems: 'center' }}>
+                <FormControl size="small" sx={{ minWidth: 130 }}>
+                  <Select
+                    value={line.paymentMethodId}
+                    onChange={(e) => updateLine(index, 'paymentMethodId', e.target.value)}
+                    displayEmpty
+                    sx={{ fontSize: '0.85rem' }}
+                  >
+                    <MenuItem value="" disabled>Method</MenuItem>
+                    {paymentMethods.map((pm) => (
+                      <MenuItem key={pm.id} value={pm.id} sx={{ fontSize: '0.85rem' }}>
+                        {pm.name}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+
+                <TextField
+                  size="small"
+                  type="number"
+                  placeholder="Amount"
+                  value={line.amount}
+                  onChange={(e) => updateLine(index, 'amount', e.target.value)}
+                  slotProps={{ htmlInput: { min: 0, step: 0.01 } }}
+                  sx={{
+                    width: 120,
+                    '& input[type=number]': { MozAppearance: 'textfield' },
+                    '& input[type=number]::-webkit-outer-spin-button, & input[type=number]::-webkit-inner-spin-button': {
+                      WebkitAppearance: 'none',
+                      margin: 0,
+                    },
+                  }}
+                />
+
+                <TextField
+                  size="small"
+                  placeholder="Reference"
+                  value={line.reference}
+                  onChange={(e) => updateLine(index, 'reference', e.target.value)}
+                  sx={{ flex: 1 }}
+                />
+
+                <IconButton
+                  size="small"
+                  onClick={() => removeLine(index)}
+                  disabled={lines.length <= 1}
+                  color="error"
+                >
+                  <DeleteIcon fontSize="small" />
+                </IconButton>
+              </Box>
+            ))}
+
+            <Button
+              startIcon={<AddIcon />}
+              size="small"
+              onClick={addLine}
+              sx={{ mt: 0.5, mb: 2 }}
+            >
+              Add Refund Row
+            </Button>
+
+            <Divider sx={{ mb: 2 }} />
+
+            {/* Totals */}
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+              <Typography variant="body2" sx={{ fontWeight: 'bold' }}>Total Refund</Typography>
+              <Typography variant="body2" sx={{ fontWeight: 'bold' }}>{formatCurrency(totalEntered)}</Typography>
+            </Box>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+              <Typography variant="body2" sx={{ color: 'text.secondary' }}>Remaining After Refund</Typography>
+              <Typography
+                variant="body2"
+                color={exceedsAvailable ? 'error.main' : 'text.secondary'}
+              >
+                {exceedsAvailable
+                  ? `${formatCurrency(Math.abs(remainingAfterRefund))} (exceeds available)`
+                  : formatCurrency(remainingAfterRefund)}
+              </Typography>
+            </Box>
+
+            {exceedsAvailable && (
+              <Alert severity="error" sx={{ mt: 2 }}>
+                Total refund exceeds available for refund by {formatCurrency(Math.abs(remainingAfterRefund))}.
+              </Alert>
+            )}
+
+            {error && (
+              <Alert severity="error" sx={{ mt: 2 }}>{error}</Alert>
+            )}
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleRequestClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color="error"
+          onClick={handleSubmit}
+          disabled={submitting || totalEntered <= 0 || exceedsAvailable || loadingPayments}
+          startIcon={submitting ? <CircularProgress size={16} /> : undefined}
+        >
+          {submitting ? 'Refunding...' : 'Refund'}
+        </Button>
+      </DialogActions>
+      <Dialog
+        open={confirmDiscard}
+        onClose={() => setConfirmDiscard(false)}
+        transitionDuration={0}
+      >
+        <DialogTitle>Discard this refund?</DialogTitle>
+        <DialogActions>
+          <Button onClick={() => setConfirmDiscard(false)}>Keep Editing</Button>
+          <Button color="error" onClick={onClose}>Discard</Button>
+        </DialogActions>
+      </Dialog>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/sales/RefundDialog.tsx
+++ b/frontend/src/components/sales/RefundDialog.tsx
@@ -22,6 +22,7 @@ import { useGetActivePaymentMethodsQuery } from '@/store/api/paymentMethodsApi'
 import { useGetSalesOrderPaymentsQuery } from '@/store/api/salesApi'
 
 interface RefundLine {
+  id: string
   paymentMethodId: string
   amount: number | string
   reference: string
@@ -80,6 +81,7 @@ export default function RefundDialog({
     if (!open || lines.length > 0 || paymentMethods.length === 0 || loadingPayments) return
     const cashMethod = paymentMethods.find((m) => m.code === 'CASH')
     setLines([{
+      id: crypto.randomUUID(),
       paymentMethodId: cashMethod?.id || paymentMethods[0]?.id || '',
       amount: availableForRefund > 0 ? availableForRefund : '',
       reference: '',
@@ -93,7 +95,7 @@ export default function RefundDialog({
   const remainingAfterRefund = availableForRefund - totalEntered
   const exceedsAvailable = totalEntered > availableForRefund
 
-  const updateLine = useCallback((index: number, field: keyof RefundLine, value: any) => {
+  const updateLine = useCallback((index: number, field: keyof RefundLine, value: string | number) => {
     setUserHasEdited(true)
     setLines((prev) => {
       const updated = [...prev]
@@ -108,6 +110,7 @@ export default function RefundDialog({
     setLines((prev) => [
       ...prev,
       {
+        id: crypto.randomUUID(),
         paymentMethodId: cashMethod?.id || paymentMethods[0]?.id || '',
         amount: remainingAfterRefund > 0 ? remainingAfterRefund : '',
         reference: '',
@@ -187,7 +190,7 @@ export default function RefundDialog({
 
             {/* Refund Lines */}
             {lines.map((line, index) => (
-              <Box key={index} sx={{ display: 'flex', gap: 1, mb: 1.5, alignItems: 'center' }}>
+              <Box key={line.id} sx={{ display: 'flex', gap: 1, mb: 1.5, alignItems: 'center' }}>
                 <FormControl size="small" sx={{ minWidth: 130 }}>
                   <Select
                     value={line.paymentMethodId}

--- a/frontend/src/components/sales/__tests__/RefundDialog.test.tsx
+++ b/frontend/src/components/sales/__tests__/RefundDialog.test.tsx
@@ -1,0 +1,213 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ComponentProps } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import RefundDialog from '../RefundDialog'
+
+const { mockUseGetActivePaymentMethodsQuery, mockUseGetSalesOrderPaymentsQuery } = vi.hoisted(() => ({
+  mockUseGetActivePaymentMethodsQuery: vi.fn(),
+  mockUseGetSalesOrderPaymentsQuery: vi.fn(),
+}))
+
+vi.mock('@/store/api/paymentMethodsApi', () => ({
+  useGetActivePaymentMethodsQuery: mockUseGetActivePaymentMethodsQuery,
+}))
+
+vi.mock('@/store/api/salesApi', () => ({
+  useGetSalesOrderPaymentsQuery: mockUseGetSalesOrderPaymentsQuery,
+}))
+
+const paymentMethods = [
+  { id: 'pm-1', name: 'Cash', code: 'CASH', isActive: true },
+  { id: 'pm-2', name: 'Bank Transfer', code: 'BANK', isActive: true },
+]
+
+const makePayments = (paid: number, refunded: number) => [
+  ...(paid > 0 ? [{ id: 'p1', salesOrderId: 'order-1', paymentMethodId: 'pm-1', amount: paid, paymentDate: '2026-01-01', createdAt: '', updatedAt: '' }] : []),
+  ...(refunded > 0 ? [{ id: 'p2', salesOrderId: 'order-1', paymentMethodId: 'pm-1', amount: -refunded, paymentDate: '2026-01-02', createdAt: '', updatedAt: '' }] : []),
+]
+
+function renderDialog(props: Partial<ComponentProps<typeof RefundDialog>> = {}) {
+  const defaults = {
+    open: true,
+    onClose: vi.fn(),
+    onSubmit: vi.fn().mockResolvedValue(undefined),
+    orderId: 'order-1',
+    orderNumber: 'SO-26-001',
+  }
+  return render(<RefundDialog {...defaults} {...props} />)
+}
+
+beforeEach(() => {
+  mockUseGetActivePaymentMethodsQuery.mockReturnValue({ data: paymentMethods })
+  mockUseGetSalesOrderPaymentsQuery.mockReturnValue({ data: makePayments(500, 0), isLoading: false })
+})
+
+describe('RefundDialog', () => {
+  it('displays summary: Total Paid, Already Refunded, Available for Refund', () => {
+    mockUseGetSalesOrderPaymentsQuery.mockReturnValue({ data: makePayments(500, 100), isLoading: false })
+    renderDialog()
+    expect(screen.getByText('Total Paid')).toBeInTheDocument()
+    expect(screen.getByText('Already Refunded')).toBeInTheDocument()
+    expect(screen.getByText('Available for Refund')).toBeInTheDocument()
+  })
+
+  it('computes Available for Refund as Total Paid minus Already Refunded', () => {
+    mockUseGetSalesOrderPaymentsQuery.mockReturnValue({ data: makePayments(500, 100), isLoading: false })
+    renderDialog()
+    // Available = 500 - 100 = 400 → RM 400.00 (appears at least once in summary)
+    expect(screen.getAllByText(/RM\s*400\.00/i).length).toBeGreaterThan(0)
+  })
+
+  it('shows loading spinner while payments are loading', () => {
+    mockUseGetSalesOrderPaymentsQuery.mockReturnValue({ data: [], isLoading: true })
+    renderDialog()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('pre-fills first refund line with Available for Refund amount', () => {
+    mockUseGetSalesOrderPaymentsQuery.mockReturnValue({ data: makePayments(500, 0), isLoading: false })
+    renderDialog()
+    const amountInput = screen.getByPlaceholderText('Amount') as HTMLInputElement
+    expect(amountInput.value).toBe('500')
+  })
+
+  it('populates payment method dropdown from API', () => {
+    renderDialog()
+    expect(screen.getByText('Cash')).toBeInTheDocument()
+  })
+
+  it('adds a refund row when Add Refund Row is clicked', async () => {
+    renderDialog()
+    await userEvent.click(screen.getByRole('button', { name: /add refund row/i }))
+    expect(screen.getAllByPlaceholderText('Amount')).toHaveLength(2)
+  })
+
+  it('remove button is disabled when only one row remains', () => {
+    renderDialog()
+    const removeButtons = screen.getAllByRole('button').filter(
+      (btn) => btn.querySelector('svg[data-testid="DeleteIcon"]'),
+    )
+    expect(removeButtons[0]).toBeDisabled()
+  })
+
+  it('Refund button is disabled when total entered is 0', () => {
+    mockUseGetSalesOrderPaymentsQuery.mockReturnValue({ data: makePayments(500, 500), isLoading: false })
+    renderDialog()
+    // Available = 0, pre-fill is '' → totalEntered = 0
+    expect(screen.getByRole('button', { name: /^refund$/i })).toBeDisabled()
+  })
+
+  it('Refund button is disabled when total exceeds available', async () => {
+    mockUseGetSalesOrderPaymentsQuery.mockReturnValue({ data: makePayments(300, 0), isLoading: false })
+    renderDialog()
+    const amountInput = screen.getByPlaceholderText('Amount')
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '400')
+    expect(screen.getByRole('button', { name: /^refund$/i })).toBeDisabled()
+  })
+
+  it('shows error alert when total exceeds available', async () => {
+    mockUseGetSalesOrderPaymentsQuery.mockReturnValue({ data: makePayments(300, 0), isLoading: false })
+    renderDialog()
+    const amountInput = screen.getByPlaceholderText('Amount')
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '400')
+    expect(screen.getAllByText(/exceeds available/i).length).toBeGreaterThan(0)
+  })
+
+  it('Cancel with no edits closes immediately without confirmation', async () => {
+    const onClose = vi.fn()
+    renderDialog({ onClose })
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(screen.queryByText('Discard this refund?')).not.toBeInTheDocument()
+  })
+
+  it('Cancel after editing shows discard confirmation', async () => {
+    renderDialog()
+    const amountInput = screen.getByPlaceholderText('Amount')
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '100')
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(screen.getByText('Discard this refund?')).toBeInTheDocument()
+  })
+
+  it('clicking Discard in confirmation calls onClose', async () => {
+    const onClose = vi.fn()
+    renderDialog({ onClose })
+    await userEvent.clear(screen.getByPlaceholderText('Amount'))
+    await userEvent.type(screen.getByPlaceholderText('Amount'), '100')
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    await userEvent.click(screen.getByRole('button', { name: /^discard$/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('clicking Keep Editing dismisses confirmation and keeps dialog open', async () => {
+    const onClose = vi.fn()
+    renderDialog({ onClose })
+    await userEvent.clear(screen.getByPlaceholderText('Amount'))
+    await userEvent.type(screen.getByPlaceholderText('Amount'), '100')
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    await userEvent.click(screen.getByRole('button', { name: /keep editing/i }))
+    expect(onClose).not.toHaveBeenCalled()
+    expect(screen.queryByText('Discard this refund?')).not.toBeInTheDocument()
+  })
+
+  it('submit success calls onSubmit with correct lines and closes dialog', async () => {
+    const onClose = vi.fn()
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    renderDialog({ onClose, onSubmit })
+    const amountInput = screen.getByPlaceholderText('Amount')
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '200')
+    await userEvent.click(screen.getByRole('button', { name: /^refund$/i }))
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce())
+    expect(onSubmit).toHaveBeenCalledWith([
+      expect.objectContaining({ paymentMethodId: 'pm-1', amount: 200 }),
+    ])
+  })
+
+  it('submit error shows error alert and does not close dialog', async () => {
+    const onClose = vi.fn()
+    const onSubmit = vi.fn().mockRejectedValue({ message: 'Server error' })
+    renderDialog({ onClose, onSubmit })
+    const amountInput = screen.getByPlaceholderText('Amount')
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '100')
+    await userEvent.click(screen.getByRole('button', { name: /^refund$/i }))
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('partial refund works — can refund less than available', async () => {
+    mockUseGetSalesOrderPaymentsQuery.mockReturnValue({ data: makePayments(500, 0), isLoading: false })
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    renderDialog({ onSubmit })
+    const amountInput = screen.getByPlaceholderText('Amount')
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '150')
+    await userEvent.click(screen.getByRole('button', { name: /^refund$/i }))
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith([
+      expect.objectContaining({ amount: 150 }),
+    ]))
+  })
+
+  it('Escape on untouched dialog closes immediately', async () => {
+    const onClose = vi.fn()
+    renderDialog({ onClose })
+    await userEvent.keyboard('{Escape}')
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('Escape after editing shows discard confirmation', async () => {
+    const onClose = vi.fn()
+    renderDialog({ onClose })
+    await userEvent.clear(screen.getByPlaceholderText('Amount'))
+    await userEvent.type(screen.getByPlaceholderText('Amount'), '100')
+    await userEvent.keyboard('{Escape}')
+    expect(onClose).not.toHaveBeenCalled()
+    expect(screen.getByText('Discard this refund?')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -11,6 +11,7 @@ import {
   useGetSalesOrdersQuery,
   useRecordOrderPaymentMutation,
   useRecordOrderPaymentsMutation,
+  useRecordOrderRefundsMutation,
   useUnfulfillSalesOrderMutation,
 } from '@/store/api/salesApi'
 import type { SalesOrder } from '@/types'
@@ -60,6 +61,7 @@ const OrdersPage: React.FC = () => {
 
   const [printOrder, setPrintOrder] = useState<SalesOrder | null>(null)
   const [paymentOrder, setPaymentOrder] = useState<SalesOrder | null>(null)
+  const [refundOrder, setRefundOrder] = useState<SalesOrder | null>(null)
 
   const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
 
@@ -96,6 +98,7 @@ const OrdersPage: React.FC = () => {
   const [cancelOrder] = useCancelSalesOrderMutation()
   const [recordPayment] = useRecordOrderPaymentMutation()
   const [recordPayments] = useRecordOrderPaymentsMutation()
+  const [recordRefunds] = useRecordOrderRefundsMutation()
 
   useEffect(() => {
     setPage(1)
@@ -139,16 +142,23 @@ const OrdersPage: React.FC = () => {
     }
   }, [cancelOrder, showError, showSuccess])
 
-  const handleRefund = useCallback(async (order: SalesOrder) => {
-    const overpayment = (order.paidAmount ?? 0) - order.totalAmount
-    if (overpayment <= 0) return
+  const handleRefund = useCallback((order: SalesOrder) => {
+    setRefundOrder(order)
+  }, [])
+
+  const handleSubmitRefund = useCallback(async (
+    refunds: { paymentMethodId: string; amount: number; reference?: string }[],
+  ) => {
+    if (!refundOrder) return
     try {
-      await recordPayment({ id: order.id, amount: overpayment }).unwrap()
-      showSuccess(`Refund of ${overpayment.toFixed(2)} processed for ${order.orderNumber}`)
+      await recordRefunds({ id: refundOrder.id, refunds }).unwrap()
+      setRefundOrder(null)
+      showSuccess(`Refund recorded for ${refundOrder.orderNumber}`)
     } catch (e: any) {
-      showError(e?.data?.message || `Failed to refund ${order.orderNumber}`)
+      showError(e?.data?.message || `Failed to record refund for ${refundOrder.orderNumber}`)
+      throw e
     }
-  }, [recordPayment, showError, showSuccess])
+  }, [refundOrder, recordRefunds, showError, showSuccess])
 
   const handleSubmitPayment = useCallback(async (
     payments: { paymentMethodId: string; amount: number; reference?: string }[],
@@ -209,6 +219,9 @@ const OrdersPage: React.FC = () => {
         paymentOrder={paymentOrder}
         onClosePayment={() => setPaymentOrder(null)}
         onSubmitPayment={handleSubmitPayment}
+        refundOrder={refundOrder}
+        onCloseRefund={() => setRefundOrder(null)}
+        onSubmitRefund={handleSubmitRefund}
       />
     </>
   )

--- a/frontend/src/pages/sales/SalesOrderDetailPage.tsx
+++ b/frontend/src/pages/sales/SalesOrderDetailPage.tsx
@@ -10,6 +10,7 @@ import ConfirmationDialog from '@/components/common/ConfirmationDialog'
 import PageHeader from '@/components/common/PageHeader'
 import SalesOrderPrint from '@/components/print/SalesOrderPrint'
 import PaymentDialog from '@/components/sales/PaymentDialog'
+import RefundDialog from '@/components/sales/RefundDialog'
 import { TABLE_STYLES } from '@/constants/tableStyles'
 import { useNotification } from '@/hooks/useNotification'
 import {
@@ -17,6 +18,7 @@ import {
   useFulfillSalesOrderMutation,
   useGetSalesOrderByNumberQuery,
   useRecordOrderPaymentsMutation,
+  useRecordOrderRefundsMutation,
   useUnfulfillSalesOrderMutation,
 } from '@/store/api/salesApi'
 
@@ -77,6 +79,7 @@ export default function SalesOrderDetailPage() {
   const [unfulfillOrder, { isLoading: isUnfulfilling }] = useUnfulfillSalesOrderMutation()
   const [cancelOrder, { isLoading: isCancelling }] = useCancelSalesOrderMutation()
   const [recordPayments] = useRecordOrderPaymentsMutation()
+  const [recordRefunds] = useRecordOrderRefundsMutation()
 
   if (isLoading) {
     return (
@@ -133,6 +136,19 @@ export default function SalesOrderDetailPage() {
       setActiveDialog(null)
     } catch (error) {
       showError(getErrorMessage(error, 'Failed to record payment'))
+      throw error
+    }
+  }
+
+  const handleSubmitRefund = async (
+    refunds: { paymentMethodId: string; amount: number; reference?: string }[],
+  ) => {
+    try {
+      await recordRefunds({ id: order.id, refunds }).unwrap()
+      showSuccess(`Refund recorded for ${order.orderNumber}`)
+      setActiveDialog(null)
+    } catch (error) {
+      showError(getErrorMessage(error, 'Failed to record refund'))
       throw error
     }
   }
@@ -219,7 +235,7 @@ export default function SalesOrderDetailPage() {
         loading={isCancelling}
       />
 
-      {(activeDialog === 'pay' || activeDialog === 'refund') && (
+      {activeDialog === 'pay' && (
         <PaymentDialog
           open
           onClose={() => setActiveDialog(null)}
@@ -227,7 +243,16 @@ export default function SalesOrderDetailPage() {
           orderNumber={order.orderNumber}
           totalAmount={order.totalAmount}
           paidAmount={order.paidAmount ?? 0}
-          title={activeDialog === 'refund' ? `Refund — ${order.orderNumber}` : undefined}
+        />
+      )}
+
+      {activeDialog === 'refund' && (
+        <RefundDialog
+          open
+          onClose={() => setActiveDialog(null)}
+          onSubmit={handleSubmitRefund}
+          orderId={order.id}
+          orderNumber={order.orderNumber}
         />
       )}
 

--- a/frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
+++ b/frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
@@ -26,6 +26,7 @@ vi.mock('@/store/api/salesApi', () => ({
   useCancelSalesOrderMutation: vi.fn(() => [vi.fn()]),
   useRecordOrderPaymentMutation: vi.fn(() => [vi.fn()]),
   useRecordOrderPaymentsMutation: vi.fn(() => [vi.fn()]),
+  useRecordOrderRefundsMutation: vi.fn(() => [vi.fn()]),
 }))
 
 vi.mock('@/hooks/useNotification', () => ({

--- a/frontend/src/pages/sales/__tests__/SalesOrderDetailPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/SalesOrderDetailPage.test.tsx
@@ -16,6 +16,7 @@ const {
   mockUnfulfill,
   mockCancel,
   mockRecordPayments,
+  mockRecordRefunds,
 } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
   mockGetSalesOrderByNumber: vi.fn(),
@@ -23,6 +24,7 @@ const {
   mockUnfulfill: vi.fn(),
   mockCancel: vi.fn(),
   mockRecordPayments: vi.fn(),
+  mockRecordRefunds: vi.fn(),
 }))
 
 vi.mock('react-router-dom', async (importOriginal) => {
@@ -46,6 +48,7 @@ vi.mock('@/store/api/salesApi', async (importOriginal) => {
     useUnfulfillSalesOrderMutation: () => [mockUnfulfill, { isLoading: false }],
     useCancelSalesOrderMutation: () => [mockCancel, { isLoading: false }],
     useRecordOrderPaymentsMutation: () => [mockRecordPayments, { isLoading: false }],
+    useRecordOrderRefundsMutation: () => [mockRecordRefunds, { isLoading: false }],
   }
 })
 
@@ -54,6 +57,7 @@ vi.mock('../components/OrderPaymentsTab', () => ({ default: () => <div>PaymentsT
 vi.mock('../components/OrderJournalEntriesTab', () => ({ default: () => <div>JournalTab</div> }))
 vi.mock('@/components/print/SalesOrderPrint', () => ({ default: () => <div>PrintDialog</div> }))
 vi.mock('@/components/sales/PaymentDialog', () => ({ default: () => <div>PaymentDialog</div> }))
+vi.mock('@/components/sales/RefundDialog', () => ({ default: () => <div>RefundDialog</div> }))
 
 function makeOrder(overrides: Partial<SalesOrder> = {}): SalesOrder {
   return {
@@ -165,10 +169,10 @@ describe('SalesOrderDetailPage', () => {
     expect(screen.getByText('PaymentDialog')).toBeInTheDocument()
   })
 
-  it('opens PaymentDialog when Refund is clicked', async () => {
+  it('opens RefundDialog when Refund is clicked', async () => {
     mockGetSalesOrderByNumber.mockReturnValue({ data: makeOrder({ status: 'DRAFT', paymentStatus: 'PAID' }), isLoading: false })
     renderPage()
     await userEvent.click(screen.getByRole('button', { name: 'Refund' }))
-    expect(screen.getByText('PaymentDialog')).toBeInTheDocument()
+    expect(screen.getByText('RefundDialog')).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/sales/components/SalesOrdersDialogs.tsx
+++ b/frontend/src/pages/sales/components/SalesOrdersDialogs.tsx
@@ -1,4 +1,5 @@
 import PaymentDialog from '@/components/sales/PaymentDialog'
+import RefundDialog from '@/components/sales/RefundDialog'
 import { SalesOrderPrint } from '@/components/print'
 import type { SalesOrder } from '@/types'
 
@@ -10,6 +11,11 @@ interface SalesOrdersDialogsProps {
   onSubmitPayment: (
     payments: { paymentMethodId: string; amount: number; reference?: string }[],
   ) => Promise<void>
+  refundOrder: SalesOrder | null
+  onCloseRefund: () => void
+  onSubmitRefund: (
+    refunds: { paymentMethodId: string; amount: number; reference?: string }[],
+  ) => Promise<void>
 }
 
 export default function SalesOrdersDialogs({
@@ -18,6 +24,9 @@ export default function SalesOrdersDialogs({
   paymentOrder,
   onClosePayment,
   onSubmitPayment,
+  refundOrder,
+  onCloseRefund,
+  onSubmitRefund,
 }: SalesOrdersDialogsProps) {
   return (
     <>
@@ -32,6 +41,15 @@ export default function SalesOrdersDialogs({
           orderNumber={paymentOrder.orderNumber}
           totalAmount={paymentOrder.totalAmount}
           paidAmount={paymentOrder.paidAmount ?? 0}
+        />
+      )}
+      {refundOrder && (
+        <RefundDialog
+          open
+          onClose={onCloseRefund}
+          onSubmit={onSubmitRefund}
+          orderId={refundOrder.id}
+          orderNumber={refundOrder.orderNumber}
         />
       )}
     </>

--- a/frontend/src/store/api/salesApi.ts
+++ b/frontend/src/store/api/salesApi.ts
@@ -235,6 +235,18 @@ export const salesApiSlice = createApi({
       transformResponse: (response: any) => normalizeSingle<SalesOrder>(response?.data ?? response),
       invalidatesTags: ['SalesOrder', 'Invoice', 'Payment'],
     }),
+    recordOrderRefunds: builder.mutation<
+      SalesOrder,
+      { id: string; refunds: { paymentMethodId: string; amount: number; reference?: string }[] }
+    >({
+      query: ({ id, refunds }) => ({
+        url: `/sales-orders/${id}/refunds`,
+        method: 'POST',
+        data: { refunds },
+      }),
+      transformResponse: (response: any) => normalizeSingle<SalesOrder>(response?.data ?? response),
+      invalidatesTags: ['SalesOrder', 'Invoice', 'Payment'],
+    }),
     unpaySalesOrder: builder.mutation<SalesOrder, string>({
       query: (id) => ({ url: `/sales-orders/${id}/unpay`, method: 'POST' }),
       transformResponse: (response: any) => normalizeSingle<SalesOrder>(response?.data ?? response),
@@ -422,6 +434,7 @@ export const {
   useDuplicateSalesOrderMutation,
   useRecordOrderPaymentMutation,
   useRecordOrderPaymentsMutation,
+  useRecordOrderRefundsMutation,
   useUnpaySalesOrderMutation,
   useFulfillSalesOrderMutation,
   useUnfulfillSalesOrderMutation,

--- a/frontend/src/store/api/salesApi.ts
+++ b/frontend/src/store/api/salesApi.ts
@@ -162,7 +162,7 @@ export const salesApiSlice = createApi({
     getSalesOrderPayments: builder.query<SalesOrderPayment[], string>({
       query: (id) => ({ url: `/sales-orders/${id}/payments` }),
       transformResponse: (response: any) => response.data ?? [],
-      providesTags: (_result, _error, id) => ['SalesOrder', { type: 'SalesOrder', id }],
+      providesTags: (_result, _error, id) => ['SalesOrder', 'Payment', { type: 'SalesOrder', id }],
     }),
     createSalesOrder: builder.mutation<SalesOrder, Partial<SalesOrder>>({
       query: (body) => ({ url: '/sales-orders', method: 'POST', data: body }),


### PR DESCRIPTION
## Summary

- New `RefundDialog` component with real payment summary (Total Paid / Already Refunded / Available for Refund) fetched from `GET /sales-orders/:id/payments`
- New `useRecordOrderRefundsMutation` hitting `POST /sales-orders/:id/refunds` (batch)
- Backend `POST /sales-orders/:id/refunds` updated to accept `{ refunds: [...] }` batch body
- `OrdersPage` and `SalesOrderDetailPage` both open `RefundDialog` via their Refund action
- `SalesOrdersDialogs` updated with `refundOrder` / `onCloseRefund` / `onSubmitRefund` props
- Replaces broken `OrdersPage` stub that used overpayment arithmetic
- Fixed stale closure bug: seeding effect waits for payment records to load before pre-filling amount

## Test plan

- [ ] Open Refund dialog from order list row action (DRAFT+Paid, FULFILLED states)
- [ ] Open Refund dialog from order detail page action bar
- [ ] Verify summary shows correct Total Paid / Already Refunded / Available for Refund
- [ ] Submit full refund — payment status changes to UNPAID, Pay button re-enabled
- [ ] Submit partial refund — payment status changes to PARTIAL
- [ ] Submit refund for more than available — button stays disabled
- [ ] Cancel with data shows "Discard this refund?" confirmation
- [ ] Cancel without data closes immediately
- [ ] Vitest suite: all tests pass

Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)