### PR TITLE
fix(topbar): show order number in SO/PO breadcrumb on refresh

### DIFF
--- a/frontend/src/components/common/TopBar.tsx
+++ b/frontend/src/components/common/TopBar.tsx
@@ -136,7 +136,7 @@ const NAVIGABLE_PATHS = new Set([
   '/settings/backup',
 ])
 
-type RouteHandle = { title?: string }
+type RouteHandle = { title?: string; breadcrumbParam?: string }
 type MatchShape = { handle?: RouteHandle | null; params?: Record<string, string | undefined> }
 
 interface BreadcrumbSegment {
@@ -147,13 +147,16 @@ interface BreadcrumbSegment {
 
 function buildBreadcrumbs(pathname: string, matches: MatchShape[], leafOverride?: string): BreadcrumbSegment[] {
   const leafMatch = [...matches].reverse().find(match => (match.handle as RouteHandle | undefined)?.title)
-  const leafHandleTitle = (leafMatch?.handle as RouteHandle | undefined)?.title
-  // Order-detail routes (/sales|purchasing/orders/:orderNumber/view) carry the
-  // human order number in the URL param. Use it as a refresh-proof leaf label —
-  // location.state.breadcrumbTitle is lost on reload. No decodeURIComponent:
-  // react-router already decodes params (a second decode throws on values with %).
-  const isOrderDetail = /^\/(sales|purchasing)\/orders\/[^/]+\/view$/.test(pathname)
-  const leafParamTitle = isOrderDetail ? leafMatch?.params?.orderNumber : undefined
+  const leafHandle = leafMatch?.handle as RouteHandle | undefined
+  const leafHandleTitle = leafHandle?.title
+  // Routes that opt in via handle.breadcrumbParam (e.g. order-detail pages) use
+  // the named URL param as a refresh-proof leaf label —
+  // location.state.breadcrumbTitle is lost on reload. The route is the single
+  // source of truth for which param to use. No decodeURIComponent: react-router
+  // already decodes params (a second decode throws on values with %).
+  const leafParamTitle = leafHandle?.breadcrumbParam
+    ? leafMatch?.params?.[leafHandle.breadcrumbParam]
+    : undefined
   const parts = pathname.split('/').filter(Boolean)
   const prefixes = parts.map((_, index) => `/${parts.slice(0, index + 1).join('/')}`)
 

--- a/frontend/src/components/common/TopBar.tsx
+++ b/frontend/src/components/common/TopBar.tsx
@@ -137,7 +137,7 @@ const NAVIGABLE_PATHS = new Set([
 ])
 
 type RouteHandle = { title?: string }
-type MatchShape = { handle?: RouteHandle | null }
+type MatchShape = { handle?: RouteHandle | null; params?: Record<string, string | undefined> }
 
 interface BreadcrumbSegment {
   label: string
@@ -148,12 +148,20 @@ interface BreadcrumbSegment {
 function buildBreadcrumbs(pathname: string, matches: MatchShape[], leafOverride?: string): BreadcrumbSegment[] {
   const leafMatch = [...matches].reverse().find(match => (match.handle as RouteHandle | undefined)?.title)
   const leafHandleTitle = (leafMatch?.handle as RouteHandle | undefined)?.title
+  // Order-detail routes (/sales|purchasing/orders/:orderNumber/view) carry the
+  // human order number in the URL param. Use it as a refresh-proof leaf label —
+  // location.state.breadcrumbTitle is lost on reload. No decodeURIComponent:
+  // react-router already decodes params (a second decode throws on values with %).
+  const isOrderDetail = /^\/(sales|purchasing)\/orders\/[^/]+\/view$/.test(pathname)
+  const leafParamTitle = isOrderDetail ? leafMatch?.params?.orderNumber : undefined
   const parts = pathname.split('/').filter(Boolean)
   const prefixes = parts.map((_, index) => `/${parts.slice(0, index + 1).join('/')}`)
 
   return prefixes.reduce<BreadcrumbSegment[]>((segments, prefix, index) => {
     const isLast = index === prefixes.length - 1
-    const label = isLast ? (leafOverride ?? leafHandleTitle ?? BREADCRUMB_MAP[prefix]) : BREADCRUMB_MAP[prefix]
+    const label = isLast
+      ? (leafOverride ?? leafParamTitle ?? leafHandleTitle ?? BREADCRUMB_MAP[prefix])
+      : BREADCRUMB_MAP[prefix]
     if (!label) return segments
     segments.push({ label, path: prefix, isNavigable: NAVIGABLE_PATHS.has(prefix) && !isLast })
     return segments

--- a/frontend/src/components/common/__tests__/TopBar.test.tsx
+++ b/frontend/src/components/common/__tests__/TopBar.test.tsx
@@ -84,6 +84,33 @@ describe('TopBar breadcrumbs', () => {
     renderTopBar('/settings/inventory-costing')
     expect(screen.getByText('Inventory Costing')).toBeInTheDocument()
   })
+
+  it('shows order number leaf for sales order detail (no location.state)', () => {
+    mockUseMatches.mockReturnValue([
+      { handle: { title: 'Sales Order' }, params: { orderNumber: 'SO-123' } },
+    ])
+    renderTopBar('/sales/orders/SO-123/view')
+    expect(screen.getByText('SO-123')).toBeInTheDocument()
+    expect(screen.queryByText('Sales Order')).not.toBeInTheDocument()
+  })
+
+  it('shows order number leaf for purchase order detail (no location.state)', () => {
+    mockUseMatches.mockReturnValue([
+      { handle: { title: 'Purchase Order' }, params: { orderNumber: 'PO-456' } },
+    ])
+    renderTopBar('/purchasing/orders/PO-456/view')
+    expect(screen.getByText('PO-456')).toBeInTheDocument()
+    expect(screen.queryByText('Purchase Order')).not.toBeInTheDocument()
+  })
+
+  it('location.state.breadcrumbTitle overrides the URL param leaf', () => {
+    mockUseMatches.mockReturnValue([
+      { handle: { title: 'Sales Order' }, params: { orderNumber: 'SO-123' } },
+    ])
+    renderTopBar({ pathname: '/sales/orders/SO-123/view', state: { breadcrumbTitle: 'SO-999' } })
+    expect(screen.getByText('SO-999')).toBeInTheDocument()
+    expect(screen.queryByText('SO-123')).not.toBeInTheDocument()
+  })
 })
 
 describe('TopBar search', () => {

--- a/frontend/src/components/common/__tests__/TopBar.test.tsx
+++ b/frontend/src/components/common/__tests__/TopBar.test.tsx
@@ -90,6 +90,8 @@ describe('TopBar breadcrumbs', () => {
       { handle: { title: 'Sales Order' }, params: { orderNumber: 'SO-123' } },
     ])
     renderTopBar('/sales/orders/SO-123/view')
+    expect(screen.getByText('Sales')).toBeInTheDocument()
+    expect(screen.getByText('Sales Orders')).toBeInTheDocument()
     expect(screen.getByText('SO-123')).toBeInTheDocument()
     expect(screen.queryByText('Sales Order')).not.toBeInTheDocument()
   })
@@ -99,6 +101,8 @@ describe('TopBar breadcrumbs', () => {
       { handle: { title: 'Purchase Order' }, params: { orderNumber: 'PO-456' } },
     ])
     renderTopBar('/purchasing/orders/PO-456/view')
+    expect(screen.getByText('Purchasing')).toBeInTheDocument()
+    expect(screen.getByText('Purchase Orders')).toBeInTheDocument()
     expect(screen.getByText('PO-456')).toBeInTheDocument()
     expect(screen.queryByText('Purchase Order')).not.toBeInTheDocument()
   })

--- a/frontend/src/components/common/__tests__/TopBar.test.tsx
+++ b/frontend/src/components/common/__tests__/TopBar.test.tsx
@@ -87,7 +87,7 @@ describe('TopBar breadcrumbs', () => {
 
   it('shows order number leaf for sales order detail (no location.state)', () => {
     mockUseMatches.mockReturnValue([
-      { handle: { title: 'Sales Order' }, params: { orderNumber: 'SO-123' } },
+      { handle: { title: 'Sales Order', breadcrumbParam: 'orderNumber' }, params: { orderNumber: 'SO-123' } },
     ])
     renderTopBar('/sales/orders/SO-123/view')
     expect(screen.getByText('Sales')).toBeInTheDocument()
@@ -98,7 +98,7 @@ describe('TopBar breadcrumbs', () => {
 
   it('shows order number leaf for purchase order detail (no location.state)', () => {
     mockUseMatches.mockReturnValue([
-      { handle: { title: 'Purchase Order' }, params: { orderNumber: 'PO-456' } },
+      { handle: { title: 'Purchase Order', breadcrumbParam: 'orderNumber' }, params: { orderNumber: 'PO-456' } },
     ])
     renderTopBar('/purchasing/orders/PO-456/view')
     expect(screen.getByText('Purchasing')).toBeInTheDocument()
@@ -109,7 +109,7 @@ describe('TopBar breadcrumbs', () => {
 
   it('location.state.breadcrumbTitle overrides the URL param leaf', () => {
     mockUseMatches.mockReturnValue([
-      { handle: { title: 'Sales Order' }, params: { orderNumber: 'SO-123' } },
+      { handle: { title: 'Sales Order', breadcrumbParam: 'orderNumber' }, params: { orderNumber: 'SO-123' } },
     ])
     renderTopBar({ pathname: '/sales/orders/SO-123/view', state: { breadcrumbTitle: 'SO-999' } })
     expect(screen.getByText('SO-999')).toBeInTheDocument()

--- a/frontend/src/components/common/__tests__/TopBar.test.tsx
+++ b/frontend/src/components/common/__tests__/TopBar.test.tsx
@@ -38,10 +38,12 @@ function makeStore(unreadCount = 0) {
   })
 }
 
-function renderTopBar(path: string, collapsed = false) {
+type RouterEntry = string | { pathname: string; state?: unknown }
+
+function renderTopBar(entry: RouterEntry, collapsed = false) {
   return render(
     <Provider store={makeStore()}>
-      <MemoryRouter initialEntries={[path]}>
+      <MemoryRouter initialEntries={[entry]}>
         <TopBar collapsed={collapsed} onMobileMenuOpen={vi.fn()} />
       </MemoryRouter>
     </Provider>

--- a/frontend/src/pages/purchasing/purchasing.routes.tsx
+++ b/frontend/src/pages/purchasing/purchasing.routes.tsx
@@ -20,7 +20,7 @@ export const purchasingRoutes: RouteObject[] = [
   { path: '/purchasing/suppliers/:slug/view', element: <SupplierProfilePage />, handle: { title: 'Supplier Profile' } },
   { path: '/purchasing/orders', element: <PurchaseOrdersPage />, handle: { title: 'Purchase Orders' } },
   { path: '/purchasing/orders/create', element: <CreatePurchaseOrderPage />, handle: { title: 'Create Purchase Order' } },
-  { path: '/purchasing/orders/:orderNumber/view', element: <PurchaseOrderDetailPage />, handle: { title: 'Purchase Order' } },
+  { path: '/purchasing/orders/:orderNumber/view', element: <PurchaseOrderDetailPage />, handle: { title: 'Purchase Order', breadcrumbParam: 'orderNumber' } },
   { path: '/purchasing/orders/:orderNumber/edit', element: <CreatePurchaseOrderPage />, handle: { title: 'Edit Purchase Order' } },
   { path: '/reports/purchasing/order-summary', element: <PurchaseOrderSummary />, handle: { title: 'Purchase Order Summary' } },
   { path: '/reports/purchasing/order-status', element: <PurchaseOrderStatusReport />, handle: { title: 'Purchase Order Status' } },

--- a/frontend/src/pages/sales/sales.routes.tsx
+++ b/frontend/src/pages/sales/sales.routes.tsx
@@ -27,7 +27,7 @@ export const salesRoutes: RouteObject[] = [
   { path: '/sales/orders', element: <OrdersPage />, handle: { title: 'Sales Orders' } },
   { path: '/sales/orders/create', element: <CreateSalesOrderPage />, handle: { title: 'Create Sales Order' } },
   { path: '/sales/orders/:orderNumber/edit', element: <CreateSalesOrderPage />, handle: { title: 'Edit Sales Order' } },
-  { path: '/sales/orders/:orderNumber/view', element: <SalesOrderDetailPage />, handle: { title: 'Sales Order' } },
+  { path: '/sales/orders/:orderNumber/view', element: <SalesOrderDetailPage />, handle: { title: 'Sales Order', breadcrumbParam: 'orderNumber' } },
   { path: '/reports/sales/product-summary', element: <SalesByProductSummary />, handle: { title: 'Sales by Product Summary' } },
   { path: '/reports/sales/product-details', element: <SalesByProductDetails />, handle: { title: 'Sales by Product Details' } },
   { path: '/reports/sales/order-summary', element: <SalesOrderSummary />, handle: { title: 'Sales Order Summary' } },


### PR DESCRIPTION
## Problem

Opening a Sales Order or Purchase Order detail page, the breadcrumb leaf showed the generic route title — `Sales Order` / `Purchase Order` — instead of the order number, on refresh / direct load / bookmark / shared link.

```
Sales > Sales Orders > Sales Order        (before)
Sales > Sales Orders > SO-123             (after)
```

## Root cause

The leaf label relied on `location.state.breadcrumbTitle`, set via a `navigate(..., { state })` in each detail page. `location.state` is ephemeral — cleared on reload — so the leaf fell through to the route `handle.title`.

## Fix

`buildBreadcrumbs` in `TopBar.tsx` now derives a refresh-proof leaf label from a named URL param. Routes opt in via `handle.breadcrumbParam`:

- `/sales/orders/:orderNumber/view` and `/purchasing/orders/:orderNumber/view` set `breadcrumbParam: 'orderNumber'`.
- Leaf priority: `leafOverride ?? leafParamTitle ?? leafHandleTitle ?? BREADCRUMB_MAP[prefix]`.
- The route is the single source of truth for which param feeds the breadcrumb — no hardcoded path matching in `TopBar`.
- No `decodeURIComponent`: React Router already decodes params (a second decode throws on values containing `%`).

Detail pages are untouched — the existing `location.state` override stays as the in-app fast path; the URL param is the refresh-proof fallback.

## Tests

`TopBar.test.tsx`:
- `renderTopBar` helper accepts a router entry object so `location.state` can be set.
- SO and PO order-detail leaf shows the order number (no state) + parent crumbs render.
- `location.state.breadcrumbTitle` still overrides the param leaf.

16/16 pass, type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)