### PR TITLE
fix(sales): block direct URL access to edit page for non-editable orders

### DIFF
--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -47,6 +47,7 @@ import { useGetDocumentNumberSettingsQuery } from '@/store/api/settingsApi'
 import { setSelectedOrder } from '@/store/slices/salesSlice'
 import type { RootState } from '@/store'
 import { formatCurrency, getCurrentDate } from '@/utils/formatters'
+import { getOrderActionMetas } from './utils/orderActions'
 
 interface OrderItem {
   productId: string
@@ -285,6 +286,14 @@ const CreateSalesOrderPage: React.FC = () => {
           if (order.items?.length) {
             seedProducts(order.items.filter((i: any) => i.product).map((i: any) => i.product))
           }
+
+          const editMeta = getOrderActionMetas(order).find((meta) => meta.action === 'edit')
+          if (!editMeta || editMeta.disabled) {
+            showError(editMeta?.tooltip ?? 'Cannot edit this sales order')
+            navigate(`/sales/orders/${orderNumber}`)
+            return
+          }
+
           setOrderToLoad(order)
         })
         .catch((err: any) => {

--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -289,8 +289,9 @@ const CreateSalesOrderPage: React.FC = () => {
 
           const editMeta = getOrderActionMetas(order).find((meta) => meta.action === 'edit')
           if (!editMeta || editMeta.disabled) {
+            setLoadingOrder(false)
             showError(editMeta?.tooltip ?? 'Cannot edit this sales order')
-            navigate(`/sales/orders/${orderNumber}`)
+            navigate(`/sales/orders/${orderNumber}`, { replace: true })
             return
           }
 

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -814,7 +814,7 @@ describe('CreateSalesOrderPage edit guard', { timeout: 60000 }, () => {
     )
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/sales/orders/SO-1')
+      expect(mockNavigate).toHaveBeenCalledWith('/sales/orders/SO-1', { replace: true })
     })
 
     expect(mockShowError).toHaveBeenCalledWith('Cancel payment first to edit')
@@ -840,7 +840,7 @@ describe('CreateSalesOrderPage edit guard', { timeout: 60000 }, () => {
     )
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/sales/orders/SO-1')
+      expect(mockNavigate).toHaveBeenCalledWith('/sales/orders/SO-1', { replace: true })
     })
 
     expect(mockShowError).toHaveBeenCalledWith('Cannot edit this sales order')

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -194,6 +194,8 @@ describe('CreateSalesOrderPage product search', { timeout: 60000 }, () => {
 
     mockFetchSalesOrder.mockReturnValue({
       unwrap: vi.fn().mockResolvedValue({
+        status: 'DRAFT',
+        paymentStatus: 'UNPAID',
         items: [
           {
             productId: 'product-9',
@@ -249,6 +251,8 @@ describe('CreateSalesOrderPage product search', { timeout: 60000 }, () => {
 
     mockFetchSalesOrder.mockReturnValue({
       unwrap: vi.fn().mockResolvedValue({
+        status: 'DRAFT',
+        paymentStatus: 'UNPAID',
         items: [
           {
             productId: 'product-9',
@@ -575,6 +579,8 @@ describe('CreateSalesOrderPage — edit mode', { timeout: 60000 }, () => {
   const existingOrder = {
     id: 'order-id-1',
     orderNumber: 'SO-26-001',
+    status: 'DRAFT',
+    paymentStatus: 'UNPAID',
     customerId: 'customer-1',
     orderDate: '2026-03-15T00:00:00.000Z',
     shippingAmount: 25,
@@ -774,5 +780,69 @@ describe('CreateSalesOrderPage — edit mode', { timeout: 60000 }, () => {
     await waitFor(() => {
       expect(screen.getByText(/discard changes/i)).toBeInTheDocument()
     })
+  })
+})
+
+describe('CreateSalesOrderPage edit guard', { timeout: 60000 }, () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockShowError.mockReset()
+    mockParams.mockReturnValue({ orderNumber: 'SO-1' })
+    mockGetDocumentNumberSettings.mockReturnValue({
+      data: { configurations: [] },
+      isLoading: false,
+    })
+  })
+
+  it('redirects to order detail and shows error when order is paid', async () => {
+    mockFetchSalesOrder.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({
+        id: 'order-123',
+        status: 'DRAFT',
+        paymentStatus: 'PAID',
+        items: [],
+        customerId: 'customer-1',
+        orderDate: '2026-01-01T00:00:00.000Z',
+        shippingAmount: 0,
+      }),
+    })
+
+    render(
+      <BrowserRouter>
+        <CreateSalesOrderPage />
+      </BrowserRouter>,
+    )
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/sales/orders/SO-1')
+    })
+
+    expect(mockShowError).toHaveBeenCalledWith('Cancel payment first to edit')
+  })
+
+  it('redirects to order detail and shows error when order is fulfilled', async () => {
+    mockFetchSalesOrder.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({
+        id: 'order-456',
+        status: 'FULFILLED',
+        paymentStatus: 'PAID',
+        items: [],
+        customerId: 'customer-1',
+        orderDate: '2026-01-01T00:00:00.000Z',
+        shippingAmount: 0,
+      }),
+    })
+
+    render(
+      <BrowserRouter>
+        <CreateSalesOrderPage />
+      </BrowserRouter>,
+    )
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/sales/orders/SO-1')
+    })
+
+    expect(mockShowError).toHaveBeenCalledWith('Cannot edit this sales order')
   })
 })

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -20,6 +20,7 @@ const {
   mockFetchSalesOrder,
   mockParams,
   mockGetDocumentNumberSettings,
+  mockShowError,
 } = vi.hoisted(() => ({
   mockDispatch: vi.fn(),
   mockNavigate: vi.fn(),
@@ -29,6 +30,7 @@ const {
   mockFetchSalesOrder: vi.fn(),
   mockParams: vi.fn(() => ({})),
   mockGetDocumentNumberSettings: vi.fn(),
+  mockShowError: vi.fn(),
 }))
 
 vi.mock('react-router-dom', async () => {
@@ -59,7 +61,7 @@ vi.mock('@/hooks/useRedux', () => ({
 vi.mock('@/hooks/useNotification', () => ({
   useNotification: () => ({
     showSuccess: vi.fn(),
-    showError: vi.fn(),
+    showError: mockShowError,
   }),
 }))
 
@@ -111,6 +113,7 @@ describe('CreateSalesOrderPage product search', { timeout: 60000 }, () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockParams.mockReturnValue({})
+    mockShowError.mockReset()
     customersResponse.data.data = [{ id: 'customer-1', name: 'Test Customer' }]
 
     mockGet.mockImplementation(async (_url: string, config?: { params?: { search?: string } }) => {


### PR DESCRIPTION
## Summary
- Adds a status guard in `CreateSalesOrderPage` that fires after the order is fetched in edit mode
- Redirects to the order detail page (with `replace: true`) and shows an error notification if the order is not editable
- Editability is derived from `getOrderActionMetas()` — the same function that drives the action bar button — so the guard and UI stay in sync automatically

## Test Plan
- [x] Targeted test suite passes: `cd frontend && npx vitest run src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx` (24 tests)
- [x] Navigate to `/sales/orders/:orderNumber/edit` for a PAID order — should redirect to detail page with "Cancel payment first to edit" error
- [x] Navigate to `/sales/orders/:orderNumber/edit` for a FULFILLED order — should redirect to detail page with "Cannot edit this sales order" error
- [x] Navigate to `/sales/orders/:orderNumber/edit` for a DRAFT/UNPAID order — edit page should load normally
- [x] After redirect, pressing Back should NOT re-trigger the guard (history entry is replaced)

Closes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)