### PR TITLE
fix(orders): default order lists to sort by order number descending

### DIFF
--- a/backend/src/modules/purchasing/dto/purchase-order.dto.ts
+++ b/backend/src/modules/purchasing/dto/purchase-order.dto.ts
@@ -134,10 +134,10 @@ export class PurchaseOrderQueryDto extends BaseQueryDto {
   @IsIn(['UNPAID', 'PARTIAL', 'PAID', 'OVERPAID'])
   paymentStatus?: PurchaseOrderPaymentStatus;
 
-  @ApiPropertyOptional({ description: 'Sort by field', default: 'orderDate' })
+  @ApiPropertyOptional({ description: 'Sort by field', default: 'orderNumber' })
   @IsOptional()
   @IsString()
-  sortBy?: string = 'orderDate';
+  sortBy?: string = 'orderNumber';
 
   @ApiPropertyOptional({ description: 'Sort order', enum: ['ASC', 'DESC'], default: 'DESC' })
   @IsOptional()

--- a/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
@@ -449,6 +449,17 @@ describe('PurchaseOrderService', () => {
         expect(order.status).toBe(PurchaseOrderStatus.RECEIVED);
       });
     });
+
+    it('defaults to ordering by orderNumber DESC when no sort is supplied', async () => {
+      const queryBuilder = createFindAllQueryBuilder([createFindAllOrder()]);
+      purchaseOrderRepository.createQueryBuilder.mockReturnValue(queryBuilder as any);
+
+      await service.findAll({});
+
+      expect(queryBuilder.orderBy).toHaveBeenCalledWith('po.orderNumber', 'DESC');
+      // sortField === 'orderNumber' so the secondary orderNumber tiebreaker is skipped
+      expect(queryBuilder.addOrderBy).not.toHaveBeenCalled();
+    });
   });
 
 

