### PR TITLE
fix(purchasing): align CANCELLED chip color with sales

### DIFF
--- a/frontend/src/pages/purchasing/components/PurchaseOrderStatusChip.tsx
+++ b/frontend/src/pages/purchasing/components/PurchaseOrderStatusChip.tsx
@@ -2,13 +2,13 @@ import { Chip } from '@mui/material'
 
 import type { PurchaseOrderStatus } from '@/types'
 
-type ChipConfig = { label: string; color: 'warning' | 'success' | 'default' | 'info' | 'error' }
+type ChipConfig = { label: string; color: 'warning' | 'success' | 'default' | 'info' }
 
 const STATUS_CONFIG: Record<PurchaseOrderStatus, ChipConfig> = {
   DRAFT: { label: 'Draft', color: 'warning' },
   READY: { label: 'Ready', color: 'info' },
   RECEIVED: { label: 'Received', color: 'success' },
-  CANCELLED: { label: 'Cancelled', color: 'error' },
+  CANCELLED: { label: 'Cancelled', color: 'default' },
 }
 
 interface Props {


### PR DESCRIPTION
## What

`PurchaseOrderStatusChip` rendered `CANCELLED` as `error` (red); `SalesOrderStatusChip` used `default` (grey). Aligns purchasing to `default` so order status chip colors match across sales and purchasing.

## Why

Cancelled is a terminal/inactive state, not an error — grey is the correct semantic. Red better reserved for true error/danger.

| Status | Before (PO) | After (PO) | Sales |
|--------|-------------|-----------|-------|
| CANCELLED | error (red) | default (grey) | default (grey) |

## Test

- `npm run type-check` clean

## Notes

Surfaced while auditing chip duplication. Broader consolidation tracked in #751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)