### PR TITLE
fix: recalculate line total when quantity is 0 (#731)

### DIFF
--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -213,8 +213,10 @@ const CreatePurchaseOrderPage: React.FC = () => {
   // Recalculate totals when items change
   useEffect(() => {
     watchedItems.forEach((item, index) => {
-      if (item.quantity && item.unitPrice !== undefined) {
-        const quantity = Number(item.quantity)
+      const quantityValue = item.quantity as number | string | null | undefined
+
+      if (quantityValue != null && quantityValue !== '' && item.unitPrice !== undefined) {
+        const quantity = Number(quantityValue)
         const unitPrice = Number(item.unitPrice)
         let unitDiscount = 0
 

--- a/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
@@ -355,4 +355,37 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
       mockNavigate.mock.invocationCallOrder[0],
     )
   })
+
+  it('recalculates row total to 0.00 when quantity is set to 0', async () => {
+    render(
+      <BrowserRouter>
+        <CreatePurchaseOrderPage />
+      </BrowserRouter>,
+    )
+
+    const supplierInput = screen.getByLabelText(/supplier/i)
+    fireEvent.mouseDown(supplierInput)
+    const supplierListbox = await screen.findByRole('listbox')
+    fireEvent.click(within(supplierListbox).getByText('Acme Supplies'))
+
+    const productInput = screen.getByPlaceholderText('Search by name or barcode...')
+    fireEvent.mouseDown(productInput)
+    const productListbox = await screen.findByRole('listbox')
+    fireEvent.click(within(productListbox).getByText('Alpha Widget'))
+
+    const qtyInput = screen.getByDisplayValue('1') as HTMLInputElement
+    const row = qtyInput.closest('tr')
+    expect(row).not.toBeNull()
+
+    await waitFor(() => {
+      expect(within(row as HTMLTableRowElement).getByText('RM 11.00')).toBeInTheDocument()
+    })
+
+    fireEvent.change(qtyInput, { target: { value: '0' } })
+
+    await waitFor(() => {
+      expect(within(row as HTMLTableRowElement).getByText('RM 0.00')).toBeInTheDocument()
+    })
+    expect(within(row as HTMLTableRowElement).queryByText('RM 11.00')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -229,8 +229,10 @@ const CreateSalesOrderPage: React.FC = () => {
 
   useEffect(() => {
     watchedItems.forEach((item, index) => {
-      if (item.quantity && item.unitPrice !== undefined) {
-        const qty = Number(item.quantity)
+      const quantityValue = item.quantity as number | string | null | undefined
+
+      if (quantityValue != null && quantityValue !== '' && item.unitPrice !== undefined) {
+        const qty = Number(quantityValue)
         const price = Number(item.unitPrice)
         const unitDiscount =
           item.discountType === 'percentage'

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -581,6 +581,40 @@ describe('CreateSalesOrderPage — new features', () => {
       expect(totalField).toHaveDisplayValue('11.00')
     })
   })
+
+  it('recalculates row total to 0.00 when quantity is set to 0', async () => {
+    mockGet.mockResolvedValue({ data: [{ id: 'product-1', name: 'Alpha Widget', basePrice: 11 }] })
+
+    render(
+      <BrowserRouter>
+        <CreateSalesOrderPage />
+      </BrowserRouter>,
+    )
+
+    const productInput = screen.getByPlaceholderText('Search by name or barcode...')
+    fireEvent.mouseDown(productInput)
+    const listbox = await screen.findByRole('listbox')
+    fireEvent.click(within(listbox).getByText('Alpha Widget'))
+
+    const row = document.querySelector('[data-cell="r0-c1"]')?.closest('tr')
+    expect(row).not.toBeNull()
+
+    await waitFor(() => {
+      expect(within(row as HTMLTableRowElement).getByText('RM 11.00')).toBeInTheDocument()
+    })
+
+    const qtyInput = document.querySelector('[data-cell="r0-c1"] input') as HTMLInputElement
+    expect(qtyInput).not.toBeNull()
+    fireEvent.change(qtyInput, { target: { value: '0' } })
+
+    await waitFor(() => {
+      expect(within(row as HTMLTableRowElement).getByText('RM 0.00')).toBeInTheDocument()
+    })
+    expect(within(row as HTMLTableRowElement).queryByText('RM 11.00')).not.toBeInTheDocument()
+
+    const totalField = screen.getByRole('textbox', { name: /total amount/i })
+    expect(totalField).toHaveDisplayValue('0.00')
+  })
 })
 
 describe('CreateSalesOrderPage — edit mode', { timeout: 60000 }, () => {


### PR DESCRIPTION
## Summary

Fixes #731 — on the Sales Order and Purchase Order forms, a line item with **quantity = 0** did not recalculate its row total, leaving the row total and the order subtotal/total stale.

Display-only bug. Save validation (`quantity >= 1`) is unchanged.

## Root cause

The auto-calc `useEffect` guarded recompute with a truthy check:

```tsx
if (item.quantity && item.unitPrice !== undefined) {
```

`quantity === 0` is falsy → the recompute was skipped → `totalPrice` kept its previous value → subtotal/total wrong.

## Fix

Explicit defined-and-non-empty guard in both forms, so `0` recomputes while empty/undefined input still skips (no `NaN`):

```tsx
if (quantityValue != null && quantityValue !== '' && item.unitPrice !== undefined) {
```

- `frontend/src/pages/sales/CreateSalesOrderPage.tsx`
- `frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx`

## Tests

Added a regression test per form: select a product (qty defaults to 1 → row total = price), set qty to `0`, assert the row total recomputes to `RM 0.00`. Mirrors referenced Test 11.5 (Zero-Quantity Item).

## Verification

- `cd frontend && npx vitest run src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx` — pass
- `cd frontend && npm run type-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)