### PR TITLE
fix: align product input height with other line-item fields

### DIFF
--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -573,6 +573,14 @@ const CreateSalesOrderPage: React.FC = () => {
                         fontSize: '0.875rem',
                       },
                       '& .MuiTextField-root .MuiInputBase-input': { padding: '6px 8px' },
+                      // Autocomplete (Product) reserves vertical padding on its
+                      // OutlinedInput root for the popup/clear adornment, making it
+                      // taller than the plain TextField cells. Collapse that padding
+                      // so all line-item inputs share the same height.
+                      '& .MuiAutocomplete-root .MuiOutlinedInput-root': {
+                        paddingTop: 0,
+                        paddingBottom: 0,
+                      },
                     }}
                   >
                     <TableHead>


### PR DESCRIPTION
## Problem

In the sales order line-item table (Create/Edit Sales Order), the **Product** input row was taller than the other input fields (Qty, Unit Price, Discount).

## Cause

The Product cell uses MUI `Autocomplete`. Its `MuiOutlinedInput-root` reserves vertical padding for the popup/clear end-adornment, making the input taller than the plain `TextField` cells — even though the inner input padding matched.

## Fix

CSS-only. Added an `Autocomplete`-specific override in the line-item table `sx` to collapse `paddingTop`/`paddingBottom` on its `OutlinedInput` root, so all 5 inputs share one height.

- One file: `frontend/src/pages/sales/CreateSalesOrderPage.tsx`
- Covers both create and edit (shared `LineItemRow`)
- No logic change

## Verification

- `npm run type-check` passes
- Manual: open Create Sales Order, Product input now matches Qty/Price height

🤖 Generated with [Claude Code](https://claude.com/claude-code)