### PR TITLE
fix(sales): pessimistic-lock + single-transaction protocol for sales order transitions

### DIFF
--- a/backend/src/common/db/tx-helpers.spec.ts
+++ b/backend/src/common/db/tx-helpers.spec.ts
@@ -1,0 +1,53 @@
+import { NotFoundException } from '@nestjs/common';
+import { repoFor, lockRowForUpdate } from './tx-helpers';
+
+class Dummy {
+  id: string;
+}
+
+describe('tx-helpers', () => {
+  describe('repoFor', () => {
+    it('returns the fallback repository when no manager is supplied', () => {
+      const fallback = { marker: 'fallback' } as any;
+      expect(repoFor(undefined, Dummy, fallback)).toBe(fallback);
+    });
+
+    it("returns the manager's repository when a manager is supplied", () => {
+      const managerRepo = { marker: 'manager' } as any;
+      const manager = { getRepository: jest.fn().mockReturnValue(managerRepo) } as any;
+      const fallback = { marker: 'fallback' } as any;
+
+      expect(repoFor(manager, Dummy, fallback)).toBe(managerRepo);
+      expect(manager.getRepository).toHaveBeenCalledWith(Dummy);
+    });
+  });
+
+  describe('lockRowForUpdate', () => {
+    it('reads the row through the manager with a pessimistic_write lock', async () => {
+      const row = { id: 'x1' };
+      const findOne = jest.fn().mockResolvedValue(row);
+      const manager = { getRepository: jest.fn().mockReturnValue({ findOne }) } as any;
+
+      const result = await lockRowForUpdate(manager, Dummy, 'x1', {
+        relations: { foo: true } as any,
+        notFoundMessage: 'Dummy not found',
+      });
+
+      expect(result).toBe(row);
+      expect(findOne).toHaveBeenCalledWith({
+        where: { id: 'x1' },
+        relations: { foo: true },
+        lock: { mode: 'pessimistic_write' },
+      });
+    });
+
+    it('throws NotFoundException with the supplied message when absent', async () => {
+      const findOne = jest.fn().mockResolvedValue(null);
+      const manager = { getRepository: jest.fn().mockReturnValue({ findOne }) } as any;
+
+      await expect(
+        lockRowForUpdate(manager, Dummy, 'missing', { notFoundMessage: 'Dummy not found' }),
+      ).rejects.toThrow(new NotFoundException('Dummy not found'));
+    });
+  });
+});

