### PR TITLE
fix(sales): exclude paid (Ready) orders from Draft status filter

### DIFF
--- a/backend/src/modules/sales/services/sales-order-query.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-query.service.spec.ts
@@ -135,7 +135,7 @@ describe('SalesOrderQueryService', () => {
       expect(paymentClauses[0].params.ps).toBe('PAID');
     });
 
-    it('still applies a plain DRAFT status filter unchanged', async () => {
+    it('excludes PAID orders when filtering by DRAFT', async () => {
       const { qb, andWhereCalls } = buildQbMock();
       salesOrderRepository.createQueryBuilder.mockReturnValue(qb);
 
@@ -143,8 +143,26 @@ describe('SalesOrderQueryService', () => {
 
       const statusClause = andWhereCalls.find((c) => c.clause === 'order.status = :status');
       expect(statusClause?.params.status).toBe('DRAFT');
-      const readyPaymentClause = andWhereCalls.find((c) => c.clause === 'order.paymentStatus = :ps');
-      expect(readyPaymentClause).toBeUndefined();
+
+      const excludeClause = andWhereCalls.find(
+        (c) => c.clause === 'order.paymentStatus != :excludePs',
+      );
+      expect(excludeClause?.params.excludePs).toBe(SalesOrderPaymentStatus.PAID);
+    });
+
+    it('does not add the PAID exclusion for a non-DRAFT status', async () => {
+      const { qb, andWhereCalls } = buildQbMock();
+      salesOrderRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.findAll({ status: SalesOrderStatus.FULFILLED } as any);
+
+      const statusClause = andWhereCalls.find((c) => c.clause === 'order.status = :status');
+      expect(statusClause?.params.status).toBe('FULFILLED');
+
+      const excludeClause = andWhereCalls.find(
+        (c) => c.clause === 'order.paymentStatus != :excludePs',
+      );
+      expect(excludeClause).toBeUndefined();
     });
   });
 });

--- a/backend/src/modules/sales/services/sales-order-query.service.ts
+++ b/backend/src/modules/sales/services/sales-order-query.service.ts
@@ -109,9 +109,15 @@ export class SalesOrderQueryService {
       }
 
       if (status && status !== 'all') {
+        const normalizedStatus = status.toUpperCase();
         queryBuilder = queryBuilder.andWhere('order.status = :status', {
-          status: status.toUpperCase(),
+          status: normalizedStatus,
         });
+        if (normalizedStatus === SalesOrderStatus.DRAFT) {
+          queryBuilder = queryBuilder.andWhere('order.paymentStatus != :excludePs', {
+            excludePs: SalesOrderPaymentStatus.PAID,
+          });
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

The **Draft** order-status filter (`status=DRAFT`) returned all DRAFT orders, including fully-paid ones that the UI renders as **Ready**. Selecting "Draft" should not surface orders the user sees labeled "Ready".

This makes the Draft filter the exact complement of the existing READY filter:
- **Ready** = `status=DRAFT` AND `paymentStatus=PAID`
- **Draft** = `status=DRAFT` AND `paymentStatus != PAID` (i.e. `UNPAID`, `PARTIAL`, or `OVERPAID`)

`OVERPAID` intentionally stays in **Draft** (it is not "fully paid"), matching the `SalesOrderStatusChip` "Ready" rule. Only `PAID` is excluded.

> Note: issue #711's suggested fix excluded both `PAID` and `OVERPAID`. That would make OVERPAID orders disappear from both Draft and Ready filters while still rendering as a "Draft" chip. We exclude only `PAID` to keep the filter consistent with the UI chip.

## Change

`backend/src/modules/sales/services/sales-order-query.service.ts` — `findAll`: when the resolved status is `DRAFT`, append `order.paymentStatus != 'PAID'`. The `READY` branch, the explicit `paymentStatus` param, and `FULFILLED`/`CANCELLED` filtering are untouched. `paymentStatus` is `NOT NULL` (default `UNPAID`), so `!=` has no NULL pitfall.

## Tests

- Replaced the stale `'still applies a plain DRAFT status filter unchanged'` test with one asserting the `PAID` exclusion clause.
- Added a test confirming non-DRAFT statuses (`FULFILLED`) do not get the exclusion.
- READY tests unchanged.

Verification: query spec 6/6 ✅, full backend suite 1082/1082 ✅, lint ✅.

Closes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)