### PR TITLE
fix: unsaved changes guard blocks nav on dirty line-item forms

### DIFF
--- a/frontend/src/hooks/__tests__/useUnsavedChangesGuard.integration.test.tsx
+++ b/frontend/src/hooks/__tests__/useUnsavedChangesGuard.integration.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import '@testing-library/jest-dom/vitest'
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createMemoryRouter, RouterProvider, useNavigate } from 'react-router-dom'
+import { useForm } from 'react-hook-form'
+
+import { useUnsavedChangesGuard } from '../useUnsavedChangesGuard'
+
+function ProgrammaticForm() {
+  const navigate = useNavigate()
+  const {
+    setValue,
+    formState: { isDirty },
+  } = useForm<{ name: string }>({
+    defaultValues: { name: '' },
+  })
+  const { UnsavedChangesDialog } = useUnsavedChangesGuard(isDirty)
+
+  return (
+    <div>
+      <span data-testid="dirty">{String(isDirty)}</span>
+      <button onClick={() => setValue('name', 'picked', { shouldDirty: true })}>Pick</button>
+      <button onClick={() => navigate('/other')}>Go</button>
+      {UnsavedChangesDialog}
+    </div>
+  )
+}
+
+function makeRouter() {
+  return createMemoryRouter(
+    [
+      { path: '/', element: <ProgrammaticForm /> },
+      { path: '/other', element: <div>OTHER PAGE</div> },
+    ],
+    { initialEntries: ['/'] },
+  )
+}
+
+describe('useUnsavedChangesGuard integration', () => {
+  it('blocks navigation after programmatic shouldDirty setValue', async () => {
+    const user = userEvent.setup()
+    render(<RouterProvider router={makeRouter()} />)
+
+    await user.click(screen.getByText('Pick'))
+    expect(screen.getByTestId('dirty').textContent).toBe('true')
+
+    await user.click(screen.getByText('Go'))
+
+    expect(screen.getByText(/discard changes/i)).toBeInTheDocument()
+    expect(screen.queryByText('OTHER PAGE')).not.toBeInTheDocument()
+  })
+
+  it('proceeds to destination when Discard is clicked', async () => {
+    const user = userEvent.setup()
+    render(<RouterProvider router={makeRouter()} />)
+
+    await user.click(screen.getByText('Pick'))
+    await user.click(screen.getByText('Go'))
+    await user.click(screen.getByRole('button', { name: /discard/i }))
+
+    expect(await screen.findByText('OTHER PAGE')).toBeInTheDocument()
+  })
+
+  it('stays on page when Keep editing is clicked', async () => {
+    const user = userEvent.setup()
+    render(<RouterProvider router={makeRouter()} />)
+
+    await user.click(screen.getByText('Pick'))
+    await user.click(screen.getByText('Go'))
+    await user.click(screen.getByRole('button', { name: /keep editing/i }))
+
+    expect(screen.queryByText('OTHER PAGE')).not.toBeInTheDocument()
+    expect(screen.getByTestId('dirty').textContent).toBe('true')
+  })
+})

--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -184,6 +184,8 @@ const CreateStockAdjustmentPage: React.FC = () => {
       const diff = newQty - oldQty
 
       if (item.difference !== diff) {
+        // Derived recompute — must NOT mark the form dirty, or loading an
+        // existing adjustment would flip isDirty true with no user action.
         setValue(`items.${index}.difference`, diff)
       }
     })
@@ -246,17 +248,17 @@ const CreateStockAdjustmentPage: React.FC = () => {
         const response = await ApiService.get(`/inventory/products/${product.id}`)
         const freshProduct = (response as any).data || product
 
-        setValue(`items.${index}.productId`, freshProduct.id)
-        setValue(`items.${index}.product`, freshProduct)
+        setValue(`items.${index}.productId`, freshProduct.id, { shouldDirty: true })
+        setValue(`items.${index}.product`, freshProduct, { shouldDirty: true })
         seedProducts([freshProduct])
-        setValue(`items.${index}.oldQuantity`, Number(freshProduct.stockQuantity || 0))
-        setValue(`items.${index}.newQuantity`, Number(freshProduct.stockQuantity || 0))
+        setValue(`items.${index}.oldQuantity`, Number(freshProduct.stockQuantity || 0), { shouldDirty: true })
+        setValue(`items.${index}.newQuantity`, Number(freshProduct.stockQuantity || 0), { shouldDirty: true })
       } catch (err) {
         console.error('Error fetching product:', err)
-        setValue(`items.${index}.productId`, product.id)
-        setValue(`items.${index}.product`, product)
-        setValue(`items.${index}.oldQuantity`, Number(product.stockQuantity || 0))
-        setValue(`items.${index}.newQuantity`, Number(product.stockQuantity || 0))
+        setValue(`items.${index}.productId`, product.id, { shouldDirty: true })
+        setValue(`items.${index}.product`, product, { shouldDirty: true })
+        setValue(`items.${index}.oldQuantity`, Number(product.stockQuantity || 0), { shouldDirty: true })
+        setValue(`items.${index}.newQuantity`, Number(product.stockQuantity || 0), { shouldDirty: true })
       }
     }
   }

