### PR TITLE
chore(deps): upgrade react-router-dom to 7.16.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erp-frontend",
-  "version": "1.145.0",
+  "version": "1.145.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erp-frontend",
-      "version": "1.145.0",
+      "version": "1.145.1",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -30,7 +30,7 @@
         "react-dom": "^19.2.4",
         "react-hook-form": "^7.71.2",
         "react-redux": "^9.2.0",
-        "react-router-dom": "7.15.1",
+        "react-router-dom": "7.16.0",
         "redux-persist": "^6.0.0",
         "socket.io-client": "^4.7.4",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
@@ -3047,6 +3047,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5284,9 +5293,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.15.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.1.tgz",
-      "integrity": "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
+      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -5306,12 +5315,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.15.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.1.tgz",
-      "integrity": "sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
+      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.15.1"
+        "react-router": "7.16.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -6450,15 +6459,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.71.2",
     "react-redux": "^9.2.0",
-    "react-router-dom": "7.15.1",
+    "react-router-dom": "7.16.0",
     "redux-persist": "^6.0.0",
     "socket.io-client": "^4.7.4",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",


### PR DESCRIPTION
## Summary

- Bumps `react-router-dom` from `7.15.1` to `7.16.0` in `frontend/package.json`
- No code changes required — no breaking changes for APIs used in this project between these versions

## redis@6 — intentionally skipped

Issue #725 also tracked upgrading `redis` to `6.0.0`. This is being skipped for the following reasons:

- TypeORM `1.0.0` declares `peerOptional redis@\"^5.0.0\"` — `redis@6` is outside this range
- TypeORM's `RedisQueryResultCache` uses the removed v3 positional expiry API: `client.set(key, value, \"PX\", duration)`. This would break at runtime if TypeORM Redis cache is ever enabled
- The project does not use TypeORM's Redis cache feature anywhere — all Redis usage is via `ioredis` (BullMQ, health check, backup service)
- Upgrading provides no benefit and introduces a latent runtime risk

Revisit when TypeORM bumps its peer dep range to accept `redis@6`.

## Test plan

- [x] `npm run type-check` passes
- [x] `npx vitest run src/__tests__/router.test.tsx` passes
- [x] Full frontend test suite passes

Closes #725