### PR TITLE
feat(sales): status-based action permissions for sales order row actions (#717)

### DIFF
--- a/backend/src/modules/sales/controllers/sales-order.controller.ts
+++ b/backend/src/modules/sales/controllers/sales-order.controller.ts
@@ -102,7 +102,7 @@ export class SalesOrderController {
   }
 
   @Put(':id')
-  @ApiOperation({ summary: 'Update sales order (DRAFT + UNPAID only)' })
+  @ApiOperation({ summary: 'Update sales order (DRAFT or READY; FULFILLED/CANCELLED locked)' })
   @ApiParam({ name: 'id', type: 'string' })
   async updateSalesOrder(
     @Param('id', ParseUUIDPipe) id: string,

--- a/backend/src/modules/sales/services/sales-order-lifecycle.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-lifecycle.service.spec.ts
@@ -37,19 +37,36 @@ describe('SalesOrderLifecycleService', () => {
   });
 
   describe('assertEditAllowed', () => {
+    it('passes when DRAFT and UNPAID', async () => {
+      orderRepo.findOne.mockResolvedValue(mockOrder());
+      await expect(service.assertEditAllowed('order-1')).resolves.not.toThrow();
+    });
+
+    it('passes when DRAFT and PARTIAL', async () => {
+      orderRepo.findOne.mockResolvedValue(mockOrder({ paymentStatus: SalesOrderPaymentStatus.PARTIAL }));
+      await expect(service.assertEditAllowed('order-1')).resolves.not.toThrow();
+    });
+
+    it('passes when DRAFT and PAID', async () => {
+      orderRepo.findOne.mockResolvedValue(mockOrder({ paymentStatus: SalesOrderPaymentStatus.PAID }));
+      await expect(service.assertEditAllowed('order-1')).resolves.not.toThrow();
+    });
+
+    it('passes when READY (persisted fully-paid order)', async () => {
+      orderRepo.findOne.mockResolvedValue(
+        mockOrder({ status: SalesOrderStatus.READY, paymentStatus: SalesOrderPaymentStatus.PAID }),
+      );
+      await expect(service.assertEditAllowed('order-1')).resolves.not.toThrow();
+    });
+
     it('throws when status is FULFILLED', async () => {
       orderRepo.findOne.mockResolvedValue(mockOrder({ status: SalesOrderStatus.FULFILLED }));
       await expect(service.assertEditAllowed('order-1')).rejects.toThrow(BadRequestException);
     });
 
-    it('throws when DRAFT but paymentStatus is PARTIAL', async () => {
-      orderRepo.findOne.mockResolvedValue(mockOrder({ paymentStatus: SalesOrderPaymentStatus.PARTIAL }));
+    it('throws when status is CANCELLED', async () => {
+      orderRepo.findOne.mockResolvedValue(mockOrder({ status: SalesOrderStatus.CANCELLED }));
       await expect(service.assertEditAllowed('order-1')).rejects.toThrow(BadRequestException);
-    });
-
-    it('passes when DRAFT and UNPAID', async () => {
-      orderRepo.findOne.mockResolvedValue(mockOrder());
-      await expect(service.assertEditAllowed('order-1')).resolves.not.toThrow();
     });
   });
 

--- a/backend/src/modules/sales/services/sales-order-lifecycle.service.ts
+++ b/backend/src/modules/sales/services/sales-order-lifecycle.service.ts
@@ -20,15 +20,21 @@ export class SalesOrderLifecycleService {
   async assertEditAllowed(id: string): Promise<void> {
     const order = await this.salesOrderRepository.findOne({ where: { id } });
     if (!order) throw new NotFoundException('Sales order not found');
+    SalesOrderLifecycleService.assertStatusEditable(order.status);
+  }
 
-    // Editable while the order is still in the active band (DRAFT or fully-paid READY),
-    // regardless of payment. FULFILLED / CANCELLED are locked.
-    const editable =
-      order.status === SalesOrderStatus.DRAFT || order.status === SalesOrderStatus.READY;
+  /**
+   * Pure editable-band guard, reusable on an already-loaded (e.g. lock-held) row.
+   * Editable while still in the active band (DRAFT or fully-paid READY), regardless of
+   * payment. FULFILLED / CANCELLED are locked. Throwing here keeps a single source of
+   * truth for the rule and its messages so callers can re-assert inside a transaction.
+   */
+  static assertStatusEditable(status: SalesOrderStatus): void {
+    const editable = status === SalesOrderStatus.DRAFT || status === SalesOrderStatus.READY;
     if (!editable) {
       throw new BadRequestException(
-        `Cannot edit sales order in ${order.status} status. ${
-          order.status === SalesOrderStatus.FULFILLED ? 'Unfulfill the order first.' : 'Uncancel the order first.'
+        `Cannot edit sales order in ${status} status. ${
+          status === SalesOrderStatus.FULFILLED ? 'Unfulfill the order first.' : 'Uncancel the order first.'
         }`,
       );
     }

--- a/backend/src/modules/sales/services/sales-order-lifecycle.service.ts
+++ b/backend/src/modules/sales/services/sales-order-lifecycle.service.ts
@@ -21,16 +21,15 @@ export class SalesOrderLifecycleService {
     const order = await this.salesOrderRepository.findOne({ where: { id } });
     if (!order) throw new NotFoundException('Sales order not found');
 
-    if (order.status !== SalesOrderStatus.DRAFT) {
+    // Editable while the order is still in the active band (DRAFT or fully-paid READY),
+    // regardless of payment. FULFILLED / CANCELLED are locked.
+    const editable =
+      order.status === SalesOrderStatus.DRAFT || order.status === SalesOrderStatus.READY;
+    if (!editable) {
       throw new BadRequestException(
         `Cannot edit sales order in ${order.status} status. ${
           order.status === SalesOrderStatus.FULFILLED ? 'Unfulfill the order first.' : 'Uncancel the order first.'
         }`,
-      );
-    }
-    if (order.paymentStatus !== SalesOrderPaymentStatus.UNPAID) {
-      throw new BadRequestException(
-        'Cannot edit sales order with recorded payments. Refund all payments first.',
       );
     }
   }

--- a/backend/src/modules/sales/services/sales-order-payment.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.spec.ts
@@ -113,7 +113,7 @@ describe('SalesOrderPaymentService', () => {
   describe('reconcileOrderState', () => {
     // Helper: build a transaction manager whose SalesOrderPayment repo returns `payments`
     // and whose SalesOrder repo captures the update() call.
-    function mockTxManager(payments: { amount: number }[]) {
+    function mockTxManager(payments: { amount: number }[], order: SalesOrder) {
       const captured: { update?: any } = {};
       const manager = {
         getRepository: (entity: any) => {
@@ -121,7 +121,10 @@ describe('SalesOrderPaymentService', () => {
             return { find: jest.fn().mockResolvedValue(payments) };
           }
           // SalesOrder repo
-          return { update: jest.fn().mockImplementation((_id, patch) => { captured.update = patch; return Promise.resolve(); }) };
+          return {
+            findOne: jest.fn().mockResolvedValue(order),
+            update: jest.fn().mockImplementation((_id, patch) => { captured.update = patch; return Promise.resolve(); }),
+          };
         },
       } as unknown as EntityManager;
       return { manager, captured };
@@ -129,9 +132,8 @@ describe('SalesOrderPaymentService', () => {
 
     it('demotes READY -> DRAFT + PARTIAL when total rises above amount paid', async () => {
       const order = { id: 'o1', status: SalesOrderStatus.READY, totalAmount: 200, paidAmount: 100 } as SalesOrder;
-      const { manager, captured } = mockTxManager([{ amount: 100 }]);
+      const { manager, captured } = mockTxManager([{ amount: 100 }], order);
       (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
-      orderRepo.findOne.mockResolvedValue(order);
 
       await service.reconcileOrderState('o1');
 
@@ -142,14 +144,35 @@ describe('SalesOrderPaymentService', () => {
 
     it('promotes DRAFT -> READY and yields OVERPAID when total drops below amount paid', async () => {
       const order = { id: 'o2', status: SalesOrderStatus.DRAFT, totalAmount: 50, paidAmount: 100 } as SalesOrder;
-      const { manager, captured } = mockTxManager([{ amount: 100 }]);
+      const { manager, captured } = mockTxManager([{ amount: 100 }], order);
       (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
-      orderRepo.findOne.mockResolvedValue(order);
 
       await service.reconcileOrderState('o2');
 
       expect(captured.update.paymentStatus).toBe(SalesOrderPaymentStatus.OVERPAID);
       expect(captured.update.status).toBe(SalesOrderStatus.READY);
+    });
+
+    it('reuses a provided transaction manager (no new transaction) and locks the order', async () => {
+      const order = { id: 'o3', status: SalesOrderStatus.DRAFT, totalAmount: 80, paidAmount: 80 } as SalesOrder;
+      const findOne = jest.fn().mockResolvedValue(order);
+      const update = jest.fn().mockResolvedValue(undefined);
+      const manager = {
+        getRepository: (entity: any) => {
+          if (entity === SalesOrderPayment) return { find: jest.fn().mockResolvedValue([{ amount: 80 }]) };
+          return { findOne, update };
+        },
+      } as unknown as EntityManager;
+
+      await service.reconcileOrderState('o3', manager);
+
+      // Must NOT start its own transaction when a manager is supplied.
+      expect(dataSource.transaction as jest.Mock).not.toHaveBeenCalled();
+      // Reads the order through the manager with a write lock.
+      expect(findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'o3' }, lock: { mode: 'pessimistic_write' } }),
+      );
+      expect(update).toHaveBeenCalled();
     });
   });
 

--- a/backend/src/modules/sales/services/sales-order-payment.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.spec.ts
@@ -110,6 +110,49 @@ describe('SalesOrderPaymentService', () => {
     });
   });
 
+  describe('reconcileOrderState', () => {
+    // Helper: build a transaction manager whose SalesOrderPayment repo returns `payments`
+    // and whose SalesOrder repo captures the update() call.
+    function mockTxManager(payments: { amount: number }[]) {
+      const captured: { update?: any } = {};
+      const manager = {
+        getRepository: (entity: any) => {
+          if (entity === SalesOrderPayment) {
+            return { find: jest.fn().mockResolvedValue(payments) };
+          }
+          // SalesOrder repo
+          return { update: jest.fn().mockImplementation((_id, patch) => { captured.update = patch; return Promise.resolve(); }) };
+        },
+      } as unknown as EntityManager;
+      return { manager, captured };
+    }
+
+    it('demotes READY -> DRAFT + PARTIAL when total rises above amount paid', async () => {
+      const order = { id: 'o1', status: SalesOrderStatus.READY, totalAmount: 200, paidAmount: 100 } as SalesOrder;
+      const { manager, captured } = mockTxManager([{ amount: 100 }]);
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
+      orderRepo.findOne.mockResolvedValue(order);
+
+      await service.reconcileOrderState('o1');
+
+      expect(captured.update.paymentStatus).toBe(SalesOrderPaymentStatus.PARTIAL);
+      expect(captured.update.balanceDue).toBe(100);
+      expect(captured.update.status).toBe(SalesOrderStatus.DRAFT);
+    });
+
+    it('promotes DRAFT -> READY and yields OVERPAID when total drops below amount paid', async () => {
+      const order = { id: 'o2', status: SalesOrderStatus.DRAFT, totalAmount: 50, paidAmount: 100 } as SalesOrder;
+      const { manager, captured } = mockTxManager([{ amount: 100 }]);
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
+      orderRepo.findOne.mockResolvedValue(order);
+
+      await service.reconcileOrderState('o2');
+
+      expect(captured.update.paymentStatus).toBe(SalesOrderPaymentStatus.OVERPAID);
+      expect(captured.update.status).toBe(SalesOrderStatus.READY);
+    });
+  });
+
   describe('recordPayment', () => {
     it('throws NotFoundException when order not found', async () => {
       orderRepo.findOne.mockResolvedValue(null);

--- a/backend/src/modules/sales/services/sales-order-payment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.ts
@@ -39,6 +39,19 @@ export class SalesOrderPaymentService {
     return SalesOrderPaymentStatus.OVERPAID;
   }
 
+  /**
+   * Re-derive paymentStatus / paidAmount / balanceDue and the DRAFT<->READY band
+   * for an order whose totalAmount may have changed (e.g. after an edit). Reuses the
+   * same recompute as payment recording so there is one source of truth.
+   */
+  async reconcileOrderState(orderId: string): Promise<SalesOrderPaymentStatus> {
+    return this.dataSource.transaction(async (manager: EntityManager) => {
+      const order = await this.salesOrderRepository.findOne({ where: { id: orderId } });
+      if (!order) throw new NotFoundException('Sales order not found');
+      return this.updatePaymentStatusInTx(order, manager);
+    });
+  }
+
   async recordPayment(orderId: string, dto: RecordPaymentDto, userId?: string, username?: string): Promise<SalesOrderPayment> {
     if (dto.amount <= 0) {
       throw new BadRequestException('Payment amount must be positive');

--- a/backend/src/modules/sales/services/sales-order-payment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.ts
@@ -41,15 +41,21 @@ export class SalesOrderPaymentService {
 
   /**
    * Re-derive paymentStatus / paidAmount / balanceDue and the DRAFT<->READY band
-   * for an order whose totalAmount may have changed (e.g. after an edit). Reuses the
-   * same recompute as payment recording so there is one source of truth.
+   * for an order whose totalAmount may have changed. Reuses the same recompute as
+   * payment recording (single source of truth). When `manager` is supplied the work
+   * joins the caller's transaction; otherwise it runs in its own.
    */
-  async reconcileOrderState(orderId: string): Promise<SalesOrderPaymentStatus> {
-    return this.dataSource.transaction(async (manager: EntityManager) => {
-      const order = await this.salesOrderRepository.findOne({ where: { id: orderId } });
+  async reconcileOrderState(orderId: string, manager?: EntityManager): Promise<SalesOrderPaymentStatus> {
+    const run = async (m: EntityManager): Promise<SalesOrderPaymentStatus> => {
+      const order = await m.getRepository(SalesOrder).findOne({
+        where: { id: orderId },
+        lock: { mode: 'pessimistic_write' },
+      });
       if (!order) throw new NotFoundException('Sales order not found');
-      return this.updatePaymentStatusInTx(order, manager);
-    });
+      return this.updatePaymentStatusInTx(order, m);
+    };
+
+    return manager ? run(manager) : this.dataSource.transaction(run);
   }
 
   async recordPayment(orderId: string, dto: RecordPaymentDto, userId?: string, username?: string): Promise<SalesOrderPayment> {

--- a/backend/src/modules/sales/services/sales-order-payment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.ts
@@ -43,16 +43,19 @@ export class SalesOrderPaymentService {
    * Re-derive paymentStatus / paidAmount / balanceDue and the DRAFT<->READY band
    * for an order whose totalAmount may have changed. Reuses the same recompute as
    * payment recording (single source of truth). When `manager` is supplied the work
-   * joins the caller's transaction; otherwise it runs in its own.
+   * joins the caller's transaction; otherwise it runs in its own. Returns the locked
+   * order with the reconciled fields applied, so callers can snapshot it without an
+   * extra read inside the same transaction.
    */
-  async reconcileOrderState(orderId: string, manager?: EntityManager): Promise<SalesOrderPaymentStatus> {
-    const run = async (m: EntityManager): Promise<SalesOrderPaymentStatus> => {
+  async reconcileOrderState(orderId: string, manager?: EntityManager): Promise<SalesOrder> {
+    const run = async (m: EntityManager): Promise<SalesOrder> => {
       const order = await m.getRepository(SalesOrder).findOne({
         where: { id: orderId },
         lock: { mode: 'pessimistic_write' },
       });
       if (!order) throw new NotFoundException('Sales order not found');
-      return this.updatePaymentStatusInTx(order, m);
+      await this.updatePaymentStatusInTx(order, m);
+      return order;
     };
 
     return manager ? run(manager) : this.dataSource.transaction(run);
@@ -282,6 +285,9 @@ export class SalesOrderPaymentService {
     }
 
     await manager.getRepository(SalesOrder).update(order.id, update);
+    // Reflect the persisted patch onto the in-memory entity so callers holding this
+    // reference (e.g. reconcileOrderState) see the reconciled state without re-reading.
+    Object.assign(order, update);
     return newStatus;
   }
 }

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -204,6 +204,67 @@ describe('SalesOrderService', () => {
   });
 
   describe('update — atomicity', () => {
+    it('throws Customer not found for a customer-only edit with an invalid customerId (no items)', async () => {
+      salesOrderRepository.findOne = jest.fn().mockResolvedValue({
+        id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID',
+        paidAmount: 0, shippingAmount: 0, subtotal: 100, totalAmount: 100, balanceDue: 100, notes: null, customerId: 'c1',
+      });
+      const mgrCustomerRepo = { findOne: jest.fn().mockResolvedValue(null) }; // supplied customer does not exist
+      const mgrOrderRepo = {
+        findOne: jest.fn().mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, subtotal: 100, totalAmount: 100, balanceDue: 100, notes: null, customerId: 'c1' }),
+        update: jest.fn(),
+      };
+      const mgrItemRepo = { delete: jest.fn(), insert: jest.fn(), find: jest.fn() };
+      const manager = {
+        getRepository: (e: any) => {
+          if (e === SalesOrderItem) return mgrItemRepo;
+          if (e === Customer) return mgrCustomerRepo;
+          return mgrOrderRepo;
+        },
+      } as unknown as EntityManager;
+      dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
+
+      // No items — only a customer change to a non-existent id.
+      await expect(service.update('order-1', { customerId: 'nope' } as any))
+        .rejects.toThrow('Customer not found');
+      // The bad customerId must NOT be written.
+      expect(mgrOrderRepo.update).not.toHaveBeenCalled();
+    });
+
+    it('reuses the validated supplied customer for pricing (single customer lookup) when items exist', async () => {
+      salesOrderRepository.findOne = jest.fn().mockResolvedValue({
+        id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID',
+        paidAmount: 0, shippingAmount: 0, subtotal: 0, totalAmount: 0, balanceDue: 0, notes: null, customerId: 'old',
+      });
+      const mgrCustomerRepo = { findOne: jest.fn().mockResolvedValue({ id: 'cust-DTO', priceListId: 'PL-DTO' }) };
+      const mgrProductRepo = { findOne: jest.fn().mockResolvedValue({ id: 'p1', baseCost: 1 }) };
+      const mgrPriceListItemRepo = { findOne: jest.fn().mockResolvedValue({ price: 55 }) };
+      const mgrOrderRepo = {
+        findOne: jest.fn()
+          .mockResolvedValueOnce({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, subtotal: 0, totalAmount: 0, balanceDue: 0, notes: null, customerId: 'cust-DTO' })
+          .mockResolvedValueOnce({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, subtotal: 55, totalAmount: 55, balanceDue: 55, notes: null, customerId: 'cust-DTO' }),
+        update: jest.fn().mockResolvedValue({ affected: 1 }),
+      };
+      const mgrItemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockResolvedValue(undefined), find: jest.fn().mockResolvedValue([]) };
+      const manager = {
+        getRepository: (e: any) => {
+          if (e === SalesOrderItem) return mgrItemRepo;
+          if (e === Customer) return mgrCustomerRepo;
+          if (e === Product) return mgrProductRepo;
+          if (e === PriceListItem) return mgrPriceListItemRepo;
+          return mgrOrderRepo;
+        },
+      } as unknown as EntityManager;
+      dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
+      reconcileSpy.mockResolvedValue('UNPAID');
+
+      await service.update('order-1', { customerId: 'cust-DTO', items: [{ productId: 'p1', quantity: 1 }] } as any);
+
+      // Customer resolved exactly once, then reused for pricing (not looked up again).
+      expect(mgrCustomerRepo.findOne).toHaveBeenCalledTimes(1);
+      expect(mgrItemRepo.insert).toHaveBeenCalledWith(expect.objectContaining({ unitPrice: 55 }));
+    });
+
     it('prices a DTO-supplied customer through the manager repos (under the lock)', async () => {
       salesOrderRepository.findOne = jest.fn().mockResolvedValue({
         id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID',

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -35,6 +35,7 @@ describe('SalesOrderService', () => {
   let priceListItemRepository: any;
   let dataSource: jest.Mocked<DataSource>;
   let reconcileSpy: jest.SpyInstance;
+  let auditLogService: jest.Mocked<AuditLogService>;
 
   beforeEach(async () => {
     dataSource = { transaction: jest.fn() } as any;
@@ -75,6 +76,7 @@ describe('SalesOrderService', () => {
     customerRepository = module.get(getRepositoryToken(Customer));
     productRepository = module.get(getRepositoryToken(Product));
     priceListItemRepository = module.get(getRepositoryToken(PriceListItem));
+    auditLogService = module.get(AuditLogService);
     reconcileSpy = jest.spyOn(salesOrderPaymentService, 'reconcileOrderState');
     dataSource.transaction.mockImplementation(async (cb: any) => cb({
       getRepository: (entity: any) => entity === SalesOrderItem ? salesOrderItemRepository : salesOrderRepository,
@@ -221,8 +223,20 @@ describe('SalesOrderService', () => {
           Promise.resolve({ id: where.id, priceListId: where.id === 'cust-FRESH' ? 'PL-FRESH' : 'PL-STALE' }),
         ),
       };
+      const mgrProductRepo = { findOne: jest.fn().mockResolvedValue({ id: 'p1', baseCost: 1 }) };
+      const mgrPriceListItemRepo = {
+        findOne: jest.fn().mockImplementation(({ where }: any) =>
+          Promise.resolve(where.priceListId === 'PL-FRESH' ? { price: 70 } : { price: 999 }),
+        ),
+      };
       const manager = {
-        getRepository: (e: any) => e === SalesOrderItem ? mgrItemRepo : e === Customer ? mgrCustomerRepo : mgrOrderRepo,
+        getRepository: (e: any) => {
+          if (e === SalesOrderItem) return mgrItemRepo;
+          if (e === Customer) return mgrCustomerRepo;
+          if (e === Product) return mgrProductRepo;
+          if (e === PriceListItem) return mgrPriceListItemRepo;
+          return mgrOrderRepo;
+        },
       } as unknown as EntityManager;
       dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
       reconcileSpy.mockResolvedValue('UNPAID');
@@ -237,15 +251,98 @@ describe('SalesOrderService', () => {
 
       await service.update('order-1', { items: [{ productId: 'p1', quantity: 1 }] } as any);
 
-      expect(priceListItemRepository.findOne).toHaveBeenCalledWith(
+      expect(mgrPriceListItemRepo.findOne).toHaveBeenCalledWith(
         expect.objectContaining({ where: expect.objectContaining({ priceListId: 'PL-FRESH' }) }),
       );
+      expect(priceListItemRepository.findOne).not.toHaveBeenCalled();
       expect(mgrItemRepo.insert).toHaveBeenCalledWith(
         expect.objectContaining({ unitPrice: 70, totalAmount: 70 }),
       );
       expect(mgrOrderRepo.update).toHaveBeenCalledWith(
         'order-1', expect.objectContaining({ subtotal: 70, totalAmount: 70 }),
       );
+    });
+
+    it('fallback pricing reads product + price-list through the manager (under the lock)', async () => {
+      salesOrderRepository.findOne = jest.fn().mockResolvedValue({
+        id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID',
+        paidAmount: 0, shippingAmount: 0, customerId: 'cust-FRESH',
+      });
+      const mgrCustomerRepo = { findOne: jest.fn().mockResolvedValue({ id: 'cust-FRESH', priceListId: 'PL-FRESH' }) };
+      const mgrProductRepo = { findOne: jest.fn().mockResolvedValue({ id: 'p1', baseCost: 1 }) };
+      const mgrPriceListItemRepo = { findOne: jest.fn().mockResolvedValue({ price: 70 }) };
+      const mgrOrderRepo = {
+        findOne: jest.fn().mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, customerId: 'cust-FRESH' }),
+        update: jest.fn().mockResolvedValue({ affected: 1 }),
+      };
+      const mgrItemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockResolvedValue(undefined), find: jest.fn().mockResolvedValue([]) };
+      const manager = {
+        getRepository: (e: any) => {
+          if (e === SalesOrderItem) return mgrItemRepo;
+          if (e === Customer) return mgrCustomerRepo;
+          if (e === Product) return mgrProductRepo;
+          if (e === PriceListItem) return mgrPriceListItemRepo;
+          return mgrOrderRepo;
+        },
+      } as unknown as EntityManager;
+      dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
+      reconcileSpy.mockResolvedValue('UNPAID');
+
+      await service.update('order-1', { items: [{ productId: 'p1', quantity: 1 }] } as any);
+
+      expect(mgrProductRepo.findOne).toHaveBeenCalled();
+      expect(mgrPriceListItemRepo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ priceListId: 'PL-FRESH', productId: 'p1' }) }),
+      );
+      expect(productRepository.findOne).not.toHaveBeenCalled();
+      expect(priceListItemRepository.findOne).not.toHaveBeenCalled();
+      expect(mgrItemRepo.insert).toHaveBeenCalledWith(expect.objectContaining({ unitPrice: 70 }));
+    });
+
+    it('throws Customer not found when the locked fallback customer is missing', async () => {
+      salesOrderRepository.findOne = jest.fn().mockResolvedValue({
+        id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID',
+        paidAmount: 0, shippingAmount: 0, customerId: 'gone',
+      });
+      const mgrCustomerRepo = { findOne: jest.fn().mockResolvedValue(null) };
+      const mgrOrderRepo = { findOne: jest.fn().mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, customerId: 'gone' }), update: jest.fn() };
+      const mgrItemRepo = { delete: jest.fn(), insert: jest.fn(), find: jest.fn() };
+      const manager = {
+        getRepository: (e: any) => {
+          if (e === SalesOrderItem) return mgrItemRepo;
+          if (e === Customer) return mgrCustomerRepo;
+          return mgrOrderRepo;
+        },
+      } as unknown as EntityManager;
+      dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
+
+      await expect(service.update('order-1', { items: [{ productId: 'p1', quantity: 1 }] } as any))
+        .rejects.toThrow('Customer not found');
+      expect(mgrItemRepo.insert).not.toHaveBeenCalled();
+    });
+
+    it('records distinct before/after audit values including reconciled fields', async () => {
+      salesOrderRepository.findOne = jest.fn()
+        .mockResolvedValueOnce({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 20, subtotal: 80, totalAmount: 100, balanceDue: 100, customerId: 'c1' })
+        .mockResolvedValueOnce({ id: 'order-1', orderNumber: 'SO-1', status: 'READY', paymentStatus: 'PAID', paidAmount: 120, shippingAmount: 20, subtotal: 100, totalAmount: 120, balanceDue: 0, customerId: 'c1' });
+      const mgrOrderRepo = {
+        findOne: jest.fn().mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 20, subtotal: 80, totalAmount: 100, balanceDue: 100, customerId: 'c1' }),
+        update: jest.fn().mockResolvedValue({ affected: 1 }),
+      };
+      const mgrItemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockResolvedValue(undefined), find: jest.fn() };
+      const manager = { getRepository: (e: any) => (e === SalesOrderItem ? mgrItemRepo : mgrOrderRepo) } as unknown as EntityManager;
+      dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
+      reconcileSpy.mockResolvedValue('PAID');
+      customerRepository.findOne = jest.fn().mockResolvedValue({ id: 'c1' });
+      productRepository.findOne = jest.fn().mockResolvedValue({ id: 'p1', baseCost: 1 });
+
+      await service.update('order-1', { customerId: 'c1', items: [{ productId: 'p1', quantity: 1, unitPrice: 100 }] } as any);
+
+      const auditCall = (auditLogService.log as jest.Mock).mock.calls.at(-1);
+      const payload = auditCall[3];
+      expect(payload.oldValues.totalAmount).not.toBe(payload.newValues.totalAmount);
+      expect(payload.newValues.paymentStatus).toBe('PAID');
+      expect(payload.newValues.status).toBe('READY');
     });
 
     it('derives shipping fallback from the LOCKED order and writes via the manager', async () => {

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import { SalesOrderService } from './sales-order.service';
 import { SalesOrder, SalesOrderPaymentStatus, SalesOrderStatus } from '../../../database/entities/sales-order.entity';
 import { SalesOrderItem, DiscountType } from '../../../database/entities/sales-order-item.entity';
@@ -30,8 +30,13 @@ describe('SalesOrderService', () => {
   let salesOrderQueryService: jest.Mocked<SalesOrderQueryService>;
   let salesOrderRepository: any;
   let salesOrderItemRepository: any;
+  let productRepository: any;
+  let dataSource: jest.Mocked<DataSource>;
+  let reconcileSpy: jest.SpyInstance;
 
   beforeEach(async () => {
+    dataSource = { transaction: jest.fn() } as any;
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SalesOrderService,
@@ -54,6 +59,7 @@ describe('SalesOrderService', () => {
         { provide: SalesOrderLifecycleService, useValue: { assertEditAllowed: jest.fn(), cancel: jest.fn(), uncancel: jest.fn() } },
         { provide: SalesOrderPaymentService, useValue: { recordPayment: jest.fn(), recordRefund: jest.fn(), listPayments: jest.fn(), reconcileOrderState: jest.fn() } },
         { provide: SalesOrderQueryService, useValue: { findById: jest.fn(), findAll: jest.fn(), findSummaries: jest.fn(), getDashboardStats: jest.fn(), findByOrderNumber: jest.fn(), findOrdersByCustomer: jest.fn() } },
+        { provide: DataSource, useValue: dataSource },
       ],
     }).compile();
 
@@ -64,6 +70,11 @@ describe('SalesOrderService', () => {
     salesOrderQueryService = module.get(SalesOrderQueryService);
     salesOrderRepository = module.get(getRepositoryToken(SalesOrder));
     salesOrderItemRepository = module.get(getRepositoryToken(SalesOrderItem));
+    productRepository = module.get(getRepositoryToken(Product));
+    reconcileSpy = jest.spyOn(salesOrderPaymentService, 'reconcileOrderState');
+    dataSource.transaction.mockImplementation(async (cb: any) => cb({
+      getRepository: (entity: any) => entity === SalesOrderItem ? salesOrderItemRepository : salesOrderRepository,
+    }));
     salesOrderQueryService.findById.mockResolvedValue({ id: 'order-1' } as any);
   });
 
@@ -182,7 +193,54 @@ describe('SalesOrderService', () => {
       expect(salesOrderRepository.update).toHaveBeenCalledWith('order-1', expect.objectContaining({
         totalAmount: 1100,
       }));
-      expect(salesOrderPaymentService.reconcileOrderState).toHaveBeenCalledWith('order-1');
+      expect(salesOrderPaymentService.reconcileOrderState).toHaveBeenCalledWith('order-1', expect.any(Object));
+    });
+  });
+
+  describe('update — atomicity', () => {
+    it('locks the order and runs item writes + reconcile in one transaction', async () => {
+      const order = {
+        id: 'o1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'PAID',
+        paidAmount: 100, totalAmount: 100, customerId: 'c1', shippingAmount: 0,
+      };
+      const orderFindOne = jest.fn().mockResolvedValue(order);
+      const itemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockResolvedValue(undefined), find: jest.fn().mockResolvedValue([]) };
+      const orderRepoTx = { findOne: orderFindOne, update: jest.fn().mockResolvedValue(undefined) };
+      const manager = {
+        getRepository: (e: any) => (e === SalesOrderItem ? itemRepo : orderRepoTx),
+      } as unknown as EntityManager;
+      salesOrderRepository.findOne.mockResolvedValue(order);
+      productRepository.findOne.mockResolvedValue({ id: 'p1', baseCost: 10 });
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
+      reconcileSpy.mockResolvedValue('PAID');
+
+      await service.update('o1', { items: [{ productId: 'p1', quantity: 1, unitPrice: 10 }] } as any);
+
+      // Order read inside the tx with a write lock.
+      expect(orderFindOne).toHaveBeenCalledWith(
+        expect.objectContaining({ lock: { mode: 'pessimistic_write' } }),
+      );
+      // Reconcile joined the SAME transaction (manager passed through).
+      expect(reconcileSpy).toHaveBeenCalledWith('o1', manager);
+    });
+
+    it('rolls back: when an item insert fails, the transaction rejects and reconcile is not called', async () => {
+      const order = { id: 'o1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, totalAmount: 0, customerId: 'c1', shippingAmount: 0 };
+      const orderRepoTx = {
+        findOne: jest.fn().mockResolvedValue(order),
+        update: jest.fn(),
+      };
+      const itemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockRejectedValue(new Error('insert failed')), find: jest.fn() };
+      const manager = { getRepository: (e: any) => (e === SalesOrderItem ? itemRepo : orderRepoTx) } as unknown as EntityManager;
+      salesOrderRepository.findOne.mockResolvedValue(order);
+      productRepository.findOne.mockResolvedValue({ id: 'p1', baseCost: 10 });
+      // Real transaction semantics: a throwing callback rejects the whole transaction.
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
+
+      await expect(
+        service.update('o1', { items: [{ productId: 'p1', quantity: 1, unitPrice: 10 }] } as any),
+      ).rejects.toThrow('insert failed');
+      expect(reconcileSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -46,11 +46,11 @@ describe('SalesOrderService', () => {
         { provide: getRepositoryToken(SalesOrder), useValue: { findOne: jest.fn(), create: jest.fn(), save: jest.fn(), update: jest.fn(), createQueryBuilder: jest.fn() } },
         { provide: getRepositoryToken(SalesOrderItem), useValue: { save: jest.fn(), delete: jest.fn(), insert: jest.fn(), find: jest.fn() } },
         { provide: getRepositoryToken(Customer), useValue: { findOne: jest.fn() } },
-        { provide: getRepositoryToken(Product), useValue: { findOne: jest.fn() } },
+        { provide: getRepositoryToken(Product), useValue: { findOne: jest.fn(), find: jest.fn() } },
         { provide: getRepositoryToken(Invoice), useValue: { createQueryBuilder: jest.fn(), create: jest.fn(), save: jest.fn(), find: jest.fn() } },
         { provide: getRepositoryToken(InvoiceItem), useValue: { insert: jest.fn(), delete: jest.fn() } },
         { provide: getRepositoryToken(User), useValue: {} },
-        { provide: getRepositoryToken(PriceListItem), useValue: { findOne: jest.fn() } },
+        { provide: getRepositoryToken(PriceListItem), useValue: { findOne: jest.fn(), find: jest.fn() } },
         { provide: CustomerService, useValue: { updateCustomerMetrics: jest.fn() } },
         { provide: InventoryIntegrationService, useValue: { checkAvailability: jest.fn(), reserveStock: jest.fn(), getOrderFulfillmentStatus: jest.fn() } },
         { provide: StockMovementService, useValue: {} },
@@ -147,6 +147,7 @@ describe('SalesOrderService', () => {
       const mockOrder = {
         id: 'order-1',
         customerId: 'customer-1',
+        status: SalesOrderStatus.DRAFT,
         shippingAmount: 0,
         subtotal: 100,
         totalAmount: 100,
@@ -231,18 +232,79 @@ describe('SalesOrderService', () => {
       expect(mgrOrderRepo.update).not.toHaveBeenCalled();
     });
 
+    it('re-asserts editability against the LOCKED row: rejects an order fulfilled after the pre-check', async () => {
+      // Pre-lock read passes the editable check (DRAFT)...
+      salesOrderRepository.findOne = jest.fn().mockResolvedValue({
+        id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID',
+        paidAmount: 0, shippingAmount: 0, subtotal: 100, totalAmount: 100, balanceDue: 100, notes: null, customerId: 'c1',
+      });
+      // ...but a concurrent fulfill committed first, so the LOCKED row is FULFILLED.
+      const mgrOrderRepo = {
+        findOne: jest.fn().mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: SalesOrderStatus.FULFILLED, paymentStatus: 'PAID', paidAmount: 100, shippingAmount: 0, subtotal: 100, totalAmount: 100, balanceDue: 0, notes: null, customerId: 'c1' }),
+        update: jest.fn(),
+      };
+      const mgrItemRepo = { delete: jest.fn(), insert: jest.fn(), find: jest.fn() };
+      const manager = { getRepository: (e: any) => (e === SalesOrderItem ? mgrItemRepo : mgrOrderRepo) } as unknown as EntityManager;
+      dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
+
+      await expect(service.update('order-1', { items: [{ productId: 'p1', quantity: 1 }] } as any))
+        .rejects.toThrow(/Cannot edit sales order in FULFILLED status/);
+      // Nothing was mutated and reconcile never ran.
+      expect(mgrItemRepo.delete).not.toHaveBeenCalled();
+      expect(mgrOrderRepo.update).not.toHaveBeenCalled();
+      expect(reconcileSpy).not.toHaveBeenCalled();
+    });
+
+    it('re-prices existing items at the new customer prices on a customer-only edit', async () => {
+      // Customer changes (c1 -> cust-NEW) with NO items in the DTO; existing line must be re-priced.
+      salesOrderRepository.findOne = jest.fn().mockResolvedValue({
+        id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID',
+        paidAmount: 0, shippingAmount: 0, subtotal: 100, totalAmount: 100, balanceDue: 100, notes: null, customerId: 'c1',
+      });
+      const mgrCustomerRepo = { findOne: jest.fn().mockResolvedValue({ id: 'cust-NEW', priceListId: 'PL-NEW' }) };
+      const mgrProductRepo = { find: jest.fn().mockResolvedValue([{ id: 'p1', baseCost: 1 }]) };
+      const mgrPriceListItemRepo = { find: jest.fn().mockResolvedValue([{ productId: 'p1', price: 70 }]) };
+      const mgrOrderRepo = {
+        findOne: jest.fn().mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, subtotal: 100, totalAmount: 100, balanceDue: 100, notes: null, customerId: 'c1' }),
+        update: jest.fn().mockResolvedValue({ affected: 1 }),
+      };
+      // Existing line on the order (qty 2) — re-priced from the new customer's price list (70 each).
+      const mgrItemRepo = {
+        delete: jest.fn().mockResolvedValue(undefined),
+        insert: jest.fn().mockResolvedValue(undefined),
+        find: jest.fn().mockResolvedValue([{ productId: 'p1', quantity: 2, discountType: DiscountType.PERCENTAGE, discountPercent: 0, discountAmount: 0, notes: null }]),
+      };
+      const manager = {
+        getRepository: (e: any) => {
+          if (e === SalesOrderItem) return mgrItemRepo;
+          if (e === Customer) return mgrCustomerRepo;
+          if (e === Product) return mgrProductRepo;
+          if (e === PriceListItem) return mgrPriceListItemRepo;
+          return mgrOrderRepo;
+        },
+      } as unknown as EntityManager;
+      dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
+      reconcileSpy.mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, subtotal: 140, totalAmount: 140, balanceDue: 140, notes: null, customerId: 'cust-NEW' });
+
+      await service.update('order-1', { customerId: 'cust-NEW' } as any);
+
+      // Existing items were re-priced (70 * 2 = 140) and the total recomputed + reconciled.
+      expect(mgrItemRepo.insert).toHaveBeenCalledWith(expect.objectContaining({ unitPrice: 70, totalAmount: 140 }));
+      expect(mgrOrderRepo.update).toHaveBeenCalledWith('order-1', expect.objectContaining({ customerId: 'cust-NEW', subtotal: 140, totalAmount: 140 }));
+      expect(reconcileSpy).toHaveBeenCalledWith('order-1', manager);
+    });
+
     it('reuses the validated supplied customer for pricing (single customer lookup) when items exist', async () => {
       salesOrderRepository.findOne = jest.fn().mockResolvedValue({
         id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID',
         paidAmount: 0, shippingAmount: 0, subtotal: 0, totalAmount: 0, balanceDue: 0, notes: null, customerId: 'old',
       });
       const mgrCustomerRepo = { findOne: jest.fn().mockResolvedValue({ id: 'cust-DTO', priceListId: 'PL-DTO' }) };
-      const mgrProductRepo = { findOne: jest.fn().mockResolvedValue({ id: 'p1', baseCost: 1 }) };
-      const mgrPriceListItemRepo = { findOne: jest.fn().mockResolvedValue({ price: 55 }) };
+      const mgrProductRepo = { find: jest.fn().mockResolvedValue([{ id: 'p1', baseCost: 1 }]) };
+      const mgrPriceListItemRepo = { find: jest.fn().mockResolvedValue([{ productId: 'p1', price: 55 }]) };
+      const reconciledOrder = { id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, subtotal: 55, totalAmount: 55, balanceDue: 55, notes: null, customerId: 'cust-DTO' };
       const mgrOrderRepo = {
-        findOne: jest.fn()
-          .mockResolvedValueOnce({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, subtotal: 0, totalAmount: 0, balanceDue: 0, notes: null, customerId: 'cust-DTO' })
-          .mockResolvedValueOnce({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, subtotal: 55, totalAmount: 55, balanceDue: 55, notes: null, customerId: 'cust-DTO' }),
+        findOne: jest.fn().mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, subtotal: 0, totalAmount: 0, balanceDue: 0, notes: null, customerId: 'cust-DTO' }),
         update: jest.fn().mockResolvedValue({ affected: 1 }),
       };
       const mgrItemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockResolvedValue(undefined), find: jest.fn().mockResolvedValue([]) };
@@ -256,7 +318,7 @@ describe('SalesOrderService', () => {
         },
       } as unknown as EntityManager;
       dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
-      reconcileSpy.mockResolvedValue('UNPAID');
+      reconcileSpy.mockResolvedValue(reconciledOrder);
 
       await service.update('order-1', { customerId: 'cust-DTO', items: [{ productId: 'p1', quantity: 1 }] } as any);
 
@@ -271,12 +333,11 @@ describe('SalesOrderService', () => {
         paidAmount: 0, shippingAmount: 0, subtotal: 0, totalAmount: 0, balanceDue: 0, notes: null, customerId: 'old',
       });
       const mgrCustomerRepo = { findOne: jest.fn().mockResolvedValue({ id: 'cust-DTO', priceListId: 'PL-DTO' }) };
-      const mgrProductRepo = { findOne: jest.fn().mockResolvedValue({ id: 'p1', baseCost: 1 }) };
-      const mgrPriceListItemRepo = { findOne: jest.fn().mockResolvedValue({ price: 55 }) };
+      const mgrProductRepo = { find: jest.fn().mockResolvedValue([{ id: 'p1', baseCost: 1 }]) };
+      const mgrPriceListItemRepo = { find: jest.fn().mockResolvedValue([{ productId: 'p1', price: 55 }]) };
+      const reconciledOrder = { id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, subtotal: 55, totalAmount: 55, balanceDue: 55, notes: null, customerId: 'cust-DTO' };
       const mgrOrderRepo = {
-        findOne: jest.fn()
-          .mockResolvedValueOnce({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, subtotal: 0, totalAmount: 0, balanceDue: 0, notes: null, customerId: 'cust-DTO' })
-          .mockResolvedValueOnce({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, subtotal: 55, totalAmount: 55, balanceDue: 55, notes: null, customerId: 'cust-DTO' }),
+        findOne: jest.fn().mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, subtotal: 0, totalAmount: 0, balanceDue: 0, notes: null, customerId: 'cust-DTO' }),
         update: jest.fn().mockResolvedValue({ affected: 1 }),
       };
       const mgrItemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockResolvedValue(undefined), find: jest.fn().mockResolvedValue([]) };
@@ -290,14 +351,14 @@ describe('SalesOrderService', () => {
         },
       } as unknown as EntityManager;
       dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
-      reconcileSpy.mockResolvedValue('UNPAID');
+      reconcileSpy.mockResolvedValue(reconciledOrder);
 
       await service.update('order-1', { customerId: 'cust-DTO', items: [{ productId: 'p1', quantity: 1 }] } as any);
 
       // Supplied-customer pricing went through the MANAGER repos, not the root repos.
       expect(mgrCustomerRepo.findOne).toHaveBeenCalledWith(expect.objectContaining({ where: { id: 'cust-DTO' } }));
-      expect(mgrProductRepo.findOne).toHaveBeenCalled();
-      expect(mgrPriceListItemRepo.findOne).toHaveBeenCalledWith(
+      expect(mgrProductRepo.find).toHaveBeenCalled();
+      expect(mgrPriceListItemRepo.find).toHaveBeenCalledWith(
         expect.objectContaining({ where: expect.objectContaining({ priceListId: 'PL-DTO' }) }),
       );
       expect(customerRepository.findOne).not.toHaveBeenCalled();
@@ -348,10 +409,10 @@ describe('SalesOrderService', () => {
           Promise.resolve({ id: where.id, priceListId: where.id === 'cust-FRESH' ? 'PL-FRESH' : 'PL-STALE' }),
         ),
       };
-      const mgrProductRepo = { findOne: jest.fn().mockResolvedValue({ id: 'p1', baseCost: 1 }) };
+      const mgrProductRepo = { find: jest.fn().mockResolvedValue([{ id: 'p1', baseCost: 1 }]) };
       const mgrPriceListItemRepo = {
-        findOne: jest.fn().mockImplementation(({ where }: any) =>
-          Promise.resolve(where.priceListId === 'PL-FRESH' ? { price: 70 } : { price: 999 }),
+        find: jest.fn().mockImplementation(({ where }: any) =>
+          Promise.resolve(where.priceListId === 'PL-FRESH' ? [{ productId: 'p1', price: 70 }] : [{ productId: 'p1', price: 999 }]),
         ),
       };
       const manager = {
@@ -364,22 +425,22 @@ describe('SalesOrderService', () => {
         },
       } as unknown as EntityManager;
       dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
-      reconcileSpy.mockResolvedValue('UNPAID');
+      reconcileSpy.mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, subtotal: 70, totalAmount: 70, balanceDue: 70, notes: null, customerId: 'cust-FRESH' });
 
       customerRepository.findOne = jest.fn().mockImplementation(({ where }: any) =>
         Promise.resolve({ id: where.id, priceListId: where.id === 'cust-FRESH' ? 'PL-FRESH' : 'PL-STALE' }),
       );
-      productRepository.findOne = jest.fn().mockResolvedValue({ id: 'p1', baseCost: 1 });
-      priceListItemRepository.findOne = jest.fn().mockImplementation(({ where }: any) =>
-        Promise.resolve(where.priceListId === 'PL-FRESH' ? { price: 70 } : { price: 999 }),
+      productRepository.find = jest.fn().mockResolvedValue([{ id: 'p1', baseCost: 1 }]);
+      priceListItemRepository.find = jest.fn().mockImplementation(({ where }: any) =>
+        Promise.resolve(where.priceListId === 'PL-FRESH' ? [{ productId: 'p1', price: 70 }] : [{ productId: 'p1', price: 999 }]),
       );
 
       await service.update('order-1', { items: [{ productId: 'p1', quantity: 1 }] } as any);
 
-      expect(mgrPriceListItemRepo.findOne).toHaveBeenCalledWith(
+      expect(mgrPriceListItemRepo.find).toHaveBeenCalledWith(
         expect.objectContaining({ where: expect.objectContaining({ priceListId: 'PL-FRESH' }) }),
       );
-      expect(priceListItemRepository.findOne).not.toHaveBeenCalled();
+      expect(priceListItemRepository.find).not.toHaveBeenCalled();
       expect(mgrItemRepo.insert).toHaveBeenCalledWith(
         expect.objectContaining({ unitPrice: 70, totalAmount: 70 }),
       );
@@ -394,8 +455,8 @@ describe('SalesOrderService', () => {
         paidAmount: 0, shippingAmount: 0, customerId: 'cust-FRESH',
       });
       const mgrCustomerRepo = { findOne: jest.fn().mockResolvedValue({ id: 'cust-FRESH', priceListId: 'PL-FRESH' }) };
-      const mgrProductRepo = { findOne: jest.fn().mockResolvedValue({ id: 'p1', baseCost: 1 }) };
-      const mgrPriceListItemRepo = { findOne: jest.fn().mockResolvedValue({ price: 70 }) };
+      const mgrProductRepo = { find: jest.fn().mockResolvedValue([{ id: 'p1', baseCost: 1 }]) };
+      const mgrPriceListItemRepo = { find: jest.fn().mockResolvedValue([{ productId: 'p1', price: 70 }]) };
       const mgrOrderRepo = {
         findOne: jest.fn().mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, customerId: 'cust-FRESH' }),
         update: jest.fn().mockResolvedValue({ affected: 1 }),
@@ -411,16 +472,16 @@ describe('SalesOrderService', () => {
         },
       } as unknown as EntityManager;
       dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
-      reconcileSpy.mockResolvedValue('UNPAID');
+      reconcileSpy.mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, subtotal: 70, totalAmount: 70, balanceDue: 70, notes: null, customerId: 'cust-FRESH' });
 
       await service.update('order-1', { items: [{ productId: 'p1', quantity: 1 }] } as any);
 
-      expect(mgrProductRepo.findOne).toHaveBeenCalled();
-      expect(mgrPriceListItemRepo.findOne).toHaveBeenCalledWith(
-        expect.objectContaining({ where: expect.objectContaining({ priceListId: 'PL-FRESH', productId: 'p1' }) }),
+      expect(mgrProductRepo.find).toHaveBeenCalled();
+      expect(mgrPriceListItemRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ priceListId: 'PL-FRESH' }) }),
       );
-      expect(productRepository.findOne).not.toHaveBeenCalled();
-      expect(priceListItemRepository.findOne).not.toHaveBeenCalled();
+      expect(productRepository.find).not.toHaveBeenCalled();
+      expect(priceListItemRepository.find).not.toHaveBeenCalled();
       expect(mgrItemRepo.insert).toHaveBeenCalledWith(expect.objectContaining({ unitPrice: 70 }));
     });
 
@@ -458,8 +519,8 @@ describe('SalesOrderService', () => {
       };
       const mgrItemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockResolvedValue(undefined), find: jest.fn() };
       const mgrCustomerRepo = { findOne: jest.fn().mockResolvedValue({ id: 'c1' }) };
-      const mgrProductRepo = { findOne: jest.fn().mockResolvedValue({ id: 'p1', baseCost: 1 }) };
-      const mgrPriceListItemRepo = { findOne: jest.fn() };
+      const mgrProductRepo = { find: jest.fn().mockResolvedValue([{ id: 'p1', baseCost: 1 }]) };
+      const mgrPriceListItemRepo = { find: jest.fn().mockResolvedValue([]) };
       const manager = {
         getRepository: (e: any) => {
           if (e === SalesOrderItem) return mgrItemRepo;
@@ -470,7 +531,8 @@ describe('SalesOrderService', () => {
         },
       } as unknown as EntityManager;
       dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
-      reconcileSpy.mockResolvedValue('PAID');
+      // Reconcile returns the reconciled order; update() snapshots it for the audit "after".
+      reconcileSpy.mockResolvedValue(reconciledAfter);
 
       await service.update('order-1', { customerId: 'c1', items: [{ productId: 'p1', quantity: 1, unitPrice: 100 }] } as any);
 
@@ -497,8 +559,8 @@ describe('SalesOrderService', () => {
       };
       const mgrItemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockResolvedValue(undefined), find: jest.fn().mockResolvedValue([]) };
       const mgrCustomerRepo = { findOne: jest.fn().mockResolvedValue({ id: 'c1' }) };
-      const mgrProductRepo = { findOne: jest.fn().mockResolvedValue({ id: 'p1', sellingPrice: 100 }) };
-      const mgrPriceListItemRepo = { findOne: jest.fn() };
+      const mgrProductRepo = { find: jest.fn().mockResolvedValue([{ id: 'p1', sellingPrice: 100 }]) };
+      const mgrPriceListItemRepo = { find: jest.fn().mockResolvedValue([]) };
       const manager = {
         getRepository: (e: any) => {
           if (e === SalesOrderItem) return mgrItemRepo;
@@ -509,7 +571,7 @@ describe('SalesOrderService', () => {
         },
       } as unknown as EntityManager;
       dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
-      reconcileSpy.mockResolvedValue('UNPAID');
+      reconcileSpy.mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 20, subtotal: 100, totalAmount: 120, balanceDue: 120, notes: null, customerId: 'c1' });
       // One product priced at 100, no shippingAmount in the DTO -> fallback must use shipping=20.
 
       await service.update('order-1', { items: [{ productId: 'p1', quantity: 1, unitPrice: 100 }] } as any);
@@ -541,7 +603,7 @@ describe('SalesOrderService', () => {
       const mgrItemRepo = { delete: jest.fn(), insert: jest.fn(), find: jest.fn().mockResolvedValue([{ totalAmount: 300 }]) };
       const manager = { getRepository: (e: any) => (e === SalesOrderItem ? mgrItemRepo : mgrOrderRepo) } as unknown as EntityManager;
       dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
-      reconcileSpy.mockResolvedValue('UNPAID');
+      reconcileSpy.mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 50, subtotal: 300, totalAmount: 350, balanceDue: 350, notes: null, customerId: 'c1' });
 
       await service.update('order-1', { shippingAmount: 50 } as any);
 
@@ -558,8 +620,8 @@ describe('SalesOrderService', () => {
       const mgrOrderRepo = { findOne: jest.fn().mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, customerId: 'c1' }), update: jest.fn() };
       const mgrItemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockRejectedValue(new Error('insert failed')), find: jest.fn() };
       const mgrCustomerRepo = { findOne: jest.fn().mockResolvedValue({ id: 'c1' }) };
-      const mgrProductRepo = { findOne: jest.fn().mockResolvedValue({ id: 'p1', sellingPrice: 10 }) };
-      const mgrPriceListItemRepo = { findOne: jest.fn() };
+      const mgrProductRepo = { find: jest.fn().mockResolvedValue([{ id: 'p1', sellingPrice: 10 }]) };
+      const mgrPriceListItemRepo = { find: jest.fn().mockResolvedValue([]) };
       const manager = {
         getRepository: (e: any) => {
           if (e === SalesOrderItem) return mgrItemRepo;

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -198,48 +198,79 @@ describe('SalesOrderService', () => {
   });
 
   describe('update — atomicity', () => {
-    it('locks the order and runs item writes + reconcile in one transaction', async () => {
-      const order = {
-        id: 'o1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'PAID',
-        paidAmount: 100, totalAmount: 100, customerId: 'c1', shippingAmount: 0,
+    it('derives shipping fallback from the LOCKED order and writes via the manager', async () => {
+      // Root repos return a STALE order (old shipping=5); the locked read returns fresh shipping=20.
+      salesOrderRepository.findOne = jest.fn().mockResolvedValue({
+        id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID',
+        paidAmount: 0, shippingAmount: 5, customerId: 'c1',
+      });
+      // Distinct manager-scoped repos so we can prove writes use them, not the root repos.
+      const mgrOrderRepo = {
+        findOne: jest.fn().mockResolvedValue({
+          id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID',
+          paidAmount: 0, shippingAmount: 20, customerId: 'c1',
+        }),
+        update: jest.fn().mockResolvedValue({ affected: 1 }),
       };
-      const orderFindOne = jest.fn().mockResolvedValue(order);
-      const itemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockResolvedValue(undefined), find: jest.fn().mockResolvedValue([]) };
-      const orderRepoTx = { findOne: orderFindOne, update: jest.fn().mockResolvedValue(undefined) };
+      const mgrItemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockResolvedValue(undefined), find: jest.fn().mockResolvedValue([]) };
       const manager = {
-        getRepository: (e: any) => (e === SalesOrderItem ? itemRepo : orderRepoTx),
+        getRepository: (e: any) => (e === SalesOrderItem ? mgrItemRepo : mgrOrderRepo),
       } as unknown as EntityManager;
-      salesOrderRepository.findOne.mockResolvedValue(order);
-      productRepository.findOne.mockResolvedValue({ id: 'p1', baseCost: 10 });
-      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
-      reconcileSpy.mockResolvedValue('PAID');
+      dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
+      reconcileSpy.mockResolvedValue('UNPAID');
+      // One product priced at 100, no shippingAmount in the DTO -> fallback must use shipping=20.
+      productRepository.findOne = jest.fn().mockResolvedValue({ id: 'p1', sellingPrice: 100 });
 
-      await service.update('o1', { items: [{ productId: 'p1', quantity: 1, unitPrice: 10 }] } as any);
+      await service.update('order-1', { items: [{ productId: 'p1', quantity: 1, unitPrice: 100 }] } as any);
 
-      // Order read inside the tx with a write lock.
-      expect(orderFindOne).toHaveBeenCalledWith(
-        expect.objectContaining({ lock: { mode: 'pessimistic_write' } }),
+      // Writes go through the MANAGER repos, never the root repos.
+      expect(mgrItemRepo.insert).toHaveBeenCalled();
+      expect(salesOrderItemRepository.insert).not.toHaveBeenCalled();
+      // The order read used a write lock.
+      expect(mgrOrderRepo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'order-1' }, lock: { mode: 'pessimistic_write' } }),
       );
-      // Reconcile joined the SAME transaction (manager passed through).
-      expect(reconcileSpy).toHaveBeenCalledWith('o1', manager);
+      // Total used the LOCKED shipping (20), not the stale root value (5): 100 + 20 = 120.
+      expect(mgrOrderRepo.update).toHaveBeenCalledWith(
+        'order-1',
+        expect.objectContaining({ shippingAmount: 20, totalAmount: 120 }),
+      );
+      // Reconcile joined the same transaction.
+      expect(reconcileSpy).toHaveBeenCalledWith('order-1', manager);
     });
 
-    it('rolls back: when an item insert fails, the transaction rejects and reconcile is not called', async () => {
-      const order = { id: 'o1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, totalAmount: 0, customerId: 'c1', shippingAmount: 0 };
-      const orderRepoTx = {
-        findOne: jest.fn().mockResolvedValue(order),
-        update: jest.fn(),
+    it('shipping-only edit reads existing items via the manager (locked), not the root repo', async () => {
+      salesOrderRepository.findOne = jest.fn().mockResolvedValue({
+        id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, customerId: 'c1',
+      });
+      const mgrOrderRepo = {
+        findOne: jest.fn().mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, customerId: 'c1' }),
+        update: jest.fn().mockResolvedValue({ affected: 1 }),
       };
-      const itemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockRejectedValue(new Error('insert failed')), find: jest.fn() };
-      const manager = { getRepository: (e: any) => (e === SalesOrderItem ? itemRepo : orderRepoTx) } as unknown as EntityManager;
-      salesOrderRepository.findOne.mockResolvedValue(order);
-      productRepository.findOne.mockResolvedValue({ id: 'p1', baseCost: 10 });
-      // Real transaction semantics: a throwing callback rejects the whole transaction.
-      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
+      const mgrItemRepo = { delete: jest.fn(), insert: jest.fn(), find: jest.fn().mockResolvedValue([{ totalAmount: 300 }]) };
+      const manager = { getRepository: (e: any) => (e === SalesOrderItem ? mgrItemRepo : mgrOrderRepo) } as unknown as EntityManager;
+      dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
+      reconcileSpy.mockResolvedValue('UNPAID');
 
-      await expect(
-        service.update('o1', { items: [{ productId: 'p1', quantity: 1, unitPrice: 10 }] } as any),
-      ).rejects.toThrow('insert failed');
+      await service.update('order-1', { shippingAmount: 50 } as any);
+
+      expect(mgrItemRepo.find).toHaveBeenCalledWith({ where: { salesOrderId: 'order-1' } });
+      expect(salesOrderItemRepository.find).not.toHaveBeenCalled();
+      expect(mgrOrderRepo.update).toHaveBeenCalledWith(
+        'order-1',
+        expect.objectContaining({ subtotal: 300, totalAmount: 350 }),
+      );
+    });
+
+    it('rolls back: when an item insert fails the transaction rejects and reconcile is not called', async () => {
+      salesOrderRepository.findOne = jest.fn().mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, customerId: 'c1' });
+      const mgrOrderRepo = { findOne: jest.fn().mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, customerId: 'c1' }), update: jest.fn() };
+      const mgrItemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockRejectedValue(new Error('insert failed')), find: jest.fn() };
+      const manager = { getRepository: (e: any) => (e === SalesOrderItem ? mgrItemRepo : mgrOrderRepo) } as unknown as EntityManager;
+      dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
+      productRepository.findOne = jest.fn().mockResolvedValue({ id: 'p1', sellingPrice: 10 });
+
+      await expect(service.update('order-1', { items: [{ productId: 'p1', quantity: 1, unitPrice: 10 }] } as any)).rejects.toThrow('insert failed');
       expect(reconcileSpy).not.toHaveBeenCalled();
     });
   });

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -30,7 +30,9 @@ describe('SalesOrderService', () => {
   let salesOrderQueryService: jest.Mocked<SalesOrderQueryService>;
   let salesOrderRepository: any;
   let salesOrderItemRepository: any;
+  let customerRepository: any;
   let productRepository: any;
+  let priceListItemRepository: any;
   let dataSource: jest.Mocked<DataSource>;
   let reconcileSpy: jest.SpyInstance;
 
@@ -70,7 +72,9 @@ describe('SalesOrderService', () => {
     salesOrderQueryService = module.get(SalesOrderQueryService);
     salesOrderRepository = module.get(getRepositoryToken(SalesOrder));
     salesOrderItemRepository = module.get(getRepositoryToken(SalesOrderItem));
+    customerRepository = module.get(getRepositoryToken(Customer));
     productRepository = module.get(getRepositoryToken(Product));
+    priceListItemRepository = module.get(getRepositoryToken(PriceListItem));
     reconcileSpy = jest.spyOn(salesOrderPaymentService, 'reconcileOrderState');
     dataSource.transaction.mockImplementation(async (cb: any) => cb({
       getRepository: (entity: any) => entity === SalesOrderItem ? salesOrderItemRepository : salesOrderRepository,
@@ -198,6 +202,52 @@ describe('SalesOrderService', () => {
   });
 
   describe('update — atomicity', () => {
+    it('prices fallback-customer items from the LOCKED order customer, not the pre-lock read', async () => {
+      // Pre-lock read returns the STALE customer; the locked read returns the FRESH one.
+      salesOrderRepository.findOne = jest.fn().mockResolvedValue({
+        id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID',
+        paidAmount: 0, shippingAmount: 0, customerId: 'cust-STALE',
+      });
+      const mgrOrderRepo = {
+        findOne: jest.fn().mockResolvedValue({
+          id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID',
+          paidAmount: 0, shippingAmount: 0, customerId: 'cust-FRESH',
+        }),
+        update: jest.fn().mockResolvedValue({ affected: 1 }),
+      };
+      const mgrItemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockResolvedValue(undefined), find: jest.fn().mockResolvedValue([]) };
+      const mgrCustomerRepo = {
+        findOne: jest.fn().mockImplementation(({ where }: any) =>
+          Promise.resolve({ id: where.id, priceListId: where.id === 'cust-FRESH' ? 'PL-FRESH' : 'PL-STALE' }),
+        ),
+      };
+      const manager = {
+        getRepository: (e: any) => e === SalesOrderItem ? mgrItemRepo : e === Customer ? mgrCustomerRepo : mgrOrderRepo,
+      } as unknown as EntityManager;
+      dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
+      reconcileSpy.mockResolvedValue('UNPAID');
+
+      customerRepository.findOne = jest.fn().mockImplementation(({ where }: any) =>
+        Promise.resolve({ id: where.id, priceListId: where.id === 'cust-FRESH' ? 'PL-FRESH' : 'PL-STALE' }),
+      );
+      productRepository.findOne = jest.fn().mockResolvedValue({ id: 'p1', baseCost: 1 });
+      priceListItemRepository.findOne = jest.fn().mockImplementation(({ where }: any) =>
+        Promise.resolve(where.priceListId === 'PL-FRESH' ? { price: 70 } : { price: 999 }),
+      );
+
+      await service.update('order-1', { items: [{ productId: 'p1', quantity: 1 }] } as any);
+
+      expect(priceListItemRepository.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ priceListId: 'PL-FRESH' }) }),
+      );
+      expect(mgrItemRepo.insert).toHaveBeenCalledWith(
+        expect.objectContaining({ unitPrice: 70, totalAmount: 70 }),
+      );
+      expect(mgrOrderRepo.update).toHaveBeenCalledWith(
+        'order-1', expect.objectContaining({ subtotal: 70, totalAmount: 70 }),
+      );
+    });
+
     it('derives shipping fallback from the LOCKED order and writes via the manager', async () => {
       // Root repos return a STALE order (old shipping=5); the locked read returns fresh shipping=20.
       salesOrderRepository.findOne = jest.fn().mockResolvedValue({

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -52,7 +52,7 @@ describe('SalesOrderService', () => {
         { provide: AccountingService, useValue: {} },
         { provide: SalesOrderFulfillmentService, useValue: { fulfillOrder: jest.fn(), unfulfillOrder: jest.fn() } },
         { provide: SalesOrderLifecycleService, useValue: { assertEditAllowed: jest.fn(), cancel: jest.fn(), uncancel: jest.fn() } },
-        { provide: SalesOrderPaymentService, useValue: { recordPayment: jest.fn(), recordRefund: jest.fn(), listPayments: jest.fn() } },
+        { provide: SalesOrderPaymentService, useValue: { recordPayment: jest.fn(), recordRefund: jest.fn(), listPayments: jest.fn(), reconcileOrderState: jest.fn() } },
         { provide: SalesOrderQueryService, useValue: { findById: jest.fn(), findAll: jest.fn(), findSummaries: jest.fn(), getDashboardStats: jest.fn(), findByOrderNumber: jest.fn(), findOrdersByCustomer: jest.fn() } },
       ],
     }).compile();
@@ -160,7 +160,7 @@ describe('SalesOrderService', () => {
       );
     });
 
-    it('recomputes balanceDue when an edit changes the total (existing payment preserved)', async () => {
+    it('reconciles payment state when an edit changes the total', async () => {
       const existing = {
         id: 'order-1',
         orderNumber: 'SO-1',
@@ -181,8 +181,8 @@ describe('SalesOrderService', () => {
 
       expect(salesOrderRepository.update).toHaveBeenCalledWith('order-1', expect.objectContaining({
         totalAmount: 1100,
-        balanceDue: 700,
       }));
+      expect(salesOrderPaymentService.reconcileOrderState).toHaveBeenCalledWith('order-1');
     });
   });
 

--- a/backend/src/modules/sales/services/sales-order.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order.service.spec.ts
@@ -204,6 +204,70 @@ describe('SalesOrderService', () => {
   });
 
   describe('update — atomicity', () => {
+    it('prices a DTO-supplied customer through the manager repos (under the lock)', async () => {
+      salesOrderRepository.findOne = jest.fn().mockResolvedValue({
+        id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID',
+        paidAmount: 0, shippingAmount: 0, subtotal: 0, totalAmount: 0, balanceDue: 0, notes: null, customerId: 'old',
+      });
+      const mgrCustomerRepo = { findOne: jest.fn().mockResolvedValue({ id: 'cust-DTO', priceListId: 'PL-DTO' }) };
+      const mgrProductRepo = { findOne: jest.fn().mockResolvedValue({ id: 'p1', baseCost: 1 }) };
+      const mgrPriceListItemRepo = { findOne: jest.fn().mockResolvedValue({ price: 55 }) };
+      const mgrOrderRepo = {
+        findOne: jest.fn()
+          .mockResolvedValueOnce({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, subtotal: 0, totalAmount: 0, balanceDue: 0, notes: null, customerId: 'cust-DTO' })
+          .mockResolvedValueOnce({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, subtotal: 55, totalAmount: 55, balanceDue: 55, notes: null, customerId: 'cust-DTO' }),
+        update: jest.fn().mockResolvedValue({ affected: 1 }),
+      };
+      const mgrItemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockResolvedValue(undefined), find: jest.fn().mockResolvedValue([]) };
+      const manager = {
+        getRepository: (e: any) => {
+          if (e === SalesOrderItem) return mgrItemRepo;
+          if (e === Customer) return mgrCustomerRepo;
+          if (e === Product) return mgrProductRepo;
+          if (e === PriceListItem) return mgrPriceListItemRepo;
+          return mgrOrderRepo;
+        },
+      } as unknown as EntityManager;
+      dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
+      reconcileSpy.mockResolvedValue('UNPAID');
+
+      await service.update('order-1', { customerId: 'cust-DTO', items: [{ productId: 'p1', quantity: 1 }] } as any);
+
+      // Supplied-customer pricing went through the MANAGER repos, not the root repos.
+      expect(mgrCustomerRepo.findOne).toHaveBeenCalledWith(expect.objectContaining({ where: { id: 'cust-DTO' } }));
+      expect(mgrProductRepo.findOne).toHaveBeenCalled();
+      expect(mgrPriceListItemRepo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ priceListId: 'PL-DTO' }) }),
+      );
+      expect(customerRepository.findOne).not.toHaveBeenCalled();
+      expect(productRepository.findOne).not.toHaveBeenCalled();
+      expect(priceListItemRepository.findOne).not.toHaveBeenCalled();
+      expect(mgrItemRepo.insert).toHaveBeenCalledWith(expect.objectContaining({ unitPrice: 55 }));
+    });
+
+    it('audit records a notes change with distinct before/after notes', async () => {
+      const lockedBefore = { id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, subtotal: 100, totalAmount: 100, balanceDue: 100, notes: 'old note', customerId: 'c1' };
+      const reconciledAfter = { ...lockedBefore, notes: 'new note' };
+      salesOrderRepository.findOne = jest.fn().mockResolvedValue(lockedBefore);
+      const mgrOrderRepo = {
+        findOne: jest.fn()
+          .mockResolvedValueOnce(lockedBefore)
+          .mockResolvedValueOnce(reconciledAfter),
+        update: jest.fn().mockResolvedValue({ affected: 1 }),
+      };
+      const mgrItemRepo = { delete: jest.fn(), insert: jest.fn(), find: jest.fn().mockResolvedValue([]) };
+      const manager = { getRepository: (e: any) => (e === SalesOrderItem ? mgrItemRepo : mgrOrderRepo) } as unknown as EntityManager;
+      dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
+
+      await service.update('order-1', { notes: 'new note' } as any);
+
+      const payload = (auditLogService.log as jest.Mock).mock.calls.at(-1)[3];
+      expect(payload.oldValues.notes).toBe('old note');
+      expect(payload.newValues.notes).toBe('new note');
+      // Audit "after" was read via the manager (inside the tx), not the root repo post-commit.
+      expect(mgrOrderRepo.findOne).toHaveBeenCalledTimes(2);
+    });
+
     it('prices fallback-customer items from the LOCKED order customer, not the pre-lock read', async () => {
       // Pre-lock read returns the STALE customer; the locked read returns the FRESH one.
       salesOrderRepository.findOne = jest.fn().mockResolvedValue({
@@ -322,19 +386,30 @@ describe('SalesOrderService', () => {
     });
 
     it('records distinct before/after audit values including reconciled fields', async () => {
-      salesOrderRepository.findOne = jest.fn()
-        .mockResolvedValueOnce({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 20, subtotal: 80, totalAmount: 100, balanceDue: 100, customerId: 'c1' })
-        .mockResolvedValueOnce({ id: 'order-1', orderNumber: 'SO-1', status: 'READY', paymentStatus: 'PAID', paidAmount: 120, shippingAmount: 20, subtotal: 100, totalAmount: 120, balanceDue: 0, customerId: 'c1' });
+      const lockedBefore = { id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 20, subtotal: 80, totalAmount: 100, balanceDue: 100, customerId: 'c1' };
+      const reconciledAfter = { id: 'order-1', orderNumber: 'SO-1', status: 'READY', paymentStatus: 'PAID', paidAmount: 120, shippingAmount: 20, subtotal: 100, totalAmount: 120, balanceDue: 0, customerId: 'c1' };
+      salesOrderRepository.findOne = jest.fn().mockResolvedValue(lockedBefore);
       const mgrOrderRepo = {
-        findOne: jest.fn().mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 20, subtotal: 80, totalAmount: 100, balanceDue: 100, customerId: 'c1' }),
+        findOne: jest.fn()
+          .mockResolvedValueOnce(lockedBefore)
+          .mockResolvedValueOnce(reconciledAfter),
         update: jest.fn().mockResolvedValue({ affected: 1 }),
       };
       const mgrItemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockResolvedValue(undefined), find: jest.fn() };
-      const manager = { getRepository: (e: any) => (e === SalesOrderItem ? mgrItemRepo : mgrOrderRepo) } as unknown as EntityManager;
+      const mgrCustomerRepo = { findOne: jest.fn().mockResolvedValue({ id: 'c1' }) };
+      const mgrProductRepo = { findOne: jest.fn().mockResolvedValue({ id: 'p1', baseCost: 1 }) };
+      const mgrPriceListItemRepo = { findOne: jest.fn() };
+      const manager = {
+        getRepository: (e: any) => {
+          if (e === SalesOrderItem) return mgrItemRepo;
+          if (e === Customer) return mgrCustomerRepo;
+          if (e === Product) return mgrProductRepo;
+          if (e === PriceListItem) return mgrPriceListItemRepo;
+          return mgrOrderRepo;
+        },
+      } as unknown as EntityManager;
       dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
       reconcileSpy.mockResolvedValue('PAID');
-      customerRepository.findOne = jest.fn().mockResolvedValue({ id: 'c1' });
-      productRepository.findOne = jest.fn().mockResolvedValue({ id: 'p1', baseCost: 1 });
 
       await service.update('order-1', { customerId: 'c1', items: [{ productId: 'p1', quantity: 1, unitPrice: 100 }] } as any);
 
@@ -360,13 +435,21 @@ describe('SalesOrderService', () => {
         update: jest.fn().mockResolvedValue({ affected: 1 }),
       };
       const mgrItemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockResolvedValue(undefined), find: jest.fn().mockResolvedValue([]) };
+      const mgrCustomerRepo = { findOne: jest.fn().mockResolvedValue({ id: 'c1' }) };
+      const mgrProductRepo = { findOne: jest.fn().mockResolvedValue({ id: 'p1', sellingPrice: 100 }) };
+      const mgrPriceListItemRepo = { findOne: jest.fn() };
       const manager = {
-        getRepository: (e: any) => (e === SalesOrderItem ? mgrItemRepo : mgrOrderRepo),
+        getRepository: (e: any) => {
+          if (e === SalesOrderItem) return mgrItemRepo;
+          if (e === Customer) return mgrCustomerRepo;
+          if (e === Product) return mgrProductRepo;
+          if (e === PriceListItem) return mgrPriceListItemRepo;
+          return mgrOrderRepo;
+        },
       } as unknown as EntityManager;
       dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
       reconcileSpy.mockResolvedValue('UNPAID');
       // One product priced at 100, no shippingAmount in the DTO -> fallback must use shipping=20.
-      productRepository.findOne = jest.fn().mockResolvedValue({ id: 'p1', sellingPrice: 100 });
 
       await service.update('order-1', { items: [{ productId: 'p1', quantity: 1, unitPrice: 100 }] } as any);
 
@@ -413,9 +496,19 @@ describe('SalesOrderService', () => {
       salesOrderRepository.findOne = jest.fn().mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, customerId: 'c1' });
       const mgrOrderRepo = { findOne: jest.fn().mockResolvedValue({ id: 'order-1', orderNumber: 'SO-1', status: 'DRAFT', paymentStatus: 'UNPAID', paidAmount: 0, shippingAmount: 0, customerId: 'c1' }), update: jest.fn() };
       const mgrItemRepo = { delete: jest.fn().mockResolvedValue(undefined), insert: jest.fn().mockRejectedValue(new Error('insert failed')), find: jest.fn() };
-      const manager = { getRepository: (e: any) => (e === SalesOrderItem ? mgrItemRepo : mgrOrderRepo) } as unknown as EntityManager;
+      const mgrCustomerRepo = { findOne: jest.fn().mockResolvedValue({ id: 'c1' }) };
+      const mgrProductRepo = { findOne: jest.fn().mockResolvedValue({ id: 'p1', sellingPrice: 10 }) };
+      const mgrPriceListItemRepo = { findOne: jest.fn() };
+      const manager = {
+        getRepository: (e: any) => {
+          if (e === SalesOrderItem) return mgrItemRepo;
+          if (e === Customer) return mgrCustomerRepo;
+          if (e === Product) return mgrProductRepo;
+          if (e === PriceListItem) return mgrPriceListItemRepo;
+          return mgrOrderRepo;
+        },
+      } as unknown as EntityManager;
       dataSource.transaction = jest.fn().mockImplementation(async (cb: any) => cb(manager));
-      productRepository.findOne = jest.fn().mockResolvedValue({ id: 'p1', sellingPrice: 10 });
 
       await expect(service.update('order-1', { items: [{ productId: 'p1', quantity: 1, unitPrice: 10 }] } as any)).rejects.toThrow('insert failed');
       expect(reconcileSpy).not.toHaveBeenCalled();

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -502,32 +502,13 @@ export class SalesOrderService extends BaseCrudService<
 
     // Update items if provided
     if (items && items.length > 0) {
-      // Validate and process new items with customer pricing
+      // Price the incoming items from the customer/price-list. This does not
+      // depend on mutable order totals, so it can run before the lock.
       orderItems = await this.validateAndProcessItems(items, customerForPricing);
-
-      const subtotal = SalesOrderService.sumItemTotals(orderItems);
-      const shippingAmount = updateSalesOrderDto.shippingAmount !== undefined
-        ? Number(updateSalesOrderDto.shippingAmount)
-        : Number(order.shippingAmount || 0);
-      const totalAmount = subtotal + shippingAmount;
-
-      // Add shipping and total amount to update data
-      updateData.shippingAmount = shippingAmount;
-      updateData.subtotal = subtotal;
-      updateData.totalAmount = totalAmount;
-    } else if (updateSalesOrderDto.shippingAmount !== undefined) {
-      // If only shipping is being updated (no items), load items from DB to recalculate total
-      const existingItems = await this.salesOrderItemRepository.find({ where: { salesOrderId: id } });
-      const currentSubtotal = SalesOrderService.sumItemTotals(existingItems);
-      const newShipping = Number(updateSalesOrderDto.shippingAmount);
-      updateData.shippingAmount = newShipping;
-      updateData.subtotal = currentSubtotal;
-      updateData.totalAmount = currentSubtotal + newShipping;
     }
 
     await this.dataSource.transaction(async (manager: EntityManager) => {
-      // Lock the parent order for the duration of the edit so concurrent
-      // payment / status transitions serialize behind it.
+      // Lock the parent order before deriving any totals from mutable state.
       const locked = await manager.getRepository(SalesOrder).findOne({
         where: { id },
         lock: { mode: 'pessimistic_write' },
@@ -552,6 +533,24 @@ export class SalesOrderService extends BaseCrudService<
             salesOrderId: id,
           });
         }
+
+        const subtotal = SalesOrderService.sumItemTotals(orderItems);
+        const shippingAmount = updateSalesOrderDto.shippingAmount !== undefined
+          ? Number(updateSalesOrderDto.shippingAmount)
+          : Number(locked.shippingAmount || 0);
+        updateData.shippingAmount = shippingAmount;
+        updateData.subtotal = subtotal;
+        updateData.totalAmount = subtotal + shippingAmount;
+      } else if (updateSalesOrderDto.shippingAmount !== undefined) {
+        // Shipping-only edits read existing items through the transaction manager.
+        const existingItems = await manager.getRepository(SalesOrderItem).find({
+          where: { salesOrderId: id },
+        });
+        const currentSubtotal = SalesOrderService.sumItemTotals(existingItems);
+        const newShipping = Number(updateSalesOrderDto.shippingAmount);
+        updateData.shippingAmount = newShipping;
+        updateData.subtotal = currentSubtotal;
+        updateData.totalAmount = currentSubtotal + newShipping;
       }
 
       if (Object.keys(updateData).length > 0) {

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -506,18 +506,30 @@ export class SalesOrderService extends BaseCrudService<
         balanceDue: Number(locked.balanceDue),
       };
 
-      // Resolve the pricing customer inside the lock: the DTO customer if supplied,
-      // otherwise the locked order's current customer.
-      if (items && items.length > 0) {
-        const pricingCustomerId = customerId ?? locked.customerId;
-        const pricingCustomer = await manager.getRepository(Customer).findOne({
-          where: { id: pricingCustomerId },
+      // Resolve the pricing/validation customer inside the lock. A supplied customerId is
+      // validated whenever present (even for customer-only edits); otherwise fall back to
+      // the locked order's current customer (only needed when pricing items).
+      let pricingCustomer: Customer | null = null;
+      if (customerId) {
+        pricingCustomer = await manager.getRepository(Customer).findOne({
+          where: { id: customerId },
           relations: { priceList: true },
         });
         if (!pricingCustomer) {
           throw new NotFoundException('Customer not found');
         }
-        orderItems = await this.validateAndProcessItems(items, pricingCustomer, manager);
+      } else if (items && items.length > 0) {
+        pricingCustomer = await manager.getRepository(Customer).findOne({
+          where: { id: locked.customerId },
+          relations: { priceList: true },
+        });
+        if (!pricingCustomer) {
+          throw new NotFoundException('Customer not found');
+        }
+      }
+
+      if (items && items.length > 0) {
+        orderItems = await this.validateAndProcessItems(items, pricingCustomer!, manager);
       }
 
       if (items && items.length > 0) {

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -6,9 +6,9 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, EntityManager, Repository, FindOptionsWhere } from 'typeorm';
+import { DataSource, EntityManager, Repository, FindOptionsWhere, In } from 'typeorm';
 import { BaseCrudService } from '../../../common/services/base-crud.service';
-import { SalesOrder } from '../../../database/entities/sales-order.entity';
+import { SalesOrder, SalesOrderStatus } from '../../../database/entities/sales-order.entity';
 import { SalesOrderItem, DiscountType } from '../../../database/entities/sales-order-item.entity';
 import { SalesOrderPayment } from '../../../database/entities/sales-order-payment.entity';
 import { Customer } from '../../../database/entities/customer.entity';
@@ -493,22 +493,22 @@ export class SalesOrderService extends BaseCrudService<
       });
       if (!locked) throw new NotFoundException('Sales order not found');
 
+      // Re-assert editability against the LOCKED row: assertEditAllowed ran on an
+      // unlocked pre-read, so a concurrent fulfill/cancel could have moved the order out
+      // of the editable band in between. This is the authoritative, race-free check.
+      SalesOrderLifecycleService.assertStatusEditable(locked.status);
+
       // Snapshot pre-edit values for the audit trail before any writes in this tx.
-      auditOldValues = {
-        customerId: locked.customerId,
-        notes: locked.notes ?? null,
-        subtotal: Number(locked.subtotal),
-        shippingAmount: Number(locked.shippingAmount),
-        totalAmount: Number(locked.totalAmount),
-        status: locked.status,
-        paymentStatus: locked.paymentStatus,
-        paidAmount: Number(locked.paidAmount),
-        balanceDue: Number(locked.balanceDue),
-      };
+      auditOldValues = SalesOrderService.snapshotOrderForAudit(locked);
+
+      // A supplied customerId changes pricing, so re-pricing is required whenever the
+      // customer changes — even with no items in the DTO. Detect that here so the
+      // customer-only path re-prices existing items rather than keeping stale totals.
+      const customerChanged = customerId !== undefined && customerId !== locked.customerId;
 
       // Resolve the pricing/validation customer inside the lock. A supplied customerId is
       // validated whenever present (even for customer-only edits); otherwise fall back to
-      // the locked order's current customer (only needed when pricing items).
+      // the locked order's current customer (needed when (re)pricing items).
       let pricingCustomer: Customer | null = null;
       if (customerId) {
         pricingCustomer = await manager.getRepository(Customer).findOne({
@@ -518,7 +518,7 @@ export class SalesOrderService extends BaseCrudService<
         if (!pricingCustomer) {
           throw new NotFoundException('Customer not found');
         }
-      } else if (items && items.length > 0) {
+      } else if ((items && items.length > 0)) {
         pricingCustomer = await manager.getRepository(Customer).findOne({
           where: { id: locked.customerId },
           relations: { priceList: true },
@@ -528,11 +528,31 @@ export class SalesOrderService extends BaseCrudService<
         }
       }
 
+      // Determine the line items to (re)price: DTO items if supplied, otherwise the
+      // existing rows when only the customer changed (so their prices follow the new
+      // customer's price list).
+      let itemsToPrice: any[] | null = null;
       if (items && items.length > 0) {
-        orderItems = await this.validateAndProcessItems(items, pricingCustomer!, manager);
+        itemsToPrice = items;
+      } else if (customerChanged) {
+        const existingItems = await manager.getRepository(SalesOrderItem).find({
+          where: { salesOrderId: id },
+        });
+        // Re-price by product at the new customer's prices; preserve per-line overrides
+        // (explicit unitPrice is respected by validateAndProcessItems).
+        itemsToPrice = existingItems.map((it) => ({
+          productId: it.productId,
+          quantity: it.quantity,
+          discountType: it.discountType,
+          discountPercent: it.discountPercent,
+          discountAmount: it.discountAmount,
+          notes: it.notes,
+        }));
       }
 
-      if (items && items.length > 0) {
+      if (itemsToPrice && itemsToPrice.length > 0) {
+        orderItems = await this.validateAndProcessItems(itemsToPrice, pricingCustomer!, manager);
+
         await manager.getRepository(SalesOrderItem).delete({ salesOrderId: id });
         for (const itemData of orderItems) {
           // Use direct repository insert instead of create/save to bypass entity hooks.
@@ -570,32 +590,28 @@ export class SalesOrderService extends BaseCrudService<
         updateData.totalAmount = currentSubtotal + newShipping;
       }
 
-      if (Object.keys(updateData).length > 0) {
+      const hasChanges = Object.keys(updateData).length > 0;
+      if (hasChanges) {
         await manager.getRepository(SalesOrder).update(id, updateData);
       }
 
       // Reconcile inside the same transaction so totals, payment state, and the
-      // DRAFT<->READY band commit atomically.
+      // DRAFT<->READY band commit atomically. reconcileOrderState returns the locked,
+      // reconciled order so we can snapshot it for the audit without re-reading.
+      let reconciled: SalesOrder | null = null;
       if (updateData.totalAmount !== undefined) {
-        await this.salesOrderPaymentService.reconcileOrderState(id, manager);
+        reconciled = await this.salesOrderPaymentService.reconcileOrderState(id, manager);
       }
 
-      // Capture the reconciled row through the manager BEFORE the lock releases so the
-      // audit "after" reflects exactly this edit (not a concurrent later mutation).
-      if (Object.keys(updateData).length > 0) {
-        const after = await manager.getRepository(SalesOrder).findOne({ where: { id } });
+      // Capture the post-edit row BEFORE the lock releases so the audit "after" reflects
+      // exactly this edit (not a concurrent later mutation). Prefer the reconciled entity
+      // (already in hand); otherwise re-read for the non-total edits (notes/customer-only
+      // with no priced items) that still mutated the row.
+      if (hasChanges) {
+        const after =
+          reconciled ?? (await manager.getRepository(SalesOrder).findOne({ where: { id } }));
         if (after) {
-          auditNewValues = {
-            customerId: after.customerId,
-            notes: after.notes ?? null,
-            subtotal: Number(after.subtotal),
-            shippingAmount: Number(after.shippingAmount),
-            totalAmount: Number(after.totalAmount),
-            status: after.status,
-            paymentStatus: after.paymentStatus,
-            paidAmount: Number(after.paidAmount),
-            balanceDue: Number(after.balanceDue),
-          };
+          auditNewValues = SalesOrderService.snapshotOrderForAudit(after);
         }
       }
     });
@@ -697,40 +713,59 @@ export class SalesOrderService extends BaseCrudService<
     return items.reduce((sum, item) => sum + Number(item.totalAmount), 0);
   }
 
+  /**
+   * Build the normalized before/after value snapshot logged on an order edit. Kept in
+   * one place so the audit "old" and "new" records always share the exact same shape.
+   */
+  private static snapshotOrderForAudit(order: SalesOrder): Record<string, unknown> {
+    return {
+      customerId: order.customerId,
+      notes: order.notes ?? null,
+      subtotal: Number(order.subtotal),
+      shippingAmount: Number(order.shippingAmount),
+      totalAmount: Number(order.totalAmount),
+      status: order.status,
+      paymentStatus: order.paymentStatus,
+      paidAmount: Number(order.paidAmount),
+      balanceDue: Number(order.balanceDue),
+    };
+  }
+
   private async validateAndProcessItems(items: any[], customer?: Customer, manager?: EntityManager) {
     const productRepo = manager ? manager.getRepository(Product) : this.productRepository;
     const priceListItemRepo = manager ? manager.getRepository(PriceListItem) : this.priceListItemRepository;
+
+    // Batch-load products and price-list rows up front to avoid an N+1 of findOne calls
+    // inside the (locked) edit transaction.
+    const productIds = [...new Set(items.map((item) => item.productId))];
+    const products = productIds.length
+      ? await productRepo.find({ where: { id: In(productIds) } })
+      : [];
+    const productById = new Map(products.map((p) => [p.id, p]));
+
+    const priceByProduct = new Map<string, number>();
+    if (customer && customer.priceListId && productIds.length) {
+      const priceListItems = await priceListItemRepo.find({
+        where: { priceListId: customer.priceListId, productId: In(productIds) },
+      });
+      for (const pli of priceListItems) {
+        priceByProduct.set(pli.productId, Number(pli.price));
+      }
+    }
+
     const processedItems = [];
     let lineNumber = 1;
 
     for (const item of items) {
-      const product = await productRepo.findOne({ where: { id: item.productId } });
+      const product = productById.get(item.productId);
       if (!product) {
         throw new NotFoundException(`Product with ID ${item.productId} not found`);
       }
 
-      // Determine unit price - try price list first, then fallback to legacy
-      let defaultPrice = 0;
-
-      // NEW: Try to get price from customer's price list first
-      if (customer && customer.priceListId) {
-        const priceListItem = await priceListItemRepo.findOne({
-          where: {
-            priceListId: customer.priceListId,
-            productId: item.productId
-          }
-        });
-
-        if (priceListItem) {
-          defaultPrice = Number(priceListItem.price);
-          console.log(`Using price list price: ${defaultPrice} for product ${item.productId}`);
-        }
-      }
-
-      // Fallback to baseCost if no price list price found
+      // Determine unit price - price list first, then fall back to baseCost.
+      let defaultPrice = priceByProduct.get(item.productId) ?? 0;
       if (defaultPrice === 0) {
         defaultPrice = Number(product.baseCost) || 0;
-        console.log(`Using baseCost fallback: ${defaultPrice} for product ${item.productId}`);
       }
 
       const unitPrice = Number(item.unitPrice) || defaultPrice;
@@ -764,7 +799,6 @@ export class SalesOrderService extends BaseCrudService<
       });
     }
 
-    console.log('Processed items from validateAndProcessItems:', JSON.stringify(processedItems, null, 2));
     return processedItems;
   }
 

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -549,14 +549,15 @@ export class SalesOrderService extends BaseCrudService<
       updateData.totalAmount = currentSubtotal + newShipping;
     }
 
-    // Whenever the total changes, keep balanceDue consistent with the unchanged paidAmount.
-    if (updateData.totalAmount !== undefined) {
-      updateData.balanceDue = Number(updateData.totalAmount) - Number(order.paidAmount || 0);
-    }
-
     // Perform all updates in a single database call
     if (Object.keys(updateData).length > 0) {
       await this.salesOrderRepository.update(id, updateData);
+    }
+
+    // When the total changed, re-derive paymentStatus / balanceDue / DRAFT<->READY band
+    // using the payment service's single source of truth.
+    if (updateData.totalAmount !== undefined) {
+      await this.salesOrderPaymentService.reconcileOrderState(id);
     }
 
     // Log audit trail for update

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -6,7 +6,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, FindOptionsWhere } from 'typeorm';
+import { DataSource, EntityManager, Repository, FindOptionsWhere } from 'typeorm';
 import { BaseCrudService } from '../../../common/services/base-crud.service';
 import { SalesOrder } from '../../../database/entities/sales-order.entity';
 import { SalesOrderItem, DiscountType } from '../../../database/entities/sales-order-item.entity';
@@ -86,6 +86,7 @@ export class SalesOrderService extends BaseCrudService<
     private readonly salesOrderLifecycleService: SalesOrderLifecycleService,
     private readonly salesOrderPaymentService: SalesOrderPaymentService,
     private readonly salesOrderQueryService: SalesOrderQueryService,
+    private readonly dataSource: DataSource,
   ) {
     super(salesOrderRepository, auditLogService);
   }
@@ -471,6 +472,7 @@ export class SalesOrderService extends BaseCrudService<
 
     // Prepare update data for the sales order
     const updateData: any = {};
+    let orderItems: any[] = [];
 
     // Get customer for pricing (either new customer or existing)
     let customerForPricing: Customer | null = null;
@@ -500,40 +502,14 @@ export class SalesOrderService extends BaseCrudService<
 
     // Update items if provided
     if (items && items.length > 0) {
-      // Delete existing items from database
-      await this.salesOrderItemRepository.delete({ salesOrderId: id });
-
       // Validate and process new items with customer pricing
-      const orderItems = await this.validateAndProcessItems(items, customerForPricing);
+      orderItems = await this.validateAndProcessItems(items, customerForPricing);
 
       const subtotal = SalesOrderService.sumItemTotals(orderItems);
       const shippingAmount = updateSalesOrderDto.shippingAmount !== undefined
         ? Number(updateSalesOrderDto.shippingAmount)
         : Number(order.shippingAmount || 0);
       const totalAmount = subtotal + shippingAmount;
-
-      // Create new order items using direct object creation to avoid entity relations issues
-      for (const itemData of orderItems) {
-        // Validate that order.id exists
-        if (!order.id) {
-          throw new Error(`Cannot create order items: order.id is ${order.id}`);
-        }
-
-        // Use direct repository insert instead of create/save to bypass entity hooks
-        await this.salesOrderItemRepository.insert({
-          lineNumber: itemData.lineNumber || 1,
-          productId: itemData.productId,
-          quantity: itemData.quantity || 1,
-          unitPrice: itemData.unitPrice || 0,
-          unitCost: itemData.unitCost || 0,
-          discountType: itemData.discountType || DiscountType.PERCENTAGE,
-          discountPercent: itemData.discountPercent || 0,
-          discountAmount: itemData.discountAmount || 0,
-          totalAmount: itemData.totalAmount || 0,
-          notes: itemData.notes || null,
-          salesOrderId: order.id, // Direct database insert ensures this is set
-        });
-      }
 
       // Add shipping and total amount to update data
       updateData.shippingAmount = shippingAmount;
@@ -549,16 +525,45 @@ export class SalesOrderService extends BaseCrudService<
       updateData.totalAmount = currentSubtotal + newShipping;
     }
 
-    // Perform all updates in a single database call
-    if (Object.keys(updateData).length > 0) {
-      await this.salesOrderRepository.update(id, updateData);
-    }
+    await this.dataSource.transaction(async (manager: EntityManager) => {
+      // Lock the parent order for the duration of the edit so concurrent
+      // payment / status transitions serialize behind it.
+      const locked = await manager.getRepository(SalesOrder).findOne({
+        where: { id },
+        lock: { mode: 'pessimistic_write' },
+      });
+      if (!locked) throw new NotFoundException('Sales order not found');
 
-    // When the total changed, re-derive paymentStatus / balanceDue / DRAFT<->READY band
-    // using the payment service's single source of truth.
-    if (updateData.totalAmount !== undefined) {
-      await this.salesOrderPaymentService.reconcileOrderState(id);
-    }
+      if (items && items.length > 0) {
+        await manager.getRepository(SalesOrderItem).delete({ salesOrderId: id });
+        for (const itemData of orderItems) {
+          // Use direct repository insert instead of create/save to bypass entity hooks.
+          await manager.getRepository(SalesOrderItem).insert({
+            lineNumber: itemData.lineNumber || 1,
+            productId: itemData.productId,
+            quantity: itemData.quantity || 1,
+            unitPrice: itemData.unitPrice || 0,
+            unitCost: itemData.unitCost || 0,
+            discountType: itemData.discountType || DiscountType.PERCENTAGE,
+            discountPercent: itemData.discountPercent || 0,
+            discountAmount: itemData.discountAmount || 0,
+            totalAmount: itemData.totalAmount || 0,
+            notes: itemData.notes || null,
+            salesOrderId: id,
+          });
+        }
+      }
+
+      if (Object.keys(updateData).length > 0) {
+        await manager.getRepository(SalesOrder).update(id, updateData);
+      }
+
+      // Reconcile inside the same transaction so totals, payment state, and the
+      // DRAFT<->READY band commit atomically.
+      if (updateData.totalAmount !== undefined) {
+        await this.salesOrderPaymentService.reconcileOrderState(id, manager);
+      }
+    });
 
     // Log audit trail for update
     if (Object.keys(updateData).length > 0) {

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -474,36 +474,29 @@ export class SalesOrderService extends BaseCrudService<
     const updateData: any = {};
     let orderItems: any[] = [];
 
-    // Get customer for pricing (either new customer or existing)
+    // When the DTO supplies a customer, it is authoritative and independent of the
+    // order's mutable state, so resolve its pricing before the lock. When omitted, the
+    // pricing customer is the order's CURRENT customer - a mutable field - so it must be
+    // read from the locked row inside the transaction (see below).
     let customerForPricing: Customer | null = null;
-
-    // Update customer if provided
     if (customerId) {
       customerForPricing = await this.customerRepository.findOne({
         where: { id: customerId },
-        relations: { priceList: true }
+        relations: { priceList: true },
       });
       if (!customerForPricing) {
         throw new NotFoundException('Customer not found');
       }
       updateData.customerId = customerId;
-    } else {
-      // Load existing customer for pricing
-      customerForPricing = await this.customerRepository.findOne({
-        where: { id: order.customerId },
-        relations: { priceList: true }
-      });
     }
 
-    // Update notes if provided (including empty string to clear notes)
     if (notes !== undefined) {
       updateData.notes = notes;
     }
 
-    // Update items if provided
-    if (items && items.length > 0) {
-      // Price the incoming items from the customer/price-list. This does not
-      // depend on mutable order totals, so it can run before the lock.
+    // Price incoming items up front only when the customer was provided. The
+    // fallback-customer case is priced inside the locked transaction.
+    if (items && items.length > 0 && customerForPricing) {
       orderItems = await this.validateAndProcessItems(items, customerForPricing);
     }
 
@@ -514,6 +507,16 @@ export class SalesOrderService extends BaseCrudService<
         lock: { mode: 'pessimistic_write' },
       });
       if (!locked) throw new NotFoundException('Sales order not found');
+
+      // When the DTO omitted customerId, price against the locked order's current
+      // customer so a concurrent customer change cannot apply stale pricing.
+      if (items && items.length > 0 && !customerForPricing) {
+        const fallbackCustomer = await manager.getRepository(Customer).findOne({
+          where: { id: locked.customerId },
+          relations: { priceList: true },
+        });
+        orderItems = await this.validateAndProcessItems(items, fallbackCustomer ?? undefined);
+      }
 
       if (items && items.length > 0) {
         await manager.getRepository(SalesOrderItem).delete({ salesOrderId: id });

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -473,6 +473,7 @@ export class SalesOrderService extends BaseCrudService<
     // Prepare update data for the sales order
     const updateData: any = {};
     let orderItems: any[] = [];
+    let auditOldValues: any = {};
 
     // When the DTO supplies a customer, it is authoritative and independent of the
     // order's mutable state, so resolve its pricing before the lock. When omitted, the
@@ -508,6 +509,18 @@ export class SalesOrderService extends BaseCrudService<
       });
       if (!locked) throw new NotFoundException('Sales order not found');
 
+      // Snapshot pre-edit values for the audit trail before any writes in this tx.
+      auditOldValues = {
+        customerId: locked.customerId,
+        subtotal: Number(locked.subtotal),
+        shippingAmount: Number(locked.shippingAmount),
+        totalAmount: Number(locked.totalAmount),
+        status: locked.status,
+        paymentStatus: locked.paymentStatus,
+        paidAmount: Number(locked.paidAmount),
+        balanceDue: Number(locked.balanceDue),
+      };
+
       // When the DTO omitted customerId, price against the locked order's current
       // customer so a concurrent customer change cannot apply stale pricing.
       if (items && items.length > 0 && !customerForPricing) {
@@ -515,7 +528,10 @@ export class SalesOrderService extends BaseCrudService<
           where: { id: locked.customerId },
           relations: { priceList: true },
         });
-        orderItems = await this.validateAndProcessItems(items, fallbackCustomer ?? undefined);
+        if (!fallbackCustomer) {
+          throw new NotFoundException('Customer not found');
+        }
+        orderItems = await this.validateAndProcessItems(items, fallbackCustomer, manager);
       }
 
       if (items && items.length > 0) {
@@ -569,6 +585,7 @@ export class SalesOrderService extends BaseCrudService<
 
     // Log audit trail for update
     if (Object.keys(updateData).length > 0) {
+      const after = await this.salesOrderRepository.findOne({ where: { id } });
       await this.auditLogService.log(
         'UPDATE',
         'SalesOrder',
@@ -577,8 +594,19 @@ export class SalesOrderService extends BaseCrudService<
           entityId: id,
           userId: userId || 'system',
           username,
-          oldValues: updateData,
-          newValues: updateData,
+          oldValues: auditOldValues,
+          newValues: after
+            ? {
+                customerId: after.customerId,
+                subtotal: Number(after.subtotal),
+                shippingAmount: Number(after.shippingAmount),
+                totalAmount: Number(after.totalAmount),
+                status: after.status,
+                paymentStatus: after.paymentStatus,
+                paidAmount: Number(after.paidAmount),
+                balanceDue: Number(after.balanceDue),
+              }
+            : updateData,
         }
       );
     }
@@ -664,12 +692,14 @@ export class SalesOrderService extends BaseCrudService<
     return items.reduce((sum, item) => sum + Number(item.totalAmount), 0);
   }
 
-  private async validateAndProcessItems(items: any[], customer?: Customer) {
+  private async validateAndProcessItems(items: any[], customer?: Customer, manager?: EntityManager) {
+    const productRepo = manager ? manager.getRepository(Product) : this.productRepository;
+    const priceListItemRepo = manager ? manager.getRepository(PriceListItem) : this.priceListItemRepository;
     const processedItems = [];
     let lineNumber = 1;
 
     for (const item of items) {
-      const product = await this.productRepository.findOne({ where: { id: item.productId } });
+      const product = await productRepo.findOne({ where: { id: item.productId } });
       if (!product) {
         throw new NotFoundException(`Product with ID ${item.productId} not found`);
       }
@@ -679,7 +709,7 @@ export class SalesOrderService extends BaseCrudService<
 
       // NEW: Try to get price from customer's price list first
       if (customer && customer.priceListId) {
-        const priceListItem = await this.priceListItemRepository.findOne({
+        const priceListItem = await priceListItemRepo.findOne({
           where: {
             priceListId: customer.priceListId,
             productId: item.productId

--- a/backend/src/modules/sales/services/sales-order.service.ts
+++ b/backend/src/modules/sales/services/sales-order.service.ts
@@ -474,31 +474,15 @@ export class SalesOrderService extends BaseCrudService<
     const updateData: any = {};
     let orderItems: any[] = [];
     let auditOldValues: any = {};
+    let auditNewValues: any = null;
 
-    // When the DTO supplies a customer, it is authoritative and independent of the
-    // order's mutable state, so resolve its pricing before the lock. When omitted, the
-    // pricing customer is the order's CURRENT customer - a mutable field - so it must be
-    // read from the locked row inside the transaction (see below).
-    let customerForPricing: Customer | null = null;
+    // customerId (if supplied) is recorded now; the customer is resolved and items are
+    // priced INSIDE the locked transaction so all pricing reads are lock-consistent.
     if (customerId) {
-      customerForPricing = await this.customerRepository.findOne({
-        where: { id: customerId },
-        relations: { priceList: true },
-      });
-      if (!customerForPricing) {
-        throw new NotFoundException('Customer not found');
-      }
       updateData.customerId = customerId;
     }
-
     if (notes !== undefined) {
       updateData.notes = notes;
-    }
-
-    // Price incoming items up front only when the customer was provided. The
-    // fallback-customer case is priced inside the locked transaction.
-    if (items && items.length > 0 && customerForPricing) {
-      orderItems = await this.validateAndProcessItems(items, customerForPricing);
     }
 
     await this.dataSource.transaction(async (manager: EntityManager) => {
@@ -512,6 +496,7 @@ export class SalesOrderService extends BaseCrudService<
       // Snapshot pre-edit values for the audit trail before any writes in this tx.
       auditOldValues = {
         customerId: locked.customerId,
+        notes: locked.notes ?? null,
         subtotal: Number(locked.subtotal),
         shippingAmount: Number(locked.shippingAmount),
         totalAmount: Number(locked.totalAmount),
@@ -521,17 +506,18 @@ export class SalesOrderService extends BaseCrudService<
         balanceDue: Number(locked.balanceDue),
       };
 
-      // When the DTO omitted customerId, price against the locked order's current
-      // customer so a concurrent customer change cannot apply stale pricing.
-      if (items && items.length > 0 && !customerForPricing) {
-        const fallbackCustomer = await manager.getRepository(Customer).findOne({
-          where: { id: locked.customerId },
+      // Resolve the pricing customer inside the lock: the DTO customer if supplied,
+      // otherwise the locked order's current customer.
+      if (items && items.length > 0) {
+        const pricingCustomerId = customerId ?? locked.customerId;
+        const pricingCustomer = await manager.getRepository(Customer).findOne({
+          where: { id: pricingCustomerId },
           relations: { priceList: true },
         });
-        if (!fallbackCustomer) {
+        if (!pricingCustomer) {
           throw new NotFoundException('Customer not found');
         }
-        orderItems = await this.validateAndProcessItems(items, fallbackCustomer, manager);
+        orderItems = await this.validateAndProcessItems(items, pricingCustomer, manager);
       }
 
       if (items && items.length > 0) {
@@ -581,11 +567,29 @@ export class SalesOrderService extends BaseCrudService<
       if (updateData.totalAmount !== undefined) {
         await this.salesOrderPaymentService.reconcileOrderState(id, manager);
       }
+
+      // Capture the reconciled row through the manager BEFORE the lock releases so the
+      // audit "after" reflects exactly this edit (not a concurrent later mutation).
+      if (Object.keys(updateData).length > 0) {
+        const after = await manager.getRepository(SalesOrder).findOne({ where: { id } });
+        if (after) {
+          auditNewValues = {
+            customerId: after.customerId,
+            notes: after.notes ?? null,
+            subtotal: Number(after.subtotal),
+            shippingAmount: Number(after.shippingAmount),
+            totalAmount: Number(after.totalAmount),
+            status: after.status,
+            paymentStatus: after.paymentStatus,
+            paidAmount: Number(after.paidAmount),
+            balanceDue: Number(after.balanceDue),
+          };
+        }
+      }
     });
 
     // Log audit trail for update
     if (Object.keys(updateData).length > 0) {
-      const after = await this.salesOrderRepository.findOne({ where: { id } });
       await this.auditLogService.log(
         'UPDATE',
         'SalesOrder',
@@ -595,18 +599,7 @@ export class SalesOrderService extends BaseCrudService<
           userId: userId || 'system',
           username,
           oldValues: auditOldValues,
-          newValues: after
-            ? {
-                customerId: after.customerId,
-                subtotal: Number(after.subtotal),
-                shippingAmount: Number(after.shippingAmount),
-                totalAmount: Number(after.totalAmount),
-                status: after.status,
-                paymentStatus: after.paymentStatus,
-                paidAmount: Number(after.paidAmount),
-                balanceDue: Number(after.balanceDue),
-              }
-            : updateData,
+          newValues: auditNewValues ?? updateData,
         }
       );
     }

--- a/backend/test/sales-order-edit.e2e-spec.ts
+++ b/backend/test/sales-order-edit.e2e-spec.ts
@@ -12,6 +12,7 @@ import {
   DiscountType,
   SalesOrderItem,
 } from '../src/database/entities/sales-order-item.entity';
+import { SalesOrderPaymentService } from '../src/modules/sales/services/sales-order-payment.service';
 import { SalesOrderService } from '../src/modules/sales/services/sales-order.service';
 import { seedCategory, seedProduct, truncateAll } from './e2e/helpers/seed';
 
@@ -94,5 +95,65 @@ describe('Sales order edit transaction (e2e)', () => {
     expect(persistedItems[0].id).toBe(originalItem.id);
     expect(persistedItems[0].quantity).toBe(1);
     expect(Number(persistedItems[0].totalAmount)).toBe(100);
+  });
+
+  it('rolls back item + total changes when post-write reconciliation fails', async () => {
+    const category = await seedCategory(dataSource);
+    const product = await seedProduct(dataSource, category.id, {
+      baseCost: 100,
+      stockQuantity: 100,
+    });
+    const customerRepo = dataSource.getRepository(Customer);
+    const customer = await customerRepo.save(customerRepo.create({
+      type: CustomerType.BUSINESS,
+      name: 'Reconcile Fail Customer',
+      isActive: true,
+    }));
+    const orderRepo = dataSource.getRepository(SalesOrder);
+    const order = await orderRepo.save(orderRepo.create({
+      orderNumber: 'SO-RECONCILE-001',
+      orderDate: new Date(),
+      customerId: customer.id,
+      status: SalesOrderStatus.DRAFT,
+      paymentStatus: SalesOrderPaymentStatus.UNPAID,
+      subtotal: 100,
+      shippingAmount: 0,
+      totalAmount: 100,
+      paidAmount: 0,
+      balanceDue: 100,
+    }));
+    const itemRepo = dataSource.getRepository(SalesOrderItem);
+    const originalItem = await itemRepo.save(itemRepo.create({
+      lineNumber: 1,
+      salesOrderId: order.id,
+      productId: product.id,
+      quantity: 1,
+      unitPrice: 100,
+      unitCost: 100,
+      discountType: DiscountType.PERCENTAGE,
+      discountPercent: 0,
+      discountAmount: 0,
+      totalAmount: 100,
+    }));
+
+    const paymentService = app.get(SalesOrderPaymentService);
+    const spy = jest
+      .spyOn(paymentService, 'reconcileOrderState')
+      .mockRejectedValueOnce(new Error('reconcile boom'));
+
+    await expect(
+      salesOrderService.update(order.id, {
+        items: [{ productId: product.id, quantity: 3, unitPrice: 40 }],
+      }),
+    ).rejects.toThrow('reconcile boom');
+    spy.mockRestore();
+
+    const persistedOrder = await orderRepo.findOneOrFail({ where: { id: order.id } });
+    const persistedItems = await itemRepo.find({ where: { salesOrderId: order.id } });
+
+    expect(Number(persistedOrder.totalAmount)).toBe(100);
+    expect(persistedItems).toHaveLength(1);
+    expect(persistedItems[0].id).toBe(originalItem.id);
+    expect(persistedItems[0].quantity).toBe(1);
   });
 });

--- a/backend/test/sales-order-edit.e2e-spec.ts
+++ b/backend/test/sales-order-edit.e2e-spec.ts
@@ -141,12 +141,15 @@ describe('Sales order edit transaction (e2e)', () => {
       .spyOn(paymentService, 'reconcileOrderState')
       .mockRejectedValueOnce(new Error('reconcile boom'));
 
-    await expect(
-      salesOrderService.update(order.id, {
-        items: [{ productId: product.id, quantity: 3, unitPrice: 40 }],
-      }),
-    ).rejects.toThrow('reconcile boom');
-    spy.mockRestore();
+    try {
+      await expect(
+        salesOrderService.update(order.id, {
+          items: [{ productId: product.id, quantity: 3, unitPrice: 40 }],
+        }),
+      ).rejects.toThrow('reconcile boom');
+    } finally {
+      spy.mockRestore();
+    }
 
     const persistedOrder = await orderRepo.findOneOrFail({ where: { id: order.id } });
     const persistedItems = await itemRepo.find({ where: { salesOrderId: order.id } });

--- a/backend/test/sales-order-edit.e2e-spec.ts
+++ b/backend/test/sales-order-edit.e2e-spec.ts
@@ -154,6 +154,10 @@ describe('Sales order edit transaction (e2e)', () => {
     const persistedOrder = await orderRepo.findOneOrFail({ where: { id: order.id } });
     const persistedItems = await itemRepo.find({ where: { salesOrderId: order.id } });
 
+    // The items branch writes subtotal, shippingAmount and totalAmount together, so prove
+    // all three rolled back — not just totalAmount — or a partial-commit regression slips through.
+    expect(Number(persistedOrder.subtotal)).toBe(100);
+    expect(Number(persistedOrder.shippingAmount)).toBe(0);
     expect(Number(persistedOrder.totalAmount)).toBe(100);
     expect(persistedItems).toHaveLength(1);
     expect(persistedItems[0].id).toBe(originalItem.id);

--- a/backend/test/sales-order-edit.e2e-spec.ts
+++ b/backend/test/sales-order-edit.e2e-spec.ts
@@ -1,0 +1,98 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { DataSource } from 'typeorm';
+import { AppModule } from '../src/app.module';
+import { Customer, CustomerType } from '../src/database/entities/customer.entity';
+import {
+  SalesOrder,
+  SalesOrderPaymentStatus,
+  SalesOrderStatus,
+} from '../src/database/entities/sales-order.entity';
+import {
+  DiscountType,
+  SalesOrderItem,
+} from '../src/database/entities/sales-order-item.entity';
+import { SalesOrderService } from '../src/modules/sales/services/sales-order.service';
+import { seedCategory, seedProduct, truncateAll } from './e2e/helpers/seed';
+
+describe('Sales order edit transaction (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+  let salesOrderService: SalesOrderService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    dataSource = app.get(DataSource);
+    salesOrderService = app.get(SalesOrderService);
+    await truncateAll(dataSource);
+  });
+
+  afterAll(async () => {
+    if (dataSource?.isInitialized) await dataSource.destroy();
+    await app.close();
+  });
+
+  it('rolls back deleted items and totals when replacement item insertion fails', async () => {
+    const category = await seedCategory(dataSource);
+    const product = await seedProduct(dataSource, category.id, {
+      baseCost: 100,
+      stockQuantity: 100,
+    });
+    const customerRepo = dataSource.getRepository(Customer);
+    const customer = await customerRepo.save(customerRepo.create({
+      type: CustomerType.BUSINESS,
+      name: 'Rollback Test Customer',
+      isActive: true,
+    }));
+    const orderRepo = dataSource.getRepository(SalesOrder);
+    const order = await orderRepo.save(orderRepo.create({
+      orderNumber: 'SO-ROLLBACK-001',
+      orderDate: new Date(),
+      customerId: customer.id,
+      status: SalesOrderStatus.DRAFT,
+      paymentStatus: SalesOrderPaymentStatus.UNPAID,
+      subtotal: 100,
+      shippingAmount: 0,
+      totalAmount: 100,
+      paidAmount: 0,
+      balanceDue: 100,
+    }));
+    const itemRepo = dataSource.getRepository(SalesOrderItem);
+    const originalItem = await itemRepo.save(itemRepo.create({
+      lineNumber: 1,
+      salesOrderId: order.id,
+      productId: product.id,
+      quantity: 1,
+      unitPrice: 100,
+      unitCost: 100,
+      discountType: DiscountType.PERCENTAGE,
+      discountPercent: 0,
+      discountAmount: 0,
+      totalAmount: 100,
+    }));
+
+    await expect(salesOrderService.update(order.id, {
+      items: [{
+        productId: product.id,
+        quantity: 2147483648,
+        unitPrice: 50,
+      }],
+    })).rejects.toThrow();
+
+    const persistedOrder = await orderRepo.findOneOrFail({ where: { id: order.id } });
+    const persistedItems = await itemRepo.find({ where: { salesOrderId: order.id } });
+
+    expect(Number(persistedOrder.subtotal)).toBe(100);
+    expect(Number(persistedOrder.totalAmount)).toBe(100);
+    expect(persistedItems).toHaveLength(1);
+    expect(persistedItems[0].id).toBe(originalItem.id);
+    expect(persistedItems[0].quantity).toBe(1);
+    expect(Number(persistedItems[0].totalAmount)).toBe(100);
+  });
+});

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -814,7 +814,7 @@ describe('CreateSalesOrderPage edit guard', { timeout: 60000 }, () => {
     )
 
     await waitFor(() => {
-      expect(mockFetchSalesOrder).toHaveBeenCalled()
+      expect(screen.getByRole('combobox', { name: /customer/i })).toHaveValue('Test Customer')
     })
 
     expect(mockNavigate).not.toHaveBeenCalledWith('/sales/orders/SO-1/view', { replace: true })

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -794,7 +794,7 @@ describe('CreateSalesOrderPage edit guard', { timeout: 60000 }, () => {
     })
   })
 
-  it('redirects to order detail and shows error when order is paid', async () => {
+  it('loads the editor (no redirect/error) when order is paid', async () => {
     mockFetchSalesOrder.mockReturnValue({
       unwrap: vi.fn().mockResolvedValue({
         id: 'order-123',
@@ -814,10 +814,11 @@ describe('CreateSalesOrderPage edit guard', { timeout: 60000 }, () => {
     )
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/sales/orders/SO-1/view', { replace: true })
+      expect(mockFetchSalesOrder).toHaveBeenCalled()
     })
 
-    expect(mockShowError).toHaveBeenCalledWith('Cancel payment first to edit')
+    expect(mockNavigate).not.toHaveBeenCalledWith('/sales/orders/SO-1/view', { replace: true })
+    expect(mockShowError).not.toHaveBeenCalled()
   })
 
   it('redirects to order detail and shows error when order is fulfilled', async () => {

--- a/frontend/src/pages/sales/components/__tests__/OrderActionBar.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/OrderActionBar.test.tsx
@@ -46,36 +46,35 @@ function renderBar(order: SalesOrder, handlers = {}) {
 }
 
 describe('OrderActionBar', () => {
-  it('Draft+Unpaid shows Pay, Fulfill (disabled), Edit, Cancel, Print', () => {
+  it('Draft+Unpaid shows Pay, Edit, Cancel, Print — no Fulfill, no Refund', () => {
     renderBar(makeOrder({ status: 'DRAFT', paymentStatus: 'UNPAID' }))
     expect(screen.getByRole('button', { name: 'Pay' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Fulfill' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Fulfill' })).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Print' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Fulfill' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Refund' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Unfulfill' })).not.toBeInTheDocument()
   })
 
-  it('Draft+Partial shows Pay, Fulfill (disabled), Refund, Edit, Cancel, Print', () => {
+  it('Draft+Partial shows Pay, Refund, Edit, Print — no Fulfill, no Cancel', () => {
     renderBar(makeOrder({ status: 'DRAFT', paymentStatus: 'PARTIAL' }))
     expect(screen.getByRole('button', { name: 'Pay' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Fulfill' })).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Refund' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Edit' })).toBeEnabled()
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled()
     expect(screen.getByRole('button', { name: 'Print' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Fulfill' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument()
   })
 
-  it('Draft+Paid shows Fulfill, Refund, Edit, Cancel, Print', () => {
+  it('Draft+Paid (Ready) shows Fulfill, Refund, Edit, Print — no Pay, no Cancel', () => {
     renderBar(makeOrder({ status: 'DRAFT', paymentStatus: 'PAID' }))
     expect(screen.getByRole('button', { name: 'Fulfill' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Refund' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeEnabled()
     expect(screen.getByRole('button', { name: 'Print' })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Pay' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Unfulfill' })).not.toBeInTheDocument()
   })
 

--- a/frontend/src/pages/sales/components/__tests__/OrderActionBar.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/OrderActionBar.test.tsx
@@ -78,10 +78,11 @@ describe('OrderActionBar', () => {
     expect(screen.queryByRole('button', { name: 'Unfulfill' })).not.toBeInTheDocument()
   })
 
-  it('Draft+Overpaid shows Fulfill, Refund, Edit, Cancel, Print', () => {
+  it('Draft+Overpaid shows Fulfill and Refund — no Cancel', () => {
     renderBar(makeOrder({ status: 'DRAFT', paymentStatus: 'OVERPAID' }))
     expect(screen.getByRole('button', { name: 'Fulfill' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Refund' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument()
   })
 
   it('Fulfilled shows Unfulfill, Refund, Print', () => {

--- a/frontend/src/pages/sales/components/__tests__/SalesOrderList.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/SalesOrderList.test.tsx
@@ -89,41 +89,33 @@ describe('SalesOrderList empty state', () => {
 })
 
 describe('SalesOrderList row actions — Draft Unpaid', () => {
-  it('shows View, Edit, Pay, Fulfill (disabled), Cancel, Print', async () => {
+  it('shows View, Edit, Pay, Cancel, Print — no Fulfill, no Refund', async () => {
     renderList()
     await openMenu()
     expect(screen.getByRole('menuitem', { name: /view/i })).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: /^edit$/i })).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: /^pay$/i })).toBeInTheDocument()
-    expect(screen.getByRole('menuitem', { name: /fulfill/i })).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: /cancel/i })).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: /print/i })).toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: /fulfill/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('menuitem', { name: /unfulfill/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('menuitem', { name: /refund/i })).not.toBeInTheDocument()
-  })
-
-  it('Fulfill is disabled with tooltip', async () => {
-    renderList()
-    await openMenu()
-    const fulfill = screen.getByRole('menuitem', { name: /fulfill/i })
-    expect(fulfill).toHaveAttribute('aria-disabled', 'true')
-    expect(fulfill.closest('[data-tooltip]')).toHaveAttribute('data-tooltip', 'Full payment required')
   })
 })
 
 describe('SalesOrderList row actions — Draft Paid', () => {
-  it('shows View, Edit (disabled), Fulfill, Refund, Cancel (disabled), Print — no Pay', async () => {
+  it('shows View, Edit (enabled), Fulfill, Refund, Print — no Pay, no Cancel', async () => {
     renderList({ ...defaultProps, orders: [makeOrder({ paymentStatus: 'PAID' })] })
     await openMenu()
     expect(screen.getByRole('menuitem', { name: /view/i })).toBeInTheDocument()
-    expect(screen.getByRole('menuitem', { name: /^edit$/i })).toBeInTheDocument()
-    expect(screen.queryByRole('menuitem', { name: /^pay$/i })).not.toBeInTheDocument()
+    const edit = screen.getByRole('menuitem', { name: /^edit$/i })
+    expect(edit).toBeInTheDocument()
+    expect(edit).not.toHaveAttribute('aria-disabled', 'true')
     expect(screen.getByRole('menuitem', { name: /^fulfill$/i })).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: /refund/i })).toBeInTheDocument()
-    expect(screen.getByRole('menuitem', { name: /cancel/i })).toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: /^pay$/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: /^cancel$/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('menuitem', { name: /unfulfill/i })).not.toBeInTheDocument()
-    const edit = screen.getByRole('menuitem', { name: /^edit$/i })
-    expect(edit).toHaveAttribute('aria-disabled', 'true')
   })
 })
 
@@ -150,17 +142,16 @@ describe('SalesOrderList row actions — Fulfilled', () => {
 })
 
 describe('SalesOrderList row actions — Draft Partial', () => {
-  it('shows View, Pay, Fulfill (disabled), Refund, Edit, Cancel, Print', async () => {
+  it('shows View, Pay, Refund, Edit (enabled), Print — no Fulfill, no Cancel', async () => {
     renderList({ ...defaultProps, orders: [makeOrder({ paymentStatus: 'PARTIAL' })] })
     await openMenu()
     expect(screen.getByRole('menuitem', { name: /view/i })).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: /^pay$/i })).toBeInTheDocument()
-    const fulfill = screen.getByRole('menuitem', { name: /^fulfill$/i })
-    expect(fulfill).toHaveAttribute('aria-disabled', 'true')
     expect(screen.getByRole('menuitem', { name: /refund/i })).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: /^edit$/i })).not.toHaveAttribute('aria-disabled', 'true')
-    expect(screen.getByRole('menuitem', { name: /cancel/i })).not.toHaveAttribute('aria-disabled', 'true')
     expect(screen.getByRole('menuitem', { name: /print/i })).toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: /^fulfill$/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: /^cancel$/i })).not.toBeInTheDocument()
   })
 })
 

--- a/frontend/src/pages/sales/utils/__tests__/orderActions.test.ts
+++ b/frontend/src/pages/sales/utils/__tests__/orderActions.test.ts
@@ -6,38 +6,59 @@ const makeOrder = (status: SalesOrder['status'], paymentStatus: SalesOrder['paym
   ({ id: 'o1', orderNumber: 'SO-26-001', status, paymentStatus } as SalesOrder)
 
 describe('getOrderActions', () => {
-  it('DRAFT + UNPAID: pay, fulfill, edit, cancel, duplicate, print — no refund, no uncancel', () => {
+  it('DRAFT + UNPAID: pay, edit, cancel, duplicate, print — no fulfill, refund, uncancel', () => {
     const actions = getOrderActions(makeOrder('DRAFT', 'UNPAID'))
     expect(actions).toContain('pay')
-    expect(actions).toContain('fulfill')
     expect(actions).toContain('edit')
     expect(actions).toContain('cancel')
     expect(actions).toContain('duplicate')
     expect(actions).toContain('print')
+    expect(actions).not.toContain('fulfill')
     expect(actions).not.toContain('refund')
     expect(actions).not.toContain('uncancel')
     expect(actions).not.toContain('unfulfill')
   })
 
-  it('DRAFT + PARTIAL: pay, fulfill (disabled), refund, edit, cancel, duplicate, print', () => {
+  it('DRAFT + PARTIAL: pay, refund, edit, duplicate, print — no fulfill, no cancel', () => {
     const actions = getOrderActions(makeOrder('DRAFT', 'PARTIAL'))
     expect(actions).toContain('pay')
+    expect(actions).toContain('refund')
+    expect(actions).toContain('edit')
+    expect(actions).toContain('duplicate')
+    expect(actions).toContain('print')
+    expect(actions).not.toContain('fulfill')
+    expect(actions).not.toContain('cancel')
+  })
+
+  it('DRAFT + PAID (Ready): fulfill, refund, edit, duplicate, print — no pay, no cancel', () => {
+    const actions = getOrderActions(makeOrder('DRAFT', 'PAID'))
     expect(actions).toContain('fulfill')
     expect(actions).toContain('refund')
     expect(actions).toContain('edit')
-    expect(actions).toContain('cancel')
     expect(actions).toContain('duplicate')
+    expect(actions).not.toContain('pay')
+    expect(actions).not.toContain('cancel')
   })
 
-  it('DRAFT + PAID: fulfill, refund, edit, cancel, duplicate, print — no pay', () => {
-    const actions = getOrderActions(makeOrder('DRAFT', 'PAID'))
-    expect(actions).not.toContain('pay')
+  it('READY + PAID: fulfill, refund, edit, duplicate, print — no pay, no cancel', () => {
+    const actions = getOrderActions(makeOrder('READY', 'PAID'))
     expect(actions).toContain('fulfill')
     expect(actions).toContain('refund')
+    expect(actions).toContain('edit')
     expect(actions).toContain('duplicate')
+    expect(actions).toContain('print')
+    expect(actions).not.toContain('pay')
+    expect(actions).not.toContain('cancel')
   })
 
-  it('FULFILLED + PAID: unfulfill, refund, duplicate, print — no pay, edit, cancel', () => {
+  it('READY + OVERPAID: still fulfill + refund + edit', () => {
+    const actions = getOrderActions(makeOrder('READY', 'OVERPAID'))
+    expect(actions).toContain('fulfill')
+    expect(actions).toContain('refund')
+    expect(actions).toContain('edit')
+  })
+
+  it('FULFILLED + PAID: unfulfill, refund, duplicate, print — no pay, edit, cancel, fulfill', () => {
     const actions = getOrderActions(makeOrder('FULFILLED', 'PAID'))
     expect(actions).toContain('unfulfill')
     expect(actions).toContain('refund')
@@ -46,17 +67,7 @@ describe('getOrderActions', () => {
     expect(actions).not.toContain('pay')
     expect(actions).not.toContain('edit')
     expect(actions).not.toContain('cancel')
-  })
-
-  it('READY + PAID: fulfill, refund, duplicate, print — no pay, edit, cancel', () => {
-    const actions = getOrderActions(makeOrder('READY', 'PAID'))
-    expect(actions).toContain('fulfill')
-    expect(actions).toContain('refund')
-    expect(actions).toContain('duplicate')
-    expect(actions).toContain('print')
-    expect(actions).not.toContain('pay')
-    expect(actions).not.toContain('edit')
-    expect(actions).not.toContain('cancel')
+    expect(actions).not.toContain('fulfill')
   })
 
   it('FULFILLED + OVERPAID: unfulfill, refund, duplicate, print', () => {
@@ -79,29 +90,33 @@ describe('getOrderActions', () => {
   })
 })
 
-describe('getOrderActionMetas — disabled flags', () => {
-  it('fulfill is disabled when DRAFT + UNPAID', () => {
+describe('getOrderActionMetas — disabled flags & tooltips', () => {
+  it('fulfill is hidden (absent) when DRAFT + UNPAID', () => {
     const metas = getOrderActionMetas(makeOrder('DRAFT', 'UNPAID'))
-    const fulfill = metas.find((m) => m.action === 'fulfill')
-    expect(fulfill?.disabled).toBe(true)
-    expect(fulfill?.tooltip).toMatch(/payment required/i)
+    expect(metas.find((m) => m.action === 'fulfill')).toBeUndefined()
   })
 
-  it('fulfill is disabled when DRAFT + PARTIAL', () => {
+  it('fulfill is hidden (absent) when DRAFT + PARTIAL', () => {
     const metas = getOrderActionMetas(makeOrder('DRAFT', 'PARTIAL'))
-    const fulfill = metas.find((m) => m.action === 'fulfill')
-    expect(fulfill?.disabled).toBe(true)
+    expect(metas.find((m) => m.action === 'fulfill')).toBeUndefined()
   })
 
-  it('edit is disabled when DRAFT + PAID', () => {
+  it('edit is enabled (no disabled flag) when DRAFT + PAID', () => {
     const metas = getOrderActionMetas(makeOrder('DRAFT', 'PAID'))
     const edit = metas.find((m) => m.action === 'edit')
-    expect(edit?.disabled).toBe(true)
+    expect(edit).toBeDefined()
+    expect(edit?.disabled).toBeFalsy()
   })
 
-  it('cancel is enabled when DRAFT + PARTIAL', () => {
+  it('cancel is hidden (absent) when DRAFT + PARTIAL', () => {
     const metas = getOrderActionMetas(makeOrder('DRAFT', 'PARTIAL'))
+    expect(metas.find((m) => m.action === 'cancel')).toBeUndefined()
+  })
+
+  it('cancel is enabled when DRAFT + UNPAID', () => {
+    const metas = getOrderActionMetas(makeOrder('DRAFT', 'UNPAID'))
     const cancel = metas.find((m) => m.action === 'cancel')
+    expect(cancel).toBeDefined()
     expect(cancel?.disabled).toBeFalsy()
   })
 

--- a/frontend/src/pages/sales/utils/orderActions.ts
+++ b/frontend/src/pages/sales/utils/orderActions.ts
@@ -24,38 +24,33 @@ export function getOrderActionMetas(order: SalesOrder): OrderActionMeta[] {
   const isFulfilled = status === 'FULFILLED'
   const isCancelled = status === 'CANCELLED'
   const isUnpaid = paymentStatus === 'UNPAID'
-  const isPartiallyPaid = paymentStatus === 'PARTIAL'
-  const needsPayment = isUnpaid || isPartiallyPaid
+  const isFullyPaid = paymentStatus === 'PAID' || paymentStatus === 'OVERPAID'
+  const needsPayment = isUnpaid || paymentStatus === 'PARTIAL'
+  // A paid DRAFT is "Ready" even if its status column still reads DRAFT.
+  const isReadyState = isReady || (isDraft && isFullyPaid)
 
   if (isCancelled) {
-    return [
-      { action: 'uncancel' },
-      { action: 'print' },
-    ]
+    return [{ action: 'uncancel' }, { action: 'print' }]
   }
 
   const metas: OrderActionMeta[] = []
 
+  // Pay — DRAFT with an outstanding balance.
   if (isDraft && needsPayment) {
     metas.push({ action: 'pay' })
   }
 
-  if (isDraft) {
-    metas.push({
-      action: 'fulfill',
-      disabled: needsPayment,
-      tooltip: needsPayment ? 'Full payment required' : undefined,
-    })
-  }
-
-  if (isReady) {
+  // Fulfill — Ready only (fully-paid). Hidden on unpaid/partial drafts.
+  if (isReadyState) {
     metas.push({ action: 'fulfill' })
   }
 
+  // Unfulfill — Fulfilled only.
   if (isFulfilled) {
     metas.push({ action: 'unfulfill' })
   }
 
+  // Refund — whenever a payment exists; disabled on Fulfilled.
   if (!isUnpaid) {
     metas.push({
       action: 'refund',
@@ -64,17 +59,14 @@ export function getOrderActionMetas(order: SalesOrder): OrderActionMeta[] {
     })
   }
 
-  if (isDraft) {
-    metas.push({
-      action: 'edit',
-      disabled: !needsPayment,
-      tooltip: !needsPayment ? 'Cancel payment first to edit' : undefined,
-    })
-    metas.push({
-      action: 'cancel',
-      disabled: !needsPayment,
-      tooltip: !needsPayment ? 'Cancel payment first' : undefined,
-    })
+  // Edit — any unfulfilled order (all DRAFT/Ready states), enabled regardless of payment.
+  if (isDraft || isReady) {
+    metas.push({ action: 'edit' })
+  }
+
+  // Cancel — DRAFT with no payment at all.
+  if (isDraft && isUnpaid) {
+    metas.push({ action: 'cancel' })
   }
 
   metas.push({ action: 'duplicate' })


### PR DESCRIPTION
Closes #717

## What

Reconciles Sales Order **row-action availability** into a single authoritative, status-aware matrix, aligns the backend edit guard with it, and hardens the order-edit path for atomicity and concurrency.

### Action matrix (frontend)
`getOrderActionMetas` rewritten so availability is driven entirely by `{ action, disabled?, tooltip? }` metas (no component changes needed):
- **Edit** — all `DRAFT` states (Unpaid/Partial/Paid); hidden on `FULFILLED`/`CANCELLED`.
- **Fulfill** — Ready only (`DRAFT` + `PAID`); hidden (not disabled) on unpaid/partial drafts.
- **Cancel** — `UNPAID` drafts only.
- **Refund** — shown **disabled** on `FULFILLED` with the unfulfill-first tooltip.
- **Duplicate/Print** always; **Uncancel** on cancelled.
- **Delete** confirmed absent and not added.

### Backend edit guard
`assertEditAllowed` relaxed from "DRAFT + UNPAID only" to **DRAFT or READY** (any payment state); `FULFILLED`/`CANCELLED` stay locked. `cancel`/`uncancel` guards unchanged. Swagger updated.

### Edit-path atomicity & concurrency hardening
The bulk of this PR makes `SalesOrderService.update` safe:
- Single `dataSource.transaction` with a `pessimistic_write` lock on the parent order before any totals are derived.
- Payment-state reconciliation (`reconcileOrderState`) runs **in the same transaction** — totals, `paymentStatus`, `balanceDue`, and the `DRAFT↔READY` band commit atomically.
- All pricing/total/customer/audit reads are lock-consistent (resolved from the locked row, via manager repositories).
- **Editability is re-asserted against the locked row** inside the transaction (closes the check-then-lock window for transitions that commit before the lock).
- **Customer-only edits re-price** existing items at the new customer's price list and reconcile.
- Audit logs distinct before/after snapshots (incl. reconciled fields and notes), captured in-lock.
- Cleanups: batched product + price-list reads (removes an N+1 under the lock), `reconcileOrderState` returns the reconciled order (removes a redundant in-lock read), shared audit-snapshot helper, single `hasChanges` gate, debug `console.log`s removed.

## Testing
- **`orderActions.test.ts`** drives every (status × paymentStatus) combination against the matrix.
- **`sales-order.service.spec.ts`** — lock/atomicity coverage: in-lock editability re-check, customer-only re-pricing, manager-repo writes, stale-customer/shipping regressions, audit before/after, rollback when an insert fails.
- **`sales-order-edit.e2e-spec.ts`** (real Postgres) — item + subtotal/shipping/total rollback on insert failure and on reconcile failure.
- Component tests (`OrderActionBar`, `SalesOrderList`, `CreateSalesOrderPage`) aligned with the new matrix.

Verification (final): backend sales services **183/183**, frontend sales **29 files / 259 tests**, `type-check` + both lints clean, e2e `sales-order-edit` **2/2** and `accounting-auto-posting` **22/22**.

## Follow-up
Applying the same parent-order lock protocol to the **payment / fulfillment / cancellation / unfulfillment** transitions is deferred and tracked in #720 (those transitions still read unlocked; the edit-path in-lock re-check narrows but doesn't fully close cross-transition races until they also lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)