### PR TITLE
fix(po): remove sales-only stock warnings from purchase order form

### DIFF
--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -46,8 +46,6 @@ import {
   updatePurchaseOrderInPlace,
 } from '@/store/slices/purchasingSlice'
 import { formatCurrency, getCurrentDate } from '@/utils/formatters'
-import { getStockOffenders } from '@/utils/stockStatus'
-import StockIndicatorChip from '@/pages/sales/components/StockIndicatorChip'
 
 interface PurchaseOrderItem {
   productId: string
@@ -197,12 +195,6 @@ const CreatePurchaseOrderPage: React.FC = () => {
   const subtotal = watchedItems.reduce((sum, item) => sum + (Number(item.totalPrice) || 0), 0)
   const shippingAmt = Number(watchedShipping) || 0
   const totals = { subtotal, shipping: shippingAmt, total: subtotal + shippingAmt }
-  const stockOffenders = getStockOffenders(
-    (watchedItems ?? []).map((item) => ({
-      product: item.product,
-      quantity: Number(item.quantity ?? 0),
-    })),
-  )
 
   useEffect(() => {
     loadProducts()
@@ -491,15 +483,6 @@ const CreatePurchaseOrderPage: React.FC = () => {
                   Line Items
                 </Typography>
 
-                {stockOffenders.length > 0 && (
-                  <Alert severity="warning" sx={{ mb: 2 }}>
-                    {`${stockOffenders.length} item(s) out of stock: `}
-                    {stockOffenders
-                      .map((o) => `${o.name} (Qty: ${o.quantity}, Stock: ${o.stock})`)
-                      .join(', ')}
-                  </Alert>
-                )}
-
                 <TableContainer
                   component={Paper}
                   sx={{ border: `1px solid ${theme.palette.divider}` }}
@@ -753,49 +736,39 @@ function LineItemRow({
           name={`items.${index}.productId`}
           control={control}
           render={({ field }) => (
-            <>
-              <Autocomplete
-                options={products}
-                getOptionLabel={(option) => option?.name || ''}
-                isOptionEqualToValue={(option, value) => option.id === value.id}
-                value={watchedItem?.product || products.find((p) => p.id === field.value) || null}
-                onChange={(_, value) => onProductSelect(index, value)}
-                onInputChange={(_, value, reason) => {
-                  if (reason === 'input') loadProducts(value.trim().length >= 1 ? value : '')
-                }}
-                filterOptions={(options) => options}
-                size="small"
-                disabled={isSaving}
-                onKeyDown={getKeyHandler(index, 0)}
-                renderInput={(params) => (
-                  <TextField
-                    {...params}
-                    placeholder="Search by name or barcode..."
-                    variant="outlined"
-                    error={!!errors.items?.[index]?.productId}
-                    helperText={errors.items?.[index]?.productId?.message}
-                    sx={{
-                      '& .MuiInputBase-input': {
-                        textAlign: 'left !important',
-                        padding: '6px 8px !important',
-                        fontSize: '0.875rem',
-                      },
-                    }}
-                  />
-                )}
-                slotProps={{
-                  paper: { sx: { '& .MuiAutocomplete-option': { fontSize: '0.875rem' } } },
-                }}
-              />
-              {watchedItem?.product && (
-                <Box sx={{ mt: 0.5 }}>
-                  <StockIndicatorChip
-                    stockQuantity={Number(watchedItem.product.stockQuantity ?? 0)}
-                    quantity={Number(watchedItem.quantity ?? 0)}
-                  />
-                </Box>
+            <Autocomplete
+              options={products}
+              getOptionLabel={(option) => option?.name || ''}
+              isOptionEqualToValue={(option, value) => option.id === value.id}
+              value={watchedItem?.product || products.find((p) => p.id === field.value) || null}
+              onChange={(_, value) => onProductSelect(index, value)}
+              onInputChange={(_, value, reason) => {
+                if (reason === 'input') loadProducts(value.trim().length >= 1 ? value : '')
+              }}
+              filterOptions={(options) => options}
+              size="small"
+              disabled={isSaving}
+              onKeyDown={getKeyHandler(index, 0)}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  placeholder="Search by name or barcode..."
+                  variant="outlined"
+                  error={!!errors.items?.[index]?.productId}
+                  helperText={errors.items?.[index]?.productId?.message}
+                  sx={{
+                    '& .MuiInputBase-input': {
+                      textAlign: 'left !important',
+                      padding: '6px 8px !important',
+                      fontSize: '0.875rem',
+                    },
+                  }}
+                />
               )}
-            </>
+              slotProps={{
+                paper: { sx: { '& .MuiAutocomplete-option': { fontSize: '0.875rem' } } },
+              }}
+            />
           )}
         />
       </TableCell>

--- a/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
@@ -443,4 +443,35 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
   // PO-local version could not be made non-vacuous here without a real store
   // re-render trigger, so it is intentionally omitted rather than left as a
   // false-passing test.
+
+  it('does not show stock warnings when ordered quantity exceeds stock (purchasing, not selling)', async () => {
+    // Default create-mode mocks are set in beforeEach. Override the product
+    // search to return a low-stock product so the (removed) warning code path
+    // would otherwise fire.
+    mockGet.mockImplementation(async (_url: string) => ({
+      data: [{ id: 'product-1', name: 'Alpha Widget', baseCost: 11, stockQuantity: 4 }],
+    }))
+
+    render(
+      <BrowserRouter>
+        <CreatePurchaseOrderPage />
+      </BrowserRouter>
+    )
+
+    const productInput = screen.getByPlaceholderText('Search by name or barcode...')
+    fireEvent.mouseDown(productInput)
+    fireEvent.change(productInput, { target: { value: 'Alpha' } })
+
+    const listbox = await screen.findByRole('listbox')
+    fireEvent.click(within(listbox).getByText('Alpha Widget'))
+
+    // Set the line-item quantity to 20 (above stock of 4).
+    const qtyInput = await screen.findByDisplayValue('1')
+    fireEvent.change(qtyInput, { target: { value: '20' } })
+
+    // Page-level "N item(s) out of stock: ..." Alert must not render.
+    expect(screen.queryByText(/out of stock/i)).not.toBeInTheDocument()
+    // Per-line StockIndicatorChip "Only 4 left (need 20)" must not render.
+    expect(screen.queryByText(/left \(need/i)).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary
- Remove the wrong "N item(s) out of stock" warning Alert and per-line "Only N left (need M)" `StockIndicatorChip` from the create/edit purchase order page. Ordering above current stock is normal for purchasing — these warnings were copied from the sales order pages, where the stock constraint is real.
- Drop the now-unused `getStockOffenders` / `StockIndicatorChip` imports and `stockOffenders` computation. Unwrap the now-single-child fragment in the product `Controller` render.
- Add a regression test asserting both warning forms stay absent when ordered quantity exceeds stock.

Same component serves both `/purchasing/orders/create` and `/purchasing/orders/:orderNumber/edit`, so this fixes both flows.

## Test Plan
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean (0 warnings)
- [x] New regression test fails on old code (RED), passes after removal (GREEN)
- [x] `CreatePurchaseOrderPage.test.tsx` — 11/11 pass
- [x] Full frontend suite — 1304 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)