--- a/backend/src/common/db/tx-helpers.spec.ts
+++ b/backend/src/common/db/tx-helpers.spec.ts
@@ -23,9 +23,28 @@ describe('tx-helpers', () => {
   });
 
   describe('lockRowForUpdate', () => {
-    it('reads the row through the manager with a pessimistic_write lock', async () => {
-      const row = { id: 'x1' };
-      const findOne = jest.fn().mockResolvedValue(row);
+    it('locks the BARE row FOR UPDATE (no relations join — Postgres rejects FOR UPDATE over an outer join)', async () => {
+      const locked = { id: 'x1' };
+      const findOne = jest.fn().mockResolvedValue(locked);
+      const manager = { getRepository: jest.fn().mockReturnValue({ findOne }) } as any;
+
+      const result = await lockRowForUpdate(manager, Dummy, 'x1', { notFoundMessage: 'Dummy not found' });
+
+      expect(result).toBe(locked);
+      expect(findOne).toHaveBeenCalledTimes(1);
+      expect(findOne).toHaveBeenCalledWith({
+        where: { id: 'x1' },
+        lock: { mode: 'pessimistic_write' },
+      });
+    });
+
+    it('locks bare then hydrates relations in a SEPARATE unlocked read on the same manager', async () => {
+      const locked = { id: 'x1' };
+      const withRelations = { id: 'x1', foo: { id: 'f1' } };
+      const findOne = jest
+        .fn()
+        .mockResolvedValueOnce(locked) // step 1: bare lock
+        .mockResolvedValueOnce(withRelations); // step 2: relations
       const manager = { getRepository: jest.fn().mockReturnValue({ findOne }) } as any;
 
       const result = await lockRowForUpdate(manager, Dummy, 'x1', {
@@ -33,15 +52,20 @@ describe('tx-helpers', () => {
         notFoundMessage: 'Dummy not found',
       });
 
-      expect(result).toBe(row);
-      expect(findOne).toHaveBeenCalledWith({
+      expect(result).toBe(withRelations);
+      // Step 1 takes the lock on the bare row (no relations in the query).
+      expect(findOne).toHaveBeenNthCalledWith(1, {
+        where: { id: 'x1' },
+        lock: { mode: 'pessimistic_write' },
+      });
+      // Step 2 loads relations without a lock (no FOR UPDATE over the join).
+      expect(findOne).toHaveBeenNthCalledWith(2, {
         where: { id: 'x1' },
         relations: { foo: true },
-        lock: { mode: 'pessimistic_write' },
       });
     });
 
-    it('throws NotFoundException with the supplied message when absent', async () => {
+    it('throws NotFoundException with the supplied message when the bare row is absent', async () => {
       const findOne = jest.fn().mockResolvedValue(null);
       const manager = { getRepository: jest.fn().mockReturnValue({ findOne }) } as any;
 

--- a/backend/src/common/db/tx-helpers.ts
+++ b/backend/src/common/db/tx-helpers.ts
@@ -29,6 +29,14 @@ export function repoFor<T extends ObjectLiteral>(
  * pessimistic-lock + single-transaction protocol used by the sales-order
  * transitions: open `dataSource.transaction`, then call this to take the row
  * lock before re-asserting any status guards on fresh, lock-held state.
+ *
+ * The lock is always taken on the BARE row (no relations). Postgres rejects
+ * `SELECT … FOR UPDATE` when the query contains a LEFT JOIN to a nullable side
+ * ("FOR UPDATE cannot be applied to the nullable side of an outer join"), which
+ * is exactly what TypeORM emits when `relations` are loaded via join. When
+ * `relations` are requested we therefore lock the bare row first, then re-load it
+ * with its relations in a second query on the same manager — still inside the
+ * transaction, so the row lock acquired in step one is held throughout.
  */
 export async function lockRowForUpdate<T extends ObjectLiteral>(
   manager: EntityManager,
@@ -36,13 +44,27 @@ export async function lockRowForUpdate<T extends ObjectLiteral>(
   id: string,
   options?: { relations?: FindOptionsRelations<T>; notFoundMessage?: string },
 ): Promise<T> {
-  const row = await manager.getRepository(entity).findOne({
+  const repo = manager.getRepository(entity);
+
+  // Step 1: lock the bare row FOR UPDATE (no join, so the lock is valid).
+  const locked = await repo.findOne({
     where: { id } as any,
-    relations: options?.relations,
     lock: { mode: 'pessimistic_write' },
   });
-  if (!row) {
+  if (!locked) {
     throw new NotFoundException(options?.notFoundMessage ?? 'Resource not found');
   }
-  return row;
+
+  // Step 2: hydrate relations in a separate (unlocked) read within the same
+  // transaction. The row is already lock-held, so this view is consistent.
+  if (options?.relations) {
+    const withRelations = await repo.findOne({
+      where: { id } as any,
+      relations: options.relations,
+    });
+    // The row exists and is locked; the re-read cannot legitimately miss it.
+    if (withRelations) return withRelations;
+  }
+
+  return locked;
 }

--- a/backend/src/common/db/tx-helpers.ts
+++ b/backend/src/common/db/tx-helpers.ts
@@ -1,0 +1,48 @@
+import { NotFoundException } from '@nestjs/common';
+import {
+  EntityManager,
+  EntityTarget,
+  FindOptionsRelations,
+  ObjectLiteral,
+  Repository,
+} from 'typeorm';
+
+/**
+ * Select the repository to use for an entity: the transaction manager's repo
+ * when a manager is supplied, otherwise the injected fallback repository.
+ *
+ * Centralises the `manager ? manager.getRepository(Entity) : this.fooRepository`
+ * idiom so transactional methods stay backward-compatible (no manager → injected
+ * repo, unchanged behaviour) without repeating the ternary at every call site.
+ */
+export function repoFor<T extends ObjectLiteral>(
+  manager: EntityManager | undefined,
+  entity: EntityTarget<T>,
+  fallback: Repository<T>,
+): Repository<T> {
+  return manager ? manager.getRepository(entity) : fallback;
+}
+
+/**
+ * Lock-read a single entity row `FOR UPDATE` inside a transaction and throw a
+ * NotFoundException when it is absent. This is the shared first step of the
+ * pessimistic-lock + single-transaction protocol used by the sales-order
+ * transitions: open `dataSource.transaction`, then call this to take the row
+ * lock before re-asserting any status guards on fresh, lock-held state.
+ */
+export async function lockRowForUpdate<T extends ObjectLiteral>(
+  manager: EntityManager,
+  entity: EntityTarget<T>,
+  id: string,
+  options?: { relations?: FindOptionsRelations<T>; notFoundMessage?: string },
+): Promise<T> {
+  const row = await manager.getRepository(entity).findOne({
+    where: { id } as any,
+    relations: options?.relations,
+    lock: { mode: 'pessimistic_write' },
+  });
+  if (!row) {
+    throw new NotFoundException(options?.notFoundMessage ?? 'Resource not found');
+  }
+  return row;
+}

--- a/backend/src/modules/accounting/services/accounting.service.spec.ts
+++ b/backend/src/modules/accounting/services/accounting.service.spec.ts
@@ -142,6 +142,13 @@ describe('AccountingService', () => {
       journalEntryService.postEntry.mockResolvedValue(mockJournalEntry as any);
     });
 
+    it('accepts an optional EntityManager argument (4th param)', async () => {
+      const manager = { getRepository: jest.fn() } as any;
+      await expect(
+        service.postSalesOrderEntry(mockSalesOrder, 'user-123', undefined, manager),
+      ).resolves.toBeDefined();
+    });
+
     it('should create two separate entries: COGS first, then Revenue', async () => {
       journalEntryService.create
         .mockResolvedValueOnce({ ...mockJournalEntry, id: 'cogs-entry' } as any)

--- a/backend/src/modules/accounting/services/accounting.service.ts
+++ b/backend/src/modules/accounting/services/accounting.service.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
   Logger,
 } from '@nestjs/common';
+import { EntityManager } from 'typeorm';
 import { JournalEntryService } from './journal-entry.service';
 import { AccountMappingService } from './account-mapping.service';
 import { FiscalPeriodService } from './fiscal-period.service';
@@ -49,6 +50,7 @@ export class AccountingService {
     salesOrder: SalesOrder,
     userId: string,
     username?: string,
+    manager?: EntityManager,
   ): Promise<JournalEntry> {
     this.logger.log(`Posting sales order entry for ${salesOrder.orderNumber}`);
 
@@ -156,6 +158,8 @@ export class AccountingService {
         },
       ],
     };
+
+    // TODO(#719): manager accepted for transactional call-site uniformity; JournalEntryService persistence is not yet manager-bound.
 
     // Post COGS entry first (when there is a cost to record)
     if (cogsEntryDto) {
@@ -943,8 +947,11 @@ export class AccountingService {
     sourceType: string,
     sourceId: string,
     userId: string,
+    manager?: EntityManager,
   ): Promise<void> {
     this.logger.log(`Reversing source entries: ${sourceType}/${sourceId}`);
+
+    // TODO(#719): manager accepted for transactional call-site uniformity; JournalEntryService persistence is not yet manager-bound.
 
     const entries = await this.journalEntryService.findBySource(sourceType, sourceId);
 

--- a/backend/src/modules/inventory/services/base-cost-calculator.service.spec.ts
+++ b/backend/src/modules/inventory/services/base-cost-calculator.service.spec.ts
@@ -1,0 +1,38 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BaseCostCalculatorService } from './base-cost-calculator.service';
+import { Product } from '../../../database/entities/product.entity';
+import { PurchaseCostHistory } from '../../../database/entities/purchase-cost-history.entity';
+import { CostingStrategyFactory } from './costing/costing-strategy-factory.service';
+
+describe('BaseCostCalculatorService', () => {
+  let service: BaseCostCalculatorService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BaseCostCalculatorService,
+        { provide: getRepositoryToken(Product), useValue: { findOne: jest.fn(), update: jest.fn() } },
+        { provide: getRepositoryToken(PurchaseCostHistory), useValue: { find: jest.fn(), update: jest.fn() } },
+        {
+          provide: CostingStrategyFactory,
+          useValue: {
+            getActiveStrategy: jest.fn().mockResolvedValue({ determineBatchReduction: jest.fn().mockReturnValue([]), calculateBaseCost: jest.fn().mockResolvedValue(0) }),
+            getCurrentCostingMethod: jest.fn().mockResolvedValue('FIFO'),
+          },
+        },
+      ],
+    }).compile();
+    service = module.get(BaseCostCalculatorService);
+  });
+
+  it('reduceStock reads cost-history batches through the supplied manager', async () => {
+    const find = jest.fn().mockResolvedValue([]); // empty → early return after find
+    const manager = { getRepository: jest.fn().mockReturnValue({ find, update: jest.fn() }) } as any;
+
+    await service.reduceStock('product-1', 5, manager);
+
+    expect(manager.getRepository).toHaveBeenCalled();
+    expect(find).toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/inventory/services/base-cost-calculator.service.ts
+++ b/backend/src/modules/inventory/services/base-cost-calculator.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, MoreThan } from 'typeorm';
+import { Repository, MoreThan, EntityManager } from 'typeorm';
 import { Product } from '../../../database/entities/product.entity';
 import { PurchaseCostHistory } from '../../../database/entities/purchase-cost-history.entity';
 import { CostingStrategyFactory } from './costing/costing-strategy-factory.service';
@@ -21,8 +21,11 @@ export class BaseCostCalculatorService {
    * Calculate base cost using configured costing strategy
    * Strategy is determined by settings (AVERAGE, FIFO, LIFO, STANDARD)
    */
-  async calculateBaseCostFromCurrentStock(productId: string): Promise<number> {
-    const product = await this.productRepository.findOne({
+  async calculateBaseCostFromCurrentStock(productId: string, manager?: EntityManager): Promise<number> {
+    const productRepo = manager ? manager.getRepository(Product) : this.productRepository;
+    const costHistoryRepo = manager ? manager.getRepository(PurchaseCostHistory) : this.costHistoryRepository;
+
+    const product = await productRepo.findOne({
       where: { id: productId },
     });
 
@@ -31,7 +34,7 @@ export class BaseCostCalculatorService {
     }
 
     // Get all batches with remaining stock
-    const batches = await this.costHistoryRepository.find({
+    const batches = await costHistoryRepo.find({
       where: {
         productId,
         remainingQuantity: MoreThan(0), // Only batches with stock
@@ -58,10 +61,11 @@ export class BaseCostCalculatorService {
   /**
    * Update product base cost
    */
-  async updateProductBaseCost(productId: string): Promise<number> {
-    const newBaseCost = await this.calculateBaseCostFromCurrentStock(productId);
+  async updateProductBaseCost(productId: string, manager?: EntityManager): Promise<number> {
+    const productRepo = manager ? manager.getRepository(Product) : this.productRepository;
+    const newBaseCost = await this.calculateBaseCostFromCurrentStock(productId, manager);
 
-    await this.productRepository.update(productId, {
+    await productRepo.update(productId, {
       baseCost: newBaseCost,
       updatedAt: new Date(),
     });
@@ -76,10 +80,12 @@ export class BaseCostCalculatorService {
    * Uses costing strategy to determine which batches to reduce from
    * Updates remainingQuantity in cost history and recalculates base cost
    */
-  async reduceStock(productId: string, quantitySold: number): Promise<void> {
+  async reduceStock(productId: string, quantitySold: number, manager?: EntityManager): Promise<void> {
+    const costHistoryRepo = manager ? manager.getRepository(PurchaseCostHistory) : this.costHistoryRepository;
+
     this.logger.log(`Reducing stock for product ${productId}: ${quantitySold} units`);
 
-    const batches = await this.costHistoryRepository.find({
+    const batches = await costHistoryRepo.find({
       where: {
         productId,
         remainingQuantity: MoreThan(0),
@@ -104,7 +110,7 @@ export class BaseCostCalculatorService {
       const batchRemaining = Number(batch.remainingQuantity);
       const newRemaining = batchRemaining - reduction.quantity;
 
-      await this.costHistoryRepository.update(batch.id, {
+      await costHistoryRepo.update(batch.id, {
         remainingQuantity: newRemaining,
         updatedAt: new Date(),
       });
@@ -122,7 +128,7 @@ export class BaseCostCalculatorService {
     }
 
     // Recalculate base cost after reduction
-    await this.updateProductBaseCost(productId);
+    await this.updateProductBaseCost(productId, manager);
   }
 
   /**
@@ -272,11 +278,13 @@ export class BaseCostCalculatorService {
    * Adds quantities back to the cost history batches in FIFO order
    * This reverses the reduceStock operation during fulfillment
    */
-  async restoreStock(productId: string, quantityToRestore: number): Promise<void> {
+  async restoreStock(productId: string, quantityToRestore: number, manager?: EntityManager): Promise<void> {
+    const costHistoryRepo = manager ? manager.getRepository(PurchaseCostHistory) : this.costHistoryRepository;
+
     this.logger.log(`Restoring stock for product ${productId}: ${quantityToRestore} units`);
 
     // Get all batches for this product, including sold-out ones
-    const batches = await this.costHistoryRepository.find({
+    const batches = await costHistoryRepo.find({
       where: {
         productId,
       },
@@ -302,7 +310,7 @@ export class BaseCostCalculatorService {
 
       const toRestore = Math.min(maxCanRestore, remainingToRestore);
 
-      await this.costHistoryRepository.update(batch.id, {
+      await costHistoryRepo.update(batch.id, {
         remainingQuantity: currentRemaining + toRestore,
         updatedAt: new Date(),
       });
@@ -321,6 +329,6 @@ export class BaseCostCalculatorService {
     }
 
     // Recalculate base cost after restoration
-    await this.updateProductBaseCost(productId);
+    await this.updateProductBaseCost(productId, manager);
   }
 }

--- a/backend/src/modules/inventory/services/base-cost-calculator.service.ts
+++ b/backend/src/modules/inventory/services/base-cost-calculator.service.ts
@@ -4,6 +4,7 @@ import { Repository, MoreThan, EntityManager } from 'typeorm';
 import { Product } from '../../../database/entities/product.entity';
 import { PurchaseCostHistory } from '../../../database/entities/purchase-cost-history.entity';
 import { CostingStrategyFactory } from './costing/costing-strategy-factory.service';
+import { repoFor } from '../../../common/db/tx-helpers';
 
 @Injectable()
 export class BaseCostCalculatorService {
@@ -22,8 +23,8 @@ export class BaseCostCalculatorService {
    * Strategy is determined by settings (AVERAGE, FIFO, LIFO, STANDARD)
    */
   async calculateBaseCostFromCurrentStock(productId: string, manager?: EntityManager): Promise<number> {
-    const productRepo = manager ? manager.getRepository(Product) : this.productRepository;
-    const costHistoryRepo = manager ? manager.getRepository(PurchaseCostHistory) : this.costHistoryRepository;
+    const productRepo = repoFor(manager, Product, this.productRepository);
+    const costHistoryRepo = repoFor(manager, PurchaseCostHistory, this.costHistoryRepository);
 
     const product = await productRepo.findOne({
       where: { id: productId },
@@ -62,7 +63,7 @@ export class BaseCostCalculatorService {
    * Update product base cost
    */
   async updateProductBaseCost(productId: string, manager?: EntityManager): Promise<number> {
-    const productRepo = manager ? manager.getRepository(Product) : this.productRepository;
+    const productRepo = repoFor(manager, Product, this.productRepository);
     const newBaseCost = await this.calculateBaseCostFromCurrentStock(productId, manager);
 
     await productRepo.update(productId, {
@@ -81,7 +82,7 @@ export class BaseCostCalculatorService {
    * Updates remainingQuantity in cost history and recalculates base cost
    */
   async reduceStock(productId: string, quantitySold: number, manager?: EntityManager): Promise<void> {
-    const costHistoryRepo = manager ? manager.getRepository(PurchaseCostHistory) : this.costHistoryRepository;
+    const costHistoryRepo = repoFor(manager, PurchaseCostHistory, this.costHistoryRepository);
 
     this.logger.log(`Reducing stock for product ${productId}: ${quantitySold} units`);
 
@@ -279,7 +280,7 @@ export class BaseCostCalculatorService {
    * This reverses the reduceStock operation during fulfillment
    */
   async restoreStock(productId: string, quantityToRestore: number, manager?: EntityManager): Promise<void> {
-    const costHistoryRepo = manager ? manager.getRepository(PurchaseCostHistory) : this.costHistoryRepository;
+    const costHistoryRepo = repoFor(manager, PurchaseCostHistory, this.costHistoryRepository);
 
     this.logger.log(`Restoring stock for product ${productId}: ${quantityToRestore} units`);
 

--- a/backend/src/modules/inventory/services/stock-movement.service.spec.ts
+++ b/backend/src/modules/inventory/services/stock-movement.service.spec.ts
@@ -1,0 +1,93 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { StockMovementService } from './stock-movement.service';
+import { StockMovement } from '../../../database/entities/stock-movement.entity';
+import { Product } from '../../../database/entities/product.entity';
+import { ProductService } from './product.service';
+
+describe('StockMovementService', () => {
+  let service: StockMovementService;
+  let stockMovementRepository: jest.Mocked<Repository<StockMovement>>;
+  let productRepository: jest.Mocked<Repository<Product>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StockMovementService,
+        {
+          provide: getRepositoryToken(StockMovement),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+            createQueryBuilder: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(Product),
+          useValue: {
+            save: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+            createQueryBuilder: jest.fn(),
+          },
+        },
+        {
+          provide: ProductService,
+          useValue: {
+            updateStockQuantity: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<StockMovementService>(StockMovementService);
+    stockMovementRepository = module.get(getRepositoryToken(StockMovement));
+    productRepository = module.get(getRepositoryToken(Product));
+
+    // Silence logger output during tests
+    jest.spyOn(service['logger'], 'log').mockImplementation(() => undefined);
+    jest.spyOn(service['logger'], 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('deleteByReference', () => {
+    it('returns deletedCount 0 when there are no movements', async () => {
+      stockMovementRepository.find.mockResolvedValue([]);
+
+      const result = await service.deleteByReference('sales_order', 'order-1');
+
+      expect(result.deletedCount).toBe(0);
+    });
+
+    it('deleteByReference reads movements through the supplied manager', async () => {
+      const find = jest.fn().mockResolvedValue([]); // no movements → early return { deletedCount: 0 }
+      const manager = {
+        getRepository: jest.fn().mockReturnValue({ find }),
+      } as any;
+
+      const result = await service.deleteByReference(
+        'sales_order',
+        'order-1',
+        manager,
+      );
+
+      expect(manager.getRepository).toHaveBeenCalled();
+      expect(find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { referenceType: 'sales_order', referenceId: 'order-1' },
+        }),
+      );
+      expect(result).toEqual({ deletedCount: 0 });
+    });
+  });
+});

--- a/backend/src/modules/inventory/services/stock-movement.service.ts
+++ b/backend/src/modules/inventory/services/stock-movement.service.ts
@@ -19,6 +19,7 @@ import {
   StockMovementType,
 } from '../../../database/entities/stock-movement.entity';
 import { Product } from '../../../database/entities/product.entity';
+import { repoFor } from '../../../common/db/tx-helpers';
 import {
   CreateStockMovementDto,
   QueryStockMovementsDto,
@@ -614,12 +615,8 @@ export class StockMovementService {
     productId: string,
     manager?: EntityManager,
   ): Promise<void> {
-    const stockMovementRepo = manager
-      ? manager.getRepository(StockMovement)
-      : this.stockMovementRepository;
-    const productRepo = manager
-      ? manager.getRepository(Product)
-      : this.productRepository;
+    const stockMovementRepo = repoFor(manager, StockMovement, this.stockMovementRepository);
+    const productRepo = repoFor(manager, Product, this.productRepository);
 
     this.logger.log(`Recalculating balances for product ${productId}`);
 
@@ -695,12 +692,8 @@ export class StockMovementService {
     referenceId: string,
     manager?: EntityManager,
   ): Promise<{ deletedCount: number }> {
-    const stockMovementRepo = manager
-      ? manager.getRepository(StockMovement)
-      : this.stockMovementRepository;
-    const productRepo = manager
-      ? manager.getRepository(Product)
-      : this.productRepository;
+    const stockMovementRepo = repoFor(manager, StockMovement, this.stockMovementRepository);
+    const productRepo = repoFor(manager, Product, this.productRepository);
 
     this.logger.log(`Deleting stock movements for ${referenceType}: ${referenceId}`);
 

--- a/backend/src/modules/inventory/services/stock-movement.service.ts
+++ b/backend/src/modules/inventory/services/stock-movement.service.ts
@@ -12,6 +12,7 @@ import {
   FindManyOptions,
   SelectQueryBuilder,
   Between,
+  EntityManager,
 } from 'typeorm';
 import {
   StockMovement,
@@ -609,11 +610,21 @@ export class StockMovementService {
    * Recalculate previousBalance and newBalance for all movements of a product
    * This ensures data integrity after movements are deleted
    */
-  async recalculateBalances(productId: string): Promise<void> {
+  async recalculateBalances(
+    productId: string,
+    manager?: EntityManager,
+  ): Promise<void> {
+    const stockMovementRepo = manager
+      ? manager.getRepository(StockMovement)
+      : this.stockMovementRepository;
+    const productRepo = manager
+      ? manager.getRepository(Product)
+      : this.productRepository;
+
     this.logger.log(`Recalculating balances for product ${productId}`);
 
     // Fetch all movements for this product in chronological order
-    const movements = await this.stockMovementRepository.find({
+    const movements = await stockMovementRepo.find({
       where: { productId },
       order: {
         movementDate: 'ASC',
@@ -627,7 +638,7 @@ export class StockMovementService {
     }
 
     // Get current product stock
-    const product = await this.productRepository.findOne({
+    const product = await productRepo.findOne({
       where: { id: productId },
     });
 
@@ -661,7 +672,7 @@ export class StockMovementService {
       ) {
         movement.previousBalance = previousBalance;
         movement.newBalance = newBalance;
-        await this.stockMovementRepository.save(movement);
+        await stockMovementRepo.save(movement);
 
         this.logger.log(
           `Updated movement ${movement.id}: ${previousBalance} + (${quantity}) = ${newBalance}`
@@ -682,11 +693,19 @@ export class StockMovementService {
   async deleteByReference(
     referenceType: string,
     referenceId: string,
+    manager?: EntityManager,
   ): Promise<{ deletedCount: number }> {
+    const stockMovementRepo = manager
+      ? manager.getRepository(StockMovement)
+      : this.stockMovementRepository;
+    const productRepo = manager
+      ? manager.getRepository(Product)
+      : this.productRepository;
+
     this.logger.log(`Deleting stock movements for ${referenceType}: ${referenceId}`);
 
     // First, fetch all movements to revert their quantities
-    const movements = await this.stockMovementRepository.find({
+    const movements = await stockMovementRepo.find({
       where: {
         referenceType,
         referenceId,
@@ -719,7 +738,7 @@ export class StockMovementService {
 
     // Update product stock quantities
     for (const [productId, adjustment] of productUpdates.entries()) {
-      const product = await this.productRepository.findOne({
+      const product = await productRepo.findOne({
         where: { id: productId },
       });
 
@@ -740,14 +759,14 @@ export class StockMovementService {
           product.stockQuantity = newStock;
         }
 
-        await this.productRepository.save(product);
+        await productRepo.save(product);
       } else {
         this.logger.warn(`Product ${productId} not found, skipping stock reversion`);
       }
     }
 
     // Now delete the stock movements
-    const result = await this.stockMovementRepository
+    const result = await stockMovementRepo
       .createQueryBuilder()
       .delete()
       .from('stock_movements')
@@ -762,7 +781,7 @@ export class StockMovementService {
 
     // Recalculate balances for all affected products
     for (const productId of affectedProductIds) {
-      await this.recalculateBalances(productId);
+      await this.recalculateBalances(productId, manager);
     }
 
     return { deletedCount };

--- a/backend/src/modules/sales/services/inventory-integration.service.spec.ts
+++ b/backend/src/modules/sales/services/inventory-integration.service.spec.ts
@@ -1,0 +1,48 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { InventoryIntegrationService } from './inventory-integration.service';
+import { Product } from '../../../database/entities/product.entity';
+import { StockMovement } from '../../../database/entities/stock-movement.entity';
+import { SalesOrder } from '../../../database/entities/sales-order.entity';
+import { SalesOrderItem } from '../../../database/entities/sales-order-item.entity';
+import { BaseCostCalculatorService } from '../../inventory/services/base-cost-calculator.service';
+import { SettingsService } from '../../settings/settings.service';
+
+describe('InventoryIntegrationService', () => {
+  let service: InventoryIntegrationService;
+  let baseCostCalculator: { reduceStock: jest.Mock; restoreStock: jest.Mock };
+
+  beforeEach(async () => {
+    baseCostCalculator = { reduceStock: jest.fn(), restoreStock: jest.fn() };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InventoryIntegrationService,
+        { provide: getRepositoryToken(Product), useValue: { findOne: jest.fn(), save: jest.fn() } },
+        { provide: getRepositoryToken(StockMovement), useValue: { create: jest.fn((d) => d), save: jest.fn() } },
+        { provide: getRepositoryToken(SalesOrder), useValue: {} },
+        { provide: getRepositoryToken(SalesOrderItem), useValue: {} },
+        { provide: BaseCostCalculatorService, useValue: baseCostCalculator },
+        { provide: SettingsService, useValue: {} },
+      ],
+    }).compile();
+    service = module.get(InventoryIntegrationService);
+  });
+
+  it('adjustStock uses the supplied manager and lets reduceStock errors propagate (no swallow)', async () => {
+    const product = { id: 'p1', stockQuantity: 10 };
+    const findOne = jest.fn().mockResolvedValue(product);
+    const save = jest.fn().mockResolvedValue(product);
+    const movementSave = jest.fn().mockResolvedValue({ id: 'm1' });
+    const manager = {
+      getRepository: jest.fn().mockImplementation((entity) =>
+        entity === StockMovement ? { create: jest.fn((d) => d), save: movementSave } : { findOne, save },
+      ),
+    } as any;
+    baseCostCalculator.reduceStock.mockRejectedValue(new Error('cost failure'));
+
+    await expect(
+      service.adjustStock('p1', -2, 'Sales order fulfillment: SO-1', 'order-1', 'user-1', undefined, manager),
+    ).rejects.toThrow('cost failure');
+    expect(findOne).toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/sales/services/inventory-integration.service.ts
+++ b/backend/src/modules/sales/services/inventory-integration.service.ts
@@ -13,6 +13,7 @@ import { SalesOrder } from '../../../database/entities/sales-order.entity';
 import { SalesOrderItem } from '../../../database/entities/sales-order-item.entity';
 import { BaseCostCalculatorService } from '../../inventory/services/base-cost-calculator.service';
 import { SettingsService } from '../../settings/settings.service';
+import { repoFor } from '../../../common/db/tx-helpers';
 
 export interface StockItem {
   productId: string;
@@ -418,7 +419,7 @@ export class InventoryIntegrationService {
     movementTypeOverride?: StockMovementType,
     manager?: EntityManager,
   ): Promise<void> {
-    const productRepo = manager ? manager.getRepository(Product) : this.productRepository;
+    const productRepo = repoFor(manager, Product, this.productRepository);
 
     const product = await productRepo.findOne({ where: { id: productId } });
     if (!product) {
@@ -527,7 +528,7 @@ export class InventoryIntegrationService {
     userId?: string,
     manager?: EntityManager,
   ): Promise<StockMovement> {
-    const stockMovementRepo = manager ? manager.getRepository(StockMovement) : this.stockMovementRepository;
+    const stockMovementRepo = repoFor(manager, StockMovement, this.stockMovementRepository);
     const movement = stockMovementRepo.create({
       productId,
       quantity,

--- a/backend/src/modules/sales/services/inventory-integration.service.ts
+++ b/backend/src/modules/sales/services/inventory-integration.service.ts
@@ -6,7 +6,7 @@ import {
   forwardRef,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, EntityManager } from 'typeorm';
 import { Product, ProductType } from '../../../database/entities/product.entity';
 import { StockMovement, StockMovementType } from '../../../database/entities/stock-movement.entity';
 import { SalesOrder } from '../../../database/entities/sales-order.entity';
@@ -416,11 +416,11 @@ export class InventoryIntegrationService {
     referenceId?: string,
     userId?: string,
     movementTypeOverride?: StockMovementType,
+    manager?: EntityManager,
   ): Promise<void> {
-    const product = await this.productRepository.findOne({
-      where: { id: productId },
-    });
+    const productRepo = manager ? manager.getRepository(Product) : this.productRepository;
 
+    const product = await productRepo.findOne({ where: { id: productId } });
     if (!product) {
       throw new NotFoundException(`Product ${productId} not found`);
     }
@@ -429,12 +429,6 @@ export class InventoryIntegrationService {
     const currentStock = Number(product.stockQuantity);
     const changeAmount = Number(quantityChange);
     const newStockQuantity = currentStock + changeAmount;
-
-    // DEBUG: Log stock values to trace the bug
-    console.log(`🔍 [adjustStock] Product ${productId}:`);
-    console.log(`  Current stock in DB: ${currentStock}`);
-    console.log(`  Change amount: ${changeAmount}`);
-    console.log(`  New stock will be: ${newStockQuantity}`);
 
     // Create stock movement record BEFORE updating product
     // This ensures previousBalance and newBalance are calculated correctly
@@ -451,24 +445,19 @@ export class InventoryIntegrationService {
       reason,
       referenceId,
       userId,
+      manager,
     );
 
-    // Update FIFO cost history for sales (negative quantity changes)
+    // Update FIFO cost history for sales (negative quantity changes).
+    // Errors propagate so a wrapping transaction rolls back.
     if (quantityChange < 0) {
       const quantitySold = Math.abs(quantityChange);
-      try {
-        await this.baseCostCalculator.reduceStock(productId, quantitySold);
-      } catch (error) {
-        // Log warning but don't fail the stock adjustment
-        // This allows sales to proceed even if cost history is missing
-        console.warn(`Failed to update cost history for product ${productId}: ${error.message}`);
-      }
+      await this.baseCostCalculator.reduceStock(productId, quantitySold, manager);
     }
 
     // Update product stock quantity (allow negative for GOODS products)
-    // Explicitly set as number to ensure TypeORM handles it correctly
     product.stockQuantity = Number(newStockQuantity);
-    await this.productRepository.save(product);
+    await productRepo.save(product);
   }
 
   // Private helper methods
@@ -536,8 +525,10 @@ export class InventoryIntegrationService {
     reason: string,
     referenceId?: string,
     userId?: string,
+    manager?: EntityManager,
   ): Promise<StockMovement> {
-    const movement = this.stockMovementRepository.create({
+    const stockMovementRepo = manager ? manager.getRepository(StockMovement) : this.stockMovementRepository;
+    const movement = stockMovementRepo.create({
       productId,
       quantity,
       previousBalance,
@@ -549,6 +540,6 @@ export class InventoryIntegrationService {
       movementDate: new Date(),
     });
 
-    return await this.stockMovementRepository.save(movement);
+    return await stockMovementRepo.save(movement);
   }
 }

--- a/backend/src/modules/sales/services/sales-order-fulfillment.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-fulfillment.service.spec.ts
@@ -98,6 +98,40 @@ describe('SalesOrderFulfillmentService', () => {
       accountingService.postSalesOrderEntry.mockRejectedValue(new Error('period closed'));
       await expect(service.fulfillOrder('order-1')).rejects.toThrow('period closed');
     });
+
+    it('posts accounting against the re-read order (fresh updatedAt + post-reduction costs), not the lock-read snapshot', async () => {
+      // Lock-read returns the stale snapshot; the post-update re-read returns a row
+      // carrying the just-persisted updatedAt and recalculated product baseCost.
+      const lockReadOrder = mockOrder({ status: SalesOrderStatus.READY });
+      const repricedOrder = mockOrder({
+        status: SalesOrderStatus.FULFILLED,
+        // sentinel distinguishing the re-read from the lock-read snapshot
+        updatedAt: new Date('2099-01-01T00:00:00Z'),
+      } as Partial<SalesOrder>);
+
+      const findOne = jest
+        .fn()
+        .mockResolvedValueOnce(lockReadOrder) // lockRowForUpdate (with pessimistic_write)
+        .mockResolvedValueOnce(repricedOrder); // priced re-read before posting
+      const update = jest.fn().mockResolvedValue(undefined);
+      const manager = { getRepository: jest.fn().mockReturnValue({ findOne, update }) } as unknown as EntityManager;
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
+
+      await service.fulfillOrder('order-1', 'user-1', 'admin');
+
+      // The status update must persist a fresh updatedAt so fulfilledDate is correct.
+      expect(update).toHaveBeenCalledWith(
+        'order-1',
+        expect.objectContaining({ status: SalesOrderStatus.FULFILLED, updatedAt: expect.any(Date) }),
+      );
+      // Accounting must be posted with the re-read row, not the stale lock-read snapshot.
+      expect(accountingService.postSalesOrderEntry).toHaveBeenCalledWith(
+        repricedOrder,
+        'user-1',
+        'admin',
+        expect.anything(),
+      );
+    });
   });
 
   describe('unfulfillOrder', () => {

--- a/backend/src/modules/sales/services/sales-order-fulfillment.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-fulfillment.service.spec.ts
@@ -100,8 +100,9 @@ describe('SalesOrderFulfillmentService', () => {
     });
 
     it('posts accounting against the re-read order (fresh updatedAt + post-reduction costs), not the lock-read snapshot', async () => {
-      // Lock-read returns the stale snapshot; the post-update re-read returns a row
-      // carrying the just-persisted updatedAt and recalculated product baseCost.
+      // lockRowForUpdate issues two reads (bare lock, then relations hydrate); the
+      // post-update re-read is a third read returning a row carrying the just-
+      // persisted updatedAt and recalculated product baseCost.
       const lockReadOrder = mockOrder({ status: SalesOrderStatus.READY });
       const repricedOrder = mockOrder({
         status: SalesOrderStatus.FULFILLED,
@@ -111,7 +112,8 @@ describe('SalesOrderFulfillmentService', () => {
 
       const findOne = jest
         .fn()
-        .mockResolvedValueOnce(lockReadOrder) // lockRowForUpdate (with pessimistic_write)
+        .mockResolvedValueOnce(lockReadOrder) // lockRowForUpdate: bare row lock
+        .mockResolvedValueOnce(lockReadOrder) // lockRowForUpdate: relations hydrate
         .mockResolvedValueOnce(repricedOrder); // priced re-read before posting
       const update = jest.fn().mockResolvedValue(undefined);
       const manager = { getRepository: jest.fn().mockReturnValue({ findOne, update }) } as unknown as EntityManager;

--- a/backend/src/modules/sales/services/sales-order-fulfillment.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-fulfillment.service.spec.ts
@@ -102,44 +102,42 @@ describe('SalesOrderFulfillmentService', () => {
 
   describe('unfulfillOrder', () => {
     it('throws ConflictException when order is not FULFILLED', async () => {
-      orderRepo.findOne.mockResolvedValue(mockOrder({ status: SalesOrderStatus.DRAFT }));
+      wireTransaction(mockOrder({ status: SalesOrderStatus.DRAFT }));
       await expect(service.unfulfillOrder('order-1')).rejects.toThrow(ConflictException);
     });
 
-    it('reverses inventory and sets status READY', async () => {
+    it('lock-reads the order, reverses inventory, and persists status READY via manager', async () => {
       const order = mockOrder({ status: SalesOrderStatus.FULFILLED });
-      orderRepo.findOne.mockResolvedValue(order);
-      orderRepo.save.mockResolvedValue({ ...order, status: SalesOrderStatus.READY } as SalesOrder);
+      const { findOne, update } = wireTransaction(order);
 
       await service.unfulfillOrder('order-1');
 
-      expect(baseCostCalculator.restoreStock).toHaveBeenCalledWith('product-1', 5);
-      expect(stockMovementService.deleteByReference).toHaveBeenCalledWith('sales_order', 'order-1');
-      expect(orderRepo.save).toHaveBeenCalledWith(expect.objectContaining({ status: SalesOrderStatus.READY }));
+      expect(findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'order-1' }, lock: { mode: 'pessimistic_write' } }),
+      );
+      expect(baseCostCalculator.restoreStock).toHaveBeenCalledWith('product-1', 5, expect.anything());
+      expect(stockMovementService.deleteByReference).toHaveBeenCalledWith('sales_order', 'order-1', expect.anything());
+      expect(update).toHaveBeenCalledWith('order-1', expect.objectContaining({ status: SalesOrderStatus.READY }));
     });
 
     it('reverses the sales_order journal entry on unfulfill', async () => {
-      const order = mockOrder({ status: SalesOrderStatus.FULFILLED });
-      orderRepo.findOne.mockResolvedValue(order);
-      orderRepo.save.mockResolvedValue({ ...order, status: SalesOrderStatus.DRAFT } as SalesOrder);
-
+      wireTransaction(mockOrder({ status: SalesOrderStatus.FULFILLED }));
       await service.unfulfillOrder('order-1', 'user-99', 'admin');
-
       expect(accountingService.reverseSourceEntries).toHaveBeenCalledWith(
-        'sales_order',
-        'order-1',
-        'user-99',
+        'sales_order', 'order-1', 'user-99', expect.anything(),
       );
     });
 
-    it('does not throw if journal entry reversal fails (non-critical path)', async () => {
-      const order = mockOrder({ status: SalesOrderStatus.FULFILLED });
-      orderRepo.findOne.mockResolvedValue(order);
-      orderRepo.save.mockResolvedValue({ ...order, status: SalesOrderStatus.DRAFT } as SalesOrder);
-      accountingService.reverseSourceEntries.mockRejectedValue(new Error('No open fiscal period'));
+    it('rolls back (propagates) when stock-movement deletion fails — no swallow', async () => {
+      wireTransaction(mockOrder({ status: SalesOrderStatus.FULFILLED }));
+      stockMovementService.deleteByReference.mockRejectedValue(new Error('delete failed'));
+      await expect(service.unfulfillOrder('order-1')).rejects.toThrow('delete failed');
+    });
 
-      // Should not throw — accounting failure must not block unfulfill
-      await expect(service.unfulfillOrder('order-1')).resolves.toBeDefined();
+    it('rolls back (propagates) when accounting reversal fails — no swallow', async () => {
+      wireTransaction(mockOrder({ status: SalesOrderStatus.FULFILLED }));
+      accountingService.reverseSourceEntries.mockRejectedValue(new Error('No open fiscal period'));
+      await expect(service.unfulfillOrder('order-1')).rejects.toThrow('No open fiscal period');
     });
   });
 
@@ -163,8 +161,7 @@ describe('SalesOrderFulfillmentService', () => {
 
     it('unfulfills a FULFILLED order back to READY', async () => {
       const order = mockOrder({ status: SalesOrderStatus.FULFILLED, paymentStatus: SalesOrderPaymentStatus.PAID, items: [] });
-      orderRepo.findOne.mockResolvedValue(order);
-      orderRepo.save.mockImplementation(async (saved: any) => saved as SalesOrder);
+      wireTransaction(order);
 
       const result = await service.unfulfillOrder('order-1');
 

--- a/backend/src/modules/sales/services/sales-order-fulfillment.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-fulfillment.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import { ConflictException, NotFoundException } from '@nestjs/common';
 import { SalesOrderFulfillmentService } from './sales-order-fulfillment.service';
 import { SalesOrder, SalesOrderStatus, SalesOrderPaymentStatus } from '../../../database/entities/sales-order.entity';
@@ -30,6 +30,15 @@ describe('SalesOrderFulfillmentService', () => {
   let baseCostCalculator: jest.Mocked<BaseCostCalculatorService>;
   let auditLogService: jest.Mocked<AuditLogService>;
   let accountingService: jest.Mocked<AccountingService>;
+  let dataSource: jest.Mocked<DataSource>;
+
+  function wireTransaction(order: SalesOrder | null) {
+    const findOne = jest.fn().mockResolvedValue(order);
+    const update = jest.fn().mockResolvedValue(undefined);
+    const manager = { getRepository: jest.fn().mockReturnValue({ findOne, update }) } as unknown as EntityManager;
+    (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
+    return { findOne, update, manager };
+  }
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -41,6 +50,7 @@ describe('SalesOrderFulfillmentService', () => {
         { provide: BaseCostCalculatorService, useValue: { restoreStock: jest.fn() } },
         { provide: AuditLogService, useValue: { log: jest.fn() } },
         { provide: AccountingService, useValue: { postSalesOrderEntry: jest.fn().mockResolvedValue(undefined), reverseSourceEntries: jest.fn().mockResolvedValue(undefined) } },
+        { provide: DataSource, useValue: { transaction: jest.fn() } },
       ],
     }).compile();
 
@@ -51,33 +61,42 @@ describe('SalesOrderFulfillmentService', () => {
     baseCostCalculator = module.get(BaseCostCalculatorService);
     auditLogService = module.get(AuditLogService);
     accountingService = module.get(AccountingService);
+    dataSource = module.get(DataSource) as jest.Mocked<DataSource>;
   });
 
   describe('fulfillOrder', () => {
     it('throws NotFoundException when order not found', async () => {
-      orderRepo.findOne.mockResolvedValue(null);
+      wireTransaction(null);
       await expect(service.fulfillOrder('order-1')).rejects.toThrow(NotFoundException);
     });
 
     it('throws ConflictException when already FULFILLED', async () => {
-      orderRepo.findOne.mockResolvedValue(mockOrder({ status: SalesOrderStatus.FULFILLED }));
+      wireTransaction(mockOrder({ status: SalesOrderStatus.FULFILLED }));
       await expect(service.fulfillOrder('order-1')).rejects.toThrow(ConflictException);
     });
 
-    it('throws ConflictException when paymentStatus is not PAID', async () => {
-      orderRepo.findOne.mockResolvedValue(mockOrder({ paymentStatus: SalesOrderPaymentStatus.PARTIAL }));
+    it('throws ConflictException when not READY', async () => {
+      wireTransaction(mockOrder({ status: SalesOrderStatus.DRAFT }));
       await expect(service.fulfillOrder('order-1')).rejects.toThrow(ConflictException);
     });
 
-    it('deducts inventory and sets status FULFILLED', async () => {
+    it('lock-reads the order and persists status via the manager', async () => {
       const order = mockOrder({ status: SalesOrderStatus.READY });
-      orderRepo.findOne.mockResolvedValue(order); // handles both the guard load and the accounting reload
-      orderRepo.save.mockResolvedValue({ ...order, status: SalesOrderStatus.FULFILLED } as SalesOrder);
+      const { findOne, update } = wireTransaction(order);
 
       await service.fulfillOrder('order-1');
 
-      expect(inventoryService.adjustStock).toHaveBeenCalledWith('product-1', -5, expect.any(String), 'order-1');
-      expect(orderRepo.save).toHaveBeenCalledWith(expect.objectContaining({ status: SalesOrderStatus.FULFILLED }));
+      expect(findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'order-1' }, lock: { mode: 'pessimistic_write' } }),
+      );
+      expect(update).toHaveBeenCalledWith('order-1', expect.objectContaining({ status: SalesOrderStatus.FULFILLED }));
+      expect(inventoryService.adjustStock).toHaveBeenCalledWith('product-1', -5, expect.any(String), 'order-1', undefined, undefined, expect.anything());
+    });
+
+    it('rolls back (propagates) when accounting posting fails — no swallow', async () => {
+      wireTransaction(mockOrder({ status: SalesOrderStatus.READY }));
+      accountingService.postSalesOrderEntry.mockRejectedValue(new Error('period closed'));
+      await expect(service.fulfillOrder('order-1')).rejects.toThrow('period closed');
     });
   });
 
@@ -126,7 +145,7 @@ describe('SalesOrderFulfillmentService', () => {
 
   describe('fulfill/unfulfill with READY status', () => {
     it('rejects fulfilling a DRAFT order', async () => {
-      orderRepo.findOne.mockResolvedValue(
+      wireTransaction(
         mockOrder({ status: SalesOrderStatus.DRAFT, paymentStatus: SalesOrderPaymentStatus.PAID, items: [] }),
       );
 
@@ -135,8 +154,7 @@ describe('SalesOrderFulfillmentService', () => {
 
     it('fulfills a READY order -> FULFILLED', async () => {
       const order = mockOrder({ status: SalesOrderStatus.READY, paymentStatus: SalesOrderPaymentStatus.PAID, items: [] });
-      orderRepo.findOne.mockResolvedValue(order);
-      orderRepo.save.mockImplementation(async (saved: any) => saved as SalesOrder);
+      wireTransaction(order);
 
       const result = await service.fulfillOrder('order-1');
 

--- a/backend/src/modules/sales/services/sales-order-fulfillment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-fulfillment.service.ts
@@ -2,11 +2,11 @@ import {
   ConflictException,
   Injectable,
   Logger,
-  NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, EntityManager, Repository } from 'typeorm';
 import { SalesOrder, SalesOrderStatus } from '../../../database/entities/sales-order.entity';
+import { lockRowForUpdate } from '../../../common/db/tx-helpers';
 import { StockMovementService } from '../../../modules/inventory/services/stock-movement.service';
 import { AuditLogService } from '../../audit-logs/services';
 import { BaseCostCalculatorService } from '../../inventory/services/base-cost-calculator.service';
@@ -30,12 +30,10 @@ export class SalesOrderFulfillmentService {
 
   async fulfillOrder(id: string, userId?: string, username?: string): Promise<SalesOrder> {
     const saved = await this.dataSource.transaction(async (manager: EntityManager) => {
-      const order = await manager.getRepository(SalesOrder).findOne({
-        where: { id },
+      const order = await lockRowForUpdate(manager, SalesOrder, id, {
         relations: { items: { product: true }, customer: true },
-        lock: { mode: 'pessimistic_write' },
+        notFoundMessage: 'Sales order not found',
       });
-      if (!order) throw new NotFoundException('Sales order not found');
       if (order.status === SalesOrderStatus.FULFILLED) {
         throw new ConflictException('Order is already fulfilled');
       }
@@ -57,11 +55,34 @@ export class SalesOrderFulfillmentService {
         }
       }
 
-      await manager.getRepository(SalesOrder).update(id, { status: SalesOrderStatus.FULFILLED });
+      const now = new Date();
+      await manager.getRepository(SalesOrder).update(id, {
+        status: SalesOrderStatus.FULFILLED,
+        updatedAt: now,
+      });
       order.status = SalesOrderStatus.FULFILLED;
 
-      // Accounting now participates in the transaction; a failure rolls back stock + status.
-      await this.accountingService.postSalesOrderEntry(order, userId || 'system', username, manager);
+      // Re-read the order after the status update + stock reduction, then post
+      // accounting against that fresh row. This fixes two things the in-memory
+      // lock-read snapshot got wrong:
+      //  1. fulfilledDate (a getter over updatedAt) — the re-read carries the just-
+      //     persisted updatedAt = now, so the journal entry lands in the correct
+      //     fiscal period instead of the order's stale pre-fulfillment date.
+      //  2. COGS — adjustStock -> reduceStock may have recalculated each product's
+      //     baseCost as FIFO batches were depleted; the re-read items.product carry
+      //     the post-reduction cost (matching the previous post-save reload).
+      const pricedOrder = await manager.getRepository(SalesOrder).findOne({
+        where: { id },
+        relations: { items: { product: true }, customer: true },
+      });
+      const orderForPosting = pricedOrder ?? order;
+
+      // NOTE: postSalesOrderEntry receives `manager` for call-site uniformity, but
+      // JournalEntryService persistence is not yet manager-bound (see #719), so the
+      // journal entries commit on a separate connection. A failure *here* still rolls
+      // back stock + status (the post is the last in-tx step); the residual gap is a
+      // failure of the outer COMMIT after the GL committed, which #719 will close.
+      await this.accountingService.postSalesOrderEntry(orderForPosting, userId || 'system', username, manager);
       this.logger.log(`Posted accounting entry for sales order ${order.orderNumber}`);
 
       return order;
@@ -80,12 +101,10 @@ export class SalesOrderFulfillmentService {
 
   async unfulfillOrder(id: string, userId?: string, username?: string): Promise<SalesOrder> {
     const saved = await this.dataSource.transaction(async (manager: EntityManager) => {
-      const order = await manager.getRepository(SalesOrder).findOne({
-        where: { id },
+      const order = await lockRowForUpdate(manager, SalesOrder, id, {
         relations: { items: { product: true } },
-        lock: { mode: 'pessimistic_write' },
+        notFoundMessage: 'Sales order not found',
       });
-      if (!order) throw new NotFoundException('Sales order not found');
       if (order.status !== SalesOrderStatus.FULFILLED) {
         throw new ConflictException('Order is not fulfilled');
       }

--- a/backend/src/modules/sales/services/sales-order-fulfillment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-fulfillment.service.ts
@@ -5,7 +5,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import { SalesOrder, SalesOrderStatus } from '../../../database/entities/sales-order.entity';
 import { StockMovementService } from '../../../modules/inventory/services/stock-movement.service';
 import { AuditLogService } from '../../audit-logs/services';
@@ -25,56 +25,55 @@ export class SalesOrderFulfillmentService {
     private readonly baseCostCalculator: BaseCostCalculatorService,
     private readonly auditLogService: AuditLogService,
     private readonly accountingService: AccountingService,
+    private readonly dataSource: DataSource,
   ) {}
 
   async fulfillOrder(id: string, userId?: string, username?: string): Promise<SalesOrder> {
-    const order = await this.salesOrderRepository.findOne({
-      where: { id },
-      relations: { items: { product: true } },
+    const saved = await this.dataSource.transaction(async (manager: EntityManager) => {
+      const order = await manager.getRepository(SalesOrder).findOne({
+        where: { id },
+        relations: { items: { product: true }, customer: true },
+        lock: { mode: 'pessimistic_write' },
+      });
+      if (!order) throw new NotFoundException('Sales order not found');
+      if (order.status === SalesOrderStatus.FULFILLED) {
+        throw new ConflictException('Order is already fulfilled');
+      }
+      if (order.status !== SalesOrderStatus.READY) {
+        throw new ConflictException('Cannot fulfill order - order must be Ready (paid in full)');
+      }
+
+      for (const item of order.items) {
+        if (item.product) {
+          await this.inventoryIntegrationService.adjustStock(
+            item.productId,
+            -item.quantity,
+            `Sales order fulfillment: ${order.orderNumber}`,
+            order.id,
+            userId,
+            undefined,
+            manager,
+          );
+        }
+      }
+
+      await manager.getRepository(SalesOrder).update(id, { status: SalesOrderStatus.FULFILLED });
+      order.status = SalesOrderStatus.FULFILLED;
+
+      // Accounting now participates in the transaction; a failure rolls back stock + status.
+      await this.accountingService.postSalesOrderEntry(order, userId || 'system', username, manager);
+      this.logger.log(`Posted accounting entry for sales order ${order.orderNumber}`);
+
+      return order;
     });
 
-    if (!order) throw new NotFoundException('Sales order not found');
-    if (order.status === SalesOrderStatus.FULFILLED) {
-      throw new ConflictException('Order is already fulfilled');
-    }
-    if (order.status !== SalesOrderStatus.READY) {
-      throw new ConflictException('Cannot fulfill order - order must be Ready (paid in full)');
-    }
-
-    for (const item of order.items) {
-      if (item.product) {
-        await this.inventoryIntegrationService.adjustStock(
-          item.productId,
-          -item.quantity,
-          `Sales order fulfillment: ${order.orderNumber}`,
-          order.id,
-        );
-      }
-    }
-
-    order.status = SalesOrderStatus.FULFILLED;
-    const saved = await this.salesOrderRepository.save(order);
-
-    await this.auditLogService.log('FULFILL', 'SalesOrder', `Fulfilled sales order: ${order.orderNumber}`, {
+    await this.auditLogService.log('FULFILL', 'SalesOrder', `Fulfilled sales order: ${saved.orderNumber}`, {
       entityId: id,
       userId: userId || 'system',
       username,
       oldValues: { status: SalesOrderStatus.READY },
       newValues: { status: SalesOrderStatus.FULFILLED },
     });
-
-    try {
-      const fullOrder = await this.salesOrderRepository.findOne({
-        where: { id },
-        relations: { customer: true, items: { product: true } },
-      });
-      if (fullOrder) {
-        await this.accountingService.postSalesOrderEntry(fullOrder, userId || 'system', username);
-        this.logger.log(`Posted accounting entry for sales order ${fullOrder.orderNumber}`);
-      }
-    } catch (error) {
-      this.logger.error(`Failed to post accounting entry for sales order ${id}: ${error.message}`, error.stack);
-    }
 
     return saved;
   }

--- a/backend/src/modules/sales/services/sales-order-fulfillment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-fulfillment.service.ts
@@ -79,53 +79,42 @@ export class SalesOrderFulfillmentService {
   }
 
   async unfulfillOrder(id: string, userId?: string, username?: string): Promise<SalesOrder> {
-    const order = await this.salesOrderRepository.findOne({
-      where: { id },
-      relations: { items: { product: true } },
-    });
+    const saved = await this.dataSource.transaction(async (manager: EntityManager) => {
+      const order = await manager.getRepository(SalesOrder).findOne({
+        where: { id },
+        relations: { items: { product: true } },
+        lock: { mode: 'pessimistic_write' },
+      });
+      if (!order) throw new NotFoundException('Sales order not found');
+      if (order.status !== SalesOrderStatus.FULFILLED) {
+        throw new ConflictException('Order is not fulfilled');
+      }
 
-    if (!order) throw new NotFoundException('Sales order not found');
-    if (order.status !== SalesOrderStatus.FULFILLED) {
-      throw new ConflictException('Order is not fulfilled');
-    }
-
-    for (const item of order.items) {
-      if (item.product) {
-        try {
-          await this.baseCostCalculator.restoreStock(item.productId, item.quantity);
-        } catch (error) {
-          this.logger.warn(`Failed to restore cost history for product ${item.productId}: ${error.message}`);
+      for (const item of order.items) {
+        if (item.product) {
+          await this.baseCostCalculator.restoreStock(item.productId, item.quantity, manager);
         }
       }
-    }
 
-    try {
-      const result = await this.stockMovementService.deleteByReference('sales_order', order.id);
+      const result = await this.stockMovementService.deleteByReference('sales_order', order.id, manager);
       this.logger.log(`Deleted ${result.deletedCount} stock movements for ${order.orderNumber}`);
-    } catch (error) {
-      this.logger.error(`Failed to delete stock movements for ${order.orderNumber}: ${error.message}`);
-    }
 
-    order.status = SalesOrderStatus.READY;
-    const saved = await this.salesOrderRepository.save(order);
+      await manager.getRepository(SalesOrder).update(id, { status: SalesOrderStatus.READY });
+      order.status = SalesOrderStatus.READY;
 
-    await this.auditLogService.log('UPDATE', 'SalesOrder', `Unfulfilled sales order: ${order.orderNumber}`, {
+      await this.accountingService.reverseSourceEntries('sales_order', id, userId || 'system', manager);
+      this.logger.log(`Reversed accounting entry for sales order ${order.orderNumber}`);
+
+      return order;
+    });
+
+    await this.auditLogService.log('UPDATE', 'SalesOrder', `Unfulfilled sales order: ${saved.orderNumber}`, {
       entityId: id,
       userId: userId || 'system',
       username,
       oldValues: { status: SalesOrderStatus.FULFILLED },
       newValues: { status: SalesOrderStatus.READY },
     });
-
-    try {
-      await this.accountingService.reverseSourceEntries('sales_order', id, userId || 'system');
-      this.logger.log(`Reversed accounting entry for sales order ${order.orderNumber}`);
-    } catch (error) {
-      this.logger.error(
-        `Failed to reverse accounting entry for sales order ${id}: ${error.message}`,
-        error.stack,
-      );
-    }
 
     return saved;
   }

--- a/backend/src/modules/sales/services/sales-order-lifecycle.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-lifecycle.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import { BadRequestException, ConflictException } from '@nestjs/common';
 import { SalesOrderLifecycleService } from './sales-order-lifecycle.service';
 import { SalesOrder, SalesOrderStatus, SalesOrderPaymentStatus } from '../../../database/entities/sales-order.entity';
@@ -21,6 +21,8 @@ describe('SalesOrderLifecycleService', () => {
   let service: SalesOrderLifecycleService;
   let orderRepo: jest.Mocked<Repository<SalesOrder>>;
   let auditLogService: jest.Mocked<AuditLogService>;
+  let dataSource: jest.Mocked<DataSource>;
+  let dataSource: jest.Mocked<DataSource>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -34,6 +36,7 @@ describe('SalesOrderLifecycleService', () => {
     service = module.get(SalesOrderLifecycleService);
     orderRepo = module.get(getRepositoryToken(SalesOrder));
     auditLogService = module.get(AuditLogService);
+    dataSource = module.get(DataSource) as jest.Mocked<DataSource>;
   });
 
   describe('assertEditAllowed', () => {

--- a/backend/src/modules/sales/services/sales-order-lifecycle.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-lifecycle.service.spec.ts
@@ -22,7 +22,6 @@ describe('SalesOrderLifecycleService', () => {
   let orderRepo: jest.Mocked<Repository<SalesOrder>>;
   let auditLogService: jest.Mocked<AuditLogService>;
   let dataSource: jest.Mocked<DataSource>;
-  let dataSource: jest.Mocked<DataSource>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -30,6 +29,7 @@ describe('SalesOrderLifecycleService', () => {
         SalesOrderLifecycleService,
         { provide: getRepositoryToken(SalesOrder), useValue: { findOne: jest.fn(), save: jest.fn() } },
         { provide: AuditLogService, useValue: { log: jest.fn() } },
+        { provide: DataSource, useValue: { transaction: jest.fn() } },
       ],
     }).compile();
 
@@ -73,42 +73,85 @@ describe('SalesOrderLifecycleService', () => {
     });
   });
 
+  // Drives the service's dataSource.transaction with a mock EntityManager whose
+  // getRepository returns { findOne, update }.
+  const setupTx = (
+    findOneResult: SalesOrder | null,
+  ): { findOne: jest.Mock; update: jest.Mock } => {
+    const findOne = jest.fn().mockResolvedValue(findOneResult);
+    const update = jest.fn().mockResolvedValue(undefined);
+    const manager = {
+      getRepository: jest.fn().mockReturnValue({ findOne, update }),
+    } as unknown as EntityManager;
+    (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
+    return { findOne, update };
+  };
+
   describe('cancel', () => {
     it('throws when status is FULFILLED', async () => {
-      orderRepo.findOne.mockResolvedValue(mockOrder({ status: SalesOrderStatus.FULFILLED }));
+      setupTx(mockOrder({ status: SalesOrderStatus.FULFILLED }));
       await expect(service.cancel('order-1')).rejects.toThrow(ConflictException);
     });
 
     it('throws when DRAFT but paymentStatus is not UNPAID', async () => {
-      orderRepo.findOne.mockResolvedValue(mockOrder({ paymentStatus: SalesOrderPaymentStatus.PARTIAL }));
+      setupTx(mockOrder({ paymentStatus: SalesOrderPaymentStatus.PARTIAL }));
       await expect(service.cancel('order-1')).rejects.toThrow(ConflictException);
     });
 
     it('sets status to CANCELLED when DRAFT and UNPAID', async () => {
-      const order = mockOrder();
-      orderRepo.findOne.mockResolvedValue(order);
-      orderRepo.save.mockResolvedValue({ ...order, status: SalesOrderStatus.CANCELLED } as SalesOrder);
+      const { update } = setupTx(mockOrder());
 
       await service.cancel('order-1');
 
-      expect(orderRepo.save).toHaveBeenCalledWith(expect.objectContaining({ status: SalesOrderStatus.CANCELLED }));
+      expect(update).toHaveBeenCalledWith(
+        'order-1',
+        expect.objectContaining({ status: SalesOrderStatus.CANCELLED }),
+      );
+    });
+  });
+
+  describe('cancel (locking)', () => {
+    it('lock-reads the order through the transaction manager and persists via manager', async () => {
+      const order = mockOrder({ status: SalesOrderStatus.DRAFT, paymentStatus: SalesOrderPaymentStatus.UNPAID });
+      const findOne = jest.fn().mockResolvedValue(order);
+      const update = jest.fn().mockResolvedValue(undefined);
+      const manager = {
+        getRepository: jest.fn().mockReturnValue({ findOne, update }),
+      } as unknown as EntityManager;
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
+
+      await service.cancel('order-1');
+
+      expect(findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'order-1' }, lock: { mode: 'pessimistic_write' } }),
+      );
+      expect(update).toHaveBeenCalledWith('order-1', expect.objectContaining({ status: SalesOrderStatus.CANCELLED }));
+    });
+
+    it('throws ConflictException in-lock when the order is already FULFILLED', async () => {
+      const findOne = jest.fn().mockResolvedValue(mockOrder({ status: SalesOrderStatus.FULFILLED }));
+      const manager = { getRepository: jest.fn().mockReturnValue({ findOne, update: jest.fn() }) } as unknown as EntityManager;
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
+
+      await expect(service.cancel('order-1')).rejects.toThrow(ConflictException);
     });
   });
 
   describe('uncancel', () => {
     it('throws when order is not CANCELLED', async () => {
-      orderRepo.findOne.mockResolvedValue(mockOrder({ status: SalesOrderStatus.DRAFT }));
+      setupTx(mockOrder({ status: SalesOrderStatus.DRAFT }));
       await expect(service.uncancel('order-1')).rejects.toThrow(ConflictException);
     });
 
     it('sets status to DRAFT when CANCELLED', async () => {
-      const order = mockOrder({ status: SalesOrderStatus.CANCELLED });
-      orderRepo.findOne.mockResolvedValue(order);
-      orderRepo.save.mockResolvedValue({ ...order, status: SalesOrderStatus.DRAFT } as SalesOrder);
+      const { update } = setupTx(mockOrder({ status: SalesOrderStatus.CANCELLED }));
 
       await service.uncancel('order-1');
 
-      expect(orderRepo.save).toHaveBeenCalledWith(expect.objectContaining({ status: SalesOrderStatus.DRAFT }));
+      expect(update).toHaveBeenCalledWith(
+        'order-1',
+        expect.objectContaining({ status: SalesOrderStatus.DRAFT }),
+      );
     });
   });
 });

--- a/backend/src/modules/sales/services/sales-order-lifecycle.service.ts
+++ b/backend/src/modules/sales/services/sales-order-lifecycle.service.ts
@@ -5,7 +5,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import { SalesOrder, SalesOrderPaymentStatus, SalesOrderStatus } from '../../../database/entities/sales-order.entity';
 import { AuditLogService } from '../../audit-logs/services';
 
@@ -15,6 +15,7 @@ export class SalesOrderLifecycleService {
     @InjectRepository(SalesOrder)
     private readonly salesOrderRepository: Repository<SalesOrder>,
     private readonly auditLogService: AuditLogService,
+    private readonly dataSource: DataSource,
   ) {}
 
   async assertEditAllowed(id: string): Promise<void> {

--- a/backend/src/modules/sales/services/sales-order-lifecycle.service.ts
+++ b/backend/src/modules/sales/services/sales-order-lifecycle.service.ts
@@ -42,23 +42,29 @@ export class SalesOrderLifecycleService {
   }
 
   async cancel(id: string, userId?: string, username?: string): Promise<SalesOrder> {
-    const order = await this.salesOrderRepository.findOne({ where: { id } });
-    if (!order) throw new NotFoundException('Sales order not found');
+    const saved = await this.dataSource.transaction(async (manager: EntityManager) => {
+      const order = await manager.getRepository(SalesOrder).findOne({
+        where: { id },
+        lock: { mode: 'pessimistic_write' },
+      });
+      if (!order) throw new NotFoundException('Sales order not found');
 
-    if (order.status === SalesOrderStatus.FULFILLED) {
-      throw new ConflictException('Cannot cancel a fulfilled order. Unfulfill it first.');
-    }
-    if (order.status === SalesOrderStatus.CANCELLED) {
-      throw new ConflictException('Order is already cancelled.');
-    }
-    if (order.paymentStatus !== SalesOrderPaymentStatus.UNPAID) {
-      throw new ConflictException('Cannot cancel an order with recorded payments. Refund all payments first.');
-    }
+      if (order.status === SalesOrderStatus.FULFILLED) {
+        throw new ConflictException('Cannot cancel a fulfilled order. Unfulfill it first.');
+      }
+      if (order.status === SalesOrderStatus.CANCELLED) {
+        throw new ConflictException('Order is already cancelled.');
+      }
+      if (order.paymentStatus !== SalesOrderPaymentStatus.UNPAID) {
+        throw new ConflictException('Cannot cancel an order with recorded payments. Refund all payments first.');
+      }
 
-    order.status = SalesOrderStatus.CANCELLED;
-    const saved = await this.salesOrderRepository.save(order);
+      await manager.getRepository(SalesOrder).update(id, { status: SalesOrderStatus.CANCELLED });
+      order.status = SalesOrderStatus.CANCELLED;
+      return order;
+    });
 
-    await this.auditLogService.log('UPDATE', 'SalesOrder', `Cancelled sales order: ${order.orderNumber}`, {
+    await this.auditLogService.log('UPDATE', 'SalesOrder', `Cancelled sales order: ${saved.orderNumber}`, {
       entityId: id,
       userId: userId || 'system',
       username,
@@ -70,17 +76,23 @@ export class SalesOrderLifecycleService {
   }
 
   async uncancel(id: string, userId?: string, username?: string): Promise<SalesOrder> {
-    const order = await this.salesOrderRepository.findOne({ where: { id } });
-    if (!order) throw new NotFoundException('Sales order not found');
+    const saved = await this.dataSource.transaction(async (manager: EntityManager) => {
+      const order = await manager.getRepository(SalesOrder).findOne({
+        where: { id },
+        lock: { mode: 'pessimistic_write' },
+      });
+      if (!order) throw new NotFoundException('Sales order not found');
 
-    if (order.status !== SalesOrderStatus.CANCELLED) {
-      throw new ConflictException('Order is not cancelled.');
-    }
+      if (order.status !== SalesOrderStatus.CANCELLED) {
+        throw new ConflictException('Order is not cancelled.');
+      }
 
-    order.status = SalesOrderStatus.DRAFT;
-    const saved = await this.salesOrderRepository.save(order);
+      await manager.getRepository(SalesOrder).update(id, { status: SalesOrderStatus.DRAFT });
+      order.status = SalesOrderStatus.DRAFT;
+      return order;
+    });
 
-    await this.auditLogService.log('UPDATE', 'SalesOrder', `Uncancelled sales order: ${order.orderNumber}`, {
+    await this.auditLogService.log('UPDATE', 'SalesOrder', `Uncancelled sales order: ${saved.orderNumber}`, {
       entityId: id,
       userId: userId || 'system',
       username,

--- a/backend/src/modules/sales/services/sales-order-lifecycle.service.ts
+++ b/backend/src/modules/sales/services/sales-order-lifecycle.service.ts
@@ -8,6 +8,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, EntityManager, Repository } from 'typeorm';
 import { SalesOrder, SalesOrderPaymentStatus, SalesOrderStatus } from '../../../database/entities/sales-order.entity';
 import { AuditLogService } from '../../audit-logs/services';
+import { lockRowForUpdate } from '../../../common/db/tx-helpers';
 
 @Injectable()
 export class SalesOrderLifecycleService {
@@ -43,11 +44,9 @@ export class SalesOrderLifecycleService {
 
   async cancel(id: string, userId?: string, username?: string): Promise<SalesOrder> {
     const saved = await this.dataSource.transaction(async (manager: EntityManager) => {
-      const order = await manager.getRepository(SalesOrder).findOne({
-        where: { id },
-        lock: { mode: 'pessimistic_write' },
+      const order = await lockRowForUpdate(manager, SalesOrder, id, {
+        notFoundMessage: 'Sales order not found',
       });
-      if (!order) throw new NotFoundException('Sales order not found');
 
       if (order.status === SalesOrderStatus.FULFILLED) {
         throw new ConflictException('Cannot cancel a fulfilled order. Unfulfill it first.');
@@ -77,11 +76,9 @@ export class SalesOrderLifecycleService {
 
   async uncancel(id: string, userId?: string, username?: string): Promise<SalesOrder> {
     const saved = await this.dataSource.transaction(async (manager: EntityManager) => {
-      const order = await manager.getRepository(SalesOrder).findOne({
-        where: { id },
-        lock: { mode: 'pessimistic_write' },
+      const order = await lockRowForUpdate(manager, SalesOrder, id, {
+        notFoundMessage: 'Sales order not found',
       });
-      if (!order) throw new NotFoundException('Sales order not found');
 
       if (order.status !== SalesOrderStatus.CANCELLED) {
         throw new ConflictException('Order is not cancelled.');

--- a/backend/src/modules/sales/services/sales-order-payment.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.spec.ts
@@ -31,6 +31,7 @@ describe('SalesOrderPaymentService', () => {
   const buildMockManager = (
     paymentRecordsAfterSave: SalesOrderPayment[] = [],
     update = jest.fn().mockResolvedValue(undefined),
+    order: SalesOrder = mockOrder(),
   ): EntityManager => ({
     getRepository: jest.fn().mockImplementation((entity) => {
       if (entity === SalesOrderPayment) {
@@ -41,7 +42,7 @@ describe('SalesOrderPaymentService', () => {
         };
       }
       if (entity === SalesOrder) {
-        return { update };
+        return { update, findOne: jest.fn().mockResolvedValue(order) };
       }
       return {};
     }),
@@ -177,14 +178,61 @@ describe('SalesOrderPaymentService', () => {
   });
 
   describe('recordPayment', () => {
+    it('lock-reads the order through the transaction manager (pessimistic_write)', async () => {
+      const order = mockOrder({ status: SalesOrderStatus.DRAFT });
+      const findOne = jest.fn().mockResolvedValue(order);
+      const update = jest.fn().mockResolvedValue(undefined);
+      const manager = {
+        getRepository: jest.fn().mockImplementation((entity) => {
+          if (entity === SalesOrderPayment) {
+            return {
+              create: jest.fn().mockImplementation((d) => d),
+              save: jest.fn().mockImplementation((d) => Promise.resolve({ id: 'p1', ...d })),
+              find: jest.fn().mockResolvedValue([{ amount: 1000 }]),
+            };
+          }
+          return { findOne, update };
+        }),
+      } as unknown as EntityManager;
+      methodRepo.findOne.mockResolvedValue(mockMethod());
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
+
+      await service.recordPayment('order-1', {
+        amount: 1000, paymentMethodId: 'method-1', paymentDate: new Date(),
+      } as any);
+
+      expect(findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'order-1' }, lock: { mode: 'pessimistic_write' } }),
+      );
+    });
+
+    it('throws ConflictException in-lock when the order is no longer DRAFT', async () => {
+      const findOne = jest.fn().mockResolvedValue(mockOrder({ status: SalesOrderStatus.READY }));
+      const manager = {
+        getRepository: jest.fn().mockImplementation((entity) =>
+          entity === SalesOrderPayment ? { create: jest.fn(), save: jest.fn(), find: jest.fn() } : { findOne, update: jest.fn() },
+        ),
+      } as unknown as EntityManager;
+      methodRepo.findOne.mockResolvedValue(mockMethod());
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
+
+      await expect(
+        service.recordPayment('order-1', { amount: 100, paymentMethodId: 'method-1', paymentDate: new Date() } as any),
+      ).rejects.toThrow(ConflictException);
+    });
+
     it('throws NotFoundException when order not found', async () => {
-      orderRepo.findOne.mockResolvedValue(null);
+      methodRepo.findOne.mockResolvedValue(mockMethod());
+      const manager = buildMockManager([], jest.fn(), null as any);
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
       await expect(service.recordPayment('order-1', { paymentMethodId: 'method-1', amount: 100, paymentDate: '2026-01-01' }))
         .rejects.toThrow(NotFoundException);
     });
 
     it('throws ConflictException when order is not DRAFT', async () => {
-      orderRepo.findOne.mockResolvedValue(mockOrder({ status: SalesOrderStatus.FULFILLED }));
+      methodRepo.findOne.mockResolvedValue(mockMethod());
+      const manager = buildMockManager([], jest.fn(), mockOrder({ status: SalesOrderStatus.FULFILLED }));
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
       await expect(service.recordPayment('order-1', { paymentMethodId: 'method-1', amount: 100, paymentDate: '2026-01-01' }))
         .rejects.toThrow(ConflictException);
     });
@@ -243,7 +291,7 @@ describe('SalesOrderPaymentService', () => {
               find: jest.fn().mockResolvedValue([{ amount: 400 }] as SalesOrderPayment[]),
             };
           }
-          if (entity === SalesOrder) return { update: updateSpy };
+          if (entity === SalesOrder) return { update: updateSpy, findOne: jest.fn().mockResolvedValue(order) };
           return {};
         }),
       } as any;
@@ -273,7 +321,7 @@ describe('SalesOrderPaymentService', () => {
               find: jest.fn().mockResolvedValue([{ amount: 1200 }] as SalesOrderPayment[]),
             };
           }
-          if (entity === SalesOrder) return { update: updateSpy };
+          if (entity === SalesOrder) return { update: updateSpy, findOne: jest.fn().mockResolvedValue(order) };
           return {};
         }),
       } as any;
@@ -373,7 +421,7 @@ describe('SalesOrderPaymentService', () => {
       orderRepo.findOne.mockResolvedValue(order);
       methodRepo.findOne.mockResolvedValue(mockMethod());
       const update = jest.fn().mockResolvedValue(undefined);
-      const manager = buildMockManager([{ amount: 100 }] as SalesOrderPayment[], update);
+      const manager = buildMockManager([{ amount: 100 }] as SalesOrderPayment[], update, order);
       (dataSource.transaction as jest.Mock).mockImplementation(async (cb: (m: EntityManager) => Promise<any>) => cb(manager));
 
       await service.recordPayment(order.id, { amount: 100, paymentMethodId: 'method-1', paymentDate: '2026-05-30' });
@@ -392,7 +440,7 @@ describe('SalesOrderPaymentService', () => {
       orderRepo.findOne.mockResolvedValue(order);
       methodRepo.findOne.mockResolvedValue(mockMethod());
       const update = jest.fn().mockResolvedValue(undefined);
-      const manager = buildMockManager([{ amount: 120 }] as SalesOrderPayment[], update);
+      const manager = buildMockManager([{ amount: 120 }] as SalesOrderPayment[], update, order);
       (dataSource.transaction as jest.Mock).mockImplementation(async (cb: (m: EntityManager) => Promise<any>) => cb(manager));
 
       await service.recordPayment(order.id, { amount: 120, paymentMethodId: 'method-1', paymentDate: '2026-05-30' });
@@ -431,7 +479,7 @@ describe('SalesOrderPaymentService', () => {
       orderRepo.findOne.mockResolvedValue(order);
       methodRepo.findOne.mockResolvedValue(mockMethod());
       const update = jest.fn().mockResolvedValue(undefined);
-      const manager = buildMockManager([{ amount: 30 }] as SalesOrderPayment[], update);
+      const manager = buildMockManager([{ amount: 30 }] as SalesOrderPayment[], update, order);
       (dataSource.transaction as jest.Mock).mockImplementation(async (cb: (m: EntityManager) => Promise<any>) => cb(manager));
 
       await service.recordPayment(order.id, { amount: 30, paymentMethodId: 'method-1', paymentDate: '2026-05-30' });
@@ -448,7 +496,9 @@ describe('SalesOrderPaymentService', () => {
 
   describe('payment guards under READY', () => {
     it('rejects a new payment on a READY order', async () => {
-      orderRepo.findOne.mockResolvedValue(mockOrder({ status: SalesOrderStatus.READY }));
+      methodRepo.findOne.mockResolvedValue(mockMethod());
+      const manager = buildMockManager([], jest.fn(), mockOrder({ status: SalesOrderStatus.READY }));
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
 
       await expect(
         service.recordPayment('order-1', { amount: 10, paymentMethodId: 'method-1', paymentDate: '2026-05-30' }),

--- a/backend/src/modules/sales/services/sales-order-payment.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.spec.ts
@@ -344,21 +344,29 @@ describe('SalesOrderPaymentService', () => {
     });
 
     it('throws NotFoundException when order not found', async () => {
-      orderRepo.findOne.mockResolvedValue(null);
+      methodRepo.findOne.mockResolvedValue(mockMethod());
+      const manager = buildMockManager([], jest.fn(), null as any);
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
       await expect(service.recordRefund('order-1', { paymentMethodId: 'method-1', amount: 100, paymentDate: '2026-01-01' }))
         .rejects.toThrow(NotFoundException);
     });
 
     it('throws ConflictException when order is CANCELLED', async () => {
-      orderRepo.findOne.mockResolvedValue(mockOrder({ status: SalesOrderStatus.CANCELLED }));
+      methodRepo.findOne.mockResolvedValue(mockMethod());
+      const manager = buildMockManager([], jest.fn(), mockOrder({ status: SalesOrderStatus.CANCELLED }));
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
       await expect(service.recordRefund('order-1', { paymentMethodId: 'method-1', amount: 100, paymentDate: '2026-01-01' }))
         .rejects.toThrow(ConflictException);
     });
 
     it('throws BadRequestException when refund amount exceeds net paid', async () => {
-      orderRepo.findOne.mockResolvedValue(mockOrder({ paymentStatus: SalesOrderPaymentStatus.PARTIAL }));
       methodRepo.findOne.mockResolvedValue(mockMethod());
-      paymentRepo.find.mockResolvedValue([{ amount: 400 }] as SalesOrderPayment[]);
+      const manager = buildMockManager(
+        [{ amount: 400 }] as SalesOrderPayment[],
+        jest.fn(),
+        mockOrder({ paymentStatus: SalesOrderPaymentStatus.PARTIAL }),
+      );
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
 
       await expect(service.recordRefund('order-1', { paymentMethodId: 'method-1', amount: 500, paymentDate: '2026-01-01' }))
         .rejects.toThrow(BadRequestException);
@@ -403,15 +411,72 @@ describe('SalesOrderPaymentService', () => {
 
     it('allows refund on FULFILLED orders', async () => {
       const order = mockOrder({ status: SalesOrderStatus.FULFILLED, paymentStatus: SalesOrderPaymentStatus.PAID });
-      orderRepo.findOne.mockResolvedValue(order);
       methodRepo.findOne.mockResolvedValue(mockMethod());
-      paymentRepo.find.mockResolvedValue([{ amount: 1000 }] as SalesOrderPayment[]);
 
-      const mockManager = buildMockManager([{ amount: 1000 }, { amount: -1000 }] as SalesOrderPayment[]);
+      const mockManager = buildMockManager([{ amount: 1000 }] as SalesOrderPayment[], jest.fn(), order);
       (dataSource.transaction as jest.Mock).mockImplementation(async (cb: (m: EntityManager) => Promise<any>) => cb(mockManager));
 
       await expect(service.recordRefund('order-1', { paymentMethodId: 'method-1', amount: 1000, paymentDate: '2026-01-01' }))
         .resolves.not.toThrow();
+    });
+
+    it('lock-reads the order and computes the refund cap inside the transaction', async () => {
+      const order = mockOrder({ status: SalesOrderStatus.READY });
+      const findOne = jest.fn().mockResolvedValue(order);
+      const paymentFind = jest.fn().mockResolvedValue([{ amount: 1000 }]);
+      const manager = {
+        getRepository: jest.fn().mockImplementation((entity) => {
+          if (entity === SalesOrderPayment) {
+            return {
+              create: jest.fn().mockImplementation((d) => d),
+              save: jest.fn().mockImplementation((d) => Promise.resolve({ id: 'r1', ...d })),
+              find: paymentFind,
+            };
+          }
+          return { findOne, update: jest.fn() };
+        }),
+      } as unknown as EntityManager;
+      methodRepo.findOne.mockResolvedValue(mockMethod());
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
+
+      await service.recordRefund('order-1', { amount: 400, paymentMethodId: 'method-1', paymentDate: new Date() } as any);
+
+      expect(findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'order-1' }, lock: { mode: 'pessimistic_write' } }),
+      );
+      expect(paymentFind).toHaveBeenCalled();
+    });
+
+    it('throws ConflictException in-lock when the order is CANCELLED', async () => {
+      const findOne = jest.fn().mockResolvedValue(mockOrder({ status: SalesOrderStatus.CANCELLED }));
+      const manager = {
+        getRepository: jest.fn().mockImplementation((entity) =>
+          entity === SalesOrderPayment ? { find: jest.fn(), create: jest.fn(), save: jest.fn() } : { findOne, update: jest.fn() },
+        ),
+      } as unknown as EntityManager;
+      methodRepo.findOne.mockResolvedValue(mockMethod());
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
+
+      await expect(
+        service.recordRefund('order-1', { amount: 100, paymentMethodId: 'method-1', paymentDate: new Date() } as any),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('rejects a refund exceeding net paid (cap read in-lock)', async () => {
+      const findOne = jest.fn().mockResolvedValue(mockOrder({ status: SalesOrderStatus.READY }));
+      const manager = {
+        getRepository: jest.fn().mockImplementation((entity) =>
+          entity === SalesOrderPayment
+            ? { find: jest.fn().mockResolvedValue([{ amount: 100 }]), create: jest.fn(), save: jest.fn() }
+            : { findOne, update: jest.fn() },
+        ),
+      } as unknown as EntityManager;
+      methodRepo.findOne.mockResolvedValue(mockMethod());
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
+
+      await expect(
+        service.recordRefund('order-1', { amount: 500, paymentMethodId: 'method-1', paymentDate: new Date() } as any),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 
@@ -456,11 +521,9 @@ describe('SalesOrderPaymentService', () => {
 
     it('flips READY -> DRAFT when a refund drops below full payment', async () => {
       const order = mockOrder({ status: SalesOrderStatus.READY, paymentStatus: SalesOrderPaymentStatus.PAID, totalAmount: 100 });
-      orderRepo.findOne.mockResolvedValue(order);
       methodRepo.findOne.mockResolvedValue(mockMethod());
-      paymentRepo.find.mockResolvedValue([{ amount: 100 }] as SalesOrderPayment[]);
       const update = jest.fn().mockResolvedValue(undefined);
-      const manager = buildMockManager([{ amount: 100 }, { amount: -40 }] as SalesOrderPayment[], update);
+      const manager = buildMockManager([{ amount: 100 }, { amount: -40 }] as SalesOrderPayment[], update, order);
       (dataSource.transaction as jest.Mock).mockImplementation(async (cb: (m: EntityManager) => Promise<any>) => cb(manager));
 
       await service.recordRefund(order.id, { amount: 40, paymentMethodId: 'method-1', paymentDate: '2026-05-30' });

--- a/backend/src/modules/sales/services/sales-order-payment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.ts
@@ -11,6 +11,7 @@ import { SalesOrderPayment } from '../../../database/entities/sales-order-paymen
 import { PaymentMethodEntity } from '../../../database/entities/payment-method.entity';
 import { AuditLogService } from '../../audit-logs/services';
 import { RecordPaymentDto } from '../dto/sales-order.dto';
+import { lockRowForUpdate } from '../../../common/db/tx-helpers';
 
 const AMOUNT_TOLERANCE = 0.001;
 
@@ -49,11 +50,9 @@ export class SalesOrderPaymentService {
    */
   async reconcileOrderState(orderId: string, manager?: EntityManager): Promise<SalesOrder> {
     const run = async (m: EntityManager): Promise<SalesOrder> => {
-      const order = await m.getRepository(SalesOrder).findOne({
-        where: { id: orderId },
-        lock: { mode: 'pessimistic_write' },
+      const order = await lockRowForUpdate(m, SalesOrder, orderId, {
+        notFoundMessage: 'Sales order not found',
       });
-      if (!order) throw new NotFoundException('Sales order not found');
       await this.updatePaymentStatusInTx(order, m);
       return order;
     };
@@ -72,11 +71,9 @@ export class SalesOrderPaymentService {
     if (!method) throw new BadRequestException(`Payment method ${dto.paymentMethodId} not found or inactive`);
 
     const { saved, orderNumber } = await this.dataSource.transaction(async (manager: EntityManager) => {
-      const order = await manager.getRepository(SalesOrder).findOne({
-        where: { id: orderId },
-        lock: { mode: 'pessimistic_write' },
+      const order = await lockRowForUpdate(manager, SalesOrder, orderId, {
+        notFoundMessage: 'Sales order not found',
       });
-      if (!order) throw new NotFoundException('Sales order not found');
       if (order.status !== SalesOrderStatus.DRAFT) {
         throw new ConflictException('Payments can only be recorded on DRAFT orders');
       }
@@ -115,11 +112,9 @@ export class SalesOrderPaymentService {
     if (!method) throw new BadRequestException(`Payment method ${dto.paymentMethodId} not found or inactive`);
 
     const { saved, resultingStatus, orderNumber } = await this.dataSource.transaction(async (manager: EntityManager) => {
-      const order = await manager.getRepository(SalesOrder).findOne({
-        where: { id: orderId },
-        lock: { mode: 'pessimistic_write' },
+      const order = await lockRowForUpdate(manager, SalesOrder, orderId, {
+        notFoundMessage: 'Sales order not found',
       });
-      if (!order) throw new NotFoundException('Sales order not found');
       if (order.status === SalesOrderStatus.CANCELLED) {
         throw new ConflictException('Cannot record a refund on a cancelled order');
       }
@@ -167,11 +162,9 @@ export class SalesOrderPaymentService {
     }
 
     const { results, orderNumber } = await this.dataSource.transaction(async (manager: EntityManager) => {
-      const order = await manager.getRepository(SalesOrder).findOne({
-        where: { id: orderId },
-        lock: { mode: 'pessimistic_write' },
+      const order = await lockRowForUpdate(manager, SalesOrder, orderId, {
+        notFoundMessage: 'Sales order not found',
       });
-      if (!order) throw new NotFoundException('Sales order not found');
       if (order.status !== SalesOrderStatus.DRAFT) {
         throw new ConflictException('Payments can only be recorded on DRAFT orders');
       }
@@ -218,11 +211,9 @@ export class SalesOrderPaymentService {
     }
 
     const { results, resultingStatus, orderNumber } = await this.dataSource.transaction(async (manager: EntityManager) => {
-      const order = await manager.getRepository(SalesOrder).findOne({
-        where: { id: orderId },
-        lock: { mode: 'pessimistic_write' },
+      const order = await lockRowForUpdate(manager, SalesOrder, orderId, {
+        notFoundMessage: 'Sales order not found',
       });
-      if (!order) throw new NotFoundException('Sales order not found');
       if (order.status === SalesOrderStatus.CANCELLED) {
         throw new ConflictException('Cannot record a refund on a cancelled order');
       }

--- a/backend/src/modules/sales/services/sales-order-payment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.ts
@@ -66,18 +66,21 @@ export class SalesOrderPaymentService {
       throw new BadRequestException('Payment amount must be positive');
     }
 
-    const order = await this.salesOrderRepository.findOne({ where: { id: orderId } });
-    if (!order) throw new NotFoundException('Sales order not found');
-    if (order.status !== SalesOrderStatus.DRAFT) {
-      throw new ConflictException('Payments can only be recorded on DRAFT orders');
-    }
-
     const method = await this.paymentMethodRepository.findOne({
       where: { id: dto.paymentMethodId, isActive: true },
     });
     if (!method) throw new BadRequestException(`Payment method ${dto.paymentMethodId} not found or inactive`);
 
-    const saved = await this.dataSource.transaction(async (manager: EntityManager) => {
+    const { saved, orderNumber } = await this.dataSource.transaction(async (manager: EntityManager) => {
+      const order = await manager.getRepository(SalesOrder).findOne({
+        where: { id: orderId },
+        lock: { mode: 'pessimistic_write' },
+      });
+      if (!order) throw new NotFoundException('Sales order not found');
+      if (order.status !== SalesOrderStatus.DRAFT) {
+        throw new ConflictException('Payments can only be recorded on DRAFT orders');
+      }
+
       const record = manager.getRepository(SalesOrderPayment).create({
         salesOrderId: orderId,
         paymentMethodId: dto.paymentMethodId,
@@ -88,10 +91,10 @@ export class SalesOrderPaymentService {
       });
       const savedRecord = await manager.getRepository(SalesOrderPayment).save(record);
       await this.updatePaymentStatusInTx(order, manager);
-      return savedRecord;
+      return { saved: savedRecord, orderNumber: order.orderNumber };
     });
 
-    await this.auditLogService.log('CREATE', 'SalesOrderPayment', `Recorded payment for ${order.orderNumber}`, {
+    await this.auditLogService.log('CREATE', 'SalesOrderPayment', `Recorded payment for ${orderNumber}`, {
       entityId: saved.id,
       userId: userId || 'system',
       username,
@@ -153,13 +156,6 @@ export class SalesOrderPaymentService {
     for (const dto of dtos) {
       if (dto.amount <= 0) throw new BadRequestException('Payment amount must be positive');
     }
-
-    const order = await this.salesOrderRepository.findOne({ where: { id: orderId } });
-    if (!order) throw new NotFoundException('Sales order not found');
-    if (order.status !== SalesOrderStatus.DRAFT) {
-      throw new ConflictException('Payments can only be recorded on DRAFT orders');
-    }
-
     for (const dto of dtos) {
       const method = await this.paymentMethodRepository.findOne({
         where: { id: dto.paymentMethodId, isActive: true },
@@ -167,7 +163,16 @@ export class SalesOrderPaymentService {
       if (!method) throw new BadRequestException(`Payment method ${dto.paymentMethodId} not found or inactive`);
     }
 
-    const results = await this.dataSource.transaction(async (manager: EntityManager) => {
+    const { results, orderNumber } = await this.dataSource.transaction(async (manager: EntityManager) => {
+      const order = await manager.getRepository(SalesOrder).findOne({
+        where: { id: orderId },
+        lock: { mode: 'pessimistic_write' },
+      });
+      if (!order) throw new NotFoundException('Sales order not found');
+      if (order.status !== SalesOrderStatus.DRAFT) {
+        throw new ConflictException('Payments can only be recorded on DRAFT orders');
+      }
+
       const saved: SalesOrderPayment[] = [];
       for (const dto of dtos) {
         const record = manager.getRepository(SalesOrderPayment).create({
@@ -181,11 +186,11 @@ export class SalesOrderPaymentService {
         saved.push(await manager.getRepository(SalesOrderPayment).save(record));
       }
       await this.updatePaymentStatusInTx(order, manager);
-      return saved;
+      return { results: saved, orderNumber: order.orderNumber };
     });
 
     for (const saved of results) {
-      await this.auditLogService.log('CREATE', 'SalesOrderPayment', `Recorded payment for ${order.orderNumber}`, {
+      await this.auditLogService.log('CREATE', 'SalesOrderPayment', `Recorded payment for ${orderNumber}`, {
         entityId: saved.id,
         userId: userId || 'system',
         username,

--- a/backend/src/modules/sales/services/sales-order-payment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.ts
@@ -109,24 +109,27 @@ export class SalesOrderPaymentService {
       throw new BadRequestException('Refund amount must be positive');
     }
 
-    const order = await this.salesOrderRepository.findOne({ where: { id: orderId } });
-    if (!order) throw new NotFoundException('Sales order not found');
-    if (order.status === SalesOrderStatus.CANCELLED) {
-      throw new ConflictException('Cannot record a refund on a cancelled order');
-    }
-
     const method = await this.paymentMethodRepository.findOne({
       where: { id: dto.paymentMethodId, isActive: true },
     });
     if (!method) throw new BadRequestException(`Payment method ${dto.paymentMethodId} not found or inactive`);
 
-    const existing = await this.salesOrderPaymentRepository.find({ where: { salesOrderId: orderId } });
-    const netPaid = existing.reduce((sum, r) => sum + Number(r.amount), 0);
-    if (dto.amount > netPaid + AMOUNT_TOLERANCE) {
-      throw new BadRequestException(`Refund amount (${dto.amount}) exceeds net paid (${netPaid.toFixed(4)})`);
-    }
+    const { saved, resultingStatus, orderNumber } = await this.dataSource.transaction(async (manager: EntityManager) => {
+      const order = await manager.getRepository(SalesOrder).findOne({
+        where: { id: orderId },
+        lock: { mode: 'pessimistic_write' },
+      });
+      if (!order) throw new NotFoundException('Sales order not found');
+      if (order.status === SalesOrderStatus.CANCELLED) {
+        throw new ConflictException('Cannot record a refund on a cancelled order');
+      }
 
-    const { saved, resultingStatus } = await this.dataSource.transaction(async (manager: EntityManager) => {
+      const existing = await manager.getRepository(SalesOrderPayment).find({ where: { salesOrderId: orderId } });
+      const netPaid = existing.reduce((sum, r) => sum + Number(r.amount), 0);
+      if (dto.amount > netPaid + AMOUNT_TOLERANCE) {
+        throw new BadRequestException(`Refund amount (${dto.amount}) exceeds net paid (${netPaid.toFixed(4)})`);
+      }
+
       const record = manager.getRepository(SalesOrderPayment).create({
         salesOrderId: orderId,
         paymentMethodId: dto.paymentMethodId,
@@ -137,10 +140,10 @@ export class SalesOrderPaymentService {
       });
       const savedRecord = await manager.getRepository(SalesOrderPayment).save(record);
       const resultingStatus = await this.updatePaymentStatusInTx(order, manager);
-      return { saved: savedRecord, resultingStatus };
+      return { saved: savedRecord, resultingStatus, orderNumber: order.orderNumber };
     });
 
-    await this.auditLogService.log('CREATE', 'SalesOrderPayment', `Recorded refund for ${order.orderNumber} (status: ${resultingStatus})`, {
+    await this.auditLogService.log('CREATE', 'SalesOrderPayment', `Recorded refund for ${orderNumber} (status: ${resultingStatus})`, {
       entityId: saved.id,
       userId: userId || 'system',
       username,
@@ -207,13 +210,6 @@ export class SalesOrderPaymentService {
     for (const dto of dtos) {
       if (dto.amount <= 0) throw new BadRequestException('Refund amount must be positive');
     }
-
-    const order = await this.salesOrderRepository.findOne({ where: { id: orderId } });
-    if (!order) throw new NotFoundException('Sales order not found');
-    if (order.status === SalesOrderStatus.CANCELLED) {
-      throw new ConflictException('Cannot record a refund on a cancelled order');
-    }
-
     for (const dto of dtos) {
       const method = await this.paymentMethodRepository.findOne({
         where: { id: dto.paymentMethodId, isActive: true },
@@ -221,14 +217,23 @@ export class SalesOrderPaymentService {
       if (!method) throw new BadRequestException(`Payment method ${dto.paymentMethodId} not found or inactive`);
     }
 
-    const existing = await this.salesOrderPaymentRepository.find({ where: { salesOrderId: orderId } });
-    const netPaid = existing.reduce((sum, r) => sum + Number(r.amount), 0);
-    const totalRefundAmount = dtos.reduce((sum, dto) => sum + dto.amount, 0);
-    if (totalRefundAmount > netPaid + AMOUNT_TOLERANCE) {
-      throw new BadRequestException(`Total refund amount (${totalRefundAmount}) exceeds net paid (${netPaid.toFixed(4)})`);
-    }
+    const { results, resultingStatus, orderNumber } = await this.dataSource.transaction(async (manager: EntityManager) => {
+      const order = await manager.getRepository(SalesOrder).findOne({
+        where: { id: orderId },
+        lock: { mode: 'pessimistic_write' },
+      });
+      if (!order) throw new NotFoundException('Sales order not found');
+      if (order.status === SalesOrderStatus.CANCELLED) {
+        throw new ConflictException('Cannot record a refund on a cancelled order');
+      }
 
-    const { results, resultingStatus } = await this.dataSource.transaction(async (manager: EntityManager) => {
+      const existing = await manager.getRepository(SalesOrderPayment).find({ where: { salesOrderId: orderId } });
+      const netPaid = existing.reduce((sum, r) => sum + Number(r.amount), 0);
+      const totalRefundAmount = dtos.reduce((sum, dto) => sum + dto.amount, 0);
+      if (totalRefundAmount > netPaid + AMOUNT_TOLERANCE) {
+        throw new BadRequestException(`Total refund amount (${totalRefundAmount}) exceeds net paid (${netPaid.toFixed(4)})`);
+      }
+
       const saved: SalesOrderPayment[] = [];
       for (const dto of dtos) {
         const record = manager.getRepository(SalesOrderPayment).create({
@@ -242,11 +247,11 @@ export class SalesOrderPaymentService {
         saved.push(await manager.getRepository(SalesOrderPayment).save(record));
       }
       const resultingStatus = await this.updatePaymentStatusInTx(order, manager);
-      return { results: saved, resultingStatus };
+      return { results: saved, resultingStatus, orderNumber: order.orderNumber };
     });
 
     for (const saved of results) {
-      await this.auditLogService.log('CREATE', 'SalesOrderPayment', `Recorded refund for ${order.orderNumber} (status: ${resultingStatus})`, {
+      await this.auditLogService.log('CREATE', 'SalesOrderPayment', `Recorded refund for ${orderNumber} (status: ${resultingStatus})`, {
         entityId: saved.id,
         userId: userId || 'system',
         username,

--- a/backend/test/e2e/accounting-auto-posting.e2e-spec.ts
+++ b/backend/test/e2e/accounting-auto-posting.e2e-spec.ts
@@ -423,9 +423,13 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
       expect(Number(cogsLine.debitAmount)).toBe(500.00); // 10 qty * 50 baseCost
     });
 
-    it('should continue fulfillment when accounting mapping missing', async () => {
-      // Delete COGS mapping
+    it('rolls back fulfillment when an accounting mapping is missing (atomic, #718/#719)', async () => {
+      // Delete COGS mapping so accounting posting fails inside the fulfillment tx.
       await dataSource.query(`DELETE FROM account_mappings WHERE "mappingKey" = $1`, [MappingType.SALES_COGS]);
+
+      const stockBefore = Number(
+        (await productRepo.findOne({ where: { id: testProduct.id } }))!.stockQuantity,
+      );
 
       const salesOrder = salesOrderRepo.create({
         orderNumber: 'SO-TEST-001',
@@ -448,11 +452,21 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
       } as any);
       await dataSource.getRepository(SalesOrderItem).save(item);
 
-      // Fulfillment should succeed
-      const fulfilledOrder = await salesOrderService.fulfillOrder(savedOrder.id);
-      expect(fulfilledOrder.status).toBe('FULFILLED');
+      // Accounting now participates in the transaction: a missing mapping fails the
+      // whole fulfillment instead of silently leaving the books unposted.
+      await expect(salesOrderService.fulfillOrder(savedOrder.id)).rejects.toThrow(
+        /Account mapping not configured/,
+      );
 
-      // But no journal entry should be created
+      // Order stays READY (status change rolled back).
+      const reloaded = await salesOrderRepo.findOne({ where: { id: savedOrder.id } });
+      expect(reloaded!.status).toBe(SalesOrderStatus.READY);
+
+      // Stock was not deducted (stock movement rolled back with the transaction).
+      const productAfter = await productRepo.findOne({ where: { id: testProduct.id } });
+      expect(Number(productAfter!.stockQuantity)).toBe(stockBefore);
+
+      // No journal entry created.
       const journalEntries = await journalEntryRepo.find({
         where: { sourceType: 'sales_order', sourceId: savedOrder.id },
       });
@@ -1226,9 +1240,15 @@ describe('Accounting Auto-Posting Integration (E2E)', () => {
       } as any);
       await dataSource.getRepository(SalesOrderItem).save(item);
 
-      // Fulfillment succeeds but accounting fails silently
-      const fulfilledOrder = await salesOrderService.fulfillOrder(savedOrder.id);
-      expect(fulfilledOrder.status).toBe('FULFILLED');
+      // Fulfillment fails and rolls back when required sales mappings are missing
+      // (accounting posting participates in the fulfillment transaction).
+      await expect(salesOrderService.fulfillOrder(savedOrder.id)).rejects.toThrow(
+        /Account mapping not configured/,
+      );
+
+      // Order stays READY (status change rolled back).
+      const reloaded = await salesOrderRepo.findOne({ where: { id: savedOrder.id } });
+      expect(reloaded!.status).toBe(SalesOrderStatus.READY);
 
       // No journal entry created
       const journalEntries = await journalEntryRepo.find({


### PR DESCRIPTION
## Summary

Follow-up to #717 (which hardened the **edit** path). Applies the same pessimistic-lock + single-transaction protocol to the remaining sales-order transitions so check-then-act races and partial-failure inconsistency are eliminated.

For every transition: open one `dataSource.transaction`, lock-read the parent order with `pessimistic_write` (`SELECT … FOR UPDATE`), re-assert the status/payment guards **in-lock** (409 on a lost race), and perform all writes via the transaction `manager`.

- **Payment** — `recordPayment` / `recordPayments` / `recordRefund` / `recordRefunds`: order read + status guard + refund-cap now computed inside the locked transaction.
- **Lifecycle** — `cancel` / `uncancel`: now atomic (`DataSource` injected), lock-read + guard in-lock, persist via the manager.
- **Fulfillment** — `fulfillOrder` / `unfulfillOrder`: lock + single transaction; `manager` threaded through `adjustStock`, `restoreStock`, `deleteByReference`, and accounting post/reverse; the swallow-and-continue `try/catch` removed so a downstream failure rolls back the whole transition.
- **Downstream services** gained an optional, backward-compatible `manager?: EntityManager` param (`InventoryIntegrationService.adjustStock`, `BaseCostCalculatorService.reduceStock/restoreStock/updateProductBaseCost/calculateBaseCostFromCurrentStock`, `StockMovementService.deleteByReference/recalculateBalances`, `AccountingService.postSalesOrderEntry/reverseSourceEntries`).
- **Cleanup**: extracted `repoFor()` and `lockRowForUpdate()` into `common/db/tx-helpers.ts`, removing ~14 duplicated repo-select ternaries and ~8 duplicated lock-read blocks; removed leftover `🔍` debug `console.log`s in `adjustStock`.

Closes #718. Closes #719.

## ⚠️ Behavior change (reviewers please note)

After this PR, an accounting or stock-movement failure during **fulfill / unfulfill rolls back** the stock movement and the status change instead of logging and continuing. This is more correct, but it turns previously-tolerated downstream failures (e.g. *no open fiscal period*, transient cost-history errors) into hard, user-visible fulfillment errors.

## ⚠️ Known gap — GL atomicity (deferred)

Fulfillment atomicity does **not** yet extend to the general ledger: `JournalEntryService` is not manager-bound, so journal entries commit on a separate connection. The accounting methods accept `manager` for call-site uniformity (documented TODO), and accounting runs as the last in-tx step to minimize the window, but a failure of the outer COMMIT *after* the GL committed can still leave an orphaned journal entry. Tracked as a follow-up to fully thread the manager into `JournalEntryService`.

## Test Plan

- [x] Full backend suite green: **1140/1140 passing, 84/84 suites**
- [x] Lint clean
- [x] Unit + rollback coverage per transition: asserts the `pessimistic_write` lock-read, 409 on a lost race (in-lock guard), and rollback/propagation when a downstream step throws (no swallow)
- [x] Regression test pinning fulfillment posts accounting against the **re-read** order (fresh `updatedAt` → correct fiscal period; post-reduction `baseCost` → correct COGS), not the stale lock-read snapshot
- [x] `tx-helpers` unit tests for `repoFor` / `lockRowForUpdate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)