### PR TITLE
fix(po): show real backend error and correct verb on edit

### DIFF
--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -353,7 +353,12 @@ const CreatePurchaseOrderPage: React.FC = () => {
         navigate(`/purchasing/orders?highlight=${(created as any).id}`)
       }
     } catch (err: any) {
-      showError(err?.response?.data?.message || 'Failed to create purchase order')
+      showError(
+        err?.data?.message ||
+          (typeof err?.data === 'string' ? err.data : undefined) ||
+          err?.response?.data?.message ||
+          `Failed to ${isEditMode ? 'update' : 'create'} purchase order`,
+      )
     } finally {
       setLoading(false)
     }

--- a/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
@@ -26,6 +26,7 @@ const {
   mockFetchPurchaseOrder,
   mockParams,
   mockGetDocumentNumberSettings,
+  mockShowError,
 } = vi.hoisted(() => ({
   mockDispatch: vi.fn(),
   mockNavigate: vi.fn(),
@@ -35,6 +36,7 @@ const {
   mockFetchPurchaseOrder: vi.fn(),
   mockParams: vi.fn(() => ({})),
   mockGetDocumentNumberSettings: vi.fn(),
+  mockShowError: vi.fn(),
 }))
 
 vi.mock('react-router-dom', async () => {
@@ -54,7 +56,7 @@ vi.mock('@/hooks/useRedux', () => ({
 vi.mock('@/hooks/useNotification', () => ({
   useNotification: () => ({
     showSuccess: vi.fn(),
-    showError: vi.fn(),
+    showError: mockShowError,
   }),
 }))
 
@@ -151,6 +153,62 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
     )
 
     expect(await screen.findByRole('heading', { name: 'Edit Purchase Order' })).toBeInTheDocument()
+  })
+
+  it('shows the backend message and an update-specific fallback when an edit submit fails', async () => {
+    mockParams.mockReturnValue({ orderNumber: 'PO-TEST' })
+    mockFetchPurchaseOrder.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({
+        id: 'po-test-id',
+        supplierId: 'supplier-1',
+        orderDate: '2026-03-01T00:00:00.000Z',
+        shippingAmount: 0,
+        items: [
+          {
+            lineNumber: 1,
+            productId: 'product-1',
+            product: { id: 'product-1', name: 'Alpha Widget', baseCost: 11 },
+            quantity: 1,
+            unitCost: 11,
+            discountType: 'percentage',
+            discountPercent: 0,
+            discountAmount: 0,
+          },
+        ],
+      }),
+    })
+
+    render(
+      <BrowserRouter>
+        <CreatePurchaseOrderPage />
+      </BrowserRouter>,
+    )
+
+    await screen.findByRole('heading', { name: 'Edit Purchase Order' })
+
+    // RTK Query error shape: { status, data: '<message>' }
+    mockUpdatePurchaseOrder.mockReturnValue({
+      unwrap: vi.fn().mockRejectedValue({ status: 400, data: 'Order is not in a draft state' }),
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /update order/i }))
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledWith('Order is not in a draft state')
+    })
+    expect(mockShowError).not.toHaveBeenCalledWith('Failed to create purchase order')
+
+    // No message → fallback names the update action, not create.
+    mockShowError.mockClear()
+    mockUpdatePurchaseOrder.mockReturnValue({
+      unwrap: vi.fn().mockRejectedValue({ status: 500 }),
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /update order/i }))
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledWith('Failed to update purchase order')
+    })
   })
 
   it('replaces the autocomplete options with only the latest product search results', async () => {

--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -407,6 +407,7 @@ const CreateSalesOrderPage: React.FC = () => {
     } catch (err: any) {
       showError(
         err?.data?.message ||
+          (typeof err?.data === 'string' ? err.data : undefined) ||
           err?.response?.data?.message ||
           `Failed to ${isEditMode ? 'update' : 'create'} sales order`,
       )

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -772,6 +772,48 @@ describe('CreateSalesOrderPage — edit mode', { timeout: 60000 }, () => {
     })
   })
 
+  it('shows the backend message and an update-specific fallback when an edit submit fails', async () => {
+    mockFetchSalesOrder.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue(existingOrder),
+    })
+
+    render(
+      <BrowserRouter>
+        <CreateSalesOrderPage />
+      </BrowserRouter>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: /customer/i })).toHaveValue('Test Customer')
+    })
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /update order/i })).toBeInTheDocument()
+    })
+
+    // RTK Query error shape: { status, data: '<message>' }
+    mockUpdateSalesOrder.mockReturnValue({
+      unwrap: vi.fn().mockRejectedValue({ status: 400, data: 'Order is not editable' }),
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /update order/i }))
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledWith('Order is not editable')
+    })
+
+    // No message → fallback names the update action, not create.
+    mockShowError.mockClear()
+    mockUpdateSalesOrder.mockReturnValue({
+      unwrap: vi.fn().mockRejectedValue({ status: 500 }),
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /update order/i }))
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledWith('Failed to update sales order')
+    })
+  })
+
   it('shows discard dialog when blocker intercepts navigation in edit mode', async () => {
     mockBlockerState.current = 'blocked'
     mockFetchSalesOrder.mockReturnValue({


### PR DESCRIPTION
Closes #764

## Summary
- PO edit form showed "Failed to create purchase order" on any update error and never surfaced the real backend reason.
- Root cause: catch read `err?.response?.data?.message` (Axios shape) but RTK Query throws `{ status, data: '<message string>' }`; the fallback also hardcoded "create".
- Fix: read `err.data` as a guarded string and use a dynamic update/create verb. Same residual gap fixed in the Sales Order form (it had the dynamic verb but still couldn't read the string `data`).
- No backend change — the update path and payload were already correct.

## Tests
- Added edit-mode error-path tests for both PO and SO forms (real message surfaced + update-verb fallback).
- `cd frontend && npm run lint && npm run type-check && npm run test` — all pass (177 files, 1308 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)