### PR TITLE
fix(print): stop print dialog chrome leaking into printed output

### DIFF
--- a/frontend/src/components/print/BasePrintTemplate.tsx
+++ b/frontend/src/components/print/BasePrintTemplate.tsx
@@ -112,6 +112,7 @@ const BasePrintTemplate: React.FC<BasePrintTemplateProps> = ({
             p: 2,
             m: 0,
             width: '100%',
+            minHeight: 'auto',
           },
         }}
       >

--- a/frontend/src/components/print/PurchaseOrderPrint.tsx
+++ b/frontend/src/components/print/PurchaseOrderPrint.tsx
@@ -70,7 +70,7 @@ const PurchaseOrderPrint: React.FC<PurchaseOrderPrintProps> = ({ open, onClose, 
             <CircularProgress />
           </Box>
         ) : (
-          <Box ref={printRef}>
+          <Box ref={printRef} className="print-root">
             <BasePrintTemplate
               settings={printSettings}
               documentTitle="Purchase Order"

--- a/frontend/src/pages/sales/components/SalesOrderPrintDialog.tsx
+++ b/frontend/src/pages/sales/components/SalesOrderPrintDialog.tsx
@@ -189,10 +189,12 @@ const SalesOrderPrintDialog: React.FC<SalesOrderPrintDialogProps> = ({
           <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
             <CircularProgress />
           </Box>
-        ) : printType === 'sales_order' ? (
-          renderSalesOrderContent()
         ) : (
-          renderInvoiceContent()
+          <Box className="print-root" data-testid="print-root">
+            {printType === 'sales_order'
+              ? renderSalesOrderContent()
+              : renderInvoiceContent()}
+          </Box>
         )}
       </DialogContent>
       <DialogActions sx={{ '@media print': { display: 'none' } }}>

--- a/frontend/src/pages/sales/components/SalesOrderPrintDialog.tsx
+++ b/frontend/src/pages/sales/components/SalesOrderPrintDialog.tsx
@@ -165,7 +165,7 @@ const SalesOrderPrintDialog: React.FC<SalesOrderPrintDialogProps> = ({
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
       <DialogTitle>Print Options</DialogTitle>
       <DialogContent>
-        <FormControl sx={{ mb: 2 }}>
+        <FormControl className="print-chrome" sx={{ mb: 2 }}>
           <RadioGroup
             value={printType}
             onChange={(_, value) => setPrintType(value as 'sales_order' | 'invoice')}

--- a/frontend/src/pages/sales/components/__tests__/SalesOrderPrintDialog.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/SalesOrderPrintDialog.test.tsx
@@ -69,4 +69,18 @@ describe('SalesOrderPrintDialog', () => {
     const invoiceRadio = screen.getByRole('radio', { name: /Invoice/i });
     expect(invoiceRadio).toBeEnabled();
   });
+
+  it('wraps the document template in a print-root container', () => {
+    render(
+      <SalesOrderPrintDialog
+        open
+        salesOrder={makeSalesOrder({ status: 'FULFILLED' })}
+        onClose={() => {}}
+      />,
+    );
+    const printRoot = screen.getByTestId('print-root');
+    expect(printRoot).toBeInTheDocument();
+    // Document title from BasePrintTemplate must be inside the print root.
+    expect(printRoot).toHaveTextContent(/SALES ORDER/i);
+  });
 });

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -252,3 +252,21 @@ html {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* Print isolation: when printing, show only the marked print root
+   (document templates in print dialogs), hide all app/dialog chrome. */
+@media print {
+  body * {
+    visibility: hidden;
+  }
+  .print-root,
+  .print-root * {
+    visibility: visible;
+  }
+  .print-root {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+  }
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -254,19 +254,38 @@ html {
 }
 
 /* Print isolation: when printing, show only the marked print root
-   (document templates in print dialogs), hide all app/dialog chrome. */
+   (document templates in print dialogs), hide all app/dialog chrome.
+
+   The app shell (#root) is removed from layout with display:none so it
+   contributes no height. Within the MUI Dialog portal the unwanted chrome
+   (title, radio toggle, action buttons) is hidden with visibility while the
+   print root is re-shown — visibility keeps the ancestor chain intact so the
+   document still renders. The print root is left in normal flow (no absolute
+   positioning) so multi-page documents paginate instead of clipping. */
 @media print {
-  body * {
-    visibility: hidden;
+  /* Remove the app shell entirely so it contributes no height. */
+  #root {
+    display: none !important;
   }
-  .print-root,
-  .print-root * {
-    visibility: visible;
+  /* Remove dialog chrome that sits ABOVE/BELOW the document so it leaves no
+     blank space (these are siblings of the print root, not ancestors). */
+  .MuiDialogTitle-root,
+  .MuiDialogActions-root,
+  .print-chrome {
+    display: none !important;
   }
+  /* Let the document and its ancestor chain flow naturally on the page. */
+  .MuiDialog-root,
+  .MuiDialog-container,
+  .MuiDialog-paper,
+  .MuiPaper-root,
+  .MuiDialogContent-root,
   .print-root {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
+    position: static !important;
+    overflow: visible !important;
+    box-shadow: none !important;
+    max-height: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
   }
 }


### PR DESCRIPTION
## Summary
- Clicking **Print** in the Sales Order and Purchase Order print dialogs leaked the dialog chrome (the "Print Options" title, the Sales Order / Invoice radio toggle, and the app shell sidebar/topbar) into the printout, because `window.print()` prints the whole page DOM.
- Isolates a `.print-root` element via a global `@media print` rule so only the document template prints.
- Removes the app shell (`#root`) and dialog chrome from print layout, and lets the document flow naturally so it paginates instead of clipping.

## Changes
- `frontend/src/styles/global.css` — global `@media print` isolation rule
- `frontend/src/pages/sales/components/SalesOrderPrintDialog.tsx` — wrap document in `.print-root`, mark radio toggle `.print-chrome`
- `frontend/src/components/print/PurchaseOrderPrint.tsx` — mark template wrapper `.print-root`
- `frontend/src/components/print/BasePrintTemplate.tsx` — reset Paper `minHeight` on print (was forcing a blank page 2)
- `SalesOrderPrintDialog.test.tsx` — assert print-root wrapper present

## Fixes during review
- Multi-page documents were clipping (`position:absolute`) → now flow/paginate.
- 1-item document produced a blank page 2 (`minHeight:297mm` not reset) → fixed.
- Large blank top margin (chrome hidden via `visibility` kept its space) → chrome now `display:none`.

## Test Plan
- [x] `npx vitest run src/pages/sales/components/__tests__/SalesOrderPrintDialog.test.tsx` — 3/3 pass
- [x] Manual: Sales Order print — only document, no chrome, no blank page/margin
- [x] Manual: Invoice print (fulfilled order) — only document
- [x] Manual: Purchase Order print — only document
- [x] Dialogs render normally on screen (print-only rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)