### PR TITLE
fix(sales): duplicate order behavior — discounts, sort position, no auto-edit

### DIFF
--- a/backend/src/modules/sales/services/sales-order-query.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-query.service.spec.ts
@@ -105,6 +105,7 @@ describe('SalesOrderQueryService', () => {
           return qb;
         }),
         orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
         skip: jest.fn().mockReturnThis(),
         take: jest.fn().mockReturnThis(),
         getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
@@ -122,6 +123,26 @@ describe('SalesOrderQueryService', () => {
       const paymentClause = andWhereCalls.find((c) => c.clause === 'order.paymentStatus = :ps');
       expect(statusClause?.params.status).toBe('READY');
       expect(paymentClause).toBeUndefined();
+    });
+
+    it('adds an orderNumber DESC tiebreaker when sorting by a non-orderNumber field', async () => {
+      const { qb } = buildQbMock();
+      salesOrderRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.findAll({ sortBy: 'orderDate', sortOrder: 'DESC' } as any);
+
+      expect(qb.orderBy).toHaveBeenCalledWith('order.orderDate', 'DESC');
+      expect(qb.addOrderBy).toHaveBeenCalledWith('order.orderNumber', 'DESC');
+    });
+
+    it('does not add a redundant tiebreaker when already sorting by orderNumber', async () => {
+      const { qb } = buildQbMock();
+      salesOrderRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.findAll({ sortBy: 'orderNumber', sortOrder: 'ASC' } as any);
+
+      expect(qb.orderBy).toHaveBeenCalledWith('order.orderNumber', 'ASC');
+      expect(qb.addOrderBy).not.toHaveBeenCalled();
     });
 
     it('applies a paymentStatus param independently of READY', async () => {

--- a/backend/src/modules/sales/services/sales-order-query.service.ts
+++ b/backend/src/modules/sales/services/sales-order-query.service.ts
@@ -115,6 +115,13 @@ export class SalesOrderQueryService {
       .skip((page - 1) * limit)
       .take(limit);
 
+    // Deterministic tiebreaker: orders sharing the same primary sort value
+    // (e.g. same orderDate) fall back to newest order number first, so a
+    // freshly created/duplicated order reliably appears at the top.
+    if (sortBy !== 'orderNumber') {
+      queryBuilder = queryBuilder.addOrderBy('order.orderNumber', 'DESC');
+    }
+
     const [orders, total] = await queryBuilder.getManyAndCount();
 
     return {

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -3,7 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { SalesOrderService } from './sales-order.service';
 import { SalesOrder, SalesOrderPaymentStatus, SalesOrderStatus } from '../../../database/entities/sales-order.entity';
-import { SalesOrderItem } from '../../../database/entities/sales-order-item.entity';
+import { SalesOrderItem, DiscountType } from '../../../database/entities/sales-order-item.entity';
 import { Customer } from '../../../database/entities/customer.entity';
 import { Product } from '../../../database/entities/product.entity';
 import { Invoice } from '../../../database/entities/invoice.entity';
@@ -183,6 +183,71 @@ describe('SalesOrderService', () => {
         totalAmount: 1100,
         balanceDue: 700,
       }));
+    });
+  });
+
+  describe('duplicateOrder', () => {
+    it('preserves a fixed-amount (AMOUNT) line discount on the duplicate', async () => {
+      const original = {
+        id: 'order-1',
+        customerId: 'customer-1',
+        notes: 'orig notes',
+        shippingAmount: 10,
+        items: [
+          {
+            productId: 'product-1',
+            quantity: 2,
+            unitPrice: 100,
+            discountType: DiscountType.AMOUNT,
+            discountPercent: 0,
+            discountAmount: 25,
+            notes: 'line notes',
+          },
+        ],
+      } as any;
+      salesOrderRepository.findOne = jest.fn().mockResolvedValue(original);
+      const createSpy = jest
+        .spyOn(service, 'create')
+        .mockResolvedValue({ id: 'order-2' } as any);
+
+      await service.duplicateOrder('order-1', 'user-1');
+
+      const passedDto = createSpy.mock.calls[0][0];
+      expect(passedDto.items[0]).toMatchObject({
+        productId: 'product-1',
+        discountType: DiscountType.AMOUNT,
+        discountPercent: 0,
+        discountAmount: 25,
+      });
+    });
+
+    it('preserves a percentage line discount on the duplicate', async () => {
+      const original = {
+        id: 'order-1',
+        customerId: 'customer-1',
+        shippingAmount: 0,
+        items: [
+          {
+            productId: 'product-1',
+            quantity: 1,
+            unitPrice: 100,
+            discountType: DiscountType.PERCENTAGE,
+            discountPercent: 15,
+            discountAmount: 15,
+          },
+        ],
+      } as any;
+      salesOrderRepository.findOne = jest.fn().mockResolvedValue(original);
+      const createSpy = jest
+        .spyOn(service, 'create')
+        .mockResolvedValue({ id: 'order-2' } as any);
+
+      await service.duplicateOrder('order-1', 'user-1');
+
+      expect(createSpy.mock.calls[0][0].items[0]).toMatchObject({
+        discountType: DiscountType.PERCENTAGE,
+        discountPercent: 15,
+      });
     });
   });
 });

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -596,7 +596,12 @@ export class SalesOrderService extends BaseCrudService<
         productId: item.productId,
         quantity: item.quantity,
         unitPrice: Number(item.unitPrice),
