### PR TITLE
fix(sales): disable refund action on fulfilled orders

### DIFF
--- a/frontend/src/pages/sales/utils/__tests__/orderActions.test.ts
+++ b/frontend/src/pages/sales/utils/__tests__/orderActions.test.ts
@@ -93,4 +93,17 @@ describe('getOrderActionMetas — disabled flags', () => {
     const cancel = metas.find((m) => m.action === 'cancel')
     expect(cancel?.disabled).toBe(true)
   })
+
+  it('refund is disabled with tooltip when FULFILLED + PAID', () => {
+    const metas = getOrderActionMetas(makeOrder('FULFILLED', 'PAID'))
+    const refund = metas.find((m) => m.action === 'refund')
+    expect(refund?.disabled).toBe(true)
+    expect(refund?.tooltip).toMatch(/unfulfill first/i)
+  })
+
+  it('refund is enabled (not disabled) when DRAFT + PAID', () => {
+    const metas = getOrderActionMetas(makeOrder('DRAFT', 'PAID'))
+    const refund = metas.find((m) => m.action === 'refund')
+    expect(refund?.disabled).toBeFalsy()
+  })
 })

--- a/frontend/src/pages/sales/utils/orderActions.ts
+++ b/frontend/src/pages/sales/utils/orderActions.ts
@@ -50,7 +50,11 @@ export function getOrderActionMetas(order: SalesOrder): OrderActionMeta[] {
   }
 
   if (!isUnpaid) {
-    metas.push({ action: 'refund' })
+    metas.push({
+      action: 'refund',
+      disabled: isFulfilled,
+      tooltip: isFulfilled ? 'Cannot refund a fulfilled order. Please unfulfill first.' : undefined,
+    })
   }
 
   if (isDraft) {


### PR DESCRIPTION
## Summary
- `getOrderActionMetas` now marks the refund action `disabled` when the order status is `FULFILLED`
- Disabled refund shows tooltip: "Cannot refund a fulfilled order. Please unfulfill first."
- Applies to both the row action menu and the detail page action bar (both consume `OrderActionMeta` from the same utility)

## Test Plan
- [x] New test: `refund is disabled with tooltip when FULFILLED + PAID`
- [x] New test: `refund is enabled (not disabled) when DRAFT + PAID` (regression guard)
- [x] Full `orderActions.test.ts` suite: 12/12 passed
- [x] Frontend lint + type-check passed
- [x] Full frontend test suite: 176 files, 1268 tests passed

Closes #696