### PR TITLE
fix(po): show real backend error and correct verb on edit

### DIFF
--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -46,6 +46,7 @@ import {
   updatePurchaseOrderInPlace,
 } from '@/store/slices/purchasingSlice'
 import { formatCurrency, getCurrentDate } from '@/utils/formatters'
+import { rtkErrorMessage } from '@/utils/errorMessage'
 
 interface PurchaseOrderItem {
   productId: string
@@ -354,10 +355,7 @@ const CreatePurchaseOrderPage: React.FC = () => {
       }
     } catch (err: any) {
       showError(
-        err?.data?.message ||
-          (typeof err?.data === 'string' ? err.data : undefined) ||
-          err?.response?.data?.message ||
-          `Failed to ${isEditMode ? 'update' : 'create'} purchase order`,
+        rtkErrorMessage(err, `Failed to ${isEditMode ? 'update' : 'create'} purchase order`),
       )
     } finally {
       setLoading(false)

--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -353,7 +353,12 @@ const CreatePurchaseOrderPage: React.FC = () => {
         navigate(`/purchasing/orders?highlight=${(created as any).id}`)
       }
     } catch (err: any) {
-      showError(err?.response?.data?.message || 'Failed to create purchase order')
+      showError(
+        err?.data?.message ||
+          (typeof err?.data === 'string' ? err.data : undefined) ||
+          err?.response?.data?.message ||
+          `Failed to ${isEditMode ? 'update' : 'create'} purchase order`,
+      )
     } finally {
       setLoading(false)
     }

--- a/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
@@ -26,6 +26,7 @@ const {
   mockFetchPurchaseOrder,
   mockParams,
   mockGetDocumentNumberSettings,
+  mockShowError,
 } = vi.hoisted(() => ({
   mockDispatch: vi.fn(),
   mockNavigate: vi.fn(),
@@ -35,6 +36,7 @@ const {
   mockFetchPurchaseOrder: vi.fn(),
   mockParams: vi.fn(() => ({})),
   mockGetDocumentNumberSettings: vi.fn(),
+  mockShowError: vi.fn(),
 }))
 
 vi.mock('react-router-dom', async () => {
@@ -54,7 +56,7 @@ vi.mock('@/hooks/useRedux', () => ({
 vi.mock('@/hooks/useNotification', () => ({
   useNotification: () => ({
     showSuccess: vi.fn(),
-    showError: vi.fn(),
+    showError: mockShowError,
   }),
 }))
 
@@ -151,6 +153,64 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
     )
 
     expect(await screen.findByRole('heading', { name: 'Edit Purchase Order' })).toBeInTheDocument()
+  })
+
+  it('shows the backend message and an update-specific fallback when an edit submit fails', async () => {
+    mockParams.mockReturnValue({ orderNumber: 'PO-TEST' })
+    mockFetchPurchaseOrder.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({
+        id: 'po-test-id',
+        supplierId: 'supplier-1',
+        orderDate: '2026-03-01T00:00:00.000Z',
+        shippingAmount: 0,
+        items: [
+          {
+            lineNumber: 1,
+            productId: 'product-1',
+            product: { id: 'product-1', name: 'Alpha Widget', baseCost: 11 },
+            quantity: 1,
+            unitPrice: 11,
+            discountType: 'percentage',
+            discountPercent: 0,
+            discountAmount: 0,
+            totalAmount: 11,
+          },
+        ],
+      }),
+    })
+
+    render(
+      <BrowserRouter>
+        <CreatePurchaseOrderPage />
+      </BrowserRouter>,
+    )
+
+    await screen.findByRole('heading', { name: 'Edit Purchase Order' })
+
+    // RTK Query error shape: { status, data: '<message>' }
+    mockUpdatePurchaseOrder.mockReturnValue({
+      unwrap: vi.fn().mockRejectedValue({ status: 400, data: 'Order is not in a draft state' }),
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /update order/i }))
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledWith('Order is not in a draft state')
+    })
+    expect(mockShowError).not.toHaveBeenCalledWith('Failed to create purchase order')
+
+    // No message → fallback names the update action, not create.
+    mockShowError.mockClear()
+    mockUpdatePurchaseOrder.mockClear()
+    mockUpdatePurchaseOrder.mockReturnValue({
+      unwrap: vi.fn().mockRejectedValue({ status: 500 }),
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /update order/i }))
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledWith('Failed to update purchase order')
+    })
   })
 
   it('replaces the autocomplete options with only the latest product search results', async () => {

--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -47,6 +47,7 @@ import { useGetDocumentNumberSettingsQuery } from '@/store/api/settingsApi'
 import { setSelectedOrder } from '@/store/slices/salesSlice'
 import type { RootState } from '@/store'
 import { formatCurrency, getCurrentDate } from '@/utils/formatters'
+import { rtkErrorMessage } from '@/utils/errorMessage'
 import { getStockOffenders } from '@/utils/stockStatus'
 import { getOrderActionMetas } from './utils/orderActions'
 import StockIndicatorChip from './components/StockIndicatorChip'
@@ -406,10 +407,7 @@ const CreateSalesOrderPage: React.FC = () => {
       }
     } catch (err: any) {
       showError(
-        err?.data?.message ||
-          (typeof err?.data === 'string' ? err.data : undefined) ||
-          err?.response?.data?.message ||
-          `Failed to ${isEditMode ? 'update' : 'create'} sales order`,
+        rtkErrorMessage(err, `Failed to ${isEditMode ? 'update' : 'create'} sales order`),
       )
     }
   }

