### PR TITLE
fix(purchasing): allow editing DRAFT purchase orders

### DIFF
--- a/backend/src/database/entities/purchase-order.entity.spec.ts
+++ b/backend/src/database/entities/purchase-order.entity.spec.ts
@@ -1,0 +1,27 @@
+import { PurchaseOrder } from './purchase-order.entity';
+
+describe('PurchaseOrder.calculateTotals', () => {
+  function makeOrder(overrides: Partial<PurchaseOrder> = {}): PurchaseOrder {
+    const order = new PurchaseOrder();
+    order.subtotal = 100;
+    order.discountPercent = 0;
+    order.discountAmount = 0;
+    order.shippingAmount = 0;
+    Object.assign(order, overrides);
+    return order;
+  }
+
+  it('computes total as subtotal - discount + shipping', () => {
+    const order = makeOrder({ discountPercent: 10, shippingAmount: 5 });
+    order.calculateTotals();
+    expect(order.discountAmount).toBe(10);
+    expect(order.totalAmount).toBe(95);
+  });
+
+  it('clears a previously derived discount when discountPercent drops to 0', () => {
+    const order = makeOrder({ discountPercent: 0, discountAmount: 10 });
+    order.calculateTotals();
+    expect(order.discountAmount).toBe(0);
+    expect(order.totalAmount).toBe(100);
+  });
+});

--- a/backend/src/database/entities/purchase-order.entity.ts
+++ b/backend/src/database/entities/purchase-order.entity.ts
@@ -219,6 +219,8 @@ export class PurchaseOrder extends BaseEntity {
     // Calculate discount amount
     if (this.discountPercent > 0) {
       this.discountAmount = (Number(this.subtotal || 0) * Number(this.discountPercent)) / 100;
+    } else {
+      this.discountAmount = 0;
     }
 
     // Calculate total (subtotal - discount + shipping)

--- a/backend/src/modules/purchasing/services/purchase-order-lifecycle.service.spec.ts
+++ b/backend/src/modules/purchasing/services/purchase-order-lifecycle.service.spec.ts
@@ -165,6 +165,32 @@ describe('PurchaseOrderLifecycleService', () => {
     });
   });
 
