### PR TITLE
fix(sales): fix order total staying 0 after product select (#690)

### DIFF
--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -222,11 +222,9 @@ const CreateSalesOrderPage: React.FC = () => {
 
   const getKeyHandler = useLineItemKeyNav(COL_COUNT, fields.length, () => append(emptyItem()))
 
-  const totals = useMemo(() => {
-    const subtotal = watchedItems.reduce((sum, item) => sum + (Number(item.totalPrice) || 0), 0)
-    const shipping = Number(watchedShipping) || 0
-    return { subtotal, shipping, total: subtotal + shipping }
-  }, [watchedItems, watchedShipping])
+  const subtotal = watchedItems.reduce((sum, item) => sum + (Number(item.totalPrice) || 0), 0)
+  const shippingAmt = Number(watchedShipping) || 0
+  const totals = { subtotal, shipping: shippingAmt, total: subtotal + shippingAmt }
 
   useEffect(() => {
     watchedItems.forEach((item, index) => {

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -562,7 +562,8 @@ describe('CreateSalesOrderPage — new features', () => {
 
     // Total Amount field also reflects the subtotal (no shipping)
     await waitFor(() => {
-      expect(screen.getByDisplayValue('11.00')).toBeInTheDocument()
+      const totalField = screen.getByRole('textbox', { name: /total amount/i })
+      expect(totalField).toHaveDisplayValue('11.00')
     })
   })
 })


### PR DESCRIPTION
## Summary

- `useMemo` was caching `totals` with `watchedItems` as a dependency, but React Hook Form's `watch()` can return the **same array reference** after `setValue()` calls
- This caused the memo to skip recomputation even though item `totalPrice` values changed — so the order-level "Total Amount" stayed at 0
- Per-line subtotals appeared correct because they read `watchedItem.totalPrice` directly as a prop (not through the memo)
- Fix: replaced `useMemo` with an inline calculation — `totals` now recomputes every render, which is correct and cheap for a small items array

## Test plan

- [x] Create a new sales order
- [x] Select a product on the first row — Total Amount should immediately update
- [x] Change the quantity on the first row — Total Amount should immediately update
- [x] Add multiple rows and verify each product selection updates Total Amount
- [x] Verify shipping fee still adds correctly to Total Amount

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)