### PR TITLE
Period filter: add "All" option (default) and fix "Last 30 Days" off-by-one

### DIFF
--- a/frontend/src/components/filters/FilterPeriod.test.tsx
+++ b/frontend/src/components/filters/FilterPeriod.test.tsx
@@ -45,9 +45,29 @@ describe('FilterPeriod', () => {
     expect(getTrigger()).toHaveTextContent('15/01/2024 - 31/01/2024')
   })
 
-  it('renders the trigger with empty text when value is null', () => {
+  it('renders the trigger with "All" when value is null', () => {
     renderFilterPeriod(null)
-    expect(getTrigger().textContent?.replace(/\u200b/g, '').trim()).toBe('')
+    expect(getTrigger()).toHaveTextContent('All')
+  })
+
+  it('renders the "All" option in the popover', async () => {
+    const user = userEvent.setup()
+    renderFilterPeriod('today')
+
+    await user.click(getTrigger())
+
+    expect(screen.getByRole('menuitem', { name: 'All' })).toBeInTheDocument()
+  })
+
+  it('calls onChange with null and closes popover when "All" is clicked', async () => {
+    const user = userEvent.setup()
+    const { onChange } = renderFilterPeriod('today')
+
+    await user.click(getTrigger())
+    await user.click(screen.getByRole('menuitem', { name: 'All' }))
+
+    expect(onChange).toHaveBeenCalledWith(null)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
   })
 
   it('renders the Period floating label', () => {

--- a/frontend/src/components/filters/FilterPeriod.tsx
+++ b/frontend/src/components/filters/FilterPeriod.tsx
@@ -41,7 +41,7 @@ function buildTriggerLabel(
     return PERIOD_LABELS[value]
   }
 
-  return ''
+  return 'All'
 }
 
 function toDisplayFormat(storedFormat: string): string {
@@ -86,6 +86,13 @@ export function FilterPeriod({ value, customFrom, customTo, onChange }: FilterPe
     setInternalTo(customTo)
   }
 
+  const handleAllClick = () => {
+    setInternalFrom(null)
+    setInternalTo(null)
+    onChange(null)
+    setAnchorEl(null)
+  }
+
   const handlePresetClick = (key: PeriodKey) => {
     setInternalFrom(null)
     setInternalTo(null)
@@ -125,6 +132,11 @@ export function FilterPeriod({ value, customFrom, customTo, onChange }: FilterPe
         transformOrigin={{ vertical: 'top', horizontal: 'left' }}
       >
         <MenuList id="period-listbox" disablePadding sx={{ minWidth: 260 }}>
+          <MenuItem selected={value === null} onClick={handleAllClick}>
+            All
+          </MenuItem>
+          <Divider />
+
           {/* 'custom' is always the last item in the last PERIOD_GROUPS group — rendered below as a subheader + pickers */}
           {PERIOD_GROUPS.flatMap((group, groupIndex) => [
             ...group.filter((key) => key !== 'custom').map((key) => (

--- a/frontend/src/pages/inventory/InventoryPage.tsx
+++ b/frontend/src/pages/inventory/InventoryPage.tsx
@@ -114,7 +114,7 @@ const InventoryPage: React.FC = () => {
       },
     ],
     defaults: {
-      period: { key: 'this_month', from: null, to: null },
+      period: { key: null, from: null, to: null },
       compareWith: null,
       supplierId: null,
       categoryId: null,

--- a/frontend/src/pages/purchasing/PurchasingPage.tsx
+++ b/frontend/src/pages/purchasing/PurchasingPage.tsx
@@ -105,7 +105,7 @@ const PurchasingPage: React.FC = () => {
       },
     ],
     defaults: {
-      period: { key: 'this_month', from: null, to: null },
+      period: { key: null, from: null, to: null },
       compareWith: null,
       supplierId: null,
       status: null,

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -45,7 +45,7 @@ const filterConfig: FilterBarConfig<SalesOrderFilters> = {
     search: '',
     customerId: null,
     paymentStatus: null,
-    period: { key: 'this_month', from: null, to: null },
+    period: { key: null, from: null, to: null },
     status: null,
   },
 }

--- a/frontend/src/pages/sales/SalesPage.tsx
+++ b/frontend/src/pages/sales/SalesPage.tsx
@@ -81,7 +81,7 @@ const SalesPage: React.FC = () => {
       },
     ],
     defaults: {
-      period: { key: 'this_month', from: null, to: null },
+      period: { key: null, from: null, to: null },
       compareWith: null,
       customerId: null,
       fulfillmentStatus: null,

--- a/frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
+++ b/frontend/src/pages/sales/__tests__/OrdersPage.filterbar.test.tsx
@@ -90,14 +90,11 @@ describe('OrdersPage FilterBar integration', () => {
     )
   })
 
-  it('defaults period to this_month and resolves to fromDate/toDate', () => {
+  it('defaults period to All and sends no fromDate/toDate', () => {
     renderPage()
-    expect(useGetSalesOrdersQuery).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        fromDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
-        toDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
-      }),
-    )
+    const call = (useGetSalesOrdersQuery as any).mock.calls.at(-1)[0]
+    expect(call.fromDate).toBeUndefined()
+    expect(call.toDate).toBeUndefined()
   })
 
   it('sends no fromDate/toDate when period key is null', () => {

--- a/frontend/src/utils/dateRange.test.ts
+++ b/frontend/src/utils/dateRange.test.ts
@@ -53,7 +53,7 @@ describe('getPeriodDateRange', () => {
 
   it('last_30_days returns from=30 days ago and to=today', () => {
     const { from, to } = getPeriodDateRange('last_30_days')
-    expect(from).toBe('2026-02-28')
+    expect(from).toBe('2026-03-01')
     expect(to).toBe('2026-03-30')
   })
 
@@ -142,7 +142,7 @@ describe('inferPeriodKey', () => {
   })
 
   it('infers last_30_days', () => {
-    expect(inferPeriodKey('2026-02-28', '2026-03-30')).toBe('last_30_days')
+    expect(inferPeriodKey('2026-03-01', '2026-03-30')).toBe('last_30_days')
   })
 
   it('infers this_week with weekStartsOn=1 (Mon)', () => {

--- a/frontend/src/utils/dateRange.ts
+++ b/frontend/src/utils/dateRange.ts
@@ -38,10 +38,9 @@ export function getPeriodDateRange(
     case 'last_7_days':
       return { from: format(subDays(now, 6), FMT), to: format(now, FMT) }
     // Ranges are inclusive: "last N days" = today + (N-1) prior days = N days total.
-    // last_7_days uses subDays(6), last_30_days uses subDays(30) = 31 days, last_365_days uses subDays(364).
-    // This is intentional — "Last 30 Days" means the trailing 31-day window ending today.
+    // So all three use subDays(N-1): last_7_days→6, last_30_days→29, last_365_days→364.
     case 'last_30_days':
-      return { from: format(subDays(now, 30), FMT), to: format(now, FMT) }
+      return { from: format(subDays(now, 29), FMT), to: format(now, FMT) }
     case 'last_365_days':
       return { from: format(subDays(now, 364), FMT), to: format(now, FMT) }
     case 'this_week':


### PR DESCRIPTION
## Summary

Two related improvements to the period filter:

1. **Add an "All" option (and make it the default).** The period data model already represents "no date restriction" as `key: null`, but there was no way to *select* it from the dropdown, and four pages defaulted to `this_month`. This adds a selectable **"All"** item at the top of the dropdown and makes it the default everywhere, so all 16 pages now load unfiltered uniformly.

2. **Fix `last_30_days` off-by-one.** `last_30_days` used `subDays(30)`, producing a 31-day inclusive window — inconsistent with `last_7_days` (`subDays 6`) and `last_365_days` (`subDays 364`), which return exactly N days. Switched to `subDays(29)` so all three follow the same "today + (N-1) prior days" rule.

## Changes

- `FilterPeriod.tsx` — "All" menuitem at top of dropdown (with divider); clicking it calls `onChange(null)` and closes. Trigger reads "All" when no period is set.
- Page defaults → `key: null` on SalesPage, OrdersPage, PurchasingPage, InventoryPage (were `this_month`).
- `dateRange.ts` — `last_30_days` now `subDays(29)`; fixed the self-contradictory comment.
- Tests updated/added in `FilterPeriod.test.tsx`, `dateRange.test.ts`, `OrdersPage.filterbar.test.tsx`.

## Behavior notes

- The four summary/list pages (Sales, Orders, Purchasing, Inventory) now show all-time data on first load instead of this-month. Lists are paginated server-side.
- "Last 30 Days" now spans exactly 30 inclusive days (shifts the start by one day).

## Testing

- `npm run type-check` — clean
- 89 filter/page tests pass; `dateRange.test.ts` (29) and `dashboardApiParams.test.ts` (20) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)