### PR TITLE
fix(sales): fix fulfill/unfulfill API URLs (404 on Fulfill button)

### DIFF
--- a/frontend/src/store/api/salesApi.ts
+++ b/frontend/src/store/api/salesApi.ts
@@ -249,12 +249,12 @@ export const salesApiSlice = createApi({
       invalidatesTags: ['SalesOrder', 'Invoice', 'Payment'],
     }),
     fulfillSalesOrder: builder.mutation<SalesOrder, string>({
-      query: (id) => ({ url: `/sales-orders/${id}/fulfill-order`, method: 'POST' }),
+      query: (id) => ({ url: `/sales-orders/${id}/fulfill`, method: 'POST' }),
       transformResponse: (response: any) => normalizeSingle<SalesOrder>(response?.data ?? response),
       invalidatesTags: ['SalesOrder', 'Invoice'],
     }),
     unfulfillSalesOrder: builder.mutation<SalesOrder, string>({
-      query: (id) => ({ url: `/sales-orders/${id}/unfulfill-order`, method: 'POST' }),
+      query: (id) => ({ url: `/sales-orders/${id}/unfulfill`, method: 'POST' }),
       transformResponse: (response: any) => normalizeSingle<SalesOrder>(response?.data ?? response),
       invalidatesTags: ['SalesOrder', 'Invoice'],
     }),


### PR DESCRIPTION
## Summary

- Frontend `salesApi.ts` was calling `POST /sales-orders/:id/fulfill-order` and `/unfulfill-order` — paths that don't exist on the backend
- Backend controller has always exposed `POST /sales-orders/:id/fulfill` and `/unfulfill`
- This caused a silent 404 whenever a user clicked **Fulfill** or **Unfulfill** on any sales order

## Changes

- `frontend/src/store/api/salesApi.ts`: fix two URL strings to match the actual backend routes
  - `/fulfill-order` → `/fulfill`
  - `/unfulfill-order` → `/unfulfill`

Consistent with the existing `/cancel`, `/uncancel`, `/unpay` route convention.

## Test Plan

- [x] Open a PAID sales order → click **Fulfill** → order status changes to FULFILLED, inventory deducted
- [x] Open a FULFILLED sales order → click **Unfulfill** → order returns to DRAFT, inventory restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)