### PR TITLE
fix(sales): block fulfill on overpaid orders

### DIFF
--- a/backend/src/database/entities/sales-order.entity.ts
+++ b/backend/src/database/entities/sales-order.entity.ts
@@ -130,7 +130,10 @@ export class SalesOrder extends BaseEntity {
     return this.status === SalesOrderStatus.FULFILLED ? this.updatedAt : undefined;
   }
 
-  /** @deprecated Use `paymentStatus === PAID || paymentStatus === OVERPAID` instead. */
+  /**
+   * @deprecated Payment truth only. OVERPAID still counts here, but fulfillability
+   * is separate and now requires status === READY.
+   */
   get isPaidInFull(): boolean {
     return (
       this.paymentStatus === SalesOrderPaymentStatus.PAID ||

--- a/backend/src/modules/sales/services/sales-order-fulfillment.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-fulfillment.service.spec.ts
@@ -114,6 +114,16 @@ describe('SalesOrderFulfillmentService', () => {
       await expect(service.fulfillOrder('order-1')).rejects.toThrow(ConflictException);
     });
 
+    it('throws ConflictException when the order is overpaid (DRAFT)', async () => {
+      wireTransaction(
+        mockOrder({
+          status: SalesOrderStatus.DRAFT,
+          paymentStatus: SalesOrderPaymentStatus.OVERPAID,
+        }),
+      );
+      await expect(service.fulfillOrder('order-1')).rejects.toThrow(ConflictException);
+    });
+
     it('lock-reads the order and persists status via the manager', async () => {
       const order = mockOrder({ status: SalesOrderStatus.READY });
       const { findOne, update } = wireTransaction(order);

--- a/backend/src/modules/sales/services/sales-order-fulfillment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-fulfillment.service.ts
@@ -34,7 +34,9 @@ export class SalesOrderFulfillmentService {
         throw new ConflictException('Order is already fulfilled');
       }
       if (order.status !== SalesOrderStatus.READY) {
-        throw new ConflictException('Cannot fulfill order - order must be Ready (paid in full)');
+        throw new ConflictException(
+          'Cannot fulfill order - order must be Ready (paid exactly in full, not over- or under-paid)',
+        );
       }
 
       const offenders = order.items

--- a/backend/src/modules/sales/services/sales-order-payment.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.spec.ts
@@ -173,7 +173,7 @@ describe('SalesOrderPaymentService', () => {
       expect(captured.update.status).toBe(SalesOrderStatus.DRAFT);
     });
 
-    it('promotes DRAFT -> READY and yields OVERPAID when total drops below amount paid', async () => {
+    it('keeps DRAFT and yields OVERPAID when total drops below amount paid', async () => {
       const order = {
         id: 'o2',
         status: SalesOrderStatus.DRAFT,
@@ -186,7 +186,23 @@ describe('SalesOrderPaymentService', () => {
       await service.reconcileOrderState('o2');
 
       expect(captured.update.paymentStatus).toBe(SalesOrderPaymentStatus.OVERPAID);
-      expect(captured.update.status).toBe(SalesOrderStatus.READY);
+      expect(order.status).toBe(SalesOrderStatus.DRAFT);
+    });
+
+    it('demotes READY -> DRAFT + OVERPAID when an extra payment tips into overpayment', async () => {
+      const order = {
+        id: 'o-over',
+        status: SalesOrderStatus.READY,
+        totalAmount: 100,
+        paidAmount: 100,
+      } as SalesOrder;
+      const { manager, captured } = mockTxManager([{ amount: 120 }], order);
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb: any) => cb(manager));
+
+      await service.reconcileOrderState('o-over');
+
+      expect(captured.update.paymentStatus).toBe(SalesOrderPaymentStatus.OVERPAID);
+      expect(captured.update.status).toBe(SalesOrderStatus.DRAFT);
     });
 
     it('reuses a provided transaction manager (no new transaction) and locks the order', async () => {
@@ -735,7 +751,7 @@ describe('SalesOrderPaymentService', () => {
       );
     });
 
-    it('flips DRAFT -> READY on overpayment', async () => {
+    it('keeps DRAFT on overpayment', async () => {
       const order = mockOrder({
         status: SalesOrderStatus.DRAFT,
         totalAmount: 100,
@@ -756,11 +772,9 @@ describe('SalesOrderPaymentService', () => {
 
       expect(update).toHaveBeenCalledWith(
         order.id,
-        expect.objectContaining({
-          status: SalesOrderStatus.READY,
-          paymentStatus: SalesOrderPaymentStatus.OVERPAID,
-        }),
+        expect.objectContaining({ paymentStatus: SalesOrderPaymentStatus.OVERPAID }),
       );
+      expect(order.status).toBe(SalesOrderStatus.DRAFT);
     });
 
     it('flips READY -> DRAFT when a refund drops below full payment', async () => {

--- a/backend/src/modules/sales/services/sales-order-payment.service.ts
+++ b/backend/src/modules/sales/services/sales-order-payment.service.ts
@@ -268,8 +268,8 @@ export class SalesOrderPaymentService {
     const all = await manager.getRepository(SalesOrderPayment).find({ where: { salesOrderId: order.id } });
     const netPaid = all.reduce((sum, r) => sum + Number(r.amount), 0);
     const newStatus = this.computePaymentStatus(all, order.totalAmount);
-    const paidInFull =
-      newStatus === SalesOrderPaymentStatus.PAID || newStatus === SalesOrderPaymentStatus.OVERPAID;
+    // OVERPAID is not fulfillable. Only exact payment (PAID) promotes to READY.
+    const paidInFull = newStatus === SalesOrderPaymentStatus.PAID;
 
     const update: Partial<SalesOrder> = {
       paymentStatus: newStatus,

--- a/frontend/src/pages/sales/SalesOrderDetailPage.tsx
+++ b/frontend/src/pages/sales/SalesOrderDetailPage.tsx
@@ -112,10 +112,12 @@ export default function SalesOrderDetailPage() {
     );
   }
 
+  // Overpaid is treated like PARTIAL: NOT fulfillable (mirrors backend, which
+  // excludes OVERPAID from the paid-in-full band so it never reaches READY).
   const isReadyState =
-    order.status === 'READY' ||
-    (order.status === 'DRAFT' &&
-      (order.paymentStatus === 'PAID' || order.paymentStatus === 'OVERPAID'));
+    order.paymentStatus !== 'OVERPAID' &&
+    (order.status === 'READY' ||
+      (order.status === 'DRAFT' && order.paymentStatus === 'PAID'));
   const stockOffenders = getStockOffenders(
     (order.items ?? []).map((item) => ({
       product: item.product,

--- a/frontend/src/pages/sales/components/__tests__/OrderActionBar.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/OrderActionBar.test.tsx
@@ -78,9 +78,10 @@ describe('OrderActionBar', () => {
     expect(screen.queryByRole('button', { name: 'Unfulfill' })).not.toBeInTheDocument()
   })
 
-  it('Draft+Overpaid shows Fulfill and Refund — no Cancel', () => {
+  it('Draft+Overpaid shows Refund — no Fulfill, no Cancel', () => {
+    // Overpaid is treated like PARTIAL: not fulfillable.
     renderBar(makeOrder({ status: 'DRAFT', paymentStatus: 'OVERPAID' }))
-    expect(screen.getByRole('button', { name: 'Fulfill' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Fulfill' })).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Refund' })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument()
   })

--- a/frontend/src/pages/sales/utils/__tests__/orderActions.test.ts
+++ b/frontend/src/pages/sales/utils/__tests__/orderActions.test.ts
@@ -51,9 +51,20 @@ describe('getOrderActions', () => {
     expect(actions).not.toContain('cancel')
   })
 
-  it('READY + OVERPAID: still fulfill + refund + edit', () => {
+  it('READY + OVERPAID: not fulfillable — refund + edit, no fulfill', () => {
+    // Overpaid is treated like PARTIAL: not fulfillable. Backend demotes such an
+    // order to DRAFT, but the UI must also hide fulfill if a stale READY+OVERPAID
+    // state ever reaches it.
     const actions = getOrderActions(makeOrder('READY', 'OVERPAID'))
-    expect(actions).toContain('fulfill')
+    expect(actions).not.toContain('fulfill')
+    expect(actions).toContain('refund')
+    expect(actions).toContain('edit')
+  })
+
+  it('DRAFT + OVERPAID: not fulfillable — refund + edit, no fulfill, no pay', () => {
+    const actions = getOrderActions(makeOrder('DRAFT', 'OVERPAID'))
+    expect(actions).not.toContain('fulfill')
+    expect(actions).not.toContain('pay')
     expect(actions).toContain('refund')
     expect(actions).toContain('edit')
   })

--- a/frontend/src/pages/sales/utils/orderActions.ts
+++ b/frontend/src/pages/sales/utils/orderActions.ts
@@ -27,8 +27,13 @@ export function getOrderActionMetas(order: SalesOrder): OrderActionMeta[] {
   const isUnpaid = paymentStatus === 'UNPAID'
   const isFullyPaid = paymentStatus === 'PAID' || paymentStatus === 'OVERPAID'
   const needsPayment = isUnpaid || paymentStatus === 'PARTIAL'
+  // Overpaid is treated like PARTIAL: NOT fulfillable. Only an exactly-paid order
+  // is fulfillable. Mirrors backend updatePaymentStatusInTx, which excludes
+  // OVERPAID from the paid-in-full band (so overpaid never reaches READY). Guard
+  // the READY arm too in case a stale READY+OVERPAID state ever reaches the UI.
+  const isOverpaid = paymentStatus === 'OVERPAID'
   // A paid DRAFT is "Ready" even if its status column still reads DRAFT.
-  const isReadyState = isReady || (isDraft && isFullyPaid)
+  const isReadyState = !isOverpaid && (isReady || (isDraft && isFullyPaid))
 
   if (isCancelled) {
     return [{ action: 'uncancel' }, { action: 'print' }]


### PR DESCRIPTION
## Problem

An overpaid sales order was fulfillable. Fulfillment gates on `status === READY`, and the payment reconciler promoted an order to `READY` when it was paid in full **or** overpaid. Overpaid orders should not be fulfillable.

## Fix

Treat **OVERPAID exactly like PARTIAL** — excluded from the "paid in full" band, so it never reaches `READY`.

**Backend** (`6405ac0ba`)
- `updatePaymentStatusInTx`: `paidInFull` now `=== PAID` only. OVERPAID no longer promotes DRAFT→READY and now demotes READY→DRAFT when an order tips into overpayment (identical to PARTIAL).
- Fulfill guard error message reworded for accuracy.
- `isPaidInFull` getter comment clarified — it is payment-semantics (is the money in?), deliberately distinct from fulfillability (the status band).

**Frontend** (`890560767`)
- `orderActions.ts` + `SalesOrderDetailPage.tsx`: `isReadyState` excludes OVERPAID, so the fulfill action is hidden. Guards the stale READY+OVERPAID case too.

## Tests
- Backend: flipped the two specs that asserted OVERPAID→READY; added a READY→DRAFT demotion-on-overpayment case and an overpaid-rejected fulfill case.
- Frontend: flipped READY+OVERPAID (now no fulfill); added DRAFT+OVERPAID case.

## Checks
- `backend`: `npm run test` PASS, `npm run lint` PASS
- `frontend`: `orderActions` 19/19, `SalesOrderDetailPage` 18/18, `type-check` clean, `lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)