### PR TITLE
fix(inventory): include inactive products in product search dropdown (#768)

### DIFF
--- a/frontend/src/hooks/useProductSearch.test.ts
+++ b/frontend/src/hooks/useProductSearch.test.ts
@@ -37,7 +37,7 @@ describe('useProductSearch', () => {
 
     expect(result.current.products).toEqual([makeProduct('1', 'Alpha')])
     expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-      params: { isActive: true, sortBy: 'name', sortOrder: 'ASC' },
+      params: { sortBy: 'name', sortOrder: 'ASC' },
     })
   })
 
@@ -48,8 +48,18 @@ describe('useProductSearch', () => {
     await act(() => result.current.loadProducts('apple'))
 
     expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-      params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: 'apple' },
+      params: { sortBy: 'name', sortOrder: 'ASC', search: 'apple' },
     })
+  })
+
+  it('does not send an isActive filter, so inactive products are included (regression #768)', async () => {
+    mockGet.mockResolvedValue(makeResponse([]))
+    const { result } = renderHook(() => useProductSearch())
+
+    await act(() => result.current.loadProducts())
+
+    const callConfig = mockGet.mock.calls[0][1] as { params: Record<string, unknown> }
+    expect(callConfig.params).not.toHaveProperty('isActive')
   })
 
   it('loadProducts replaces the list, not merges', async () => {

--- a/frontend/src/hooks/useProductSearch.ts
+++ b/frontend/src/hooks/useProductSearch.ts
@@ -33,8 +33,7 @@ export function useProductSearch() {
     try {
       // sortBy/sortOrder are explicit rather than relying on backend defaults
       // so this keeps working if the backend default ever changes.
-      const params: Record<string, string | boolean> = {
-        isActive: true,
+      const params: Record<string, string> = {
         sortBy: 'name',
         sortOrder: 'ASC',
       }

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -118,7 +118,7 @@ describe('CreateStockAdjustmentPage product search', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
+        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 
@@ -156,7 +156,7 @@ describe('CreateStockAdjustmentPage product search', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
+        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 
@@ -257,7 +257,7 @@ describe('CreateStockAdjustmentPage product search', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
+        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 

--- a/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
@@ -230,7 +230,7 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
+        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 
@@ -268,7 +268,7 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
+        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 
@@ -325,7 +325,7 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
+        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 
@@ -356,7 +356,7 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC' },
+        params: { sortBy: 'name', sortOrder: 'ASC' },
       })
     })
 
@@ -365,7 +365,7 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
+        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -154,7 +154,7 @@ describe('CreateSalesOrderPage product search', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
+        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 
@@ -192,7 +192,7 @@ describe('CreateSalesOrderPage product search', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
+        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 
@@ -248,7 +248,7 @@ describe('CreateSalesOrderPage product search', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
+        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
       })
     })
 


### PR DESCRIPTION
## Summary

The product search dropdown in Sales Order, Purchase Order, and Stock Adjustment line items excluded inactive (but not deleted) products. The shared `useProductSearch` hook hardcoded `isActive: true` on every `GET /inventory/products` request, so deactivated products never appeared — even though they still exist and can legitimately be referenced on a draft document.

This removes the active-only filter so the dropdown returns all non-deleted products (active + inactive), consistent with other entity dropdowns (e.g. the SO customer dropdown). Deleted products remain excluded via TypeORM soft-delete.

## Changes

- `useProductSearch.ts` — remove `isActive: true` from request params; narrow params type to `Record<string, string>`.
- `useProductSearch.test.ts` — update 2 assertions, add regression test guarding #768.
- SO / PO / Stock Adjustment page tests — drop `isActive: true` from 11 stale assertions (3 / 5 / 3).

## Verification

- `npm run lint` — clean
- `npm run type-check` — clean
- `npm run test` — 1314 tests pass across 177 files

Closes #768

🤖 Generated with [Claude Code](https://claude.com/claude-code)