+  describe('assertStatusEditable', () => {
+    it('does not throw for DRAFT', () => {
+      expect(() =>
+        PurchaseOrderLifecycleService.assertStatusEditable(PurchaseOrderStatus.DRAFT),
+      ).not.toThrow();
+    });
+
+    it('does not throw for READY', () => {
+      expect(() =>
+        PurchaseOrderLifecycleService.assertStatusEditable(PurchaseOrderStatus.READY),
+      ).not.toThrow();
+    });
+
+    it('throws "Return the goods first." for RECEIVED', () => {
+      expect(() =>
+        PurchaseOrderLifecycleService.assertStatusEditable(PurchaseOrderStatus.RECEIVED),
+      ).toThrow('Return the goods first.');
+    });
+
+    it('throws "Uncancel the order first." for CANCELLED', () => {
+      expect(() =>
+        PurchaseOrderLifecycleService.assertStatusEditable(PurchaseOrderStatus.CANCELLED),
+      ).toThrow('Uncancel the order first.');
+    });
+  });
+
   describe('receive and return', () => {
     it('receive posts stock + cost + GL and sets RECEIVED', async () => {
       const readyOrder = {

--- a/backend/src/modules/purchasing/services/purchase-order-lifecycle.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order-lifecycle.service.ts
@@ -49,7 +49,7 @@ export class PurchaseOrderLifecycleService {
   }
 
   static assertStatusEditable(status: PurchaseOrderStatus): void {
-    if (status !== PurchaseOrderStatus.READY) {
+    if (status !== PurchaseOrderStatus.DRAFT && status !== PurchaseOrderStatus.READY) {
       throw new BadRequestException(
         `Cannot edit purchase order in ${status} status. ${
           status === PurchaseOrderStatus.RECEIVED
@@ -280,4 +280,3 @@ export class PurchaseOrderLifecycleService {
     return saved;
   }
 }
-

--- a/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
@@ -100,6 +100,7 @@ describe('PurchaseOrderService', () => {
           provide: getRepositoryToken(PurchaseOrderItem),
           useValue: {
             save: jest.fn(),
+            delete: jest.fn(),
           },
         },
         {
@@ -290,6 +291,149 @@ describe('PurchaseOrderService', () => {
       const results = await service.searchGlobal('Vendor', adminUser);
 
       expect(results[0].score).toBe(70);
+    });
+  });
+
+  describe('update workflow', () => {
+    // Wire the transaction so every in-callback getRepository(...) returns a
+    // manager-bound mock, and the locked row is a REAL PurchaseOrder instance (so
+    // calculateTotals() — a method on the entity — is callable).
+    function setupTxMocks(opts: {
+      lockedStatus: PurchaseOrderStatus;
+      lockedOverrides?: Partial<PurchaseOrder>;
+      payments?: { amount: number }[];
+    }) {
+      const savedOrders: PurchaseOrder[] = [];
+      const poManagerRepo = {
+        findOne: jest.fn(),
+        save: jest.fn().mockImplementation((o: PurchaseOrder) => {
+          savedOrders.push(Object.assign(new PurchaseOrder(), o));
+          return Promise.resolve(o);
+        }),
+      };
+      const itemManagerRepo = {
+        delete: jest.fn().mockResolvedValue(undefined),
+        save: jest.fn().mockResolvedValue([]),
+      };
+      const productManagerRepo = {
+        findOne: jest.fn().mockResolvedValue({ id: 'product-1' }),
+      };
+
+      const lockedOrder = Object.assign(new PurchaseOrder(), {
+        id: 'po-1',
+        orderNumber: 'PO-000001',
+        status: opts.lockedStatus,
+        subtotal: 100,
+        discountPercent: 0,
+        discountAmount: 0,
+        shippingAmount: 0,
+        totalAmount: 100,
+        paidAmount: 0,
+        paymentStatus: PurchaseOrderPaymentStatus.UNPAID,
+        orderDate: new Date('2024-01-01'),
+        ...opts.lockedOverrides,
+      });
+      // lockRowForUpdate -> manager.getRepository(PurchaseOrder).findOne(...)
+      poManagerRepo.findOne.mockResolvedValue(lockedOrder);
+
+      const manager = {
+        getRepository: jest.fn().mockImplementation((entity: any) => {
+          if (entity === PurchaseOrder) return poManagerRepo;
+          if (entity === PurchaseOrderItem) return itemManagerRepo;
+          if (entity === Product) return productManagerRepo;
+          return { save: jest.fn(), findOne: jest.fn(), delete: jest.fn() };
+        }),
+      };
+
+      dataSource.transaction.mockImplementation(async (cb: any) => cb(manager));
+      vendorPaymentService.findAllByPurchaseOrder.mockResolvedValue(
+        (opts.payments ?? []) as any,
+      );
+
+      return { manager, poManagerRepo, itemManagerRepo, productManagerRepo, savedOrders };
+    }
+
+    it('all in-transaction data access uses the manager, not injected repos', async () => {
+      const { poManagerRepo, itemManagerRepo, productManagerRepo } = setupTxMocks({
+        lockedStatus: PurchaseOrderStatus.DRAFT,
+      });
+      // After transaction entry there must be no injected-repo data access.
+      purchaseOrderRepository.save.mockClear();
+      purchaseOrderItemRepository.delete.mockClear();
+      purchaseOrderItemRepository.save.mockClear();
+      productRepository.findOne.mockClear();
+
+      await service.update('po-1', {
+        items: [{ productId: 'product-1', quantity: 1, unitPrice: 50 } as any],
+      } as any);
+
+      expect(productManagerRepo.findOne).toHaveBeenCalled();
+      expect(itemManagerRepo.delete).toHaveBeenCalledWith({ purchaseOrderId: 'po-1' });
+      expect(itemManagerRepo.save).toHaveBeenCalled();
+      expect(poManagerRepo.save).toHaveBeenCalled();
+
+      expect(purchaseOrderRepository.save).not.toHaveBeenCalled();
+      expect(purchaseOrderItemRepository.delete).not.toHaveBeenCalled();
+      expect(purchaseOrderItemRepository.save).not.toHaveBeenCalled();
+      expect(productRepository.findOne).not.toHaveBeenCalled();
+    });
+
+    it('re-asserts editability against the locked row and rejects a RECEIVED order', async () => {
+      setupTxMocks({ lockedStatus: PurchaseOrderStatus.RECEIVED });
+
+      await expect(
+        service.update('po-1', { shippingAmount: 10 } as any),
+      ).rejects.toThrow('Return the goods first.');
+    });
+
+    it('recomputes totals and reconciles on a shipping-only update (no items)', async () => {
+      const { savedOrders } = setupTxMocks({
+        lockedStatus: PurchaseOrderStatus.READY,
+        payments: [{ amount: 100 }], // fully paid against old total of 100
+      });
+
+      await service.update('po-1', { shippingAmount: 20 } as any);
+
+      // total recomputed to 120, paid is only 100 -> PARTIAL, demoted to DRAFT
+      const finalSave = savedOrders[savedOrders.length - 1];
+      expect(finalSave.totalAmount).toBe(120);
+      expect(finalSave.paymentStatus).toBe(PurchaseOrderPaymentStatus.PARTIAL);
+      expect(finalSave.status).toBe(PurchaseOrderStatus.DRAFT);
+    });
+
+    it('promotes a partially-paid DRAFT to READY when a lower total makes it fully paid', async () => {
+      // DRAFT, subtotal 100, paid 80 (PARTIAL). Apply 20% discount -> total 80,
+      // now fully paid -> PAID + promoted to READY.
+      const { savedOrders } = setupTxMocks({
+        lockedStatus: PurchaseOrderStatus.DRAFT,
+        payments: [{ amount: 80 }],
+      });
+
+      await service.update('po-1', { discountPercent: 20 } as any);
+
+      const finalSave = savedOrders[savedOrders.length - 1];
+      expect(finalSave.totalAmount).toBe(80);
+      expect(finalSave.paymentStatus).toBe(PurchaseOrderPaymentStatus.PAID);
+      expect(finalSave.status).toBe(PurchaseOrderStatus.READY);
+    });
+
+    it('clears the discount on a discount-removal update (10% -> 0%)', async () => {
+      // Locked DRAFT carrying a stale 10% discount (subtotal 100, discountAmount 10,
+      // total 90). Removing the discount restores total to 100.
+      const { savedOrders } = setupTxMocks({
+        lockedStatus: PurchaseOrderStatus.DRAFT,
+        lockedOverrides: {
+          discountPercent: 10,
+          discountAmount: 10,
+          totalAmount: 90,
+        },
+      });
+
+      await service.update('po-1', { discountPercent: 0 } as any);
+
+      const finalSave = savedOrders[savedOrders.length - 1];
+      expect(finalSave.discountAmount).toBe(0);
+      expect(finalSave.totalAmount).toBe(100);
     });
   });
 

--- a/backend/src/modules/purchasing/services/purchase-order.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.ts
@@ -36,6 +36,7 @@ import { SettingsService } from '../../settings/settings.service';
 import { AuditLogService } from '../../audit-logs/services';
 import { AccountingService } from '../../accounting/services/accounting.service';
 import { PurchaseOrderLifecycleService } from './purchase-order-lifecycle.service';
+import { lockRowForUpdate, repoFor } from '../../../common/db/tx-helpers';
 
 @Injectable()
 export class PurchaseOrderService extends BaseCrudService<
@@ -501,97 +502,73 @@ export class PurchaseOrderService extends BaseCrudService<
     username?: string,
   ): Promise<PurchaseOrderResponseDto> {
     this.logger.log(`Updating purchase order: ${id}`);
-
-    const purchaseOrder = await this.purchaseOrderRepository.findOne({
-      where: { id },
-      // Don't load items relation to avoid cascade issues when we manually save them
-    });
-
-    if (!purchaseOrder) {
-      throw new NotFoundException(`Purchase order with ID ${id} not found`);
-    }
-
-    await this.purchaseOrderLifecycleService.assertEditAllowed(id);
-
-    // Check if order can be modified
     try {
-      // Update basic fields (exclude items as they're handled separately)
-      const { items: _, ...updateFields } = updatePurchaseOrderDto;
-      Object.assign(purchaseOrder, {
-        ...updateFields,
-        orderDate: updatePurchaseOrderDto.orderDate ?
-          new Date(updatePurchaseOrderDto.orderDate) : purchaseOrder.orderDate,
+      const updatedPurchaseOrder = await this.dataSource.transaction(async (manager: EntityManager) => {
+        const itemRepo = repoFor(manager, PurchaseOrderItem, this.purchaseOrderItemRepository);
+        const productRepo = repoFor(manager, Product, this.productRepository);
+
+        const purchaseOrder = await lockRowForUpdate(manager, PurchaseOrder, id, {
+          notFoundMessage: `Purchase order with ID ${id} not found`,
+        });
+
+        PurchaseOrderLifecycleService.assertStatusEditable(purchaseOrder.status);
+
+        const { items: _, ...updateFields } = updatePurchaseOrderDto;
+        Object.assign(purchaseOrder, {
+          ...updateFields,
+          orderDate: updatePurchaseOrderDto.orderDate ? new Date(updatePurchaseOrderDto.orderDate) : purchaseOrder.orderDate,
+        });
+
+        if (updatePurchaseOrderDto.items) {
+          await itemRepo.delete({ purchaseOrderId: id });
+
+          const orderItems: PurchaseOrderItem[] = [];
+          let subtotal = 0;
+          let lineNum = 1;
+
+          for (const itemDto of updatePurchaseOrderDto.items) {
+            const product = await productRepo.findOne({ where: { id: itemDto.productId } });
+            if (!product) {
+              throw new BadRequestException(`Product with ID ${itemDto.productId} not found`);
+            }
+
+            const item = new PurchaseOrderItem();
+            item.purchaseOrderId = id;
+            item.productId = itemDto.productId;
+            item.quantity = itemDto.quantity;
+            item.unitCost = itemDto.unitPrice;
+            item.discountType = itemDto.discountType || 'percentage';
+            item.discountPercent = itemDto.discountPercent || 0;
+            item.discountAmount = itemDto.discountAmount || 0;
+            item.status = 'pending' as any;
+            item.receivedQuantity = 0;
+            item.lineNumber = lineNum;
+
+            let unitDiscount = 0;
+            if (item.discountType === 'percentage') {
+              unitDiscount = item.discountPercent > 0 ? (Number(item.unitCost) * Number(item.discountPercent)) / 100 : 0;
+            } else if (item.discountType === 'fixed_amount') {
+              unitDiscount = Number(item.discountAmount) || 0;
+            }
+            const discountedUnitPrice = Number(item.unitCost) - unitDiscount;
+            const totalAmount = discountedUnitPrice * Number(item.quantity);
+
+            orderItems.push(item);
+            subtotal += totalAmount;
+            lineNum++;
+          }
+
+          await itemRepo.save(orderItems);
+          purchaseOrder.subtotal = subtotal;
+          purchaseOrder.items = orderItems;
+        }
+
+        purchaseOrder.calculateTotals();
+
+        await this.reconcilePaymentState(purchaseOrder, manager);
+        return purchaseOrder;
       });
 
-      // Update items if provided
-      if (updatePurchaseOrderDto.items) {
-        // Remove existing items
-        await this.purchaseOrderItemRepository.delete({ purchaseOrderId: id });
-
-        // Create new items
-        const orderItems: PurchaseOrderItem[] = [];
-        let subtotal = 0;
-        let lineNum = 1;
-
-        for (const itemDto of updatePurchaseOrderDto.items) {
-          let product: Product | undefined;
-
-          if (itemDto.productId) {
-            product = await this.productRepository.findOne({
-              where: { id: itemDto.productId },
-            });
-          }
-
-          if (!product) {
-            throw new BadRequestException(`Product with ID ${itemDto.productId} not found`);
-          }
-
-          const item = new PurchaseOrderItem();
-          item.purchaseOrderId = id;
-          item.productId = itemDto.productId;
-          item.quantity = itemDto.quantity;
-          item.unitCost = itemDto.unitPrice;
-          item.discountType = itemDto.discountType || 'percentage';
-          item.discountPercent = itemDto.discountPercent || 0;
-          item.discountAmount = itemDto.discountAmount || 0;
-          item.status = 'pending' as any;
-          item.receivedQuantity = 0;
-          item.lineNumber = lineNum;
-
-          // Calculate totals manually to get the amount before saving
-          // Discount is applied to unit price first, then multiplied by quantity
-          let unitDiscount = 0;
-          if (item.discountType === 'percentage') {
-            unitDiscount = item.discountPercent > 0
-              ? (Number(item.unitCost) * Number(item.discountPercent)) / 100
-              : 0;
-          } else if (item.discountType === 'fixed_amount') {
-            unitDiscount = Number(item.discountAmount) || 0;
-          }
-          const discountedUnitPrice = Number(item.unitCost) - unitDiscount;
-          const totalAmount = discountedUnitPrice * Number(item.quantity);
-
-          orderItems.push(item);
-          subtotal += totalAmount;
-          lineNum++;
-        }
-
-        try {
-          await this.purchaseOrderItemRepository.save(orderItems);
-        } catch (saveError) {
-          this.logger.error(`Failed to save purchase order items: ${saveError.message}`);
-          throw saveError;
-        }
-
-        purchaseOrder.subtotal = subtotal;
-        // Attach items to purchase order before calculating totals
-        purchaseOrder.items = orderItems;
-        purchaseOrder.calculateTotals();
-      }
-
-      const updatedPurchaseOrder = await this.purchaseOrderRepository.save(purchaseOrder);
-
-      // Log audit trail for update
       await this.auditLogService.log(
         'UPDATE',
         'PurchaseOrder',
@@ -611,6 +588,9 @@ export class PurchaseOrderService extends BaseCrudService<
       return await this.findOne(updatedPurchaseOrder.id);
     } catch (error) {
       this.logger.error(`Error updating purchase order: ${error.message}`, error.stack);
+      if (error instanceof HttpException) {
+        throw error;
+      }
       throw new BadRequestException('Failed to update purchase order');
     }
   }
@@ -986,8 +966,8 @@ export class PurchaseOrderService extends BaseCrudService<
    * partially applied. Only the DRAFT<->READY band is auto-managed here;
    * RECEIVED/CANCELLED orders never reach this method.
    */
-  private async reconcilePaymentState(purchaseOrder: PurchaseOrder): Promise<void> {
-    const activePayments = await this.vendorPaymentService.findAllByPurchaseOrder(purchaseOrder.id);
+  private async reconcilePaymentState(purchaseOrder: PurchaseOrder, manager?: EntityManager): Promise<void> {
+    const activePayments = await this.vendorPaymentService.findAllByPurchaseOrder(purchaseOrder.id, manager);
     const paidAmount = activePayments.reduce((sum, p) => sum + Number(p.amount || 0), 0);
     const total = Number(purchaseOrder.totalAmount);
 
@@ -1005,8 +985,7 @@ export class PurchaseOrderService extends BaseCrudService<
     } else if (!fullyPaid && purchaseOrder.status === PurchaseOrderStatus.READY) {
       purchaseOrder.status = PurchaseOrderStatus.DRAFT;
     }
-
-    await this.purchaseOrderRepository.save(purchaseOrder);
+    await repoFor(manager, PurchaseOrder, this.purchaseOrderRepository).save(purchaseOrder);
   }
 
   /**

--- a/backend/src/modules/purchasing/services/vendor-payment.service.spec.ts
+++ b/backend/src/modules/purchasing/services/vendor-payment.service.spec.ts
@@ -227,6 +227,30 @@ describe('VendorPaymentService', () => {
     });
   });
 
+  describe('findAllByPurchaseOrder manager binding', () => {
+    it('uses the injected repository when no manager is passed', async () => {
+      vendorPaymentRepository.find.mockResolvedValue([]);
+
+      await service.findAllByPurchaseOrder('po-1');
+
+      expect(vendorPaymentRepository.find).toHaveBeenCalledWith({
+        where: { purchaseOrderId: 'po-1', isActive: true },
+      });
+    });
+
+    it('uses the manager repository when a manager is passed', async () => {
+      const managerRepo = { find: jest.fn().mockResolvedValue([]) };
+      const manager = { getRepository: jest.fn().mockReturnValue(managerRepo) } as any;
+
+      await service.findAllByPurchaseOrder('po-1', manager);
+
+      expect(manager.getRepository).toHaveBeenCalledWith(VendorPayment);
+      expect(managerRepo.find).toHaveBeenCalledWith({
+        where: { purchaseOrderId: 'po-1', isActive: true },
+      });
+    });
+  });
+
   describe('searchGlobal', () => {
     const adminUser = { role: UserRole.ADMIN } as any;
 

--- a/backend/src/modules/purchasing/services/vendor-payment.service.ts
+++ b/backend/src/modules/purchasing/services/vendor-payment.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException, BadRequestException, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, Between, LessThanOrEqual, MoreThanOrEqual } from 'typeorm';
+import { Repository, Between, LessThanOrEqual, MoreThanOrEqual, EntityManager } from 'typeorm';
 import { BaseCrudService } from '../../../common/services/base-crud.service';
 import {
   VendorPayment,
@@ -20,6 +20,7 @@ import {
 import { AuditLogService } from '../../audit-logs/services';
 import { AccountingService } from '@modules/accounting/services/accounting.service';
 import { SettingsService } from '@modules/settings/settings.service';
+import { repoFor } from '../../../common/db/tx-helpers';
 import { GlobalSearchResultDto } from '../../search/dto/global-search-result.dto';
 import { canSearchVendorPayments } from '../../search/search.permissions';
 import {
@@ -597,8 +598,8 @@ export class VendorPaymentService extends BaseCrudService<
   /**
    * Find all vendor payments for a purchase order
    */
-  async findAllByPurchaseOrder(poId: string): Promise<VendorPayment[]> {
-    return this.vendorPaymentRepository.find({
+  async findAllByPurchaseOrder(poId: string, manager?: EntityManager): Promise<VendorPayment[]> {
+    return repoFor(manager, VendorPayment, this.vendorPaymentRepository).find({
       where: {
         purchaseOrderId: poId,
         isActive: true,


### PR DESCRIPTION
## Summary
- Relax the PO edit guard from READY-only to `DRAFT || READY`, matching the sales-order rule and the frontend, which already offers Edit for DRAFT. Previously editing a DRAFT order failed with *"Order must be paid in full (Ready) before editing."*
- Harden the now-reachable paid-DRAFT edit path: run `update` inside a pessimistic-locked transaction, re-assert editability against the locked row, and route all in-transaction reads/writes (PO, items, product) through the transaction manager.
- Recompute totals on **every** update (shipping-/discount-only edits included), then reconcile `paymentStatus` and the DRAFT↔READY band against the new total.
- `calculateTotals()` clears `discountAmount` when `discountPercent` is 0 (removing a discount no longer keeps a stale total).
- `findAllByPurchaseOrder` / `reconcilePaymentState` accept an optional `EntityManager` so reconciliation runs on the locked connection (avoids self-deadlock / non-atomic writes).
- Preserve `HttpException` through `update`'s catch so guard messages (e.g. *"Return the goods first."*) reach the client instead of a generic error.

## Test Plan
- [x] `purchase-order-lifecycle.service.spec.ts` — editable band: DRAFT/READY allowed; RECEIVED/CANCELLED rejected with specific messages
- [x] `purchase-order.entity.spec.ts` (new) — `calculateTotals` math + discount removal (10% → 0%)
- [x] `vendor-payment.service.spec.ts` — `findAllByPurchaseOrder` manager vs injected-repo binding
- [x] `purchase-order.service.spec.ts` — update workflow: manager-bound in-tx access (injected repos not called), RECEIVED rejection, shipping-only reconcile, partially-paid DRAFT → READY promotion, discount removal
- [x] Full backend suite green (1121 tests); lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)