--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -407,6 +407,7 @@ const CreateSalesOrderPage: React.FC = () => {
     } catch (err: any) {
       showError(
         err?.data?.message ||
+          (typeof err?.data === 'string' ? err.data : undefined) ||
           err?.response?.data?.message ||
           `Failed to ${isEditMode ? 'update' : 'create'} sales order`,
       )

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -772,6 +772,49 @@ describe('CreateSalesOrderPage — edit mode', { timeout: 60000 }, () => {
     })
   })
 
+  it('shows the backend message and an update-specific fallback when an edit submit fails', async () => {
+    mockFetchSalesOrder.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue(existingOrder),
+    })
+
+    render(
+      <BrowserRouter>
+        <CreateSalesOrderPage />
+      </BrowserRouter>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: /customer/i })).toHaveValue('Test Customer')
+    })
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /update order/i })).toBeInTheDocument()
+    })
+
+    // RTK Query error shape: { status, data: '<message>' }
+    mockUpdateSalesOrder.mockReturnValue({
+      unwrap: vi.fn().mockRejectedValue({ status: 400, data: 'Order is not editable' }),
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /update order/i }))
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledWith('Order is not editable')
+    })
+
+    // No message → fallback names the update action, not create.
+    mockShowError.mockClear()
+    mockUpdateSalesOrder.mockClear()
+    mockUpdateSalesOrder.mockReturnValue({
+      unwrap: vi.fn().mockRejectedValue({ status: 500 }),
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /update order/i }))
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledWith('Failed to update sales order')
+    })
+  })
+
   it('shows discard dialog when blocker intercepts navigation in edit mode', async () => {
     mockBlockerState.current = 'blocked'
     mockFetchSalesOrder.mockReturnValue({

--- a/frontend/src/utils/errorMessage.test.ts
+++ b/frontend/src/utils/errorMessage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getErrorMessage } from './errorMessage';
+import { getErrorMessage, rtkErrorMessage } from './errorMessage';
 
 describe('getErrorMessage', () => {
   it('returns plain string errors', () => {
@@ -36,5 +36,34 @@ describe('getErrorMessage', () => {
 
   it('falls back when message is empty', () => {
     expect(getErrorMessage('', 'Fallback message')).toBe('Fallback message');
+  });
+});
+
+describe('rtkErrorMessage', () => {
+  it('returns the RTK string data (axiosBaseQuery shape)', () => {
+    const error = { status: 400, data: 'Order is not in a draft state' };
+    expect(rtkErrorMessage(error, 'Fallback')).toBe('Order is not in a draft state');
+  });
+
+  it('returns object-shaped data.message when present', () => {
+    const error = { status: 400, data: { message: 'Account not found' } };
+    expect(rtkErrorMessage(error, 'Fallback')).toBe('Account not found');
+  });
+
+  it('falls back to legacy Axios response shape', () => {
+    const error = { response: { data: { message: 'Account not found' } } };
+    expect(rtkErrorMessage(error, 'Fallback')).toBe('Account not found');
+  });
+
+  it('uses the fallback when data is missing', () => {
+    expect(rtkErrorMessage({ status: 500 }, 'Failed to update purchase order')).toBe(
+      'Failed to update purchase order',
+    );
+  });
+
+  it('uses the fallback when data is an empty string', () => {
+    expect(rtkErrorMessage({ status: 500, data: '' }, 'Fallback message')).toBe(
+      'Fallback message',
+    );
   });
 });

--- a/frontend/src/utils/errorMessage.ts
+++ b/frontend/src/utils/errorMessage.ts
@@ -17,6 +17,31 @@ export const getErrorMessage = (error: unknown, fallback: string): string => {
   return fallback;
 };
 
+/**
+ * Resolve a user-facing message from an error thrown by an RTK Query mutation's
+ * `.unwrap()`. The shared axiosBaseQuery returns `{ status, data: '<message>' }`,
+ * where `data` is the backend message string. Falls back to legacy Axios shapes
+ * and finally the provided fallback.
+ */
+export const rtkErrorMessage = (error: unknown, fallback: string): string => {
+  const err = error as {
+    data?: unknown
+    response?: { data?: { message?: unknown } }
+  }
+
+  if (err?.data && typeof err.data === 'object' && 'message' in err.data) {
+    const message = (err.data as { message?: unknown }).message
+    if (typeof message === 'string' && message.trim().length > 0) return message
+  }
+
+  if (typeof err?.data === 'string' && err.data.trim().length > 0) return err.data
+
+  const axiosMessage = err?.response?.data?.message
+  if (typeof axiosMessage === 'string' && axiosMessage.trim().length > 0) return axiosMessage
+
+  return fallback
+}
+
 const extractMessageValue = (error: unknown): unknown => {
   if (!error || typeof error !== 'object') {
     return error;


### PR DESCRIPTION
Closes #764

## Summary
- PO edit form showed "Failed to create purchase order" on any update error and never surfaced the real backend reason.
- Root cause: catch read `err?.response?.data?.message` (Axios shape) but RTK Query throws `{ status, data: '<message string>' }`; the fallback also hardcoded "create".
- Fix: read the RTK `data` string (guarded) and use a dynamic update/create verb. Same residual gap fixed in the Sales Order form (it had the dynamic verb but still couldn't read the string `data`).
- Extracted the guarded read into a shared `rtkErrorMessage(err, fallback)` helper (`frontend/src/utils/errorMessage.ts`) used by both forms, with unit coverage.
- No backend change — the update path and payload were already correct.

## Tests
- Added edit-mode error-path tests for both PO and SO forms (real message surfaced + update-verb fallback).
- Added unit tests for `rtkErrorMessage`.
- `cd frontend && npm run lint && npm run type-check && npm run test` — all pass (177 files, 1313 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)