### PR TITLE
fix: clock-skew-resistant account lockout (#710)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,8 @@ Reports are embedded in their business modules (Inventory, Sales, Purchasing) �
 
 **API response structure**: `ApiService` strips the Axios wrapper and returns the backend body directly. For paginated list endpoints the body is `{ data: T[], meta: {...} }` — access items as `response.data` and pagination as `response.meta`. For tree/hierarchy endpoints (categories, chart of accounts) the body is a plain array — access as `response` directly (no `.data`). Getting this wrong causes empty lists with no errors.
 
+**Account lockout clock:** Lockout expiry (`User.isLocked`, the login check in `auth.service.ts`, and the `isLocked` filter/count in `users.service.ts`) is evaluated against the **Node container clock** (`new Date()`), never SQL `NOW()`. This keeps login and the user list using one clock so a skewed Postgres container clock can't disagree (issue #710). Docker container clocks can drift after host sleep/resume or container start; if a lockout seems wrong, run `docker compose restart backend` (or resync the host clock). Do not change these comparisons to SQL `NOW()`.
+
 **Frontend Docker**: Changes to frontend source require a rebuild — `docker compose build frontend && docker compose up -d frontend`. The Vite dev server (`npm run dev`) is for local-only development.
 
 **Path aliases**: Frontend uses `@/` as alias for `src/`. Backend uses `@/*` → `src/*` and `@modules/*` → `src/modules/*`.

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -63,6 +63,23 @@ export class AuthService {
       throw new UnauthorizedException('Invalid credentials');
     }
 
+    // Self-heal: if the lock has expired by the app clock, clear it before the
+    // lock check. Guards against a stale lockedUntil lingering when a user can
+    // never reach the success path that normally resets it. See issue #710.
+    if (user.lockedUntil && user.lockedUntil <= new Date()) {
+      user.failedLoginAttempts = 0;
+      user.lockedUntil = null;
+      try {
+        await this.userRepository.save(user);
+      } catch (err) {
+        // A failed cleanup must not block login; the in-memory isLocked check
+        // below still governs the decision. Retry happens on the next attempt.
+        this.logger.warn(
+          `Failed to persist lock self-heal for ${user.username}: ${err}`,
+        );
+      }
+    }
+
     // Check if account is locked
     if (user.isLocked) {
       throw new ForbiddenException(

--- a/backend/src/modules/users/users.service.spec.ts
+++ b/backend/src/modules/users/users.service.spec.ts
@@ -61,6 +61,24 @@ describe('UsersService', () => {
       expect(partial).toEqual({ lockedUntil: null, failedLoginAttempts: 0 });
     });
 
+    it('skips the cleanup update when explicitly filtering isLocked === true', async () => {
+      const qb = createQueryBuilderMock();
+      jest.spyOn(service as any, 'createQueryBuilder').mockReturnValue(qb);
+      const updateSpy = jest
+        .spyOn(userRepository, 'update')
+        .mockResolvedValue({ affected: 0 } as any);
+
+      await service.findAll({
+        page: 1,
+        limit: 10,
+        sortBy: 'username',
+        sortOrder: 'ASC',
+        isLocked: true,
+      } as any);
+
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
     it('does not fail findAll when the cleanup update throws', async () => {
       const qb = createQueryBuilderMock();
       jest.spyOn(service as any, 'createQueryBuilder').mockReturnValue(qb);

--- a/backend/src/modules/users/users.service.spec.ts
+++ b/backend/src/modules/users/users.service.spec.ts
@@ -1,0 +1,79 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../../database/entities/user.entity';
+import { UsersService } from './users.service';
+
+describe('UsersService', () => {
+  let service: UsersService;
+  let userRepository: Repository<User>;
+
+  const mockUserRepository = {
+    update: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: mockUserRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+    userRepository = module.get<Repository<User>>(getRepositoryToken(User));
+
+    jest.clearAllMocks();
+  });
+
+  describe('findAll() lazy lock self-heal (issue #710)', () => {
+    const createQueryBuilderMock = () => ({
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    });
+
+    it('clears expired locks via a single bulk update before returning', async () => {
+      const qb = createQueryBuilderMock();
+      jest.spyOn(service as any, 'createQueryBuilder').mockReturnValue(qb);
+      const updateSpy = jest
+        .spyOn(userRepository, 'update')
+        .mockResolvedValue({ affected: 1 } as any);
+
+      await service.findAll({
+        page: 1,
+        limit: 10,
+        sortBy: 'username',
+        sortOrder: 'ASC',
+      } as any);
+
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      const [criteria, partial] = updateSpy.mock.calls[0];
+      expect(criteria).toEqual(
+        expect.objectContaining({ lockedUntil: expect.anything() }),
+      );
+      expect(partial).toEqual({ lockedUntil: null, failedLoginAttempts: 0 });
+    });
+
+    it('does not fail findAll when the cleanup update throws', async () => {
+      const qb = createQueryBuilderMock();
+      jest.spyOn(service as any, 'createQueryBuilder').mockReturnValue(qb);
+      jest.spyOn(userRepository, 'update').mockRejectedValue(new Error('db down'));
+
+      await expect(
+        service.findAll({
+          page: 1,
+          limit: 10,
+          sortBy: 'username',
+          sortOrder: 'ASC',
+        } as any),
+      ).resolves.toBeDefined();
+    });
+  });
+});

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -96,13 +96,20 @@ export class UsersService {
       // lockedUntil timestamps don't linger or show as "locked" in the list.
       // One bulk UPDATE, not per-row saves, and failures must not break the
       // read. See issue #710.
-      try {
-        await this.userRepository.update(
-          { lockedUntil: LessThanOrEqual(new Date()) },
-          { lockedUntil: null, failedLoginAttempts: 0 },
-        );
-      } catch (err) {
-        this.logger.warn(`Failed to self-heal expired locks during findAll: ${err}`);
+      //
+      // Skip when explicitly filtering isLocked === true: that branch already
+      // excludes expired rows via `lockedUntil > :now`, so clearing them here
+      // would be a pure write with no effect on the result. Only run when the
+      // result set could otherwise surface a stale "locked" row.
+      if (isLocked !== true) {
+        try {
+          await this.userRepository.update(
+            { lockedUntil: LessThanOrEqual(new Date()) },
+            { lockedUntil: null, failedLoginAttempts: 0 },
+          );
+        } catch (err) {
+          this.logger.warn(`Failed to self-heal expired locks during findAll: ${err}`);
+        }
       }
 
       // Build query
@@ -342,6 +349,10 @@ export class UsersService {
         this.userRepository.count(),
         this.userRepository.count({ where: { isActive: true, status: UserStatus.ACTIVE } }),
         this.userRepository.count({ where: { isActive: false } }),
+        // Clock-correct via the Node app clock (:now = new Date()), consistent
+        // with findAll and the login path (see issue #710). No self-heal write
+        // here: this is a read-only stats endpoint and the count already
+        // excludes expired locks.
         this.userRepository
           .createQueryBuilder('user')
           .where('user.lockedUntil > :now', { now: new Date() })

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -7,7 +7,7 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, SelectQueryBuilder, Like, ILike } from 'typeorm';
+import { Repository, SelectQueryBuilder, Like, ILike, LessThanOrEqual } from 'typeorm';
 import * as bcrypt from 'bcrypt';
 import { User, UserRole, UserStatus } from '../../database/entities/user.entity';
 import {
@@ -92,6 +92,19 @@ export class UsersService {
     try {
       const { page, limit, search, role, status, isActive, isLocked, sortBy, sortOrder } = queryDto;
 
+      // Lazy self-heal: clear locks that have expired by the app clock so stale
+      // lockedUntil timestamps don't linger or show as "locked" in the list.
+      // One bulk UPDATE, not per-row saves, and failures must not break the
+      // read. See issue #710.
+      try {
+        await this.userRepository.update(
+          { lockedUntil: LessThanOrEqual(new Date()) },
+          { lockedUntil: null, failedLoginAttempts: 0 },
+        );
+      } catch (err) {
+        this.logger.warn(`Failed to self-heal expired locks during findAll: ${err}`);
+      }
+
       // Build query
       const queryBuilder = this.createQueryBuilder('user');
 
@@ -119,6 +132,9 @@ export class UsersService {
       }
 
       if (typeof isLocked === 'boolean') {
+        // :now is intentionally the Node app clock (new Date()), NOT SQL NOW().
+        // Lockout decisions must use one clock so a skewed Postgres container
+        // clock can't disagree with the login path. See issue #710.
         if (isLocked) {
           queryBuilder.andWhere('user.lockedUntil > :now', { now: new Date() });
         } else {

--- a/backend/test/unit/auth.service.spec.ts
+++ b/backend/test/unit/auth.service.spec.ts
@@ -280,14 +280,14 @@ describe('AuthService', () => {
       rememberMe: false,
     };
 
-    it('clears an expired lockedUntil before later login validation stops', async () => {
+    it('clears an expired lockedUntil and bypasses the lock check, reaching password validation', async () => {
       const pastLock = new Date(Date.now() - 60 * 1000);
       const user = {
         id: 'u1',
         username: 'admin',
         email: 'admin@example.com',
         password: 'hashed',
-        isActive: false,
+        isActive: true,
         status: UserStatus.ACTIVE,
         failedLoginAttempts: 5,
         lockedUntil: pastLock,
@@ -298,14 +298,18 @@ describe('AuthService', () => {
 
       mockUserRepository.findOne.mockResolvedValue(user);
       mockUserRepository.save.mockImplementation((u) => Promise.resolve(u));
+      // Wrong password: proves execution passed the lock check and reached
+      // password validation (handleFailedLogin), not stopped by ForbiddenException.
+      mockedBcrypt.compare.mockResolvedValue(false as never);
 
       await expect(service.login(loginDto as any)).rejects.toThrow(UnauthorizedException);
 
-      expect(user.failedLoginAttempts).toBe(0);
+      // bcrypt.compare being reached proves the lock check was bypassed — the
+      // self-heal cleared the stale lock instead of throwing ForbiddenException.
+      expect(mockedBcrypt.compare).toHaveBeenCalled();
+      // The stale lock was cleared (failedLoginAttempts is then re-incremented
+      // by handleFailedLogin on the wrong password, so we assert on lockedUntil).
       expect(user.lockedUntil).toBeNull();
-      expect(mockUserRepository.save).toHaveBeenCalledWith(
-        expect.objectContaining({ failedLoginAttempts: 0, lockedUntil: null }),
-      );
     });
 
     it('still rejects a user whose lockedUntil is in the future', async () => {

--- a/backend/test/unit/auth.service.spec.ts
+++ b/backend/test/unit/auth.service.spec.ts
@@ -273,6 +273,59 @@ describe('AuthService', () => {
     });
   });
 
+  describe('login() proactive self-heal (issue #710)', () => {
+    const loginDto = {
+      usernameOrEmail: 'admin',
+      password: 'pw',
+      rememberMe: false,
+    };
+
+    it('clears an expired lockedUntil before later login validation stops', async () => {
+      const pastLock = new Date(Date.now() - 60 * 1000);
+      const user = {
+        id: 'u1',
+        username: 'admin',
+        email: 'admin@example.com',
+        password: 'hashed',
+        isActive: false,
+        status: UserStatus.ACTIVE,
+        failedLoginAttempts: 5,
+        lockedUntil: pastLock,
+        get isLocked() {
+          return this.lockedUntil != null && this.lockedUntil > new Date();
+        },
+      } as any;
+
+      mockUserRepository.findOne.mockResolvedValue(user);
+      mockUserRepository.save.mockImplementation((u) => Promise.resolve(u));
+
+      await expect(service.login(loginDto as any)).rejects.toThrow(UnauthorizedException);
+
+      expect(user.failedLoginAttempts).toBe(0);
+      expect(user.lockedUntil).toBeNull();
+      expect(mockUserRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ failedLoginAttempts: 0, lockedUntil: null }),
+      );
+    });
+
+    it('still rejects a user whose lockedUntil is in the future', async () => {
+      const futureLock = new Date(Date.now() + 60 * 1000);
+      const user = {
+        id: 'u2',
+        username: 'admin',
+        lockedUntil: futureLock,
+        failedLoginAttempts: 5,
+        get isLocked() {
+          return this.lockedUntil != null && this.lockedUntil > new Date();
+        },
+      } as any;
+
+      mockUserRepository.findOne.mockResolvedValue(user);
+
+      await expect(service.login(loginDto as any)).rejects.toThrow(ForbiddenException);
+    });
+  });
+
   describe('token generation', () => {
     const loginDto = {
       usernameOrEmail: 'testuser',


### PR DESCRIPTION
## Summary
Makes account-lockout decisions depend on a single clock (the Node container's `new Date()`) and self-heals stale `lockedUntil` timestamps, so a lagging Postgres container clock can never extend a lockout past its intended expiry.

- **Login (`auth.service.ts`):** proactive self-heal clears an expired `lockedUntil` before the lock check, so a stale lock unlocks on the next attempt instead of lingering (a locked user could never reach the success path that normally resets it).
- **User list (`users.service.ts`):** lazy bulk `UPDATE` clears expired locks in one statement; skipped when explicitly filtering `isLocked=true` (that branch already excludes expired rows). Cleanup failures are logged and never break the read.
- **Consistency guard:** comments mark the `:now = new Date()` params and `getStatistics` count as intentionally the Node clock, never SQL `NOW()`.
- **Docs:** `CLAUDE.md` documents the Node-clock dependency and the `docker compose restart backend` remedy for suspected skew.

No schema change / migration. Backend only.

## Test Plan
- [x] `cd backend && npx jest test/unit/auth.service.spec.ts src/modules/users/users.service.spec.ts --no-coverage` → 27 passing
- [x] `cd backend && npm run lint` → exit 0
- Covered: expired lock cleared and login proceeds to password validation; future lock still rejected; bulk cleanup clears expired/leaves active; cleanup-failure tolerated; `isLocked=true` skips the write.

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)