### PR TITLE
fix(forms): suppress unsaved-changes guard while submitting

### DIFF
--- a/frontend/src/hooks/__tests__/useUnsavedChangesGuard.integration.test.tsx
+++ b/frontend/src/hooks/__tests__/useUnsavedChangesGuard.integration.test.tsx
@@ -12,11 +12,11 @@ function ProgrammaticForm() {
   const navigate = useNavigate()
   const {
     setValue,
-    formState: { isDirty },
+    formState: { isDirty, isSubmitting },
   } = useForm<{ name: string }>({
     defaultValues: { name: '' },
   })
-  const { UnsavedChangesDialog } = useUnsavedChangesGuard(isDirty)
+  const { UnsavedChangesDialog } = useUnsavedChangesGuard(isDirty, isSubmitting)
 
   return (
     <div>

--- a/frontend/src/hooks/__tests__/useUnsavedChangesGuard.test.tsx
+++ b/frontend/src/hooks/__tests__/useUnsavedChangesGuard.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import '@testing-library/jest-dom/vitest'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 const mockProceed = vi.fn()
@@ -113,6 +113,28 @@ describe('useUnsavedChangesGuard', () => {
     render(<TestConsumer isDirty={true} isSubmitting={false} />)
 
     expect(screen.getByText(/discard changes/i)).toBeInTheDocument()
+  })
+
+  it('re-arms the guard after a failed save leaves the form dirty', () => {
+    vi.useFakeTimers()
+    mockBlockerState = 'blocked'
+
+    // Submit in flight: dialog suppressed.
+    const { rerender } = render(<TestConsumer isDirty={true} isSubmitting={true} />)
+    expect(screen.queryByText(/discard changes/i)).not.toBeInTheDocument()
+
+    // Submit fails: still dirty, no longer submitting.
+    rerender(<TestConsumer isDirty={true} isSubmitting={false} />)
+    // Latch clears on next tick.
+    act(() => {
+      vi.runAllTimers()
+    })
+
+    // Re-render to pick up the cleared latch in shouldBlock.
+    rerender(<TestConsumer isDirty={true} isSubmitting={false} />)
+    expect(screen.getByText(/discard changes/i)).toBeInTheDocument()
+
+    vi.useRealTimers()
   })
 
   it('calls blocker.proceed() when Discard is clicked', async () => {

--- a/frontend/src/hooks/__tests__/useUnsavedChangesGuard.test.tsx
+++ b/frontend/src/hooks/__tests__/useUnsavedChangesGuard.test.tsx
@@ -25,8 +25,14 @@ vi.mock('react-router-dom', async () => {
 
 import { useUnsavedChangesGuard } from '../useUnsavedChangesGuard'
 
-const TestConsumer = ({ isDirty }: { isDirty: boolean }) => {
-  const { UnsavedChangesDialog } = useUnsavedChangesGuard(isDirty)
+const TestConsumer = ({
+  isDirty,
+  isSubmitting = false,
+}: {
+  isDirty: boolean
+  isSubmitting?: boolean
+}) => {
+  const { UnsavedChangesDialog } = useUnsavedChangesGuard(isDirty, isSubmitting)
 
   return <>{UnsavedChangesDialog}</>
 }
@@ -58,6 +64,14 @@ describe('useUnsavedChangesGuard', () => {
     expect(spy).toHaveBeenCalledWith('beforeunload', expect.any(Function))
   })
 
+  it('does not register beforeunload listener when dirty but submitting', () => {
+    const spy = vi.spyOn(window, 'addEventListener')
+
+    render(<TestConsumer isDirty={true} isSubmitting={true} />)
+
+    expect(spy).not.toHaveBeenCalledWith('beforeunload', expect.any(Function))
+  })
+
   it('removes beforeunload listener on unmount', () => {
     const spy = vi.spyOn(window, 'removeEventListener')
     const { unmount } = render(<TestConsumer isDirty={true} />)
@@ -83,6 +97,22 @@ describe('useUnsavedChangesGuard', () => {
     expect(screen.getByText(/discard changes/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /discard/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /keep editing/i })).toBeInTheDocument()
+  })
+
+  it('does not show dialog when dirty but submitting', () => {
+    mockBlockerState = 'blocked'
+
+    render(<TestConsumer isDirty={true} isSubmitting={true} />)
+
+    expect(screen.queryByText(/discard changes/i)).not.toBeInTheDocument()
+  })
+
+  it('still shows dialog when dirty and not submitting', () => {
+    mockBlockerState = 'blocked'
+
+    render(<TestConsumer isDirty={true} isSubmitting={false} />)
+
+    expect(screen.getByText(/discard changes/i)).toBeInTheDocument()
   })
 
   it('calls blocker.proceed() when Discard is clicked', async () => {

--- a/frontend/src/hooks/useUnsavedChangesGuard.tsx
+++ b/frontend/src/hooks/useUnsavedChangesGuard.tsx
@@ -11,14 +11,18 @@ export function useUnsavedChangesGuard(isDirty: boolean, isSubmitting = false): 
   useEffect(() => {
     if (isSubmitting) {
       savedRef.current = true
+      return
     }
-  }, [isSubmitting])
 
-  useEffect(() => {
-    if (!isDirty) {
+    // Submit ended. Clear the latch on the next tick so a navigate fired during
+    // the same commit still sees it, but a failed save that leaves the form
+    // dirty re-arms the guard instead of staying silently disabled.
+    const id = setTimeout(() => {
       savedRef.current = false
-    }
-  }, [isDirty])
+    }, 0)
+
+    return () => clearTimeout(id)
+  }, [isSubmitting])
 
   const blocker = useBlocker(
     useCallback(() => isDirty && !isSubmitting && !savedRef.current, [isDirty, isSubmitting]),

--- a/frontend/src/hooks/useUnsavedChangesGuard.tsx
+++ b/frontend/src/hooks/useUnsavedChangesGuard.tsx
@@ -1,15 +1,31 @@
-import React, { useCallback, useEffect } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import { useBlocker } from 'react-router-dom'
 
 import ConfirmationDialog from '@/components/common/ConfirmationDialog'
 
-export function useUnsavedChangesGuard(isDirty: boolean): {
+export function useUnsavedChangesGuard(isDirty: boolean, isSubmitting = false): {
   UnsavedChangesDialog: React.ReactElement
 } {
-  const blocker = useBlocker(useCallback(() => isDirty, [isDirty]))
+  const savedRef = useRef(false)
+
+  useEffect(() => {
+    if (isSubmitting) {
+      savedRef.current = true
+    }
+  }, [isSubmitting])
 
   useEffect(() => {
     if (!isDirty) {
+      savedRef.current = false
+    }
+  }, [isDirty])
+
+  const blocker = useBlocker(
+    useCallback(() => isDirty && !isSubmitting && !savedRef.current, [isDirty, isSubmitting]),
+  )
+
+  useEffect(() => {
+    if (!isDirty || isSubmitting) {
       return
     }
 
@@ -22,7 +38,7 @@ export function useUnsavedChangesGuard(isDirty: boolean): {
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload)
     }
-  }, [isDirty])
+  }, [isDirty, isSubmitting])
 
   const UnsavedChangesDialog = (
     <ConfirmationDialog

--- a/frontend/src/pages/inventory/CreateProductPage.tsx
+++ b/frontend/src/pages/inventory/CreateProductPage.tsx
@@ -252,7 +252,7 @@ const CreateProductPage: React.FC = () => {
   // Currency hook
   const { currency } = useCurrency()
 
-  const { control, handleSubmit, watch, reset, formState: { errors, isDirty } } = useForm<ProductFormData>({
+  const { control, handleSubmit, watch, reset, formState: { errors, isDirty, isSubmitting } } = useForm<ProductFormData>({
     resolver: yupResolver(productSchema) as any,
     defaultValues: {
       name: '',
@@ -266,7 +266,7 @@ const CreateProductPage: React.FC = () => {
       isActive: true,
     },
   })
-  const { UnsavedChangesDialog } = useUnsavedChangesGuard(isDirty)
+  const { UnsavedChangesDialog } = useUnsavedChangesGuard(isDirty, isSubmitting)
 
   const watchedType = watch('type')
   const watchedName = watch('name')

--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -81,7 +81,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
   const [adjustmentToLoad, setAdjustmentToLoad] = useState<any>(null)
   const [editingAdjustmentId, setEditingAdjustmentId] = useState<string | null>(null)
 
-  const { control, handleSubmit, watch, setValue, reset, formState: { errors, isDirty } } = useForm<CreateAdjustmentFormData>({
+  const { control, handleSubmit, watch, setValue, reset, formState: { errors, isDirty, isSubmitting } } = useForm<CreateAdjustmentFormData>({
     resolver: yupResolver(schema) as any,
     defaultValues: {
       adjustmentDate: getCurrentDate(),
@@ -96,7 +96,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
       ],
     },
   })
-  const { UnsavedChangesDialog } = useUnsavedChangesGuard(isDirty)
+  const { UnsavedChangesDialog } = useUnsavedChangesGuard(isDirty, isSubmitting)
 
   const { fields, append, remove } = useFieldArray({
     control,

--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -103,7 +103,7 @@ const CreatePurchaseOrderPage: React.FC = () => {
   const [editingOrderId, setEditingOrderId] = useState<string | null>(null)
   const suppliers = suppliersResponse?.data || []
 
-  const { control, handleSubmit, watch, setValue, reset, formState: { errors, isDirty } } = useForm<CreatePurchaseOrderFormData>({
+  const { control, handleSubmit, watch, setValue, reset, formState: { errors, isDirty, isSubmitting } } = useForm<CreatePurchaseOrderFormData>({
     resolver: yupResolver(schema) as any,
     defaultValues: {
       supplierId: '',
@@ -123,7 +123,7 @@ const CreatePurchaseOrderPage: React.FC = () => {
       ],
     },
   })
-  const { UnsavedChangesDialog } = useUnsavedChangesGuard(isDirty)
+  const { UnsavedChangesDialog } = useUnsavedChangesGuard(isDirty, isSubmitting)
 
   const { fields, append, remove } = useFieldArray({
     control,

--- a/frontend/src/pages/purchasing/SupplierFormPage.tsx
+++ b/frontend/src/pages/purchasing/SupplierFormPage.tsx
@@ -121,7 +121,7 @@ const SupplierFormPage: React.FC = () => {
     reset,
     watch,
     setValue,
-    formState: { errors, isDirty },
+    formState: { errors, isDirty, isSubmitting },
   } = useForm<SupplierFormData>({
     resolver: yupResolver(supplierSchema) as any,
     defaultValues: {
@@ -145,7 +145,7 @@ const SupplierFormPage: React.FC = () => {
       notes: null,
     },
   })
-  const { UnsavedChangesDialog } = useUnsavedChangesGuard(isDirty)
+  const { UnsavedChangesDialog } = useUnsavedChangesGuard(isDirty, isSubmitting)
 
   const watchedCompanyName = watch('companyName')
   const watchedBilling = watch([

--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -204,7 +204,7 @@ const CreateSalesOrderPage: React.FC = () => {
     watch,
     setValue,
     reset,
-    formState: { errors, isDirty },
+    formState: { errors, isDirty, isSubmitting },
   } = useForm<CreateOrderFormData>({
     resolver: yupResolver(schema) as any,
     defaultValues: {
@@ -215,7 +215,7 @@ const CreateSalesOrderPage: React.FC = () => {
       items: [emptyItem()],
     },
   })
-  const { UnsavedChangesDialog } = useUnsavedChangesGuard(isDirty)
+  const { UnsavedChangesDialog } = useUnsavedChangesGuard(isDirty, isSubmitting)
 
   const { fields, append, remove } = useFieldArray({ control, name: 'items' })
   const watchedItems = watch('items')

--- a/frontend/src/pages/sales/CustomerFormPage.tsx
+++ b/frontend/src/pages/sales/CustomerFormPage.tsx
@@ -122,7 +122,7 @@ const CustomerFormPage: React.FC = () => {
     watch,
     setValue,
     setError,
-    formState: { errors, isDirty },
+    formState: { errors, isDirty, isSubmitting },
   } = useForm<CustomerFormData>({
     resolver: yupResolver(customerSchema) as any,
     defaultValues: {
@@ -146,7 +146,7 @@ const CustomerFormPage: React.FC = () => {
       notes: null,
     },
   })
-  const { UnsavedChangesDialog } = useUnsavedChangesGuard(isDirty)
+  const { UnsavedChangesDialog } = useUnsavedChangesGuard(isDirty, isSubmitting)
 
   const watchedPhone = watch('phone')
   const watchedName = watch('name')


### PR DESCRIPTION
## Problem

Clicking **Create order** on the new Sales Order page popped a "Discard changes?" dialog on a *successful* save. `useUnsavedChangesGuard(isDirty)` blocks all navigation while the form is dirty; on save the page calls `navigate(...)` while still dirty (no `reset` before nav), so the blocker treats the legit save-and-redirect as leaving with unsaved changes.

Same anti-pattern across all 6 form pages using the hook.

## Fix

- Hook takes a second `isSubmitting` arg. Blocker + `beforeunload` fire only when `isDirty && !isSubmitting`.
- A latched `savedRef` covers the gap between the submit promise resolving and React Router flushing navigation.
- Latch clears on the next tick once submit ends, so a **failed** save that leaves the form dirty re-arms the guard instead of silently disabling it.
- All 6 pages pass `formState.isSubmitting`:
  - CreateSalesOrderPage, CreatePurchaseOrderPage, CreateStockAdjustmentPage, CreateProductPage, SupplierFormPage, CustomerFormPage

## Tests

New cases in `useUnsavedChangesGuard.test.tsx`: no block / no `beforeunload` while submitting, still blocks when dirty + not submitting, re-arms after failed save. Integration test updated to pass `isSubmitting`.

## Verify

- `npx vitest run src/hooks/__tests__/useUnsavedChangesGuard*.tsx` — 15 pass ✅
- `npm run type-check` ✅
- `npm run lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)