### PR TITLE
fix: filter journal entries list when navigating from sales order

### DIFF
--- a/frontend/src/pages/sales/components/OrderJournalEntriesTab.tsx
+++ b/frontend/src/pages/sales/components/OrderJournalEntriesTab.tsx
@@ -70,7 +70,7 @@ export default function OrderJournalEntriesTab({ orderId }: OrderJournalEntriesT
             return (
               <TableRow key={entry.id} hover>
                 <TableCell>
-                  <Link component={RouterLink} to={`/accounting/journal-entries/${entry.id}`}>
+                  <Link component={RouterLink} to={`/accounting/journal-entries?sourceType=sales_order&sourceId=${orderId}`}>
                     {entry.referenceNumber}
                   </Link>
                 </TableCell>

--- a/frontend/src/pages/sales/components/__tests__/OrderJournalEntriesTab.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/OrderJournalEntriesTab.test.tsx
@@ -68,7 +68,7 @@ describe('OrderJournalEntriesTab', () => {
     mockGetJournalEntries.mockReturnValue({ data: { data: [makeEntry()], meta: { total: 1 } }, isLoading: false })
     renderTab('o1')
     const link = screen.getByRole('link', { name: 'JE-001' })
-    expect(link).toHaveAttribute('href', '/accounting/journal-entries/je1')
+    expect(link).toHaveAttribute('href', '/accounting/journal-entries?sourceType=sales_order&sourceId=o1')
   })
 
   it('renders description', () => {


### PR DESCRIPTION
## Problem

Clicking a journal entry link from the sales order view page landed on the **full unfiltered** journal entries list instead of showing only that sales order's entries.

**Root cause:** The link in `OrderJournalEntriesTab.tsx` pointed to `/accounting/journal-entries/:id` (path-param form). That route (`accounting.routes.tsx:27`) redirects to the bare list and discards the `:id` — there is no detail page — so all filter context was lost.

## Fix

Changed the link to the query-param form the journal entries list page **already supports** (`?sourceType=sales_order&sourceId=<orderId>`). The list reads these params, sets `hasUrlFilters`, and auto-filters. Uses the same `sourceType`/`sourceId` pair the tab already queries with, so a match is guaranteed.

- 1-line change in `OrderJournalEntriesTab.tsx`
- Test href assertion updated to match

## Testing

`npx vitest run src/pages/sales/components/__tests__/OrderJournalEntriesTab.test.tsx` — 6/6 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)