### PR TITLE
fix(sales): update subtotal and total immediately on product selection

### DIFF
--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -336,11 +336,14 @@ const CreateSalesOrderPage: React.FC = () => {
     (index: number, product: any) => {
       if (!product) return
       seedProducts([product])
+      const price = getProductPrice(product, selectedCustomer)
+      const qty = Number(watchedItems[index]?.quantity) || 1
       setValue(`items.${index}.productId`, product.id)
-      setValue(`items.${index}.unitPrice`, getProductPrice(product, selectedCustomer))
+      setValue(`items.${index}.unitPrice`, price)
+      setValue(`items.${index}.totalPrice`, Number((price * qty).toFixed(2)))
       setValue(`items.${index}.product`, product)
     },
-    [seedProducts, setValue, selectedCustomer],
+    [seedProducts, setValue, selectedCustomer, watchedItems],
   )
 
   const handleCancel = () => {

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -540,6 +540,31 @@ describe('CreateSalesOrderPage — new features', () => {
       expect(rows()).toHaveLength(2)
     })
   })
+
+  it('updates subtotal and total immediately when a product is selected', async () => {
+    mockGet.mockResolvedValue({ data: [{ id: 'product-1', name: 'Alpha Widget', basePrice: 11 }] })
+
+    render(
+      <BrowserRouter>
+        <CreateSalesOrderPage />
+      </BrowserRouter>,
+    )
+
+    const productInput = screen.getByPlaceholderText('Search by name or barcode...')
+    fireEvent.mouseDown(productInput)
+    const listbox = await screen.findByRole('listbox')
+    fireEvent.click(within(listbox).getByText('Alpha Widget'))
+
+    // Subtotal cell shows qty(1) × price(11) = RM 11.00 immediately after selection
+    await waitFor(() => {
+      expect(screen.getByText('RM 11.00')).toBeInTheDocument()
+    })
+
+    // Total Amount field also reflects the subtotal (no shipping)
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('11.00')).toBeInTheDocument()
+    })
+  })
 })
 
 describe('CreateSalesOrderPage — edit mode', { timeout: 60000 }, () => {


### PR DESCRIPTION
## Summary
- `handleProductSelect` now computes `totalPrice` synchronously when a product is selected, instead of relying on the async `useEffect` recalculation
- `watchedItems` added to `useCallback` deps so the current row quantity is always used
- Test added verifying the subtotal cell and Total Amount field update immediately after product selection

## Test Plan
- [ ] Create a new sales order, select a product — subtotal and Total Amount should update immediately without needing to change quantity
- [ ] Verify quantity/discount changes still recalculate correctly (existing effect still handles those)
- [ ] All 22 CreateSalesOrderPage tests pass

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)