### PR TITLE
fix: navigate to detail on list row click (#756)

### DIFF
--- a/frontend/src/pages/purchasing/components/SupplierList.tsx
+++ b/frontend/src/pages/purchasing/components/SupplierList.tsx
@@ -75,7 +75,7 @@ export default function SupplierList({
       headers={['Company Name', 'Contact Person', 'Type', 'Status', 'Actions']}
       selectedId={undefined}
       focusedIndex={-1}
-      onSelect={() => {}}
+      onSelect={(supplier) => navigate(`/purchasing/suppliers/${supplier.slug}/view`)}
       listRef={{ current: null }}
       dataAttr="supplier"
       paginationSlot={paginationSlot}

--- a/frontend/src/pages/purchasing/components/__tests__/SupplierList.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/SupplierList.test.tsx
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { Supplier } from '@/types'
+
 import SupplierList from '../SupplierList'
 
 const navigateMock = vi.fn()
@@ -15,20 +17,25 @@ beforeEach(() => {
   navigateMock.mockClear()
 })
 
-const baseSupplier = {
+const baseSupplier: Supplier = {
   id: 'sup-1',
   slug: 'globex',
-  companyName: 'Globex',
-  contactPerson: 'Hank Scorpio',
   type: 'local',
+  companyName: 'Globex',
   isActive: true,
+  contactPerson: 'Hank Scorpio',
+  totalPurchases: 0,
+  totalOrders: 0,
+  averageOrderValue: 0,
+  createdAt: '2026-01-01',
+  updatedAt: '2026-01-01',
 }
 
-function renderList(suppliers = [baseSupplier]) {
+function renderList(suppliers: Supplier[] = [baseSupplier]) {
   return render(
     <MemoryRouter>
       <SupplierList
-        suppliers={suppliers as any}
+        suppliers={suppliers}
         loading={false}
         total={suppliers.length}
         onStatusToggle={vi.fn()}
@@ -36,6 +43,52 @@ function renderList(suppliers = [baseSupplier]) {
     </MemoryRouter>,
   )
 }
+
+describe('SupplierList columns', () => {
+  it('renders column headers', () => {
+    renderList()
+    expect(screen.getByText('Company Name')).toBeInTheDocument()
+    expect(screen.getByText('Contact Person')).toBeInTheDocument()
+    expect(screen.getByText('Type')).toBeInTheDocument()
+    expect(screen.getByText('Status')).toBeInTheDocument()
+    expect(screen.getByText('Actions')).toBeInTheDocument()
+  })
+
+  it('renders company name', () => {
+    renderList()
+    expect(screen.getByText('Globex')).toBeInTheDocument()
+  })
+
+  it('renders contact person', () => {
+    renderList()
+    expect(screen.getByText('Hank Scorpio')).toBeInTheDocument()
+  })
+
+  it('renders - when contact person is not set', () => {
+    renderList([{ ...baseSupplier, contactPerson: null }])
+    expect(screen.getByText('-')).toBeInTheDocument()
+  })
+
+  it('renders Local for local type', () => {
+    renderList()
+    expect(screen.getByText('Local')).toBeInTheDocument()
+  })
+
+  it('renders International for international type', () => {
+    renderList([{ ...baseSupplier, type: 'international' }])
+    expect(screen.getByText('International')).toBeInTheDocument()
+  })
+
+  it('renders Active chip for active supplier', () => {
+    renderList()
+    expect(screen.getByText('Active')).toBeInTheDocument()
+  })
+
+  it('renders Inactive chip for inactive supplier', () => {
+    renderList([{ ...baseSupplier, isActive: false }])
+    expect(screen.getByText('Inactive')).toBeInTheDocument()
+  })
+})
 
 describe('SupplierList row click', () => {
   it('navigates to the supplier detail page when a row is clicked', async () => {

--- a/frontend/src/pages/purchasing/components/__tests__/SupplierList.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/SupplierList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -66,7 +66,9 @@ describe('SupplierList columns', () => {
 
   it('renders - when contact person is not set', () => {
     renderList([{ ...baseSupplier, contactPerson: null }])
-    expect(screen.getByText('-')).toBeInTheDocument()
+    const row = screen.getByText('Globex').closest('tr') as HTMLElement
+    expect(within(row).getByText('-')).toBeInTheDocument()
+    expect(within(row).queryByText('Hank Scorpio')).not.toBeInTheDocument()
   })
 
   it('renders Local for local type', () => {

--- a/frontend/src/pages/purchasing/components/__tests__/SupplierList.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/SupplierList.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import SupplierList from '../SupplierList'
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+beforeEach(() => {
+  navigateMock.mockClear()
+})
+
+const baseSupplier = {
+  id: 'sup-1',
+  slug: 'globex',
+  companyName: 'Globex',
+  contactPerson: 'Hank Scorpio',
+  type: 'local',
+  isActive: true,
+}
+
+function renderList(suppliers = [baseSupplier]) {
+  return render(
+    <MemoryRouter>
+      <SupplierList
+        suppliers={suppliers as any}
+        loading={false}
+        total={suppliers.length}
+        onStatusToggle={vi.fn()}
+      />
+    </MemoryRouter>,
+  )
+}
+
+describe('SupplierList row click', () => {
+  it('navigates to the supplier detail page when a row is clicked', async () => {
+    renderList()
+    await userEvent.click(screen.getByText('Globex'))
+    expect(navigateMock).toHaveBeenCalledWith('/purchasing/suppliers/globex/view')
+  })
+})

--- a/frontend/src/pages/sales/__tests__/OrdersPage.rowclick.test.tsx
+++ b/frontend/src/pages/sales/__tests__/OrdersPage.rowclick.test.tsx
@@ -5,21 +5,22 @@ import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { SalesOrder } from '@/types'
 import salesReducer from '@/store/slices/salesSlice'
 
 import OrdersPage from '../OrdersPage'
 
-const order = {
+const order: SalesOrder = {
   id: 'ord-1',
   orderNumber: 'SO-26-001',
   status: 'DRAFT',
   paymentStatus: 'UNPAID',
   customerId: 'cust-1',
-  customer: { id: 'cust-1', name: 'Amuro Ray' },
+  customer: { id: 'cust-1', name: 'Amuro Ray' } as any,
   totalAmount: 1000,
-  orderDate: '2026-01-15',
-  createdAt: '2026-01-15',
-  updatedAt: '2026-01-15',
+  orderDate: new Date('2026-01-15'),
+  createdAt: new Date('2026-01-15'),
+  updatedAt: new Date('2026-01-15'),
 }
 
 vi.mock('@/store/api/salesApi', () => ({

--- a/frontend/src/pages/sales/__tests__/OrdersPage.rowclick.test.tsx
+++ b/frontend/src/pages/sales/__tests__/OrdersPage.rowclick.test.tsx
@@ -1,0 +1,79 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import salesReducer from '@/store/slices/salesSlice'
+
+import OrdersPage from '../OrdersPage'
+
+const order = {
+  id: 'ord-1',
+  orderNumber: 'SO-26-001',
+  status: 'DRAFT',
+  paymentStatus: 'UNPAID',
+  customerId: 'cust-1',
+  customer: { id: 'cust-1', name: 'Amuro Ray' },
+  totalAmount: 1000,
+  orderDate: '2026-01-15',
+  createdAt: '2026-01-15',
+  updatedAt: '2026-01-15',
+}
+
+vi.mock('@/store/api/salesApi', () => ({
+  useGetSalesOrdersQuery: vi.fn(() => ({
+    data: { data: [order], meta: { total: 1 } },
+    isFetching: false,
+    error: undefined,
+  })),
+  useGetCustomersQuery: vi.fn(() => ({
+    data: { data: [{ id: 'cust-1', name: 'Amuro Ray' }] },
+  })),
+  useFulfillSalesOrderMutation: vi.fn(() => [vi.fn()]),
+  useUnfulfillSalesOrderMutation: vi.fn(() => [vi.fn()]),
+  useCancelSalesOrderMutation: vi.fn(() => [vi.fn()]),
+  useRecordOrderPaymentsMutation: vi.fn(() => [vi.fn()]),
+  useRecordOrderRefundsMutation: vi.fn(() => [vi.fn()]),
+  useUncancelSalesOrderMutation: vi.fn(() => [vi.fn()]),
+  useDuplicateSalesOrderMutation: vi.fn(() => [vi.fn()]),
+}))
+
+vi.mock('@/hooks/useNotification', () => ({
+  useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
+}))
+
+vi.mock('../components/SalesOrdersDialogs', () => ({
+  default: () => null,
+}))
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+function renderPage() {
+  const store = configureStore({ reducer: { sales: salesReducer } })
+
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/']}>
+        <OrdersPage />
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('OrdersPage row click navigation', () => {
+  beforeEach(() => {
+    navigateMock.mockClear()
+  })
+
+  it('navigates to the order detail page when a Sales Order row is clicked', async () => {
+    renderPage()
+    await userEvent.click(screen.getByText('SO-26-001'))
+    expect(navigateMock).toHaveBeenCalledWith('/sales/orders/SO-26-001/view')
+  })
+})

--- a/frontend/src/pages/sales/__tests__/OrdersPage.rowclick.test.tsx
+++ b/frontend/src/pages/sales/__tests__/OrdersPage.rowclick.test.tsx
@@ -5,8 +5,8 @@ import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { SalesOrder } from '@/types'
 import salesReducer from '@/store/slices/salesSlice'
+import type { SalesOrder } from '@/types'
 
 import OrdersPage from '../OrdersPage'
 

--- a/frontend/src/pages/sales/components/CustomerList.tsx
+++ b/frontend/src/pages/sales/components/CustomerList.tsx
@@ -73,7 +73,7 @@ export default function CustomerList({
       headers={['Name', 'Phone', 'Type', 'Price List', 'Status', 'Actions']}
       selectedId={undefined}
       focusedIndex={-1}
-      onSelect={() => {}}
+      onSelect={(customer) => navigate(`/sales/customers/${customer.slug}/view`)}
       listRef={{ current: null }}
       dataAttr="customer"
       paginationSlot={paginationSlot}

--- a/frontend/src/pages/sales/components/SalesOrderList.tsx
+++ b/frontend/src/pages/sales/components/SalesOrderList.tsx
@@ -120,7 +120,7 @@ export default function SalesOrderList(props: SalesOrderListProps) {
       headers={['Order #', 'Customer', 'Date', 'Total', 'Status', 'Payment', 'Actions']}
       selectedId={undefined}
       focusedIndex={-1}
-      onSelect={() => {}}
+      onSelect={props.onView}
       listRef={{ current: null }}
       dataAttr="order"
       paginationSlot={paginationSlot}

--- a/frontend/src/pages/sales/components/__tests__/CustomerList.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/CustomerList.test.tsx
@@ -1,14 +1,20 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CustomerType } from '@/types'
 
 import CustomerList from '../CustomerList'
 
+const navigateMock = vi.fn()
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-router-dom')>()
-  return { ...actual, useNavigate: () => vi.fn() }
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+beforeEach(() => {
+  navigateMock.mockClear()
 })
 
 const baseCustomer = {
@@ -114,5 +120,13 @@ describe('CustomerList columns', () => {
   it('renders Inactive chip for inactive customer', () => {
     renderList([{ ...baseCustomer, isActive: false }])
     expect(screen.getByText('Inactive')).toBeInTheDocument()
+  })
+})
+
+describe('CustomerList row click', () => {
+  it('navigates to the customer detail page when a row is clicked', async () => {
+    renderList()
+    await userEvent.click(screen.getByText('Acme Corp'))
+    expect(navigateMock).toHaveBeenCalledWith('/sales/customers/acme-corp/view')
   })
 })

--- a/frontend/src/pages/sales/components/__tests__/SalesOrderList.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/SalesOrderList.test.tsx
@@ -81,6 +81,15 @@ describe('SalesOrderList columns', () => {
   })
 })
 
+describe('SalesOrderList row click', () => {
+  it('calls onView when a row is clicked', async () => {
+    const onView = vi.fn()
+    renderList({ ...defaultProps, onView })
+    await userEvent.click(screen.getByText('SO-26-001'))
+    expect(onView).toHaveBeenCalledWith(expect.objectContaining({ orderNumber: 'SO-26-001' }))
+  })
+})
+
 describe('SalesOrderList empty state', () => {
   it('shows empty message when no orders', () => {
     renderList({ ...defaultProps, orders: [], total: 0 })


### PR DESCRIPTION
## Summary

Clicking a row on the Sales Order, Customer, and Supplier list pages did nothing — each passed a no-op `onSelect={() => {}}` to `EntityTable`, so row clicks fired nothing. Now each row click navigates to that record's detail page, matching the list's existing "View" action.

Issue #756 reported Sales Order; Customer and Supplier had the identical root pattern and are fixed in the same PR.

| List | Destination | Fix shape |
|------|-------------|-----------|
| Sales Order | `/sales/orders/:orderNumber/view` | forwards existing `onView` prop |
| Customer | `/sales/customers/:slug/view` | inline `navigate` |
| Supplier | `/purchasing/suppliers/:slug/view` | inline `navigate` |

Purchase Order list already navigated correctly and is the reference pattern (untouched).

## Tests

- **`SalesOrderList.test.tsx`** — row click calls `onView` with the order.
- **`OrdersPage.rowclick.test.tsx`** (new) — integration test: real `OrdersPage` + real `SalesOrderList`, row click navigates to the actual URL `/sales/orders/SO-26-001/view` (covers the page-level wiring, not just the prop).
- **`CustomerList.test.tsx`** — mock changed to a shared spy so navigation is assertable; row click navigates to `/sales/customers/acme-corp/view`.
- **`SupplierList.test.tsx`** (new) — row-click navigation plus column-render coverage (headers, company, contact-person fallback, type, status), matching the CustomerList sibling. `baseSupplier` fully typed as `Supplier`.

## Verification

`cd frontend && npm run lint && npm run type-check && npm run test` — all green.

- lint: 0 warnings
- type-check: clean
- full suite: **1299 tests / 176 files pass**

Closes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)