### PR TITLE
feat(sales): status-aware refund for overpaid orders

### DIFF
--- a/backend/src/modules/sales/services/sales-order-payment.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.spec.ts
@@ -202,6 +202,28 @@ describe('SalesOrderPaymentService', () => {
       expect(auditLogService.log).toHaveBeenCalledWith('CREATE', 'SalesOrderPayment', expect.any(String), expect.objectContaining({ newValues: expect.objectContaining({ amount: -400 }) }));
     });
 
+    it('records the resulting payment status in the refund audit log', async () => {
+      const order = mockOrder({ paymentStatus: SalesOrderPaymentStatus.OVERPAID, totalAmount: 1000 });
+      orderRepo.findOne.mockResolvedValue(order);
+      methodRepo.findOne.mockResolvedValue(mockMethod());
+      paymentRepo.find.mockResolvedValue([{ amount: 1200 }] as SalesOrderPayment[]);
+
+      // After refunding 200, the manager-side find returns net 1000 -> status PAID
+      const mockManager = buildMockManager([{ amount: 1200 }, { amount: -200 }] as SalesOrderPayment[]);
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: (m: EntityManager) => Promise<any>) => cb(mockManager));
+
+      await service.recordRefund('order-1', { paymentMethodId: 'method-1', amount: 200, paymentDate: '2026-01-01' });
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        'CREATE',
+        'SalesOrderPayment',
+        expect.any(String),
+        expect.objectContaining({
+          newValues: expect.objectContaining({ amount: -200, resultingPaymentStatus: SalesOrderPaymentStatus.PAID }),
+        }),
+      );
+    });
+
     it('allows refund on FULFILLED orders', async () => {
       const order = mockOrder({ status: SalesOrderStatus.FULFILLED, paymentStatus: SalesOrderPaymentStatus.PAID });
       orderRepo.findOne.mockResolvedValue(order);

--- a/backend/src/modules/sales/services/sales-order-payment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.ts
@@ -101,7 +101,7 @@ export class SalesOrderPaymentService {
       throw new BadRequestException(`Refund amount (${dto.amount}) exceeds net paid (${netPaid.toFixed(4)})`);
     }
 
-    const saved = await this.dataSource.transaction(async (manager: EntityManager) => {
+    const { saved, resultingStatus } = await this.dataSource.transaction(async (manager: EntityManager) => {
       const record = manager.getRepository(SalesOrderPayment).create({
         salesOrderId: orderId,
         paymentMethodId: dto.paymentMethodId,
@@ -111,15 +111,15 @@ export class SalesOrderPaymentService {
         notes: dto.notes,
       });
       const savedRecord = await manager.getRepository(SalesOrderPayment).save(record);
-      await this.updatePaymentStatusInTx(order, manager);
-      return savedRecord;
+      const resultingStatus = await this.updatePaymentStatusInTx(order, manager);
+      return { saved: savedRecord, resultingStatus };
     });
 
-    await this.auditLogService.log('CREATE', 'SalesOrderPayment', `Recorded refund for ${order.orderNumber}`, {
+    await this.auditLogService.log('CREATE', 'SalesOrderPayment', `Recorded refund for ${order.orderNumber} (status: ${resultingStatus})`, {
       entityId: saved.id,
       userId: userId || 'system',
       username,
-      newValues: { amount: -dto.amount, paymentMethodId: dto.paymentMethodId },
+      newValues: { amount: -dto.amount, paymentMethodId: dto.paymentMethodId, resultingPaymentStatus: resultingStatus },
     });
 
     return saved;
@@ -201,7 +201,7 @@ export class SalesOrderPaymentService {
       throw new BadRequestException(`Total refund amount (${totalRefundAmount}) exceeds net paid (${netPaid.toFixed(4)})`);
     }
 
-    const results = await this.dataSource.transaction(async (manager: EntityManager) => {
+    const { results, resultingStatus } = await this.dataSource.transaction(async (manager: EntityManager) => {
       const saved: SalesOrderPayment[] = [];
       for (const dto of dtos) {
         const record = manager.getRepository(SalesOrderPayment).create({
@@ -214,16 +214,16 @@ export class SalesOrderPaymentService {
         });
         saved.push(await manager.getRepository(SalesOrderPayment).save(record));
       }
-      await this.updatePaymentStatusInTx(order, manager);
-      return saved;
+      const resultingStatus = await this.updatePaymentStatusInTx(order, manager);
+      return { results: saved, resultingStatus };
     });
 
     for (const saved of results) {
-      await this.auditLogService.log('CREATE', 'SalesOrderPayment', `Recorded refund for ${order.orderNumber}`, {
+      await this.auditLogService.log('CREATE', 'SalesOrderPayment', `Recorded refund for ${order.orderNumber} (status: ${resultingStatus})`, {
         entityId: saved.id,
         userId: userId || 'system',
         username,
-        newValues: { amount: saved.amount, paymentMethodId: saved.paymentMethodId },
+        newValues: { amount: saved.amount, paymentMethodId: saved.paymentMethodId, resultingPaymentStatus: resultingStatus },
       });
     }
 
@@ -241,9 +241,10 @@ export class SalesOrderPaymentService {
     });
   }
 
-  private async updatePaymentStatusInTx(order: SalesOrder, manager: EntityManager): Promise<void> {
+  private async updatePaymentStatusInTx(order: SalesOrder, manager: EntityManager): Promise<SalesOrderPaymentStatus> {
     const all = await manager.getRepository(SalesOrderPayment).find({ where: { salesOrderId: order.id } });
     const newStatus = this.computePaymentStatus(all, order.totalAmount);
     await manager.getRepository(SalesOrder).update(order.id, { paymentStatus: newStatus });
+    return newStatus;
   }
 }

--- a/frontend/src/components/sales/RefundDialog.tsx
+++ b/frontend/src/components/sales/RefundDialog.tsx
@@ -217,7 +217,13 @@ export default function RefundDialog({
         ) : (
           <>
             {/* Refund Summary */}
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2, mt: 1 }}>
+            {hasSurplus && (
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1, mt: 1 }}>
+                <Typography variant="body2" sx={{ fontWeight: 'bold' }}>Surplus over total</Typography>
+                <Typography variant="body2" sx={{ fontWeight: 'bold' }}>{formatCurrency(surplus)}</Typography>
+              </Box>
+            )}
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2, mt: hasSurplus ? 0 : 1 }}>
               <Typography variant="body2" sx={{ fontWeight: 'bold' }}>Available for Refund</Typography>
               <Typography variant="body2" sx={{ fontWeight: 'bold' }}>{formatCurrency(availableForRefund)}</Typography>
             </Box>

--- a/frontend/src/components/sales/RefundDialog.tsx
+++ b/frontend/src/components/sales/RefundDialog.tsx
@@ -41,6 +41,7 @@ interface RefundDialogProps {
   onSubmit: (refunds: { paymentMethodId: string; amount: number; paymentDate: string; reference?: string }[]) => Promise<void>
   orderId: string
   orderNumber: string
+  totalAmount: number
 }
 
 const formatCurrency = (amount: number) =>
@@ -52,6 +53,7 @@ export default function RefundDialog({
   onSubmit,
   orderId,
   orderNumber,
+  totalAmount,
 }: RefundDialogProps) {
   const { data: paymentMethods = [] } = useGetActivePaymentMethodsQuery(undefined, { skip: !open })
   const { data: paymentRecords = [], isLoading: loadingPayments } = useGetSalesOrderPaymentsQuery(
@@ -68,6 +70,9 @@ export default function RefundDialog({
     .reduce((sum, r) => sum + Math.abs(Number(r.amount)), 0)
 
   const availableForRefund = Math.max(0, totalPaid - alreadyRefunded)
+  const netPaid = totalPaid - alreadyRefunded
+  const surplus = Math.max(0, netPaid - Number(totalAmount))
+  const hasSurplus = surplus > 0
 
   const [lines, setLines] = useState<RefundLine[]>([])
   const [submitting, setSubmitting] = useState(false)
@@ -93,6 +98,7 @@ export default function RefundDialog({
     }, {})
     const netPositiveMethods = Object.entries(netByMethod).filter(([, net]) => net > 0)
     if (netPositiveMethods.length > 0) {
+      const refundTarget = hasSurplus ? surplus : availableForRefund
       const netTotal = netPositiveMethods.reduce((sum, [, net]) => sum + net, 0)
       setLines(netPositiveMethods.map(([methodId, net]) => {
         const resolvedMethodId = paymentMethods.find((m) => m.id === methodId)?.id
@@ -100,7 +106,7 @@ export default function RefundDialog({
           ?? paymentMethods[0]?.id
           ?? ''
         const scaledAmount = netTotal > 0
-          ? Math.round((net / netTotal) * availableForRefund * 100) / 100
+          ? Math.round((net / netTotal) * refundTarget * 100) / 100
           : 0
         return {
           id: newId(),
@@ -113,15 +119,16 @@ export default function RefundDialog({
     } else {
       if (paymentMethods.length === 0) return
       const cashMethod = paymentMethods.find((m) => m.code === 'CASH')
+      const refundTarget = hasSurplus ? surplus : availableForRefund
       setLines([{
         id: newId(),
         paymentMethodId: cashMethod?.id || paymentMethods[0]?.id || '',
-        amount: availableForRefund > 0 ? availableForRefund : '',
+        amount: refundTarget > 0 ? refundTarget : '',
         paymentDate: getCurrentDate(),
         reference: '',
       }])
     }
-  }, [open, paymentMethods, lines.length, availableForRefund, loadingPayments, paymentRecords])
+  }, [open, paymentMethods, lines.length, availableForRefund, surplus, hasSurplus, loadingPayments, paymentRecords])
 
   const totalEntered = lines.reduce(
     (sum, l) => sum + (typeof l.amount === 'number' ? l.amount : parseFloat(l.amount as string) || 0),

--- a/frontend/src/components/sales/RefundDialog.tsx
+++ b/frontend/src/components/sales/RefundDialog.tsx
@@ -136,6 +136,7 @@ export default function RefundDialog({
   )
   const remainingAfterRefund = availableForRefund - totalEntered
   const exceedsAvailable = totalEntered > availableForRefund
+  const exceedsSurplus = hasSurplus && totalEntered > surplus && !exceedsAvailable
 
   const updateLine = useCallback((index: number, field: keyof RefundLine, value: string | number) => {
     setUserHasEdited(true)
@@ -325,6 +326,12 @@ export default function RefundDialog({
             {exceedsAvailable && (
               <Alert severity="error" sx={{ mt: 2 }}>
                 Total refund exceeds available for refund by {formatCurrency(Math.abs(remainingAfterRefund))}.
+              </Alert>
+            )}
+
+            {exceedsSurplus && (
+              <Alert severity="warning" sx={{ mt: 2 }}>
+                Refunding more than the surplus ({formatCurrency(surplus)}) will drop this order below Paid.
               </Alert>
             )}
 

--- a/frontend/src/components/sales/__tests__/RefundDialog.test.tsx
+++ b/frontend/src/components/sales/__tests__/RefundDialog.test.tsx
@@ -87,6 +87,20 @@ describe('RefundDialog', () => {
     expect(amountInput.value).toBe('200')
   })
 
+  it('shows a Surplus over total row when the order is overpaid', () => {
+    // Net paid 500, total 300 -> surplus 200
+    mockUseGetSalesOrderPaymentsQuery.mockReturnValue({ data: makePayments(500, 0), isLoading: false })
+    renderDialog({ totalAmount: 300 })
+    expect(screen.getByText('Surplus over total')).toBeInTheDocument()
+  })
+
+  it('hides the Surplus over total row when the order is exactly paid', () => {
+    // Net paid 500, total 500 -> surplus 0
+    mockUseGetSalesOrderPaymentsQuery.mockReturnValue({ data: makePayments(500, 0), isLoading: false })
+    renderDialog({ totalAmount: 500 })
+    expect(screen.queryByText('Surplus over total')).not.toBeInTheDocument()
+  })
+
   it('populates payment method dropdown from API', () => {
     renderDialog()
     expect(screen.getByText('Cash')).toBeInTheDocument()

--- a/frontend/src/components/sales/__tests__/RefundDialog.test.tsx
+++ b/frontend/src/components/sales/__tests__/RefundDialog.test.tsx
@@ -40,6 +40,7 @@ function renderDialog(props: Partial<ComponentProps<typeof RefundDialog>> = {}) 
     onSubmit: vi.fn().mockResolvedValue(undefined),
     orderId: 'order-1',
     orderNumber: 'SO-26-001',
+    totalAmount: 500,
   }
   return render(<RefundDialog {...defaults} {...props} />)
 }
@@ -76,6 +77,14 @@ describe('RefundDialog', () => {
     renderDialog()
     const amountInput = screen.getByPlaceholderText('Amount') as HTMLInputElement
     expect(amountInput.value).toBe('500')
+  })
+
+  it('defaults refund amount to the surplus on an overpaid order', () => {
+    // Net paid 500, order total 300 -> surplus 200
+    mockUseGetSalesOrderPaymentsQuery.mockReturnValue({ data: makePayments(500, 0), isLoading: false })
+    renderDialog({ totalAmount: 300 })
+    const amountInput = screen.getByPlaceholderText('Amount') as HTMLInputElement
+    expect(amountInput.value).toBe('200')
   })
 
   it('populates payment method dropdown from API', () => {

--- a/frontend/src/components/sales/__tests__/RefundDialog.test.tsx
+++ b/frontend/src/components/sales/__tests__/RefundDialog.test.tsx
@@ -101,6 +101,26 @@ describe('RefundDialog', () => {
     expect(screen.queryByText('Surplus over total')).not.toBeInTheDocument()
   })
 
+  it('warns but keeps submit enabled when refund exceeds surplus but is within available', async () => {
+    // Net paid 500, total 300 -> surplus 200, available 500
+    mockUseGetSalesOrderPaymentsQuery.mockReturnValue({ data: makePayments(500, 0), isLoading: false })
+    renderDialog({ totalAmount: 300 })
+    const amountInput = screen.getByPlaceholderText('Amount')
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '350')
+    expect(screen.getByText(/below Paid/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^refund$/i })).not.toBeDisabled()
+  })
+
+  it('does not show the surplus warning when refund is within the surplus', async () => {
+    mockUseGetSalesOrderPaymentsQuery.mockReturnValue({ data: makePayments(500, 0), isLoading: false })
+    renderDialog({ totalAmount: 300 })
+    const amountInput = screen.getByPlaceholderText('Amount')
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '150')
+    expect(screen.queryByText(/below Paid/i)).not.toBeInTheDocument()
+  })
+
   it('populates payment method dropdown from API', () => {
     renderDialog()
     expect(screen.getByText('Cash')).toBeInTheDocument()

--- a/frontend/src/pages/sales/SalesOrderDetailPage.tsx
+++ b/frontend/src/pages/sales/SalesOrderDetailPage.tsx
@@ -299,6 +299,7 @@ export default function SalesOrderDetailPage() {
           onSubmit={handleSubmitRefund}
           orderId={order.id}
           orderNumber={order.orderNumber}
+          totalAmount={order.totalAmount}
         />
       )}
 

--- a/frontend/src/pages/sales/components/SalesOrdersDialogs.tsx
+++ b/frontend/src/pages/sales/components/SalesOrdersDialogs.tsx
@@ -50,6 +50,7 @@ export default function SalesOrdersDialogs({
           onSubmit={onSubmitRefund}
           orderId={refundOrder.id}
           orderNumber={refundOrder.orderNumber}
+          totalAmount={refundOrder.totalAmount}
         />
       )}
     </>


### PR DESCRIPTION
## Summary

Makes the refund flow distinguish **OVERPAID** orders from fully **PAID** ones. On an overpaid order, the refund dialog now defaults to refunding just the *surplus* (`netPaid − total`) — which returns the order to PAID — instead of defaulting to the full available amount. The operator can still refund up to the full available amount; doing so now shows a non-blocking warning.

## Changes

**Frontend (`RefundDialog`)**
- New `totalAmount` prop; derives `surplus = max(0, netPaid − totalAmount)`. All new behavior keys off the locally-computed `surplus`, not a `paymentStatus` prop (which could be stale).
- Default refund amount = surplus when one exists (single- and multi-payment-method orders), else full available (unchanged for PAID orders).
- New **"Surplus over total"** summary row, shown only when a surplus exists.
- Non-blocking **warning** when the entered total exceeds the surplus but is still within available ("…will drop this order below Paid"). The hard cap at available is unchanged and still blocks submit.
- Both call sites (`SalesOrderDetailPage`, `SalesOrdersDialogs`) pass `totalAmount`.

**Backend (`SalesOrderPaymentService`)**
- `updatePaymentStatusInTx` now returns the computed status.
- `recordRefund` / `recordRefunds` record the resulting `paymentStatus` in the refund audit log (message + `newValues.resultingPaymentStatus`). No DTO change, no migration; the existing `refund ≤ netPaid` cap is unchanged.

## Testing

- Frontend: 31 tests pass (`RefundDialog.test.tsx`), incl. new surplus default / surplus row / warning cases; `npm run type-check` clean.
- Backend: 26 tests pass (`sales-order-payment.service.spec.ts`), incl. resulting-status audit assertion; net-paid cap regression guard intact.
- Manual verification on rebuilt branch containers: order `SO-26-024` (netPaid 50, total 40 → surplus 10) — dialog defaulted to 10.00, showed Surplus 10.00 / Available 50.00, warned at 50 with submit enabled, and refunding 10 flipped the order OVERPAID → Paid.

Spec: `docs/superpowers/specs/2026-05-29-status-aware-refund-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)