--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -230,6 +230,8 @@ const CreatePurchaseOrderPage: React.FC = () => {
         const total = discountedUnitPrice * quantity
 
         if (Math.abs(item.totalPrice - total) > 0.01) {
+          // Derived recompute — must NOT mark the form dirty, or loading an
+          // existing order would flip isDirty true with no user action.
           setValue(`items.${index}.totalPrice`, Number(total.toFixed(2)))
         }
       }
@@ -290,9 +292,9 @@ const CreatePurchaseOrderPage: React.FC = () => {
     if (product) {
       seedProducts([product])
       await Promise.resolve()
-      setValue(`items.${index}.productId`, product.id)
-      setValue(`items.${index}.unitPrice`, Number(product.baseCost || 0))
-      setValue(`items.${index}.product`, product)
+      setValue(`items.${index}.productId`, product.id, { shouldDirty: true })
+      setValue(`items.${index}.unitPrice`, Number(product.baseCost || 0), { shouldDirty: true })
+      setValue(`items.${index}.product`, product, { shouldDirty: true })
     }
   }
 

--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -238,6 +238,9 @@ const CreateSalesOrderPage: React.FC = () => {
             : Number(item.discountValue || 0)
         const total = (price - unitDiscount) * qty
         if (Math.abs((item.totalPrice || 0) - total) > 0.001) {
+          // Derived recompute — must NOT mark the form dirty, or loading an
+          // existing order (backend stores unrounded totals; this rounds to 2dp)
+          // would flip isDirty true with no user action and falsely block nav.
           setValue(`items.${index}.totalPrice`, Number(total.toFixed(2)))
         }
       }
@@ -254,7 +257,7 @@ const CreateSalesOrderPage: React.FC = () => {
       if (!fullProduct) return
       const price = getProductPrice(fullProduct, selectedCustomer)
       if (Number(item.unitPrice) !== price) {
-        setValue(`items.${index}.unitPrice`, price)
+        setValue(`items.${index}.unitPrice`, price, { shouldDirty: true })
       }
     })
   }, [selectedCustomer, setValue, loadingOrder, orderToLoad, products, watchedItems])
@@ -265,7 +268,7 @@ const CreateSalesOrderPage: React.FC = () => {
     const found = customers.find((c: any) => c.id === preselectId)
     if (found) {
       preselectAppliedRef.current = true
-      setValue('customerId', found.id)
+      setValue('customerId', found.id, { shouldDirty: true })
       setSelectedCustomer(found)
       customerChangedByUserRef.current = true
     }
@@ -346,10 +349,10 @@ const CreateSalesOrderPage: React.FC = () => {
       seedProducts([product])
       const price = getProductPrice(product, selectedCustomer)
       const qty = Number(watchedItems[index]?.quantity) || 1
-      setValue(`items.${index}.productId`, product.id)
-      setValue(`items.${index}.unitPrice`, price)
-      setValue(`items.${index}.totalPrice`, Number((price * qty).toFixed(2)))
-      setValue(`items.${index}.product`, product)
+      setValue(`items.${index}.productId`, product.id, { shouldDirty: true })
+      setValue(`items.${index}.unitPrice`, price, { shouldDirty: true })
+      setValue(`items.${index}.totalPrice`, Number((price * qty).toFixed(2)), { shouldDirty: true })
+      setValue(`items.${index}.product`, product, { shouldDirty: true })
     },
     [seedProducts, setValue, selectedCustomer, watchedItems],
   )


### PR DESCRIPTION
## Problem

The unsaved-changes navigation guard (PR #728 / issue #726) did not block navigation when leaving the **Create Sales Order** page after editing. The "Discard changes?" dialog never appeared; navigation proceeded and unsaved data was lost silently.

## Root cause

`useUnsavedChangesGuard(isDirty)` wraps `useBlocker(() => isDirty)`, which only fires when `isDirty === true`. The product-selection handlers populate line-item fields with bare `setValue(name, value)` calls. `react-hook-form`'s `setValue` defaults to `{ shouldDirty: false }`, so selecting a product — the central line-item action — left `formState.isDirty === false` and the blocker never intercepted navigation.

Same hole existed on the Purchase Order and Stock Adjustment create pages.

Existing hook tests **mocked `useBlocker`**, so real router blocking was never exercised — which is why the bug shipped uncaught.

## Fix

Add `{ shouldDirty: true }` to the **user-intent** programmatic `setValue` calls (product select, customer preselect/reprice) across the three line-item pages.

**Derived auto-calc writes** (`totalPrice`, `difference`) are deliberately left bare. The backend computes line totals as `unitPrice * qty - discount` with **no rounding** (`sales-order.service.ts:776-786`), while the frontend rounds to 2dp. On edit-load the recompute can differ from the stored total by >0.001 and fire `setValue`; marking those dirty would flip `isDirty` true with no user action and falsely block navigation away from a pristine edit page.

## Tests

- New real-router integration test (`useUnsavedChangesGuard.integration.test.tsx`) — un-mocked `useBlocker` + `createMemoryRouter`, asserts block / Discard-proceed / Keep-editing-stay. Closes the gap that let the bug ship.
- Existing mocked unit tests retained for the dialog layer.

## Verification

- `npx vitest run` guard + 3 page suites — **45 passed**
- `npm run type-check` — clean
- `npm run lint` — clean

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)