### PR TITLE
fix(accounting+sales): fix journal entry amount mismatch, JE reversal on unfulfill, and RefundDialog crash

### DIFF
--- a/backend/src/modules/accounting/services/accounting.service.spec.ts
+++ b/backend/src/modules/accounting/services/accounting.service.spec.ts
@@ -224,6 +224,40 @@ describe('AccountingService', () => {
       expect(revenueLine.creditAmount).toBe(30);
     });
 
+    it('should throw BadRequestException when items relation is not loaded', async () => {
+      const orderWithoutItems = {
+        id: 'so-no-items',
+        orderNumber: 'SO-NO-ITEMS',
+        totalAmount: 100,
+        shippingAmount: 0,
+        fulfilledDate: new Date('2026-01-15'),
+        customer: { id: 'customer-123', name: 'Test Customer' },
+        items: undefined, // relation not loaded
+      } as any;
+
+      await expect(service.postSalesOrderEntry(orderWithoutItems, 'user-123')).rejects.toThrow(
+        'Cannot post sales order entry for SO-NO-ITEMS: items relation not loaded',
+      );
+    });
+
+    it('should throw when items not loaded even when shippingAmount is non-zero', async () => {
+      // Regression: old warn condition (revenueAmount === 0) was bypassed when shipping > 0,
+      // silently posting only shipping as revenue and missing all item revenue.
+      const orderWithShippingNoItems = {
+        id: 'so-shipping-only',
+        orderNumber: 'SO-SHIP',
+        totalAmount: 110,
+        shippingAmount: 10,
+        fulfilledDate: new Date('2026-01-15'),
+        customer: { id: 'customer-123', name: 'Test Customer' },
+        items: undefined,
+      } as any;
+
+      await expect(service.postSalesOrderEntry(orderWithShippingNoItems, 'user-123')).rejects.toThrow(
+        'Cannot post sales order entry for SO-SHIP: items relation not loaded',
+      );
+    });
+
     it('should use correct account mappings', async () => {
       await service.postSalesOrderEntry(mockSalesOrder, 'user-123');
 

--- a/backend/src/modules/accounting/services/accounting.service.spec.ts
+++ b/backend/src/modules/accounting/services/accounting.service.spec.ts
@@ -98,6 +98,7 @@ describe('AccountingService', () => {
       id: 'so-123',
       orderNumber: 'SO-001',
       totalAmount: 1500,
+      shippingAmount: 0,
       fulfilledDate: new Date('2026-01-15'),
       customer: {
         id: 'customer-123',
@@ -108,6 +109,7 @@ describe('AccountingService', () => {
           id: 'item-1',
           quantity: 10,
           unitPrice: 100,
+          totalAmount: 1000,
           product: {
             id: 'product-1',
             name: 'Product A',
@@ -118,6 +120,7 @@ describe('AccountingService', () => {
           id: 'item-2',
           quantity: 5,
           unitPrice: 100,
+          totalAmount: 500,
           product: {
             id: 'product-2',
             name: 'Product B',
@@ -190,6 +193,35 @@ describe('AccountingService', () => {
       const cogsLine = createCall.lines.find((l: any) => l.accountId === 'cogs-account-id');
 
       expect(cogsLine.debitAmount).toBe(1000); // (10 * 60) + (5 * 80) = 600 + 400
+    });
+
+    it('should use items sum for AR/Revenue, not stale totalAmount column', async () => {
+      const staleOrder = {
+        id: 'so-stale',
+        orderNumber: 'SO-STALE',
+        totalAmount: 40,
+        shippingAmount: 0,
+        fulfilledDate: new Date('2026-01-15'),
+        customer: { id: 'customer-123', name: 'Test Customer' },
+        items: [
+          {
+            id: 'item-1',
+            quantity: 1,
+            unitPrice: 30,
+            totalAmount: 30,
+            product: { id: 'product-1', name: 'Product A', baseCost: 20 },
+          },
+        ],
+      } as any;
+
+      await service.postSalesOrderEntry(staleOrder, 'user-123');
+
+      const createCall = journalEntryService.create.mock.calls[0][0];
+      const arLine = createCall.lines.find((l: any) => l.accountId === 'ar-account-id');
+      const revenueLine = createCall.lines.find((l: any) => l.accountId === 'revenue-account-id');
+
+      expect(arLine.debitAmount).toBe(30);
+      expect(revenueLine.creditAmount).toBe(30);
     });
 
     it('should use correct account mappings', async () => {

--- a/backend/src/modules/accounting/services/accounting.service.ts
+++ b/backend/src/modules/accounting/services/accounting.service.ts
@@ -87,21 +87,22 @@ export class AccountingService {
       );
     }
 
+    // Guard: items relation must be loaded — without it revenue and COGS are both wrong
+    if (salesOrder.items == null) {
+      throw new BadRequestException(
+        `Cannot post sales order entry for ${salesOrder.orderNumber}: items relation not loaded`,
+      );
+    }
+
     // Calculate COGS
     const cogsAmount = this.calculateCOGS(salesOrder.items);
 
     // Derive revenue from items (defensive: avoids stale totalAmount column)
-    const itemsSubtotal = (salesOrder.items ?? []).reduce(
+    const itemsSubtotal = salesOrder.items.reduce(
       (sum, item) => sum + Number(item.totalAmount ?? 0),
       0,
     );
     const revenueAmount = itemsSubtotal + Number(salesOrder.shippingAmount ?? 0);
-
-    if (revenueAmount === 0 && Number(salesOrder.totalAmount) !== 0) {
-      this.logger.warn(
-        `Revenue derived from items is 0 but totalAmount is ${salesOrder.totalAmount} for order ${salesOrder.orderNumber}. Items may not be loaded.`,
-      );
-    }
 
     // Build journal entry lines
     const lines: CreateJournalEntryLineDto[] = [

--- a/backend/src/modules/accounting/services/accounting.service.ts
+++ b/backend/src/modules/accounting/services/accounting.service.ts
@@ -90,6 +90,19 @@ export class AccountingService {
     // Calculate COGS
     const cogsAmount = this.calculateCOGS(salesOrder.items);
 
+    // Derive revenue from items (defensive: avoids stale totalAmount column)
+    const itemsSubtotal = (salesOrder.items ?? []).reduce(
+      (sum, item) => sum + Number(item.totalAmount ?? 0),
+      0,
+    );
+    const revenueAmount = itemsSubtotal + Number(salesOrder.shippingAmount ?? 0);
+
+    if (revenueAmount === 0 && Number(salesOrder.totalAmount) !== 0) {
+      this.logger.warn(
+        `Revenue derived from items is 0 but totalAmount is ${salesOrder.totalAmount} for order ${salesOrder.orderNumber}. Items may not be loaded.`,
+      );
+    }
+
     // Build journal entry lines
     const lines: CreateJournalEntryLineDto[] = [
       // DR Cost of Goods Sold
@@ -109,7 +122,7 @@ export class AccountingService {
       // DR Accounts Receivable
       {
         accountId: mappings[MappingType.SALES_AR],
-        debitAmount: Number(salesOrder.totalAmount),
+        debitAmount: revenueAmount,
         creditAmount: 0,
         memo: 'Amount receivable from customer',
       },
@@ -117,7 +130,7 @@ export class AccountingService {
       {
         accountId: mappings[MappingType.SALES_REVENUE],
         debitAmount: 0,
-        creditAmount: Number(salesOrder.totalAmount),
+        creditAmount: revenueAmount,
         memo: 'Sales revenue recognition',
       },
     ];

--- a/backend/src/modules/sales/services/sales-order-fulfillment.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-fulfillment.service.spec.ts
@@ -29,6 +29,7 @@ describe('SalesOrderFulfillmentService', () => {
   let stockMovementService: jest.Mocked<StockMovementService>;
   let baseCostCalculator: jest.Mocked<BaseCostCalculatorService>;
   let auditLogService: jest.Mocked<AuditLogService>;
+  let accountingService: jest.Mocked<AccountingService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -39,7 +40,7 @@ describe('SalesOrderFulfillmentService', () => {
         { provide: StockMovementService, useValue: { deleteByReference: jest.fn().mockResolvedValue({ deletedCount: 1 }) } },
         { provide: BaseCostCalculatorService, useValue: { restoreStock: jest.fn() } },
         { provide: AuditLogService, useValue: { log: jest.fn() } },
-        { provide: AccountingService, useValue: { postSalesOrderEntry: jest.fn().mockResolvedValue(undefined) } },
+        { provide: AccountingService, useValue: { postSalesOrderEntry: jest.fn().mockResolvedValue(undefined), reverseSourceEntries: jest.fn().mockResolvedValue(undefined) } },
       ],
     }).compile();
 
@@ -49,6 +50,7 @@ describe('SalesOrderFulfillmentService', () => {
     stockMovementService = module.get(StockMovementService);
     baseCostCalculator = module.get(BaseCostCalculatorService);
     auditLogService = module.get(AuditLogService);
+    accountingService = module.get(AccountingService);
   });
 
   describe('fulfillOrder', () => {
@@ -95,6 +97,30 @@ describe('SalesOrderFulfillmentService', () => {
       expect(baseCostCalculator.restoreStock).toHaveBeenCalledWith('product-1', 5);
       expect(stockMovementService.deleteByReference).toHaveBeenCalledWith('sales_order', 'order-1');
       expect(orderRepo.save).toHaveBeenCalledWith(expect.objectContaining({ status: SalesOrderStatus.DRAFT }));
+    });
+
+    it('reverses the sales_order journal entry on unfulfill', async () => {
+      const order = mockOrder({ status: SalesOrderStatus.FULFILLED });
+      orderRepo.findOne.mockResolvedValue(order);
+      orderRepo.save.mockResolvedValue({ ...order, status: SalesOrderStatus.DRAFT } as SalesOrder);
+
+      await service.unfulfillOrder('order-1', 'user-99', 'admin');
+
+      expect(accountingService.reverseSourceEntries).toHaveBeenCalledWith(
+        'sales_order',
+        'order-1',
+        'user-99',
+      );
+    });
+
+    it('does not throw if journal entry reversal fails (non-critical path)', async () => {
+      const order = mockOrder({ status: SalesOrderStatus.FULFILLED });
+      orderRepo.findOne.mockResolvedValue(order);
+      orderRepo.save.mockResolvedValue({ ...order, status: SalesOrderStatus.DRAFT } as SalesOrder);
+      accountingService.reverseSourceEntries.mockRejectedValue(new Error('No open fiscal period'));
+
+      // Should not throw — accounting failure must not block unfulfill
+      await expect(service.unfulfillOrder('order-1')).resolves.toBeDefined();
     });
   });
 });

--- a/backend/src/modules/sales/services/sales-order-fulfillment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-fulfillment.service.ts
@@ -118,6 +118,16 @@ export class SalesOrderFulfillmentService {
       newValues: { status: SalesOrderStatus.DRAFT },
     });
 
+    try {
+      await this.accountingService.reverseSourceEntries('sales_order', id, userId || 'system');
+      this.logger.log(`Reversed accounting entry for sales order ${order.orderNumber}`);
+    } catch (error) {
+      this.logger.error(
+        `Failed to reverse accounting entry for sales order ${id}: ${error.message}`,
+        error.stack,
+      );
+    }
+
     return saved;
   }
 }

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -28,13 +28,15 @@ describe('SalesOrderService', () => {
   let salesOrderPaymentService: jest.Mocked<SalesOrderPaymentService>;
   let salesOrderFulfillmentService: jest.Mocked<SalesOrderFulfillmentService>;
   let salesOrderQueryService: jest.Mocked<SalesOrderQueryService>;
+  let salesOrderRepository: any;
+  let salesOrderItemRepository: any;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SalesOrderService,
         { provide: getRepositoryToken(SalesOrder), useValue: { findOne: jest.fn(), create: jest.fn(), save: jest.fn(), update: jest.fn(), createQueryBuilder: jest.fn() } },
-        { provide: getRepositoryToken(SalesOrderItem), useValue: { save: jest.fn(), delete: jest.fn(), insert: jest.fn() } },
+        { provide: getRepositoryToken(SalesOrderItem), useValue: { save: jest.fn(), delete: jest.fn(), insert: jest.fn(), find: jest.fn() } },
         { provide: getRepositoryToken(Customer), useValue: { findOne: jest.fn() } },
         { provide: getRepositoryToken(Product), useValue: { findOne: jest.fn() } },
         { provide: getRepositoryToken(Invoice), useValue: { createQueryBuilder: jest.fn(), create: jest.fn(), save: jest.fn(), find: jest.fn() } },
@@ -60,6 +62,8 @@ describe('SalesOrderService', () => {
     salesOrderPaymentService = module.get(SalesOrderPaymentService);
     salesOrderFulfillmentService = module.get(SalesOrderFulfillmentService);
     salesOrderQueryService = module.get(SalesOrderQueryService);
+    salesOrderRepository = module.get(getRepositoryToken(SalesOrder));
+    salesOrderItemRepository = module.get(getRepositoryToken(SalesOrderItem));
     salesOrderQueryService.findById.mockResolvedValue({ id: 'order-1' } as any);
   });
 
@@ -119,5 +123,41 @@ describe('SalesOrderService', () => {
 
     expect(order.status).toBe(SalesOrderStatus.DRAFT);
     expect(order.paymentStatus).toBe(SalesOrderPaymentStatus.PAID);
+  });
+
+  describe('update - shipping only', () => {
+    it('should recalculate totalAmount from DB items when only shippingAmount changes', async () => {
+      const mockOrder = {
+        id: 'order-1',
+        customerId: 'customer-1',
+        shippingAmount: 0,
+        subtotal: 100,
+        totalAmount: 100,
+        items: undefined,
+      };
+
+      const mockItems = [
+        { totalAmount: 60 },
+        { totalAmount: 40 },
+      ];
+
+      salesOrderRepository.findOne = jest.fn().mockResolvedValue(mockOrder);
+      salesOrderItemRepository.find = jest.fn().mockResolvedValue(mockItems);
+      salesOrderRepository.update = jest.fn().mockResolvedValue({ affected: 1 });
+      salesOrderQueryService.findById.mockResolvedValue({ ...mockOrder, shippingAmount: 15, totalAmount: 115 } as any);
+      salesOrderLifecycleService.assertEditAllowed.mockResolvedValue(undefined);
+
+      await service.update('order-1', { shippingAmount: 15 } as any, 'user-1', 'admin');
+
+      expect(salesOrderItemRepository.find).toHaveBeenCalledWith({ where: { salesOrderId: 'order-1' } });
+      expect(salesOrderRepository.update).toHaveBeenCalledWith(
+        'order-1',
+        expect.objectContaining({
+          shippingAmount: 15,
+          subtotal: 100,
+          totalAmount: 115,
+        }),
+      );
+    });
   });
 });

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -540,10 +540,12 @@ export class SalesOrderService extends BaseCrudService<
       updateData.subtotal = subtotal;
       updateData.totalAmount = totalAmount;
     } else if (updateSalesOrderDto.shippingAmount !== undefined) {
-      // If only shipping is being updated (no items), recalculate total
-      const currentSubtotal = order.items?.reduce((sum, item) => sum + Number(item.totalAmount), 0) || 0;
+      // If only shipping is being updated (no items), load items from DB to recalculate total
+      const existingItems = await this.salesOrderItemRepository.find({ where: { salesOrderId: id } });
+      const currentSubtotal = existingItems.reduce((sum, item) => sum + Number(item.totalAmount), 0);
       const newShipping = Number(updateSalesOrderDto.shippingAmount);
       updateData.shippingAmount = newShipping;
+      updateData.subtotal = currentSubtotal;
       updateData.totalAmount = currentSubtotal + newShipping;
     }
 

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -191,7 +191,7 @@ export class SalesOrderService extends BaseCrudService<
 
     // Validate and calculate order totals with customer pricing scheme
     const orderItems = await this.validateAndProcessItems(items, customer);
-    const subtotal = orderItems.reduce((sum, item) => sum + Number(item.totalAmount), 0);
+    const subtotal = SalesOrderService.sumItemTotals(orderItems);
     const shippingAmount = Number(createSalesOrderDto.shippingAmount || 0);
     const totalAmount = subtotal + shippingAmount;
 
@@ -506,7 +506,7 @@ export class SalesOrderService extends BaseCrudService<
       // Validate and process new items with customer pricing
       const orderItems = await this.validateAndProcessItems(items, customerForPricing);
 
-      const subtotal = orderItems.reduce((sum, item) => sum + Number(item.totalAmount), 0);
+      const subtotal = SalesOrderService.sumItemTotals(orderItems);
       const shippingAmount = updateSalesOrderDto.shippingAmount !== undefined
         ? Number(updateSalesOrderDto.shippingAmount)
         : Number(order.shippingAmount || 0);
@@ -542,7 +542,7 @@ export class SalesOrderService extends BaseCrudService<
     } else if (updateSalesOrderDto.shippingAmount !== undefined) {
       // If only shipping is being updated (no items), load items from DB to recalculate total
       const existingItems = await this.salesOrderItemRepository.find({ where: { salesOrderId: id } });
-      const currentSubtotal = existingItems.reduce((sum, item) => sum + Number(item.totalAmount), 0);
+      const currentSubtotal = SalesOrderService.sumItemTotals(existingItems);
       const newShipping = Number(updateSalesOrderDto.shippingAmount);
       updateData.shippingAmount = newShipping;
       updateData.subtotal = currentSubtotal;
@@ -635,6 +635,15 @@ export class SalesOrderService extends BaseCrudService<
         this.logger.error(`Failed to update customer metrics after ${context} (customerId: ${customerId}): ${error.message}`);
       }
     }
+  }
+
+  /**
+   * Sum the post-discount totalAmount across a list of order items.
+   * Used in create, update (items branch), and update (shipping-only branch)
+   * to ensure the same calculation logic is applied everywhere.
+   */
+  private static sumItemTotals(items: Array<{ totalAmount: number }>): number {
+    return items.reduce((sum, item) => sum + Number(item.totalAmount), 0);
   }
 
   private async validateAndProcessItems(items: any[], customer?: Customer) {

--- a/frontend/src/components/sales/RefundDialog.tsx
+++ b/frontend/src/components/sales/RefundDialog.tsx
@@ -22,6 +22,11 @@ import { useGetActivePaymentMethodsQuery } from '@/store/api/paymentMethodsApi'
 import { useGetSalesOrderPaymentsQuery } from '@/store/api/salesApi'
 import { getCurrentDate } from '@/utils/formatters'
 
+const newId = () =>
+  typeof crypto !== 'undefined' && crypto.randomUUID
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2)
+
 interface RefundLine {
   id: string
   paymentMethodId: string
@@ -83,7 +88,7 @@ export default function RefundDialog({
     if (!open || lines.length > 0 || paymentMethods.length === 0 || loadingPayments) return
     const cashMethod = paymentMethods.find((m) => m.code === 'CASH')
     setLines([{
-      id: crypto.randomUUID(),
+      id: newId(),
       paymentMethodId: cashMethod?.id || paymentMethods[0]?.id || '',
       amount: availableForRefund > 0 ? availableForRefund : '',
       paymentDate: getCurrentDate(),
@@ -113,7 +118,7 @@ export default function RefundDialog({
     setLines((prev) => [
       ...prev,
       {
-        id: crypto.randomUUID(),
+        id: newId(),
         paymentMethodId: cashMethod?.id || paymentMethods[0]?.id || '',
         amount: remainingAfterRefund > 0 ? remainingAfterRefund : '',
         paymentDate: getCurrentDate(),


### PR DESCRIPTION
## Summary

- **Fix JE amount mismatch**: Sales order journal entries were posting wrong amounts (e.g. RM40 instead of RM30) because `postSalesOrderEntry` trusted the stale `totalAmount` DB column. Now derives revenue from `sum(item.totalAmount) + shippingAmount` at post time.
- **Fix missing items guard**: Added `BadRequestException` when `salesOrder.items` relation is not loaded before posting a JE — replaces a warn-only guard that was silently bypassed when `shippingAmount > 0`.
- **Fix shipping-only update zeroing subtotal**: `update()` loaded the order without the `items` relation, so shipping-only updates set `totalAmount = shippingAmount` only. Now queries items from DB before recalculating.
- **Fix JE not reversed on unfulfill**: `unfulfillOrder` restored stock but never called `reverseSourceEntries`. The AR/Revenue/COGS/Inventory JE posted at fulfillment was never reversed. Added `reverseSourceEntries('sales_order', id)` after status is set to DRAFT.
- **Fix RefundDialog crash on HTTP**: Same `crypto.randomUUID` crash as PaymentDialog (PR #692). Applied the same `newId()` fallback helper.
- **Refactor**: Extracted `SalesOrderService.sumItemTotals()` to deduplicate three identical `reduce` calls across create, update-items, and update-shipping-only branches.

## Test Plan
- [x] Create a sales order, edit item prices, fulfill — journal entry should reflect edited price (not original)
- [x] Unfulfill a fulfilled sales order — journal entry should be reversed in the accounting ledger
- [x] Open RefundDialog on HTTP (non-secure context) — should no longer crash
- [x] Backend: `npm run test` — 1067 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)