### PR TITLE
fix(sales): correct edit guard redirect to include /view suffix

### DIFF
--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -291,7 +291,7 @@ const CreateSalesOrderPage: React.FC = () => {
           if (!editMeta || editMeta.disabled) {
             setLoadingOrder(false)
             showError(editMeta?.tooltip ?? 'Cannot edit this sales order')
-            navigate(`/sales/orders/${orderNumber}`, { replace: true })
+            navigate(`/sales/orders/${orderNumber}/view`, { replace: true })
             return
           }
 

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -814,7 +814,7 @@ describe('CreateSalesOrderPage edit guard', { timeout: 60000 }, () => {
     )
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/sales/orders/SO-1', { replace: true })
+      expect(mockNavigate).toHaveBeenCalledWith('/sales/orders/SO-1/view', { replace: true })
     })
 
     expect(mockShowError).toHaveBeenCalledWith('Cancel payment first to edit')
@@ -840,7 +840,7 @@ describe('CreateSalesOrderPage edit guard', { timeout: 60000 }, () => {
     )
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/sales/orders/SO-1', { replace: true })
+      expect(mockNavigate).toHaveBeenCalledWith('/sales/orders/SO-1/view', { replace: true })
     })
 
     expect(mockShowError).toHaveBeenCalledWith('Cannot edit this sales order')


### PR DESCRIPTION
## Summary
- Edit guard in `CreateSalesOrderPage.tsx` redirected to `/sales/orders/:orderNumber` when blocking edit access on paid/fulfilled orders
- That route doesn't exist — the correct detail route is `/sales/orders/:orderNumber/view`
- Added `/view` suffix so the redirect lands on the correct page instead of a 404

## Test plan
- [ ] Navigate directly to `/sales/orders/<paid-order>/edit`
- [ ] Confirm redirect lands on the order detail page (not 404)
- [ ] Confirm error toast "Cannot edit this sales order" is shown

Closes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)