### PR TITLE
fix(sales): show real paid amount & balance due on order detail

### DIFF
--- a/backend/src/database/entities/sales-order.entity.ts
+++ b/backend/src/database/entities/sales-order.entity.ts
@@ -86,6 +86,14 @@ export class SalesOrder extends BaseEntity {
   @Min(0)
   totalAmount: number;
 
+  @Column({ type: 'decimal', precision: 15, scale: 4, default: 0 })
+  @Min(0)
+  paidAmount: number;
+
+  // = totalAmount - paidAmount; negative value means the order is overpaid (surplus). No @Min(0).
+  @Column({ type: 'decimal', precision: 15, scale: 4, default: 0 })
+  balanceDue: number;
+
   @Column({ type: 'text', nullable: true })
   @IsOptional()
   @IsString()
@@ -129,29 +137,12 @@ export class SalesOrder extends BaseEntity {
     return this.status === SalesOrderStatus.FULFILLED ? this.updatedAt : undefined;
   }
 
-  /** @deprecated Approximation only — does not reflect actual SalesOrderPayment records. Use paymentStatus enum instead. */
-  get paidAmount(): number {
-    if (this.paymentStatus === SalesOrderPaymentStatus.UNPAID) return 0;
-    if (
-      this.paymentStatus === SalesOrderPaymentStatus.PAID ||
-      this.paymentStatus === SalesOrderPaymentStatus.OVERPAID
-    ) {
-      return Number(this.totalAmount);
-    }
-    return 0.01;
-  }
-
   /** @deprecated Use `paymentStatus === PAID || paymentStatus === OVERPAID` instead. */
   get isPaidInFull(): boolean {
     return (
       this.paymentStatus === SalesOrderPaymentStatus.PAID ||
       this.paymentStatus === SalesOrderPaymentStatus.OVERPAID
     );
-  }
-
-  /** @deprecated Approximation only — returns 0 or totalAmount, not the real partial balance. */
-  get balanceDue(): number {
-    return this.isPaidInFull ? 0 : Number(this.totalAmount);
   }
 
   /** @deprecated Use status and paymentStatus enums directly. */

--- a/backend/src/database/migrations/1780053327024-AddPaidBalanceToSalesOrder.ts
+++ b/backend/src/database/migrations/1780053327024-AddPaidBalanceToSalesOrder.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPaidBalanceToSalesOrder1780053327024 implements MigrationInterface {
+  name = 'AddPaidBalanceToSalesOrder1780053327024';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "sales_orders"
+      ADD COLUMN IF NOT EXISTS "paidAmount" decimal(15,4) NOT NULL DEFAULT 0
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "sales_orders"
+      ADD COLUMN IF NOT EXISTS "balanceDue" decimal(15,4) NOT NULL DEFAULT 0
+    `);
+
+    await queryRunner.query(`
+      UPDATE "sales_orders" o SET
+        "paidAmount" = COALESCE(
+          (SELECT SUM(p."amount") FROM "sales_order_payments" p WHERE p."salesOrderId" = o."id"), 0),
+        "balanceDue" = o."totalAmount" - COALESCE(
+          (SELECT SUM(p."amount") FROM "sales_order_payments" p WHERE p."salesOrderId" = o."id"), 0)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "sales_orders" DROP COLUMN IF EXISTS "balanceDue"`);
+    await queryRunner.query(`ALTER TABLE "sales_orders" DROP COLUMN IF EXISTS "paidAmount"`);
+  }
+}

--- a/backend/src/modules/sales/dto/sales-order.dto.ts
+++ b/backend/src/modules/sales/dto/sales-order.dto.ts
@@ -238,6 +238,12 @@ export class SalesOrderResponseDto {
   @ApiProperty({ example: 991.50 })
   totalAmount: number;
 
+  @ApiProperty({ example: 400.0 })
+  paidAmount: number;
+
+  @ApiProperty({ example: 591.5, description: 'totalAmount - paidAmount; negative means overpaid (surplus)' })
+  balanceDue: number;
+
   @ApiProperty({ example: 'Fragile items, handle with care', nullable: true })
   notes?: string;
 

--- a/backend/src/modules/sales/services/sales-order-payment.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.spec.ts
@@ -158,6 +158,66 @@ describe('SalesOrderPaymentService', () => {
 
       expect(auditLogService.log).toHaveBeenCalledWith('CREATE', 'SalesOrderPayment', expect.any(String), expect.objectContaining({ userId: 'user-abc', username: 'alice' }));
     });
+
+    it('persists paidAmount and balanceDue (partial payment)', async () => {
+      const order = mockOrder({ totalAmount: 1000 });
+      orderRepo.findOne.mockResolvedValue(order);
+      methodRepo.findOne.mockResolvedValue(mockMethod());
+
+      const updateSpy = jest.fn().mockResolvedValue(undefined);
+      const manager = {
+        getRepository: jest.fn().mockImplementation((entity) => {
+          if (entity === SalesOrderPayment) {
+            return {
+              create: jest.fn().mockImplementation((d) => d),
+              save: jest.fn().mockImplementation((d) => Promise.resolve({ id: 'p1', ...d })),
+              find: jest.fn().mockResolvedValue([{ amount: 400 }] as SalesOrderPayment[]),
+            };
+          }
+          if (entity === SalesOrder) return { update: updateSpy };
+          return {};
+        }),
+      } as any;
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
+
+      await service.recordPayment('order-1', { paymentMethodId: 'method-1', amount: 400, paymentDate: '2026-01-01' });
+
+      expect(updateSpy).toHaveBeenCalledWith('order-1', expect.objectContaining({
+        paymentStatus: SalesOrderPaymentStatus.PARTIAL,
+        paidAmount: 400,
+        balanceDue: 600,
+      }));
+    });
+
+    it('persists negative balanceDue when overpaid', async () => {
+      const order = mockOrder({ totalAmount: 1000 });
+      orderRepo.findOne.mockResolvedValue(order);
+      methodRepo.findOne.mockResolvedValue(mockMethod());
+
+      const updateSpy = jest.fn().mockResolvedValue(undefined);
+      const manager = {
+        getRepository: jest.fn().mockImplementation((entity) => {
+          if (entity === SalesOrderPayment) {
+            return {
+              create: jest.fn().mockImplementation((d) => d),
+              save: jest.fn().mockImplementation((d) => Promise.resolve({ id: 'p1', ...d })),
+              find: jest.fn().mockResolvedValue([{ amount: 1200 }] as SalesOrderPayment[]),
+            };
+          }
+          if (entity === SalesOrder) return { update: updateSpy };
+          return {};
+        }),
+      } as any;
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
+
+      await service.recordPayment('order-1', { paymentMethodId: 'method-1', amount: 1200, paymentDate: '2026-01-01' });
+
+      expect(updateSpy).toHaveBeenCalledWith('order-1', expect.objectContaining({
+        paymentStatus: SalesOrderPaymentStatus.OVERPAID,
+        paidAmount: 1200,
+        balanceDue: -200,
+      }));
+    });
   });
 
   describe('recordRefund', () => {

--- a/backend/src/modules/sales/services/sales-order-payment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.ts
@@ -243,8 +243,13 @@ export class SalesOrderPaymentService {
 
   private async updatePaymentStatusInTx(order: SalesOrder, manager: EntityManager): Promise<SalesOrderPaymentStatus> {
     const all = await manager.getRepository(SalesOrderPayment).find({ where: { salesOrderId: order.id } });
+    const netPaid = all.reduce((sum, r) => sum + Number(r.amount), 0);
     const newStatus = this.computePaymentStatus(all, order.totalAmount);
-    await manager.getRepository(SalesOrder).update(order.id, { paymentStatus: newStatus });
+    await manager.getRepository(SalesOrder).update(order.id, {
+      paymentStatus: newStatus,
+      paidAmount: netPaid,
+      balanceDue: Number(order.totalAmount) - netPaid,
+    });
     return newStatus;
   }
 }

--- a/backend/src/modules/sales/services/sales-order.mapper.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.mapper.spec.ts
@@ -46,4 +46,52 @@ describe('mapSalesOrderToResponseDto', () => {
       ],
     });
   });
+
+  it('emits paidAmount and balanceDue from the entity', () => {
+    const order = {
+      id: 'o1',
+      orderNumber: 'SO-1',
+      orderDate: new Date('2026-01-01'),
+      status: SalesOrderStatus.DRAFT,
+      paymentStatus: SalesOrderPaymentStatus.PARTIAL,
+      subtotal: 1000,
+      shippingAmount: 0,
+      totalAmount: 1000,
+      paidAmount: 400,
+      balanceDue: 600,
+      customerId: 'c1',
+      items: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const dto = mapSalesOrderToResponseDto(order as any);
+
+    expect(dto.paidAmount).toBe(400);
+    expect(dto.balanceDue).toBe(600);
+  });
+
+  it('emits negative balanceDue for an overpaid order', () => {
+    const order = {
+      id: 'o1',
+      orderNumber: 'SO-1',
+      orderDate: new Date('2026-01-01'),
+      status: SalesOrderStatus.DRAFT,
+      paymentStatus: SalesOrderPaymentStatus.OVERPAID,
+      subtotal: 1000,
+      shippingAmount: 0,
+      totalAmount: 1000,
+      paidAmount: 1200,
+      balanceDue: -200,
+      customerId: 'c1',
+      items: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const dto = mapSalesOrderToResponseDto(order as any);
+
+    expect(dto.paidAmount).toBe(1200);
+    expect(dto.balanceDue).toBe(-200);
+  });
 });

--- a/backend/src/modules/sales/services/sales-order.mapper.ts
+++ b/backend/src/modules/sales/services/sales-order.mapper.ts
@@ -17,6 +17,8 @@ export function mapSalesOrderToResponseDto(
     subtotal: Number(order.subtotal || 0),
     shippingAmount: Number(order.shippingAmount || 0),
     totalAmount: Number(order.totalAmount),
+    paidAmount: Number(order.paidAmount || 0),
+    balanceDue: Number(order.balanceDue ?? (Number(order.totalAmount) - Number(order.paidAmount || 0))),
     notes: order.notes,
     customerId: order.customerId,
     customer: order.customer

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -159,5 +159,30 @@ describe('SalesOrderService', () => {
         }),
       );
     });
+
+    it('recomputes balanceDue when an edit changes the total (existing payment preserved)', async () => {
+      const existing = {
+        id: 'order-1',
+        orderNumber: 'SO-1',
+        customerId: 'customer-1',
+        status: SalesOrderStatus.DRAFT,
+        paidAmount: 400,
+        totalAmount: 1000,
+        shippingAmount: 0,
+      } as any;
+
+      salesOrderRepository.findOne = jest.fn().mockResolvedValue(existing);
+      salesOrderItemRepository.find = jest.fn().mockResolvedValue([{ totalAmount: 1100 }] as any);
+      salesOrderRepository.update = jest.fn().mockResolvedValue({ affected: 1 });
+      salesOrderQueryService.findById.mockResolvedValue({ ...existing, totalAmount: 1100, balanceDue: 700 } as any);
+      salesOrderLifecycleService.assertEditAllowed.mockResolvedValue(undefined);
+
+      await service.update('order-1', { shippingAmount: 0 } as any);
+
+      expect(salesOrderRepository.update).toHaveBeenCalledWith('order-1', expect.objectContaining({
+        totalAmount: 1100,
+        balanceDue: 700,
+      }));
+    });
   });
 });

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -549,6 +549,11 @@ export class SalesOrderService extends BaseCrudService<
       updateData.totalAmount = currentSubtotal + newShipping;
     }
 
+    // Whenever the total changes, keep balanceDue consistent with the unchanged paidAmount.
+    if (updateData.totalAmount !== undefined) {
+      updateData.balanceDue = Number(updateData.totalAmount) - Number(order.paidAmount || 0);
+    }
+
     // Perform all updates in a single database call
     if (Object.keys(updateData).length > 0) {
       await this.salesOrderRepository.update(id, updateData);

--- a/frontend/src/pages/sales/components/OrderOverviewTab.tsx
+++ b/frontend/src/pages/sales/components/OrderOverviewTab.tsx
@@ -62,6 +62,9 @@ export default function OrderOverviewTab({ order }: OrderOverviewTabProps) {
   const shippingAmount = order.shippingAmount ?? 0
   const paidAmount = order.paidAmount ?? 0
   const balance = order.balanceDue ?? order.totalAmount - paidAmount
+  const isSurplus = balance < 0
+  const balanceLabel = isSurplus ? 'Surplus' : 'Balance Due'
+  const balanceValue = formatCurrency(isSurplus ? -balance : balance)
 
   return (
     <Box>
@@ -107,7 +110,7 @@ export default function OrderOverviewTab({ order }: OrderOverviewTabProps) {
               <Field label="Total Amount" value={formatCurrency(order.totalAmount)} />
               <Field label="Shipping Fee" value={formatCurrency(shippingAmount)} />
               <Field label="Paid Amount" value={formatCurrency(paidAmount)} />
-              <Field label="Balance Due" value={formatCurrency(balance)} />
+              <Field label={balanceLabel} value={balanceValue} />
             </CardContent>
           </Card>
         </Grid>
@@ -145,7 +148,7 @@ export default function OrderOverviewTab({ order }: OrderOverviewTabProps) {
             { label: 'Shipping', value: formatCurrency(shippingAmount) },
             { label: 'Total', value: formatCurrency(order.totalAmount), bold: true },
             { label: 'Paid', value: formatCurrency(paidAmount) },
-            { label: 'Balance', value: formatCurrency(balance), bold: true },
+            { label: isSurplus ? 'Surplus' : 'Balance', value: balanceValue, bold: true },
           ].map(({ label, value, bold }) => (
             <Box key={label} sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
               <Typography variant="body2" sx={{ fontWeight: bold ? 600 : 400 }}>

--- a/frontend/src/pages/sales/components/__tests__/OrderOverviewTab.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/OrderOverviewTab.test.tsx
@@ -127,4 +127,29 @@ describe('OrderOverviewTab', () => {
     expect(screen.getByText('Paid')).toBeInTheDocument()
     expect(screen.getByText('Balance')).toBeInTheDocument()
   })
+
+  it('shows the real partial balance due', () => {
+    renderTab(makeOrder({
+      paymentStatus: 'PARTIAL',
+      totalAmount: 1000,
+      paidAmount: 400,
+      balanceDue: 600,
+    }))
+
+    expect(screen.getAllByText('Balance Due').length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/600/).length).toBeGreaterThan(0)
+  })
+
+  it('shows Surplus for an overpaid order', () => {
+    renderTab(makeOrder({
+      paymentStatus: 'OVERPAID',
+      totalAmount: 1000,
+      paidAmount: 1200,
+      balanceDue: -200,
+    }))
+
+    expect(screen.getAllByText('Surplus').length).toBeGreaterThan(0)
+    expect(screen.queryByText(/-.*200/)).toBeNull()
+    expect(screen.getAllByText(/200/).length).toBeGreaterThan(0)
+  })
 })


### PR DESCRIPTION
## Summary
- Order detail showed **Paid = 0 / Balance = full total** for every order regardless of payments — the response mapper never emitted `paidAmount`/`balanceDue`, so the frontend always fell back to defaults.
- Adds real persisted `sales_orders.paidAmount` and `sales_orders.balanceDue` columns, kept in sync from actual `SalesOrderPayment` records at the single payment write chokepoint (`updatePaymentStatusInTx`), and recomputed when an edit changes the total.
- Exposes both fields through `SalesOrderResponseDto` + the mapper (so list rows benefit too).
- Replaces the deprecated, status-derived `paidAmount`/`balanceDue` entity getters (partial used to return a hardcoded `0.01`).
- Overpaid orders store a negative `balanceDue`; the order detail relabels it as a positive **Surplus**.
- Migration `1780053327024-AddPaidBalanceToSalesOrder` adds the columns and backfills from `sales_order_payments`.

## Test Plan
- [x] `backend`: `npx jest src/modules/sales --no-coverage` — 15 suites / 156 tests pass
- [x] `backend`: `npx tsc --noEmit -p tsconfig.build.json`, `npm run lint`
- [x] `backend`: `npm run migration:run` + verified columns/backfill via psql
- [x] `frontend`: `npx vitest run src/pages/sales/components/__tests__/OrderOverviewTab.test.tsx` — 11 tests pass
- [x] `frontend`: `npm run type-check`, `npm run lint`
- [x] Manual: record partial payment → correct Paid/Balance; record overpayment → shows "Surplus"

🤖 Generated with [Claude Code](https://claude.com/claude-code)