+        // Copy the full discount shape: a fixed-amount (AMOUNT) discount has
+        // discountPercent = 0, so without discountType + discountAmount the
+        // duplicate would silently drop the discount.
+        discountType: item.discountType,
         discountPercent: Number(item.discountPercent),
+        discountAmount: Number(item.discountAmount),
         notes: item.notes,
       })),
     };

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -157,11 +157,10 @@ const OrdersPage: React.FC = () => {
     try {
       const newOrder = await duplicateOrder(order.id).unwrap()
       showSuccess(`Order duplicated as ${newOrder.orderNumber}`)
-      navigate(`/sales/orders/${newOrder.orderNumber}/edit`)
     } catch (e: any) {
       showError(e?.data?.message || `Failed to duplicate ${order.orderNumber}`)
     }
-  }, [duplicateOrder, navigate, showError, showSuccess])
+  }, [duplicateOrder, showError, showSuccess])
 
   const handleRefund = useCallback((order: SalesOrder) => {
     setRefundOrder(order)

--- a/frontend/src/pages/sales/SalesOrderDetailPage.tsx
+++ b/frontend/src/pages/sales/SalesOrderDetailPage.tsx
@@ -155,7 +155,6 @@ export default function SalesOrderDetailPage() {
     try {
       const newOrder = await duplicateOrder(order.id).unwrap()
       showSuccess(`Order duplicated as ${newOrder.orderNumber}`)
-      navigate(`/sales/orders/${newOrder.orderNumber}/edit`)
     } catch (error) {
       showError(getErrorMessage(error, 'Failed to duplicate order'))
     }

--- a/frontend/src/pages/sales/__tests__/SalesOrderDetailPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/SalesOrderDetailPage.test.tsx
@@ -216,7 +216,7 @@ describe('SalesOrderDetailPage', () => {
     expect(screen.getByRole('button', { name: /duplicate/i })).toBeInTheDocument()
   })
 
-  it('Duplicate button calls mutation and navigates to new order edit page', async () => {
+  it('Duplicate button calls mutation and stays on the current order (no edit-page navigation)', async () => {
     mockDuplicate.mockReturnValue({ unwrap: () => Promise.resolve({ orderNumber: 'SO-26-002' }) })
     mockGetSalesOrderByNumber.mockReturnValue({
       data: makeOrder({ status: 'DRAFT', paymentStatus: 'UNPAID' }),
@@ -224,6 +224,7 @@ describe('SalesOrderDetailPage', () => {
     })
     renderPage()
     await userEvent.click(screen.getByRole('button', { name: /duplicate/i }))
-    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/sales/orders/SO-26-002/edit'))
+    await waitFor(() => expect(mockDuplicate).toHaveBeenCalled())
+    expect(mockNavigate).not.toHaveBeenCalledWith('/sales/orders/SO-26-002/edit')
   })
 })


### PR DESCRIPTION
## Summary

Fixes three issues with duplicating a sales order:

- **Line discounts are now preserved.** `duplicateOrder` copied only `discountPercent`, dropping `discountType` and `discountAmount`. A fixed-amount (`AMOUNT`) discount has `discountPercent = 0`, so the duplicate silently lost the discount and its line totals came out higher than the original. Now copies the full discount shape through to `create()`.
- **The duplicate reliably sorts to the top.** The list query had no secondary sort, so orders sharing today's `orderDate` had no deterministic order and a fresh duplicate wasn't guaranteed at the top. Added an `orderNumber DESC` tiebreaker (skipped when already sorting by `orderNumber`).
- **No more auto-opening the edit page.** Duplicating from the orders list or the order detail page no longer navigates to the new order's edit page. The list stays put (and refreshes via existing tag invalidation); the detail page stays on the current order. Both keep the success toast.

Note: the duplicate's date was already reset to today by `create()` — no change needed there.

## Test Plan

- [x] Backend: `sales-order.service.spec.ts` — new `duplicateOrder` tests (AMOUNT + PERCENTAGE discount preserved); verified red→green against the fix
- [x] Backend: `sales-order-query.service.spec.ts` — new tiebreaker tests (applied for non-`orderNumber` sort, skipped for `orderNumber`)
- [x] Frontend: `SalesOrderDetailPage.test.tsx` — duplicate no longer navigates to edit page
- [x] `nest build` clean, frontend `type-check` clean, ESLint clean on touched files
- [x] Manual: duplicate an order with a fixed-amount discount; confirm totals match and it appears at the top of the list without opening the edit form

🤖 Generated with [Claude Code](https://claude.com/claude-code)