### PR TITLE
feat(accounting): split sales auto-posting into separate Revenue and COGS journal entries

### DIFF
--- a/backend/src/modules/accounting/services/accounting.service.spec.ts
+++ b/backend/src/modules/accounting/services/accounting.service.spec.ts
@@ -146,6 +146,9 @@ describe('AccountingService', () => {
       journalEntryService.create
         .mockResolvedValueOnce({ ...mockJournalEntry, id: 'cogs-entry' } as any)
         .mockResolvedValueOnce({ ...mockJournalEntry, id: 'revenue-entry' } as any);
+      journalEntryService.postEntry
+        .mockResolvedValueOnce({ ...mockJournalEntry, id: 'cogs-entry' } as any)
+        .mockResolvedValueOnce({ ...mockJournalEntry, id: 'revenue-entry' } as any);
 
       const result = await service.postSalesOrderEntry(mockSalesOrder, 'user-123');
 
@@ -208,8 +211,9 @@ describe('AccountingService', () => {
     it('should calculate COGS correctly', async () => {
       await service.postSalesOrderEntry(mockSalesOrder, 'user-123');
 
-      const createCall = journalEntryService.create.mock.calls[0][0];
-      const cogsLine = createCall.lines.find((l: any) => l.accountId === 'cogs-account-id');
+      // COGS entry is the first create call
+      const cogsCreateCall = journalEntryService.create.mock.calls[0][0];
+      const cogsLine = cogsCreateCall.lines.find((l: any) => l.accountId === 'cogs-account-id');
 
       expect(cogsLine.debitAmount).toBe(1000); // (10 * 60) + (5 * 80) = 600 + 400
     });
@@ -235,9 +239,12 @@ describe('AccountingService', () => {
 
       await service.postSalesOrderEntry(staleOrder, 'user-123');
 
-      const createCall = journalEntryService.create.mock.calls[0][0];
-      const arLine = createCall.lines.find((l: any) => l.accountId === 'ar-account-id');
-      const revenueLine = createCall.lines.find((l: any) => l.accountId === 'revenue-account-id');
+      // Revenue entry is the second create call (cogs = 20 > 0, so COGS entry is first)
+      const revenueCreateCall = journalEntryService.create.mock.calls[1][0];
+      const arLine = revenueCreateCall.lines.find((l: any) => l.accountId === 'ar-account-id');
+      const revenueLine = revenueCreateCall.lines.find(
+        (l: any) => l.accountId === 'revenue-account-id',
+      );
 
       expect(arLine.debitAmount).toBe(30);
       expect(revenueLine.creditAmount).toBe(30);
@@ -282,8 +289,10 @@ describe('AccountingService', () => {
 
       expect(accountMappingService.getMappings).toHaveBeenCalled();
 
-      const createCall = journalEntryService.create.mock.calls[0][0];
-      const accountIds = createCall.lines.map((l: any) => l.accountId);
+      const allLines = journalEntryService.create.mock.calls.flatMap(
+        (call: any) => call[0].lines,
+      );
+      const accountIds = allLines.map((l: any) => l.accountId);
 
       expect(accountIds).toContain('cogs-account-id');
       expect(accountIds).toContain('inventory-account-id');

--- a/backend/src/modules/accounting/services/accounting.service.spec.ts
+++ b/backend/src/modules/accounting/services/accounting.service.spec.ts
@@ -300,6 +300,37 @@ describe('AccountingService', () => {
       expect(accountIds).toContain('revenue-account-id');
     });
 
+    it('creates only the Revenue entry when COGS is zero (service order)', async () => {
+      const serviceOrder = {
+        id: 'so-service',
+        orderNumber: 'SO-SVC',
+        totalAmount: 200,
+        shippingAmount: 0,
+        fulfilledDate: new Date('2026-01-15'),
+        customer: { id: 'customer-123', name: 'Test Customer' },
+        items: [
+          {
+            id: 'svc-1',
+            quantity: 1,
+            unitPrice: 200,
+            totalAmount: 200,
+            product: { id: 'svc-product', name: 'Consulting', baseCost: 0 },
+          },
+        ],
+      } as any;
+
+      await service.postSalesOrderEntry(serviceOrder, 'user-123');
+
+      // Exactly one entry created: the Revenue entry; no COGS entry
+      expect(journalEntryService.create).toHaveBeenCalledTimes(1);
+      const createCall = journalEntryService.create.mock.calls[0][0];
+      expect(createCall.description).toBe('Sales Order SO-SVC - Test Customer (Revenue)');
+      const accountIds = createCall.lines.map((l: any) => l.accountId);
+      expect(accountIds).toContain('ar-account-id');
+      expect(accountIds).toContain('revenue-account-id');
+      expect(accountIds).not.toContain('cogs-account-id');
+    });
+
     it('should validate period is open', async () => {
       await service.postSalesOrderEntry(mockSalesOrder, 'user-123');
 

--- a/backend/src/modules/accounting/services/accounting.service.spec.ts
+++ b/backend/src/modules/accounting/services/accounting.service.spec.ts
@@ -331,6 +331,25 @@ describe('AccountingService', () => {
       expect(accountIds).not.toContain('cogs-account-id');
     });
 
+    it('posts COGS before Revenue and does not create Revenue if COGS post fails', async () => {
+      journalEntryService.create.mockResolvedValue({
+        ...mockJournalEntry,
+        id: 'cogs-entry',
+      } as any);
+      journalEntryService.postEntry.mockRejectedValueOnce(new Error('infra failure'));
+
+      await expect(service.postSalesOrderEntry(mockSalesOrder, 'user-123')).rejects.toThrow(
+        'infra failure',
+      );
+
+      // COGS entry was created; Revenue entry was never created
+      expect(journalEntryService.create).toHaveBeenCalledTimes(1);
+      const onlyCreateCall = journalEntryService.create.mock.calls[0][0];
+      expect(onlyCreateCall.description).toBe(
+        'Sales Order SO-001 - Test Customer (Cost of Goods Sold)',
+      );
+    });
+
     it('should validate period is open', async () => {
       await service.postSalesOrderEntry(mockSalesOrder, 'user-123');
 

--- a/backend/src/modules/accounting/services/accounting.service.spec.ts
+++ b/backend/src/modules/accounting/services/accounting.service.spec.ts
@@ -142,48 +142,67 @@ describe('AccountingService', () => {
       journalEntryService.postEntry.mockResolvedValue(mockJournalEntry as any);
     });
 
-    it('should create journal entry with correct lines', async () => {
+    it('should create two separate entries: COGS first, then Revenue', async () => {
+      journalEntryService.create
+        .mockResolvedValueOnce({ ...mockJournalEntry, id: 'cogs-entry' } as any)
+        .mockResolvedValueOnce({ ...mockJournalEntry, id: 'revenue-entry' } as any);
+
       const result = await service.postSalesOrderEntry(mockSalesOrder, 'user-123');
 
-      expect(journalEntryService.create).toHaveBeenCalledWith(
+      // First create call = COGS entry
+      expect(journalEntryService.create).toHaveBeenNthCalledWith(
+        1,
         expect.objectContaining({
-          entryDate: mockSalesOrder.fulfilledDate,
-          description: `Sales Order SO-001 - Test Customer`,
+          description: 'Sales Order SO-001 - Test Customer (Cost of Goods Sold)',
           sourceType: 'sales_order',
           sourceId: 'so-123',
           fiscalPeriodId: 'period-123',
-          lines: expect.arrayContaining([
-            // COGS line
+          lines: [
             expect.objectContaining({
               accountId: 'cogs-account-id',
-              debitAmount: 1000, // (10 * 60) + (5 * 80)
+              debitAmount: 1000,
               creditAmount: 0,
             }),
-            // Inventory line
             expect.objectContaining({
               accountId: 'inventory-account-id',
               debitAmount: 0,
               creditAmount: 1000,
             }),
-            // AR line
+          ],
+        }),
+        'user-123',
+      );
+
+      // Second create call = Revenue entry
+      expect(journalEntryService.create).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          description: 'Sales Order SO-001 - Test Customer (Revenue)',
+          sourceType: 'sales_order',
+          sourceId: 'so-123',
+          fiscalPeriodId: 'period-123',
+          lines: [
             expect.objectContaining({
               accountId: 'ar-account-id',
               debitAmount: 1500,
               creditAmount: 0,
             }),
-            // Revenue line
             expect.objectContaining({
               accountId: 'revenue-account-id',
               debitAmount: 0,
               creditAmount: 1500,
             }),
-          ]),
+          ],
         }),
         'user-123',
       );
 
-      expect(journalEntryService.postEntry).toHaveBeenCalledWith('entry-123', 'user-123');
-      expect(result).toEqual(mockJournalEntry);
+      // Both entries posted
+      expect(journalEntryService.postEntry).toHaveBeenCalledWith('cogs-entry', 'user-123');
+      expect(journalEntryService.postEntry).toHaveBeenCalledWith('revenue-entry', 'user-123');
+
+      // Returns the revenue entry
+      expect(result).toEqual(expect.objectContaining({ id: 'revenue-entry' }));
     });
 
     it('should calculate COGS correctly', async () => {

--- a/backend/src/modules/accounting/services/accounting.service.ts
+++ b/backend/src/modules/accounting/services/accounting.service.ts
@@ -104,57 +104,85 @@ export class AccountingService {
     );
     const revenueAmount = itemsSubtotal + Number(salesOrder.shippingAmount ?? 0);
 
-    // Build journal entry lines
-    const lines: CreateJournalEntryLineDto[] = [
-      // DR Cost of Goods Sold
-      {
-        accountId: mappings[MappingType.SALES_COGS],
-        debitAmount: cogsAmount,
-        creditAmount: 0,
-        memo: 'Cost of goods sold',
-      },
-      // CR Inventory Asset
-      {
-        accountId: mappings[MappingType.SALES_INVENTORY],
-        debitAmount: 0,
-        creditAmount: cogsAmount,
-        memo: 'Inventory reduction',
-      },
-      // DR Accounts Receivable
-      {
-        accountId: mappings[MappingType.SALES_AR],
-        debitAmount: revenueAmount,
-        creditAmount: 0,
-        memo: 'Amount receivable from customer',
-      },
-      // CR Sales Revenue
-      {
-        accountId: mappings[MappingType.SALES_REVENUE],
-        debitAmount: 0,
-        creditAmount: revenueAmount,
-        memo: 'Sales revenue recognition',
-      },
-    ];
+    // Build BOTH entry DTOs up front so all business-rule validation (mappings,
+    // period, amounts) happens before anything is persisted. Post COGS first so
+    // that if the revenue post fails after COGS posted, a re-run hits the
+    // duplicate guard (which sees the COGS entry) and never double-posts.
+    const baseDescription = `Sales Order ${salesOrder.orderNumber} - ${salesOrder.customer.name}`;
 
-    // Create journal entry DTO
-    const entryDto: CreateJournalEntryDto = {
+    const cogsEntryDto: CreateJournalEntryDto | null =
+      cogsAmount > 0
+        ? {
+            entryDate: new Date(salesOrder.fulfilledDate),
+            description: `${baseDescription} (Cost of Goods Sold)`,
+            fiscalPeriodId: periodValidation.period.id,
+            sourceType: 'sales_order',
+            sourceId: salesOrder.id,
+            lines: [
+              {
+                accountId: mappings[MappingType.SALES_COGS],
+                debitAmount: cogsAmount,
+                creditAmount: 0,
+                memo: 'Cost of goods sold',
+              },
+              {
+                accountId: mappings[MappingType.SALES_INVENTORY],
+                debitAmount: 0,
+                creditAmount: cogsAmount,
+                memo: 'Inventory reduction',
+              },
+            ],
+          }
+        : null;
+
+    const revenueEntryDto: CreateJournalEntryDto = {
       entryDate: new Date(salesOrder.fulfilledDate),
-      description: `Sales Order ${salesOrder.orderNumber} - ${salesOrder.customer.name}`,
+      description: `${baseDescription} (Revenue)`,
       fiscalPeriodId: periodValidation.period.id,
       sourceType: 'sales_order',
       sourceId: salesOrder.id,
-      lines,
+      lines: [
+        {
+          accountId: mappings[MappingType.SALES_AR],
+          debitAmount: revenueAmount,
+          creditAmount: 0,
+          memo: 'Amount receivable from customer',
+        },
+        {
+          accountId: mappings[MappingType.SALES_REVENUE],
+          debitAmount: 0,
+          creditAmount: revenueAmount,
+          memo: 'Sales revenue recognition',
+        },
+      ],
     };
 
-    // Create and post the entry
-    const entry = await this.journalEntryService.create(entryDto, userId);
-    const postedEntry = await this.journalEntryService.postEntry(entry.id, userId);
+    // Post COGS entry first (when there is a cost to record)
+    if (cogsEntryDto) {
+      const cogsEntry = await this.journalEntryService.create(cogsEntryDto, userId);
+      await this.journalEntryService.postEntry(cogsEntry.id, userId);
+      await this.auditLogService.log(
+        'AUTO_POST',
+        'JournalEntry',
+        `Auto-posted sales order COGS journal entry for order: ${salesOrder.orderNumber}`,
+        {
+          entityId: cogsEntry.id,
+          userId: userId ?? 'system',
+          username,
+          metadata: { sourceType: 'sales_order', sourceId: salesOrder.id },
+        },
+      );
+    }
+
+    // Post revenue entry
+    const revenueEntry = await this.journalEntryService.create(revenueEntryDto, userId);
+    const postedRevenueEntry = await this.journalEntryService.postEntry(revenueEntry.id, userId);
     await this.auditLogService.log(
       'AUTO_POST',
       'JournalEntry',
-      `Auto-posted sales order journal entry for order: ${salesOrder.orderNumber}`,
+      `Auto-posted sales order revenue journal entry for order: ${salesOrder.orderNumber}`,
       {
-        entityId: entry.id,
+        entityId: revenueEntry.id,
         userId: userId ?? 'system',
         username,
         metadata: { sourceType: 'sales_order', sourceId: salesOrder.id },
@@ -162,9 +190,10 @@ export class AccountingService {
     );
 
     this.logger.log(
-      `Sales order entry posted successfully: ${postedEntry.referenceNumber}`,
+      `Sales order entries posted successfully for order: ${salesOrder.orderNumber}`,
     );
-    return postedEntry as any;
+
+    return postedRevenueEntry as any;
   }
 
   /**

--- a/backend/test/e2e/accounting-auto-posting.e2e-spec.ts
+++ b/backend/test/e2e/accounting-auto-posting.e2e-spec.ts
@@ -343,35 +343,46 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
       expect(fulfilledOrder.status).toBe('FULFILLED');
       expect(fulfilledOrder.updatedAt).toBeTruthy();
 
-      // Verify journal entry was created
+      // Verify two separate journal entries were created: COGS and Revenue
       const journalEntries = await journalEntryRepo.find({
         where: { sourceType: 'sales_order', sourceId: savedOrder.id },
         relations: { lines: true },
       });
 
-      expect(journalEntries).toHaveLength(1);
-      const entry = journalEntries[0];
+      expect(journalEntries).toHaveLength(2);
+      expect(journalEntries.every(e => e.status === JournalEntryStatus.POSTED)).toBe(true);
 
-      expect(entry.status).toBe(JournalEntryStatus.POSTED);
-      expect(entry.lines).toHaveLength(4);
+      // Each entry has exactly 2 lines
+      const allLines = journalEntries.flatMap(e => e.lines);
+      expect(allLines).toHaveLength(4);
 
-      // Verify COGS debit line
-      const cogsLine = entry.lines.find(l => l.accountId === accounts['5000'].id && Number(l.debitAmount) > 0);
+      // COGS entry: DR Cost of Goods Sold / CR Inventory
+      const cogsEntry = journalEntries.find(e =>
+        e.description.includes('(Cost of Goods Sold)'),
+      );
+      expect(cogsEntry).toBeDefined();
+      expect(cogsEntry.lines).toHaveLength(2);
+
+      const cogsLine = cogsEntry.lines.find(l => l.accountId === accounts['5000'].id && Number(l.debitAmount) > 0);
       expect(cogsLine).toBeDefined();
       expect(Number(cogsLine.debitAmount)).toBe(500.00); // 10 * 50 baseCost
 
-      // Verify Inventory credit line
-      const inventoryLine = entry.lines.find(l => l.accountId === accounts['1300'].id && Number(l.creditAmount) > 0);
+      const inventoryLine = cogsEntry.lines.find(l => l.accountId === accounts['1300'].id && Number(l.creditAmount) > 0);
       expect(inventoryLine).toBeDefined();
       expect(Number(inventoryLine.creditAmount)).toBe(500.00);
 
-      // Verify AR debit line
-      const arLine = entry.lines.find(l => l.accountId === accounts['1200'].id && Number(l.debitAmount) > 0);
+      // Revenue entry: DR Accounts Receivable / CR Sales Revenue
+      const revenueEntry = journalEntries.find(e =>
+        e.description.includes('(Revenue)'),
+      );
+      expect(revenueEntry).toBeDefined();
+      expect(revenueEntry.lines).toHaveLength(2);
+
+      const arLine = revenueEntry.lines.find(l => l.accountId === accounts['1200'].id && Number(l.debitAmount) > 0);
       expect(arLine).toBeDefined();
       expect(Number(arLine.debitAmount)).toBe(1000.00);
 
-      // Verify Revenue credit line
-      const revenueLine = entry.lines.find(l => l.accountId === accounts['4000'].id && Number(l.creditAmount) > 0);
+      const revenueLine = revenueEntry.lines.find(l => l.accountId === accounts['4000'].id && Number(l.creditAmount) > 0);
       expect(revenueLine).toBeDefined();
       expect(Number(revenueLine.creditAmount)).toBe(1000.00);
     });
@@ -405,8 +416,9 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
         relations: { lines: true },
       });
 
-      const entry = journalEntries[0];
-      const cogsLine = entry.lines.find(l => l.accountId === accounts['5000'].id && Number(l.debitAmount) > 0);
+      const cogsEntry = journalEntries.find(e => e.description.includes('(Cost of Goods Sold)'));
+      expect(cogsEntry).toBeDefined();
+      const cogsLine = cogsEntry.lines.find(l => l.accountId === accounts['5000'].id && Number(l.debitAmount) > 0);
 
       expect(Number(cogsLine.debitAmount)).toBe(500.00); // 10 qty * 50 baseCost
     });
@@ -477,7 +489,8 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
       const journalEntries = await journalEntryRepo.find({
         where: { sourceType: 'sales_order', sourceId: savedOrder.id },
       });
-      expect(journalEntries).toHaveLength(1);
+      // Two entries: COGS + Revenue
+      expect(journalEntries).toHaveLength(2);
     });
   });
 
@@ -1147,7 +1160,8 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
       const journalEntries = await journalEntryRepo.find({
         where: { sourceType: 'sales_order', sourceId: savedOrder.id },
       });
-      expect(journalEntries).toHaveLength(1);
+      // Two entries: COGS + Revenue
+      expect(journalEntries).toHaveLength(2);
     });
 
     it('should allow auto-posting to open period', async () => {
@@ -1174,12 +1188,12 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
 
       await salesOrderService.fulfillOrder(savedOrder.id);
 
-      // Journal entry should be created successfully
+      // Journal entries should be created successfully (COGS + Revenue)
       const journalEntries = await journalEntryRepo.find({
         where: { sourceType: 'sales_order', sourceId: savedOrder.id },
       });
-      expect(journalEntries).toHaveLength(1);
-      expect(journalEntries[0].status).toBe(JournalEntryStatus.POSTED);
+      expect(journalEntries).toHaveLength(2);
+      expect(journalEntries.every(e => e.status === JournalEntryStatus.POSTED)).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Why

Auto-posted sales-order journal entries combined two distinct economic events — the sale (DR Accounts Receivable / CR Sales Revenue) and the cost of goods sold (DR COGS / CR Inventory) — into a single entry. The entry's total therefore read as `revenue + cogs`, which looks inflated next to the order total.

**Example — SO-26-025:** order total 74 (subtotal 54 + shipping 20), COGS 30 → the single combined entry showed a total of **104**, confusing anyone reconciling it against the 74 order. The accounting was correct (104 DR = 104 CR), but the presentation conflated two amounts.

## What

Fulfilling a sales order now posts **two separate journal entries** (the QuickBooks/Xero model), so every entry total matches an intuitive number:

- **Revenue entry** (always) — DR Accounts Receivable / CR Sales Revenue (e.g. 74)
- **Cost of Goods Sold entry** (only when cost > 0) — DR COGS / CR Inventory (e.g. 30)

Both entries share `sourceType: 'sales_order'` and `sourceId`.

### Design notes
- **COGS-first ordering + validate-up-front:** both DTOs are built and validated (mappings, period, amounts) before anything is persisted; the COGS entry posts first. If the revenue post fails after COGS posted, a re-run hits the existing duplicate guard (which sees the COGS entry) and never double-posts. This is the deliberate, accepted alternative to a true cross-service DB transaction.
- **Service orders (zero cost)** post only the revenue entry — no meaningless \$0 COGS entry.
- **Refunds/reversals unchanged:** `reverseSourceEntries` already loops over all entries for a source, so both are reversed automatically.
- **No backfill / no migration:** historical combined entries are left as-is; only future fulfillments are split.

## Testing

- Accounting service spec: 47 tests pass (two-entry split, COGS-first ordering, zero-COGS service order, no-double-post-on-failure, and updated existing assertions)
- Fulfillment caller spec: 11 tests pass (caller ignores the return value; behavior unchanged)
- `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)