--- a/backend/src/modules/purchasing/services/purchase-order.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.ts
@@ -154,7 +154,7 @@ export class PurchaseOrderService extends BaseCrudService<
   private applyListOrdering(
     queryBuilder: any,
     query: PurchaseOrderQueryDto,
-    defaultSortField: 'orderDate' | 'deletedAt',
+    defaultSortField: 'orderNumber' | 'orderDate' | 'deletedAt',
     options: { addSecondaryOrderNumber: boolean },
   ) {
     const sortField = this.allowedSortFields.includes(query.sortBy ?? '')
@@ -370,7 +370,7 @@ export class PurchaseOrderService extends BaseCrudService<
     const skip = limit ? (page - 1) * limit : 0;
     const queryBuilder = this.buildPurchaseOrderListQuery(query, { includeDeleted: false });
 
-    this.applyListOrdering(queryBuilder, query, 'orderDate', { addSecondaryOrderNumber: true });
+    this.applyListOrdering(queryBuilder, query, 'orderNumber', { addSecondaryOrderNumber: true });
 
     const total = await queryBuilder.getCount();
 

--- a/backend/src/modules/sales/services/sales-order-query.service.spec.ts
+++ b/backend/src/modules/sales/services/sales-order-query.service.spec.ts
@@ -182,6 +182,17 @@ describe('SalesOrderQueryService', () => {
       expect(qb.addOrderBy).not.toHaveBeenCalled();
     });
 
+    it('defaults to ordering by orderNumber DESC when no sort is supplied', async () => {
+      const { qb } = buildQbMock();
+      salesOrderRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.findAll({} as any);
+
+      expect(qb.orderBy).toHaveBeenCalledWith('order.orderNumber', 'DESC');
+      // orderNumber is unique, so no secondary tiebreaker is added
+      expect(qb.addOrderBy).not.toHaveBeenCalled();
+    });
+
     it('applies a paymentStatus param independently of READY', async () => {
       const { qb, andWhereCalls } = buildQbMock();
       salesOrderRepository.createQueryBuilder.mockReturnValue(qb);

--- a/backend/src/modules/sales/services/sales-order-query.service.ts
+++ b/backend/src/modules/sales/services/sales-order-query.service.ts
@@ -34,7 +34,7 @@ export class SalesOrderQueryService {
       paymentStatus,
       status,
       sortBy = 'orderNumber',
-      sortOrder = 'ASC',
+      sortOrder = 'DESC',
       page = 1,
       limit = 1000,
     } = query;

--- a/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
@@ -72,7 +72,7 @@ const PurchaseOrdersPage: React.FC = () => {
   const searchInputRef = useRef<HTMLInputElement | null>(null)
 
   const [sortBy, setSortBy] = useState('orderNumber')
-  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
   const [page, setPage] = useState(1)
   const [limit, setLimit] = useState(DEFAULT_LIMIT)
   const [printOrder, setPrintOrder] = useState<PurchaseOrder | null>(null)

--- a/frontend/src/pages/purchasing/__tests__/PurchaseOrdersPage.filterbar.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/PurchaseOrdersPage.filterbar.test.tsx
@@ -79,7 +79,7 @@ describe('PurchaseOrdersPage FilterBar integration', () => {
         status: 'READY',
         paymentStatus: 'PAID',
         sortBy: 'orderNumber',
-        sortOrder: 'ASC',
+        sortOrder: 'DESC',
         page: 1,
         limit: 25,
       }),

--- a/frontend/src/pages/sales/OrdersPage.tsx
+++ b/frontend/src/pages/sales/OrdersPage.tsx
@@ -55,7 +55,7 @@ const OrdersPage: React.FC = () => {
   const { showSuccess, showError } = useNotification()
   const searchInputRef = useRef<HTMLInputElement | null>(null)
 
-  const [sortBy, setSortBy] = useState('orderDate')
+  const [sortBy, setSortBy] = useState('orderNumber')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
   const [page, setPage] = useState(1)
   const [limit, setLimit] = useState(DEFAULT_LIMIT)
@@ -204,7 +204,7 @@ const OrdersPage: React.FC = () => {
         handlers={handlers}
         hasActiveFilters={hasActiveFilters}
         searchInputRef={searchInputRef}
-        sort={{ field: 'orderDate', sortBy, sortOrder, onSort: handleSort }}
+        sort={{ field: 'orderNumber', sortBy, sortOrder, onSort: handleSort }}
         isFetching={isFetching}
         error={error ? 'Failed to load sales orders.' : null}
         tableSlot={(

--- a/frontend/src/pages/sales/__tests__/OrdersPage.sort.test.tsx
+++ b/frontend/src/pages/sales/__tests__/OrdersPage.sort.test.tsx
@@ -12,7 +12,7 @@ import OrdersPage from '../OrdersPage'
 const simpleListPageSpy = vi.fn()
 
 vi.mock('@/store/api/salesApi', () => ({
-  useGetSalesOrdersQuery: vi.fn(() => ({ data: undefined, isFetching: false, error: undefined })),
+  useGetSalesOrdersQuery: vi.fn(() => ({ data: { data: [], meta: { total: 0 } }, isFetching: false, error: undefined })),
   useGetCustomersQuery: vi.fn(() => ({ data: undefined, isFetching: false })),
   useFulfillSalesOrderMutation: vi.fn(() => [vi.fn()]),
   useUnfulfillSalesOrderMutation: vi.fn(() => [vi.fn()]),

--- a/frontend/src/pages/sales/__tests__/OrdersPage.sort.test.tsx
+++ b/frontend/src/pages/sales/__tests__/OrdersPage.sort.test.tsx
@@ -1,0 +1,70 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { render } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import salesReducer from '@/store/slices/salesSlice'
+import { useGetSalesOrdersQuery } from '@/store/api/salesApi'
+
+import OrdersPage from '../OrdersPage'
+
+const simpleListPageSpy = vi.fn()
+
+vi.mock('@/store/api/salesApi', () => ({
+  useGetSalesOrdersQuery: vi.fn(() => ({ data: undefined, isFetching: false, error: undefined })),
+  useGetCustomersQuery: vi.fn(() => ({ data: undefined, isFetching: false })),
+  useFulfillSalesOrderMutation: vi.fn(() => [vi.fn()]),
+  useUnfulfillSalesOrderMutation: vi.fn(() => [vi.fn()]),
+  useCancelSalesOrderMutation: vi.fn(() => [vi.fn()]),
+  useRecordOrderPaymentsMutation: vi.fn(() => [vi.fn()]),
+  useRecordOrderRefundsMutation: vi.fn(() => [vi.fn()]),
+  useUncancelSalesOrderMutation: vi.fn(() => [vi.fn()]),
+  useDuplicateSalesOrderMutation: vi.fn(() => [vi.fn()]),
+}))
+
+vi.mock('@/components/common/SimpleListPage', () => ({
+  default: (props: { sort?: { field?: string } }) => {
+    simpleListPageSpy(props)
+    return null
+  },
+}))
+
+vi.mock('@/hooks/useNotification', () => ({
+  useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
+}))
+
+vi.mock('../components/SalesOrdersDialogs', () => ({
+  default: () => null,
+}))
+
+function renderPage() {
+  const store = configureStore({ reducer: { sales: salesReducer } })
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <OrdersPage />
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('OrdersPage default sort', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('requests orders sorted by orderNumber DESC by default', () => {
+    renderPage()
+
+    const firstCallArg = vi.mocked(useGetSalesOrdersQuery).mock.calls[0][0]
+    expect(firstCallArg).toMatchObject({ sortBy: 'orderNumber', sortOrder: 'DESC' })
+  })
+
+  it('passes sort.field=orderNumber to the list page so the column highlights', () => {
+    renderPage()
+
+    const listProps = simpleListPageSpy.mock.calls.at(-1)?.[0] as { sort?: { field?: string } }
+    expect(listProps.sort?.field).toBe('orderNumber')
+  })
+})


### PR DESCRIPTION
## Summary

Both the Sales Orders and Purchase Orders list pages now default-sort by `orderNumber` descending — the biggest (newest) order number appears on top. Previously the two pages disagreed: Sales defaulted to `orderDate desc` and Purchase to `orderNumber asc`.

## Changes

**Backend**
- `sales-order-query.service.ts` — `findAll` default `sortOrder` `ASC` → `DESC` (list path only).
- `purchase-order.dto.ts` — default `sortBy` `orderDate` → `orderNumber` (initializer + Swagger metadata).
- `purchase-order.service.ts` — `applyListOrdering` list caller default field `orderDate` → `orderNumber`; param type widened to include `orderNumber`. The DTO default alone does not cover `findAll({})`, which resolves through this parameter.

**Frontend**
- `OrdersPage.tsx` (sales) — default sort state and `sort.field` → `orderNumber`.
- `PurchaseOrdersPage.tsx` — default `sortOrder` `asc` → `desc`.

## Out of scope

`findSummaries` (Sales Order Summary report / customer profile) keeps its `orderNumber ASC` default — it is a separate report path, not the order list.

## Notes

Order numbers are zero-padded fixed-width strings (`PO-26-001`), so lexical `DESC` equals numeric `DESC` while the prefix and padding width stay fixed. Across a year boundary the `yy` segment keeps newer years on top.

## Testing

- Backend: added `findAll({})` default-sort assertions (sales + purchase).
- Frontend: new `OrdersPage.sort.test.tsx` asserts both the API query params and the `sort.field` UI prop; updated the existing PurchaseOrdersPage filterbar assertion to `DESC`.
- Full suites pass: 1111 backend, 1306 frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)