### PR TITLE
feat(purchasing): PO refunds follow the SO model (method-based)

### DIFF
--- a/backend/src/modules/accounting/services/accounting.service.spec.ts
+++ b/backend/src/modules/accounting/services/accounting.service.spec.ts
@@ -644,6 +644,41 @@ describe('AccountingService', () => {
     });
   });
 
+  describe('postVendorRefundEntry', () => {
+    it('posts reversed polarity with positive amounts (DR Cash / CR AP)', async () => {
+      const refundRow = {
+        id: 'vp-refund-1',
+        paymentNumber: 'VP-REFUND-1',
+        amount: -200,
+        paymentDate: new Date('2026-06-13'),
+        supplier: { companyName: 'Acme' },
+        paymentMethodEntity: { code: 'CASH' },
+      } as any;
+
+      accountMappingService.getMappings.mockResolvedValue(mockMappings);
+      fiscalPeriodService.validatePeriod.mockResolvedValue({
+        isValid: true,
+        message: 'Period is open',
+        period: mockOpenPeriod as any,
+      });
+      journalEntryService.create.mockResolvedValue(mockJournalEntry as any);
+      journalEntryService.postEntry.mockResolvedValue(mockJournalEntry as any);
+
+      await service.postVendorRefundEntry(refundRow, 'user-1');
+
+      const entryDto = (journalEntryService.create as jest.Mock).mock.calls[0][0];
+      const apLine = entryDto.lines.find((l: any) => l.accountId === mockMappings[MappingType.VENDOR_PAYMENT_AP]);
+      const cashLine = entryDto.lines.find((l: any) => l.accountId === mockMappings['vendor_payment_cash']);
+
+      expect(apLine.creditAmount).toBe(200);
+      expect(apLine.debitAmount).toBe(0);
+      expect(cashLine.debitAmount).toBe(200);
+      expect(cashLine.creditAmount).toBe(0);
+      expect(apLine.creditAmount).toBeGreaterThan(0);
+      expect(cashLine.debitAmount).toBeGreaterThan(0);
+    });
+  });
+
   describe('postStockAdjustmentEntry', () => {
     const mockAdjustmentIncrease = {
       id: 'adj-123',

--- a/backend/src/modules/accounting/services/accounting.service.ts
+++ b/backend/src/modules/accounting/services/accounting.service.ts
@@ -528,6 +528,77 @@ export class AccountingService {
     return postedEntry as any;
   }
 
+  async postVendorRefundEntry(
+    vendorPayment: VendorPayment,
+    userId: string,
+    username?: string,
+  ): Promise<JournalEntry> {
+    this.logger.log(`Posting vendor refund entry for ${vendorPayment.paymentNumber}`);
+
+    const mappings = await this.accountMappingService.getMappings();
+
+    this.validateMapping(mappings, MappingType.VENDOR_PAYMENT_AP, 'Accounts Payable');
+    const paymentMethodCode = vendorPayment.paymentMethodEntity?.code || 'CASH';
+    const creditMappingKey = `vendor_payment_${paymentMethodCode.toLowerCase()}`;
+    this.validateMappingByKey(
+      mappings,
+      creditMappingKey,
+      `vendor payment method "${paymentMethodCode}"`,
+    );
+
+    await this.validatePeriodOpen(vendorPayment.paymentDate);
+
+    const periodValidation = await this.fiscalPeriodService.validatePeriod({
+      date: vendorPayment.paymentDate,
+    });
+    if (!periodValidation.period) {
+      throw new BadRequestException(`No fiscal period found for date ${vendorPayment.paymentDate}`);
+    }
+
+    const refundAmount = Math.abs(Number(vendorPayment.amount));
+
+    const lines: CreateJournalEntryLineDto[] = [
+      {
+        accountId: mappings[creditMappingKey],
+        debitAmount: refundAmount,
+        creditAmount: 0,
+        memo: 'Cash refunded by vendor',
+      },
+      {
+        accountId: mappings[MappingType.VENDOR_PAYMENT_AP],
+        debitAmount: 0,
+        creditAmount: refundAmount,
+        memo: 'Accounts payable restored',
+      },
+    ];
+
+    const entryDto: CreateJournalEntryDto = {
+      entryDate: new Date(vendorPayment.paymentDate),
+      description: `Vendor Refund ${vendorPayment.paymentNumber} from ${vendorPayment.supplier.companyName}`,
+      fiscalPeriodId: periodValidation.period.id,
+      sourceType: 'vendor_payment',
+      sourceId: vendorPayment.id,
+      lines,
+    };
+
+    const entry = await this.journalEntryService.create(entryDto, userId);
+    const postedEntry = await this.journalEntryService.postEntry(entry.id, userId);
+    await this.auditLogService.log(
+      'AUTO_POST',
+      'JournalEntry',
+      `Auto-posted vendor refund journal entry: ${vendorPayment.paymentNumber}`,
+      {
+        entityId: entry.id,
+        userId: userId ?? 'system',
+        username,
+        metadata: { sourceType: 'vendor_payment', sourceId: vendorPayment.id },
+      },
+    );
+
+    this.logger.log(`Vendor refund entry posted successfully: ${postedEntry.referenceNumber}`);
+    return postedEntry as any;
+  }
+
   /**
    * Post journal entry for stock adjustment
    * Handles both increases and decreases

--- a/backend/src/modules/purchasing/dto/purchase-order.dto.ts
+++ b/backend/src/modules/purchasing/dto/purchase-order.dto.ts
@@ -396,9 +396,9 @@ export class RecordVendorPaymentsDto {
 export class RecordOrderPaymentsDto extends RecordVendorPaymentsDto {}
 
 export class RefundLineDto {
-  @ApiProperty({ description: 'Original vendor payment to reverse' })
+  @ApiProperty({ description: 'Payment method to refund against' })
   @IsUUID()
-  vendorPaymentId: string;
+  paymentMethodId: string;
 
   @ApiProperty({ description: 'Refund amount (positive)' })
   @Transform(({ value }) => parseFloat(value))
@@ -406,10 +406,10 @@ export class RefundLineDto {
   @Min(0.01)
   amount: number;
 
-  @ApiPropertyOptional({ description: 'Refund reason' })
+  @ApiPropertyOptional({ description: 'Refund reference / note' })
   @IsOptional()
   @IsString()
-  reason?: string;
+  reference?: string;
 }
 
 export class RecordPurchaseOrderRefundsDto {

--- a/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
@@ -11,6 +11,7 @@ import {
   Supplier,
   Product,
   VendorPayment,
+  PaymentMethodEntity,
 } from '../../../database/entities';
 import { UserRole } from '../../../database/entities/user.entity';
 import { SupplierService } from './supplier.service';
@@ -34,6 +35,7 @@ describe('PurchaseOrderService', () => {
   let accountingService: jest.Mocked<AccountingService>;
   let stockMovementService: jest.Mocked<StockMovementService>;
   let vendorPaymentService: jest.Mocked<VendorPaymentService>;
+  let paymentMethodRepository: any;
   let dataSource: jest.Mocked<DataSource>
   const adminUser = { role: UserRole.ADMIN } as any;
 
@@ -61,24 +63,27 @@ describe('PurchaseOrderService', () => {
     orderNumber: 'PO-000001',
   } as any;
 
-  // Builds a fake EntityManager whose VendorPayment repo is controllable.
-  function mockTxManager(opts) {
+  function mockTxManager(opts: { lockedPO?: any; existing?: any[]; conditionalUpdateAffected?: number } = {}) {
+    const { lockedPO, existing } = opts
     const saved = []
     const vpRepo = {
-      findOne: jest.fn().mockResolvedValue(opts.original),
-      // atomic conditional flip: UPDATE ... WHERE id AND status='completed'
-      update: jest.fn().mockResolvedValue({ affected: opts.conditionalUpdateAffected ?? 1 }),
+      find: jest.fn().mockResolvedValue(existing ?? []),
+      findOne: jest.fn().mockResolvedValue(undefined),
       create: jest.fn((row) => row),
       save: jest.fn(async (row) => {
-        const persisted = { id: 'refund-row', ...row }
+        const persisted = { id: `refund-${saved.length + 1}`, ...row }
         saved.push(persisted)
         return persisted
       }),
     }
-    const manager = {
-      getRepository: jest.fn().mockReturnValue(vpRepo),
+    const poRepo = {
+      findOne: jest.fn().mockResolvedValue(lockedPO),
+      save: jest.fn(async (row) => row),
     }
-    return { manager, vpRepo, saved }
+    const manager = {
+      getRepository: jest.fn((entity) => (entity === PurchaseOrder ? poRepo : vpRepo)),
+    }
+    return { manager, vpRepo, poRepo, saved }
   }
 
   beforeEach(async () => {
@@ -125,6 +130,12 @@ describe('PurchaseOrderService', () => {
           },
         },
         {
+          provide: getRepositoryToken(PaymentMethodEntity),
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+        {
           provide: SupplierService,
           useValue: {},
         },
@@ -166,6 +177,7 @@ describe('PurchaseOrderService', () => {
             postPurchaseReceiptEntry: jest.fn(),
             reverseSourceEntries: jest.fn(),
             postVendorPaymentEntry: jest.fn(),
+            postVendorRefundEntry: jest.fn(),
           },
         },
         {
@@ -189,6 +201,7 @@ describe('PurchaseOrderService', () => {
     purchaseOrderItemRepository = module.get(getRepositoryToken(PurchaseOrderItem));
     productRepository = module.get(getRepositoryToken(Product));
     vendorPaymentRepository = module.get(getRepositoryToken(VendorPayment));
+    paymentMethodRepository = module.get(getRepositoryToken(PaymentMethodEntity));
     auditLogService = module.get(AuditLogService);
     accountingService = module.get(AccountingService);
     stockMovementService = module.get(StockMovementService);
@@ -891,100 +904,151 @@ describe('PurchaseOrderService', () => {
   })
 
   describe('recordRefunds', () => {
-    const draftPaidPO = {
+    const lockedPO = {
       id: 'po-1',
       orderNumber: 'PO-001',
-      status: 'READY',
+      status: 'DRAFT',
       supplierId: 'sup-1',
-      totalAmount: '0',
+      totalAmount: '100',
     }
 
-    it('inserts a negative refunded row via the manager repo (NOT VendorPaymentService.create) and reverses the original GL', async () => {
-      purchaseOrderRepository.findOne.mockResolvedValueOnce(draftPaidPO as any)
-      const original = {
-        id: 'vp-1',
-        purchaseOrderId: 'po-1',
-        supplierId: 'sup-1',
-        paymentMethodId: 'pm-1',
-        amount: '100',
-        status: 'completed',
-      }
-      const { manager, saved } = mockTxManager({ original })
-      ;(dataSource.transaction as jest.Mock).mockImplementation(async (cb) => cb(manager))
-      ;(service as any).settingsService.generateDocumentNumber = jest.fn().mockResolvedValue('VP-REF-1')
+    beforeEach(() => {
+      paymentMethodRepository.findOne.mockResolvedValue({ id: 'pm-1', isActive: true })
+      ;(service as any).settingsService = { generateDocumentNumber: jest.fn().mockResolvedValue('VP-REF-1') }
+      vendorPaymentRepository.findOne.mockResolvedValue({
+        id: 'refund-1',
+        amount: -40,
+        supplier: { companyName: 'Acme' },
+        paymentMethodEntity: { code: 'CASH' },
+      } as any)
+      jest.spyOn(service as any, 'findOne').mockResolvedValue({ id: 'po-1' } as any)
+    })
+
+    function wireTx(opts: { existing?: any[] } = {}) {
+      const { existing } = opts
+      const ctx = mockTxManager({ lockedPO, existing: existing ?? [{ id: 'vp-1', amount: '100', paymentMethodId: 'pm-1', status: 'completed', isActive: true }] })
+      ;(dataSource.transaction as jest.Mock).mockImplementation(async (cb) => cb(ctx.manager))
+      return ctx
+    }
+
+    it('inserts a negative VP row (status completed) with paymentMethodId and reference->notes', async () => {
+      const ctx = wireTx()
       jest.spyOn(service as any, 'reconcilePaymentState').mockResolvedValue(undefined)
 
-      await service.recordRefunds(
-        'po-1',
-        [{ vendorPaymentId: 'vp-1', amount: 100, reason: 'overpaid' }],
-        'user-1',
-        'admin',
-      )
+      await service.recordRefunds('po-1', [{ paymentMethodId: 'pm-1', amount: 40, reference: 'damaged goods' }], 'user-1', 'admin')
 
-      // Negative row persisted with all non-null columns + refunded status.
-      expect(saved).toHaveLength(1)
-      expect(saved[0]).toMatchObject({
+      expect(ctx.saved).toHaveLength(1)
+      expect(ctx.saved[0]).toMatchObject({
         supplierId: 'sup-1',
         purchaseOrderId: 'po-1',
         paymentMethodId: 'pm-1',
         paymentNumber: 'VP-REF-1',
-        amount: -100,
-        status: 'refunded',
-        notes: 'overpaid',
+        amount: -40,
+        status: 'completed',
+        notes: 'damaged goods',
       })
-      expect(saved[0].paymentDate).toBeDefined()
+      expect(ctx.saved[0].paymentDate).toBeDefined()
+    })
 
-      // Refund row NOT routed through the auto-posting service.create (would double-post GL).
-      expect(vendorPaymentService.create).not.toHaveBeenCalled()
-      // Original entry reversed (not the refund row).
-      expect(accountingService.reverseSourceEntries).toHaveBeenCalledWith(
-        'vendor_payment',
-        'vp-1',
-        'user-1',
+    it('leaves originals untouched — no reverseSourceEntries (no per-original flip)', async () => {
+      wireTx()
+      jest.spyOn(service as any, 'reconcilePaymentState').mockResolvedValue(undefined)
+
+      await service.recordRefunds('po-1', [{ paymentMethodId: 'pm-1', amount: 40 }], 'u')
+
+      expect(accountingService.reverseSourceEntries).not.toHaveBeenCalled()
+    })
+
+    it('rejects total refund exceeding net paid across ACTIVE rows (aggregate guard)', async () => {
+      wireTx({ existing: [{ amount: '100', isActive: true }] })
+      await expect(
+        service.recordRefunds('po-1', [{ paymentMethodId: 'pm-1', amount: 150 }], 'u'),
+      ).rejects.toThrow(/exceeds net paid/i)
+    })
+
+    it('computes netPaid from ACTIVE rows only (guard query filters isActive: true)', async () => {
+      const ctx = wireTx()
+      jest.spyOn(service as any, 'reconcilePaymentState').mockResolvedValue(undefined)
+
+      await service.recordRefunds('po-1', [{ paymentMethodId: 'pm-1', amount: 40 }], 'u')
+
+      expect(ctx.vpRepo.find).toHaveBeenCalledWith({
+        where: { purchaseOrderId: 'po-1', isActive: true },
+      })
+    })
+
+    it('reconciles payment state INSIDE the transaction with the manager', async () => {
+      wireTx()
+      const reconcileSpy = jest.spyOn(service as any, 'reconcilePaymentState').mockResolvedValue(undefined)
+
+      await service.recordRefunds('po-1', [{ paymentMethodId: 'pm-1', amount: 40 }], 'u')
+
+      expect(reconcileSpy).toHaveBeenCalledWith(lockedPO, expect.anything())
+    })
+
+    it('posts the refund GL via postVendorRefundEntry AFTER the transaction commits', async () => {
+      const order = []
+      const ctx = mockTxManager({ lockedPO, existing: [{ id: 'vp-1', amount: '100', paymentMethodId: 'pm-1', isActive: true }] })
+      ;(dataSource.transaction as jest.Mock).mockImplementation(async (cb) => {
+        const result = await cb(ctx.manager)
+        order.push('tx-committed')
+        return result
+      })
+      jest.spyOn(service as any, 'reconcilePaymentState').mockResolvedValue(undefined)
+      ;(accountingService.postVendorRefundEntry as jest.Mock).mockImplementation(async () => {
+        order.push('gl-posted')
+      })
+
+      await service.recordRefunds('po-1', [{ paymentMethodId: 'pm-1', amount: 40 }], 'u')
+
+      expect(vendorPaymentRepository.findOne).toHaveBeenCalledWith({ where: { id: 'refund-1' } })
+      expect(accountingService.postVendorRefundEntry).toHaveBeenCalled()
+      expect(order).toEqual(['tx-committed', 'gl-posted'])
+    })
+
+    it('audit-logs each refund row with its id and paymentMethodId', async () => {
+      wireTx()
+      jest.spyOn(service as any, 'reconcilePaymentState').mockResolvedValue(undefined)
+
+      await service.recordRefunds('po-1', [{ paymentMethodId: 'pm-1', amount: 40 }], 'u')
+
+      expect(auditLogService.log).toHaveBeenCalledWith(
+        'CREATE',
+        'VendorPayment',
+        expect.any(String),
+        expect.objectContaining({
+          newValues: expect.objectContaining({ paymentMethodId: 'pm-1' }),
+        }),
       )
-      // postVendorPaymentEntry never called for the refund row.
-      expect(accountingService.postVendorPaymentEntry).not.toHaveBeenCalled()
     })
 
     it('rejects refund on a RECEIVED purchase order', async () => {
-      purchaseOrderRepository.findOne.mockResolvedValueOnce({ ...draftPaidPO, status: 'RECEIVED' } as any)
+      const ctx = mockTxManager({ lockedPO: { ...lockedPO, status: 'RECEIVED' } })
+      ;(dataSource.transaction as jest.Mock).mockImplementation(async (cb) => cb(ctx.manager))
       await expect(
-        service.recordRefunds('po-1', [{ vendorPaymentId: 'vp-1', amount: 10 }], 'u'),
+        service.recordRefunds('po-1', [{ paymentMethodId: 'pm-1', amount: 10 }], 'u'),
       ).rejects.toThrow('Cannot refund a RECEIVED purchase order.')
     })
 
     it('rejects refund on a CANCELLED purchase order', async () => {
-      purchaseOrderRepository.findOne.mockResolvedValueOnce({ ...draftPaidPO, status: 'CANCELLED' } as any)
+      const ctx = mockTxManager({ lockedPO: { ...lockedPO, status: 'CANCELLED' } })
+      ;(dataSource.transaction as jest.Mock).mockImplementation(async (cb) => cb(ctx.manager))
       await expect(
-        service.recordRefunds('po-1', [{ vendorPaymentId: 'vp-1', amount: 10 }], 'u'),
+        service.recordRefunds('po-1', [{ paymentMethodId: 'pm-1', amount: 10 }], 'u'),
       ).rejects.toThrow('Cannot refund a CANCELLED purchase order.')
     })
 
     it('rejects a non-positive amount', async () => {
-      purchaseOrderRepository.findOne.mockResolvedValueOnce(draftPaidPO as any)
       await expect(
-        service.recordRefunds('po-1', [{ vendorPaymentId: 'vp-1', amount: 0 }], 'u'),
+        service.recordRefunds('po-1', [{ paymentMethodId: 'pm-1', amount: 0 }], 'u'),
       ).rejects.toThrow('greater than zero')
     })
 
-    it('rejects re-refunding an already-refunded original (conditional update affected 0)', async () => {
-      purchaseOrderRepository.findOne.mockResolvedValueOnce(draftPaidPO as any)
-      const { manager } = mockTxManager({ original: { id: 'vp-1' }, conditionalUpdateAffected: 0 })
-      ;(dataSource.transaction as jest.Mock).mockImplementation(async (cb) => cb(manager))
+    it('rejects an inactive / unknown payment method', async () => {
+      paymentMethodRepository.findOne.mockResolvedValue(null)
       await expect(
-        service.recordRefunds('po-1', [{ vendorPaymentId: 'vp-1', amount: 10 }], 'u'),
-      ).rejects.toThrow('not refundable')
-    })
-
-    it('rejects a refund amount greater than the original payment', async () => {
-      purchaseOrderRepository.findOne.mockResolvedValueOnce(draftPaidPO as any)
-      const original = { id: 'vp-1', purchaseOrderId: 'po-1', supplierId: 'sup-1', amount: '50', status: 'completed' }
-      const { manager } = mockTxManager({ original })
-      ;(dataSource.transaction as jest.Mock).mockImplementation(async (cb) => cb(manager))
-      ;(service as any).settingsService.generateDocumentNumber = jest.fn().mockResolvedValue('VP-REF-1')
-      await expect(
-        service.recordRefunds('po-1', [{ vendorPaymentId: 'vp-1', amount: 100 }], 'u'),
-      ).rejects.toThrow('exceeds original payment amount')
+        service.recordRefunds('po-1', [{ paymentMethodId: 'bad', amount: 10 }], 'u'),
+      ).rejects.toThrow(/not found or inactive/i)
     })
   })
 });

--- a/backend/src/modules/purchasing/services/purchase-order.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.ts
@@ -758,6 +758,14 @@ export class PurchaseOrderService extends BaseCrudService<
       }
     }
 
+    // Generate document numbers BEFORE opening the transaction. generateDocumentNumber
+    // does its own DB work and is not bound to this tx manager (#719); running it while
+    // holding the PO pessimistic_write lock would extend the lock for no benefit.
+    const paymentNumbers: string[] = [];
+    for (let i = 0; i < refunds.length; i++) {
+      paymentNumbers.push(await this.settingsService.generateDocumentNumber('Vendor Payments'));
+    }
+
     const savedRefundRows: { id: string; paymentMethodId: string }[] = [];
 
     await this.dataSource.transaction(async (manager: EntityManager) => {
@@ -782,14 +790,14 @@ export class PurchaseOrderService extends BaseCrudService<
         );
       }
 
-      for (const line of refunds) {
-        const paymentNumber = await this.settingsService.generateDocumentNumber('Vendor Payments');
+      for (let i = 0; i < refunds.length; i++) {
+        const line = refunds[i];
         const refundRow = repo.create({
           supplierId: purchaseOrder.supplierId,
           purchaseOrderId: orderId,
           paymentMethodId: line.paymentMethodId,
           paymentDate: new Date(),
-          paymentNumber,
+          paymentNumber: paymentNumbers[i],
           amount: -Number(line.amount),
           notes: line.reference,
           status: 'completed',
@@ -823,7 +831,7 @@ export class PurchaseOrderService extends BaseCrudService<
           entityId: row.id,
           userId: actor,
           username,
-          newValues: { vendorPaymentId: row.id, paymentMethodId: row.paymentMethodId, refund: true },
+          newValues: { refundVendorPaymentId: row.id, paymentMethodId: row.paymentMethodId, refund: true },
         },
       );
     }

--- a/backend/src/modules/purchasing/services/purchase-order.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.ts
@@ -758,14 +758,6 @@ export class PurchaseOrderService extends BaseCrudService<
       }
     }
 
-    // Generate document numbers BEFORE opening the transaction. generateDocumentNumber
-    // does its own DB work and is not bound to this tx manager (#719); running it while
-    // holding the PO pessimistic_write lock would extend the lock for no benefit.
-    const paymentNumbers: string[] = [];
-    for (let i = 0; i < refunds.length; i++) {
-      paymentNumbers.push(await this.settingsService.generateDocumentNumber('Vendor Payments'));
-    }
-
     const savedRefundRows: { id: string; paymentMethodId: string }[] = [];
 
     await this.dataSource.transaction(async (manager: EntityManager) => {
@@ -790,14 +782,20 @@ export class PurchaseOrderService extends BaseCrudService<
         );
       }
 
-      for (let i = 0; i < refunds.length; i++) {
-        const line = refunds[i];
+      // Generate the document number only AFTER the guards pass. generateDocumentNumber
+      // commits its counter in its own transaction (#719), so a number is burned the
+      // moment it is consumed — generating before the guards would leave sequence gaps
+      // on every rejected refund. SO avoids this entirely because SalesOrderPayment has
+      // no document number; VendorPayment requires a unique paymentNumber, so PO must
+      // generate one, and we do it past the point where the refund can still be rejected.
+      for (const line of refunds) {
+        const paymentNumber = await this.settingsService.generateDocumentNumber('Vendor Payments');
         const refundRow = repo.create({
           supplierId: purchaseOrder.supplierId,
           purchaseOrderId: orderId,
           paymentMethodId: line.paymentMethodId,
           paymentDate: new Date(),
-          paymentNumber: paymentNumbers[i],
+          paymentNumber,
           amount: -Number(line.amount),
           notes: line.reference,
           status: 'completed',

--- a/backend/src/modules/purchasing/services/purchase-order.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException, BadRequestException, ConflictException, ForbiddenException, HttpException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, BadRequestException, ForbiddenException, HttpException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, FindOptionsWhere, Like, In, Between, DataSource, EntityManager } from 'typeorm';
 import { BaseCrudService } from '../../../common/services/base-crud.service';

--- a/backend/src/modules/purchasing/services/purchase-order.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.ts
@@ -9,7 +9,8 @@ import {
   PurchaseOrderStatus,
   Supplier,
   Product,
-  VendorPayment
+  VendorPayment,
+  PaymentMethodEntity
 } from '../../../database/entities';
 import {
   CreatePurchaseOrderDto,
@@ -58,6 +59,8 @@ export class PurchaseOrderService extends BaseCrudService<
     private readonly productRepository: Repository<Product>,
     @InjectRepository(VendorPayment)
     private readonly vendorPaymentRepository: Repository<VendorPayment>,
+    @InjectRepository(PaymentMethodEntity)
+    private readonly paymentMethodRepository: Repository<PaymentMethodEntity>,
     private readonly supplierService: SupplierService,
     private readonly vendorPaymentService: VendorPaymentService,
     private readonly settingsService: SettingsService,
@@ -732,102 +735,95 @@ export class PurchaseOrderService extends BaseCrudService<
 
   async recordRefunds(
     orderId: string,
-    refunds: { vendorPaymentId: string; amount: number; reason?: string }[],
+    refunds: { paymentMethodId: string; amount: number; reference?: string }[],
     userId?: string,
     username?: string,
   ): Promise<PurchaseOrderResponseDto> {
     const actor = userId || 'system';
 
+    if (refunds.length === 0) {
+      throw new BadRequestException('At least one refund line is required');
+    }
     for (const line of refunds) {
       if (!(Number(line.amount) > 0)) {
         throw new BadRequestException('Each refund amount must be greater than zero');
       }
     }
-
-    const purchaseOrder = await this.purchaseOrderRepository.findOne({ where: { id: orderId } });
-    if (!purchaseOrder) {
-      throw new NotFoundException('Purchase order not found');
-    }
-    if (
-      purchaseOrder.status === PurchaseOrderStatus.CANCELLED ||
-      purchaseOrder.status === PurchaseOrderStatus.RECEIVED
-    ) {
-      throw new BadRequestException(
-        `Cannot refund a ${purchaseOrder.status} purchase order.`,
-      );
+    for (const line of refunds) {
+      const method = await this.paymentMethodRepository.findOne({
+        where: { id: line.paymentMethodId, isActive: true },
+      });
+      if (!method) {
+        throw new BadRequestException(`Payment method ${line.paymentMethodId} not found or inactive`);
+      }
     }
 
-    // The reversed originals, captured inside the tx so GL reversal can run after commit.
-    const reversedOriginalIds: string[] = [];
+    const savedRefundRows: { id: string; paymentMethodId: string }[] = [];
 
     await this.dataSource.transaction(async (manager: EntityManager) => {
+      const purchaseOrder = await lockRowForUpdate(manager, PurchaseOrder, orderId, {
+        notFoundMessage: 'Purchase order not found',
+      });
+      if (
+        purchaseOrder.status === PurchaseOrderStatus.CANCELLED ||
+        purchaseOrder.status === PurchaseOrderStatus.RECEIVED
+      ) {
+        throw new BadRequestException(`Cannot refund a ${purchaseOrder.status} purchase order.`);
+      }
+
       const repo = manager.getRepository(VendorPayment);
 
-      for (const line of refunds) {
-        // Atomic flip completed -> refunded. If no row matched (already refunded,
-        // wrong PO, or missing), affected === 0 -> reject. This is the
-        // concurrency-safe re-refund guard.
-        const flip = await repo.update(
-          { id: line.vendorPaymentId, purchaseOrderId: orderId, status: 'completed' } as any,
-          { status: 'refunded' } as any,
+      const existing = await repo.find({ where: { purchaseOrderId: orderId, isActive: true } });
+      const netPaid = existing.reduce((sum, r) => sum + Number(r.amount), 0);
+      const totalRefund = refunds.reduce((sum, l) => sum + Number(l.amount), 0);
+      if (totalRefund > netPaid + 0.001) {
+        throw new BadRequestException(
+          `Total refund amount (${totalRefund}) exceeds net paid (${netPaid.toFixed(4)})`,
         );
-        if (!flip.affected) {
-          throw new ConflictException(
-            `Vendor payment ${line.vendorPaymentId} is not refundable (not found, not this order, or already refunded).`,
-          );
-        }
+      }
 
-        const original = await repo.findOne({ where: { id: line.vendorPaymentId } });
-        if (!original) {
-          throw new ConflictException(`Vendor payment ${line.vendorPaymentId} not found`);
-        }
-        if (Number(line.amount) > Number(original.amount)) {
-          throw new BadRequestException(
-            `Refund amount (${line.amount}) exceeds original payment amount (${original.amount})`,
-          );
-        }
-
+      for (const line of refunds) {
         const paymentNumber = await this.settingsService.generateDocumentNumber('Vendor Payments');
         const refundRow = repo.create({
-          supplierId: original.supplierId,
+          supplierId: purchaseOrder.supplierId,
           purchaseOrderId: orderId,
-          paymentMethodId: original.paymentMethodId,
+          paymentMethodId: line.paymentMethodId,
           paymentDate: new Date(),
           paymentNumber,
           amount: -Number(line.amount),
-          notes: line.reason,
-          status: 'refunded',
+          notes: line.reference,
+          status: 'completed',
         } as any);
-        await repo.save(refundRow);
-
-        reversedOriginalIds.push(line.vendorPaymentId);
+        const saved = await repo.save(refundRow);
+        savedRefundRows.push({ id: (saved as any).id, paymentMethodId: line.paymentMethodId });
       }
+
+      await this.reconcilePaymentState(purchaseOrder, manager);
     });
 
-    // GL reversal runs after the DB tx (accounting is not manager-bound, #719).
-    // reverseSourceEntries is idempotent on already-reversed entries.
-    for (const originalId of reversedOriginalIds) {
+    for (const row of savedRefundRows) {
       try {
-        await this.accountingService.reverseSourceEntries('vendor_payment', originalId, actor);
+        const fullRow = await this.vendorPaymentRepository.findOne({ where: { id: row.id } });
+        if (fullRow) {
+          await this.accountingService.postVendorRefundEntry(fullRow, actor, username);
+        }
       } catch (error) {
         this.logger.error(
-          `Failed to reverse accounting for vendor payment ${originalId}: ${error.message}`,
+          `Failed to post refund accounting entry for vendor payment ${row.id}: ${error.message}`,
         );
       }
     }
 
-    await this.reconcilePaymentState(purchaseOrder);
-
-    for (const originalId of reversedOriginalIds) {
+    for (const row of savedRefundRows) {
       await this.auditLogService.log(
         'CREATE',
         'VendorPayment',
-        `Recorded refund for ${purchaseOrder.orderNumber}`,
+        `Recorded refund for purchase order ${orderId}`,
         {
-          entityId: originalId,
+          entityId: row.id,
           userId: actor,
           username,
-          newValues: { originalVendorPaymentId: originalId, resultingPaymentStatus: purchaseOrder.paymentStatus },
+          newValues: { vendorPaymentId: row.id, paymentMethodId: row.paymentMethodId, refund: true },
         },
       );
     }

--- a/frontend/src/pages/purchasing/PurchaseOrderDetailPage.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderDetailPage.tsx
@@ -24,6 +24,7 @@ import {
 import type { VendorPayment } from '@/types'
 import RefundDialog, { type RefundSource } from '@/components/common/RefundDialog'
 
+import { buildPoRefundSources, toPoRefundPayload } from './utils/poRefund'
 import PurchaseOrderActionBar from './components/PurchaseOrderActionBar'
 import PurchaseOrderJournalEntriesTab from './components/PurchaseOrderJournalEntriesTab'
 import PurchaseOrderOverviewTab from './components/PurchaseOrderOverviewTab'
@@ -96,23 +97,11 @@ export default function PurchaseOrderDetailPage() {
   const [recordRefunds] = useRecordPurchaseOrderRefundsMutation()
   const [recordPayments] = useRecordVendorPaymentsMutation()
 
-  // Build RefundSource[] from vendor payments (net by payment)
-  const refundSources: RefundSource[] = useMemo(() => {
-    const netByPayment: Record<string, { paid: number; refunded: number; label: string }> = {}
-    for (const p of payments ?? []) {
-      const key = p.id
-      const entry = (netByPayment[key] ??= { paid: 0, refunded: 0, label: p.paymentNumber ?? 'Payment' })
-      const amt = Number(p.amount)
-      if (amt >= 0) entry.paid += amt
-      else entry.refunded += Math.abs(amt)
-    }
-    return Object.entries(netByPayment).map(([id, v]) => ({
-      id,
-      label: v.label,
-      paidAmount: v.paid,
-      alreadyRefunded: v.refunded,
-    }))
-  }, [payments])
+  // Build RefundSource[] from vendor payments (grouped by payment method)
+  const refundSources: RefundSource[] = useMemo(
+    () => buildPoRefundSources(payments ?? []),
+    [payments],
+  )
 
   if (isLoading) {
     return (
@@ -198,7 +187,7 @@ export default function PurchaseOrderDetailPage() {
     try {
       await recordRefunds({
         id: order.id,
-        refunds: lines.map((l) => ({ vendorPaymentId: l.sourceId, amount: l.amount, reason: l.reference })),
+        refunds: toPoRefundPayload(lines),
       }).unwrap()
       showSuccess(`Refund recorded for ${order.orderNumber}`)
       setActiveDialog(null)

--- a/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrdersPage.tsx
@@ -24,6 +24,7 @@ import RefundDialog, { type RefundSource } from '@/components/common/RefundDialo
 import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
 import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
 
+import { buildPoRefundSources, toPoRefundPayload } from './utils/poRefund'
 import PurchaseOrderList from './components/PurchaseOrderList'
 import PurchaseOrderPrintDialog from './components/PurchaseOrderPrintDialog'
 
@@ -139,23 +140,10 @@ const PurchaseOrdersPage: React.FC = () => {
     refundOrder ? refundOrder.id : skipToken,
   )
 
-  // Build RefundSource[] from vendor payments (net by payment)
+  // Build RefundSource[] from vendor payments (grouped by payment method)
   const refundSources: RefundSource[] = useMemo(() => {
     if (!refundOrder) return []
-    const netByPayment: Record<string, { paid: number; refunded: number; label: string }> = {}
-    for (const p of refundPaymentRecords ?? []) {
-      const key = p.id
-      const entry = (netByPayment[key] ??= { paid: 0, refunded: 0, label: p.paymentNumber ?? 'Payment' })
-      const amt = Number(p.amount)
-      if (amt >= 0) entry.paid += amt
-      else entry.refunded += Math.abs(amt)
-    }
-    return Object.entries(netByPayment).map(([id, v]) => ({
-      id,
-      label: v.label,
-      paidAmount: v.paid,
-      alreadyRefunded: v.refunded,
-    }))
+    return buildPoRefundSources(refundPaymentRecords ?? [])
   }, [refundOrder, refundPaymentRecords])
 
   const handleSort = useCallback((field: string) => {
@@ -304,7 +292,7 @@ const PurchaseOrdersPage: React.FC = () => {
     try {
       await recordPurchaseOrderRefunds({
         id: refundOrder.id,
-        refunds: lines.map((l) => ({ vendorPaymentId: l.sourceId, amount: l.amount, reason: l.reference })),
+        refunds: toPoRefundPayload(lines),
       }).unwrap()
       showSuccess(`Refund recorded for ${refundOrder.orderNumber}`)
       setRefundOrder(null)

--- a/frontend/src/pages/purchasing/utils/__tests__/poRefund.test.ts
+++ b/frontend/src/pages/purchasing/utils/__tests__/poRefund.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { buildPoRefundSources, toPoRefundPayload } from '../poRefund'
+
+describe('buildPoRefundSources', () => {
+  it('groups by paymentMethodId, labels with method name, nets +/-', () => {
+    const sources = buildPoRefundSources([
+      { id: 'p1', paymentMethodId: 'm1', paymentMethodEntity: { name: 'Cash' }, amount: 100 },
+      { id: 'p2', paymentMethodId: 'm1', paymentMethodEntity: { name: 'Cash' }, amount: -30 },
+      { id: 'p3', paymentMethodId: 'm2', paymentMethodEntity: { name: 'Bank' }, amount: 50 },
+    ] as any)
+
+    const cash = sources.find((s) => s.id === 'm1')!
+    expect(cash.label).toBe('Cash')
+    expect(cash.paidAmount).toBe(100)
+    expect(cash.alreadyRefunded).toBe(30)
+    const bank = sources.find((s) => s.id === 'm2')!
+    expect(bank.paidAmount).toBe(50)
+  })
+
+  it('skips payments with a falsy paymentMethodId (legacy null-method rows)', () => {
+    const sources = buildPoRefundSources([
+      { id: 'p1', paymentMethodId: null, paymentMethodEntity: undefined, amount: 100 },
+      { id: 'p2', paymentMethodId: 'm1', paymentMethodEntity: { name: 'Cash' }, amount: 40 },
+    ] as any)
+    expect(sources.map((s) => s.id)).toEqual(['m1'])
+  })
+
+  it('falls back to "Payment" label when method entity missing but id present', () => {
+    const sources = buildPoRefundSources([
+      { id: 'p1', paymentMethodId: 'm1', paymentMethodEntity: undefined, amount: 10 },
+    ] as any)
+    expect(sources[0].label).toBe('Payment')
+  })
+})
+
+describe('toPoRefundPayload', () => {
+  it('maps sourceId -> paymentMethodId and keeps reference (no vendorPaymentId/reason)', () => {
+    const payload = toPoRefundPayload([
+      { sourceId: 'm1', amount: 40, reference: 'damaged' },
+    ])
+    expect(payload).toEqual([{ paymentMethodId: 'm1', amount: 40, reference: 'damaged' }])
+  })
+})

--- a/frontend/src/pages/purchasing/utils/poRefund.ts
+++ b/frontend/src/pages/purchasing/utils/poRefund.ts
@@ -1,0 +1,30 @@
+import type { RefundSource } from '@/components/common/RefundDialog'
+import type { VendorPayment } from '@/types'
+
+export function buildPoRefundSources(payments: VendorPayment[]): RefundSource[] {
+  const netByMethod: Record<string, { paid: number; refunded: number; label: string }> = {}
+  for (const p of payments ?? []) {
+    if (!p.paymentMethodId) continue
+    const key = p.paymentMethodId
+    const entry = (netByMethod[key] ??= {
+      paid: 0,
+      refunded: 0,
+      label: p.paymentMethodEntity?.name ?? 'Payment',
+    })
+    const amt = Number(p.amount)
+    if (amt >= 0) entry.paid += amt
+    else entry.refunded += Math.abs(amt)
+  }
+  return Object.entries(netByMethod).map(([id, v]) => ({
+    id,
+    label: v.label,
+    paidAmount: v.paid,
+    alreadyRefunded: v.refunded,
+  }))
+}
+
+export function toPoRefundPayload(
+  lines: { sourceId: string; amount: number; reference?: string }[],
+): { paymentMethodId: string; amount: number; reference?: string }[] {
+  return lines.map((l) => ({ paymentMethodId: l.sourceId, amount: l.amount, reference: l.reference }))
+}

--- a/frontend/src/store/api/purchasingApi.ts
+++ b/frontend/src/store/api/purchasingApi.ts
@@ -243,7 +243,7 @@ export const purchasingApiSlice = createApi({
     }),
     recordPurchaseOrderRefunds: builder.mutation<
       PurchaseOrder,
-      { id: string; refunds: { vendorPaymentId: string; amount: number; reason?: string }[] }
+      { id: string; refunds: { paymentMethodId: string; amount: number; reference?: string }[] }
     >({
       query: ({ id, refunds }) => ({
         url: `/purchasing/orders/${id}/refunds`,


### PR DESCRIPTION
## Summary

Makes Purchase Order refunds behave like Sales Order refunds: the shared `RefundDialog` now groups refund sources by **payment method** (Cash, Bank, …) instead of by individual vendor payment number (VP-xxxx), and refunds are recorded against a method rather than a specific VP document.

### Backend
- **`recordRefunds` rewritten** to mirror SO: locks the PO row in-transaction, validates each `paymentMethodId` is active, applies an aggregate-only guard (`totalRefund ≤ netPaid` across active rows), inserts a negative-amount `VendorPayment` row (status stays `completed`, originals never flipped), reconciles payment state in-tx, and posts the refund GL after commit.
- **New `AccountingService.postVendorRefundEntry`** — posts a reversed-polarity entry `DR Cash / CR Accounts Payable` using `Math.abs(amount)`. A naive negative-amount post is rejected by `validateEntryLines` (debit/credit must be positive); this dedicated path avoids that.
- **`RefundLineDto`** — `vendorPaymentId` → `paymentMethodId`, `reason` → `reference`.
- Document number generated **after** the guards (inside the tx) so rejected refunds don't burn `VendorPayment` sequence numbers.

### Frontend
- **New `utils/poRefund.ts`** — shared `buildPoRefundSources` (method-grouped, skips legacy null-method rows) + `toPoRefundPayload`. Used by both `PurchaseOrderDetailPage` and `PurchaseOrdersPage` (the list-page inline refund dialog), eliminating duplicated logic.
- RTK Query refund request type updated to `{ paymentMethodId, amount, reference }`.

## Behavior changes (intentional, matches SO)
- Original vendor payments stay `completed` (not flipped to `refunded`).
- Refund GL is a standalone reversing entry on the negative VP row, not a reversal of the original payment's entry.
- Refunds tie to a payment **method**, not a specific VP document (per-VP traceability dropped).
- Aggregate-only guard (no per-method cap): refunding a method that wasn't paid can reclassify cash accounts. Accepted to match SO; documented in the design spec.

## Test Plan
- [x] Backend: `npm run lint && npm run test` — 1130/1130 pass, lint clean
- [x] Frontend: `npm run type-check && npm run lint` clean; refund + RefundDialog tests pass (23/23)
- [x] Manual smoke: record a PO payment, open the refund dialog on **both** the detail and list pages, confirm sources are labelled by method name; submit a partial refund and confirm a negative VP row appears, the original stays `completed`, payment status drops, and a `DR Cash / CR AP` journal entry was posted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)