### PR TITLE
feat(purchasing): add GRN print option to PO print dialog

### DIFF
--- a/backend/src/database/entities/purchase-order.entity.ts
+++ b/backend/src/database/entities/purchase-order.entity.ts
@@ -64,6 +64,15 @@ export class PurchaseOrder extends BaseEntity {
   @IsDate()
   orderDate: Date;
 
+  @Column({
+    type: 'date',
+    nullable: true,
+    comment: 'Date goods were received (set on RECEIVED transition)',
+  })
+  @IsOptional()
+  @IsDate()
+  receivedDate?: Date | null;
+
   // Financial Information
   @Column({
     type: 'decimal',

--- a/backend/src/database/migrations/1781376533442-AddPurchaseOrderReceivedDate.ts
+++ b/backend/src/database/migrations/1781376533442-AddPurchaseOrderReceivedDate.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPurchaseOrderReceivedDate1781376533442 implements MigrationInterface {
+  name = 'AddPurchaseOrderReceivedDate1781376533442';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "purchase_orders"
+      ADD COLUMN IF NOT EXISTS "receivedDate" date
+    `);
+    await queryRunner.query(`
+      COMMENT ON COLUMN "purchase_orders"."receivedDate"
+      IS 'Date goods were received (set on RECEIVED transition)'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "purchase_orders"
+      DROP COLUMN IF EXISTS "receivedDate"
+    `);
+  }
+}

--- a/backend/src/modules/purchasing/dto/purchase-order.dto.ts
+++ b/backend/src/modules/purchasing/dto/purchase-order.dto.ts
@@ -216,6 +216,9 @@ export class PurchaseOrderResponseDto {
   @ApiProperty({ description: 'Order date' })
   orderDate: Date;
 
+  @ApiPropertyOptional({ description: 'Date goods were received' })
+  receivedDate?: Date | null;
+
   @ApiProperty({ description: 'Subtotal amount' })
   subtotal: number;
 

--- a/backend/src/modules/purchasing/services/purchase-order-lifecycle.service.spec.ts
+++ b/backend/src/modules/purchasing/services/purchase-order-lifecycle.service.spec.ts
@@ -255,6 +255,15 @@ describe('PurchaseOrderLifecycleService', () => {
       );
       expect(accountingService.postPurchaseReceiptEntry).toHaveBeenCalled();
       expect(result.status).toBe(PurchaseOrderStatus.RECEIVED);
+
+      expect(poRepo.update).toHaveBeenCalledWith(
+        'po-1',
+        expect.objectContaining({
+          status: PurchaseOrderStatus.RECEIVED,
+          receivedDate: expect.any(Date),
+        }),
+      );
+      expect(result.receivedDate).toBeInstanceOf(Date);
     });
 
     it('capitalizes inventory at the NET (after-discount) unit cost so GL matches the subledger', async () => {
@@ -320,6 +329,7 @@ describe('PurchaseOrderLifecycleService', () => {
       const receivedOrder = {
         ...mockOrder,
         status: PurchaseOrderStatus.RECEIVED,
+        receivedDate: new Date('2026-06-01'),
         items: [
           {
             id: 'po-item-1',
@@ -372,6 +382,15 @@ describe('PurchaseOrderLifecycleService', () => {
         expect.anything(),
       );
       expect(result.status).toBe(PurchaseOrderStatus.READY);
+
+      expect(poRepo.update).toHaveBeenCalledWith(
+        'po-1',
+        expect.objectContaining({
+          status: PurchaseOrderStatus.READY,
+          receivedDate: null,
+        }),
+      );
+      expect(result.receivedDate).toBeNull();
     });
   });
 

--- a/backend/src/modules/purchasing/services/purchase-order-lifecycle.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order-lifecycle.service.ts
@@ -209,8 +209,10 @@ export class PurchaseOrderLifecycleService {
 
       await manager.getRepository(PurchaseOrder).update(id, {
         status: PurchaseOrderStatus.RECEIVED,
+        receivedDate: receiveDate,
       });
       purchaseOrder.status = PurchaseOrderStatus.RECEIVED;
+      purchaseOrder.receivedDate = receiveDate;
 
       await this.accountingService.postPurchaseReceiptEntry(
         purchaseOrder,
@@ -256,8 +258,10 @@ export class PurchaseOrderLifecycleService {
 
       await manager.getRepository(PurchaseOrder).update(id, {
         status: PurchaseOrderStatus.READY,
+        receivedDate: null,
       });
       purchaseOrder.status = PurchaseOrderStatus.READY;
+      purchaseOrder.receivedDate = null;
 
       await this.accountingService.reverseSourceEntries(
         'purchase_order',

--- a/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.spec.ts
@@ -617,6 +617,29 @@ describe('PurchaseOrderService', () => {
       // sortField === 'orderNumber' so the secondary orderNumber tiebreaker is skipped
       expect(queryBuilder.addOrderBy).not.toHaveBeenCalled();
     });
+
+    it('maps receivedDate through to the response dto', async () => {
+      const received = new Date('2026-06-10');
+      const queryBuilder = createFindAllQueryBuilder([
+        createFindAllOrder({ receivedDate: received } as any),
+      ]);
+      purchaseOrderRepository.createQueryBuilder.mockReturnValue(queryBuilder as any);
+
+      const result = await service.findAll({});
+
+      expect(result.orders[0].receivedDate).toEqual(received);
+    });
+
+    it('maps a null receivedDate as null', async () => {
+      const queryBuilder = createFindAllQueryBuilder([
+        createFindAllOrder({ receivedDate: null } as any),
+      ]);
+      purchaseOrderRepository.createQueryBuilder.mockReturnValue(queryBuilder as any);
+
+      const result = await service.findAll({});
+
+      expect(result.orders[0].receivedDate).toBeNull();
+    });
   });
 
 

--- a/backend/src/modules/purchasing/services/purchase-order.service.ts
+++ b/backend/src/modules/purchasing/services/purchase-order.service.ts
@@ -1064,6 +1064,7 @@ export class PurchaseOrderService extends BaseCrudService<
         country: purchaseOrder.supplier.billingCountry,
       } : undefined,
       orderDate: purchaseOrder.orderDate,
+      receivedDate: purchaseOrder.receivedDate,
       subtotal: Number(purchaseOrder.subtotal),
       discountPercent: Number(purchaseOrder.discountPercent),
       discountAmount: Number(purchaseOrder.discountAmount),

--- a/frontend/src/pages/purchasing/components/PurchaseOrderPrintDialog.tsx
+++ b/frontend/src/pages/purchasing/components/PurchaseOrderPrintDialog.tsx
@@ -62,6 +62,7 @@ export interface PrintPurchaseOrderItem {
   unitCost?: number
   discountAmount?: number
   totalAmount?: number
+  receivedQuantity?: number
 }
 
 export type PurchaseOrderPrintData = Omit<PurchaseOrder, 'supplier' | 'items'> & {
@@ -97,7 +98,7 @@ const PurchaseOrderPrintDialog: React.FC<PurchaseOrderPrintDialogProps> = ({
   purchaseOrder,
   payment,
 }) => {
-  const [printType, setPrintType] = useState<'purchase_order' | 'vendor_payment'>(
+  const [printType, setPrintType] = useState<'purchase_order' | 'vendor_payment' | 'grn'>(
     'purchase_order',
   )
   const { currency } = useCurrency()
@@ -204,6 +205,36 @@ const PurchaseOrderPrintDialog: React.FC<PurchaseOrderPrintDialogProps> = ({
     )
   }
 
+  const renderGRNContent = () => {
+    const items = (purchaseOrder.items || []).map((item) => ({
+      description: itemDescription(item),
+      // GRN is a receiving doc: show what arrived, fall back to ordered qty.
+      quantity: Number(item.receivedQuantity ?? item.quantity ?? 0),
+      // amount is a required PrintItem field but unused when showPricing is false.
+      amount: 0,
+    }))
+
+    return (
+      <BasePrintTemplate
+        settings={printSettings}
+        documentTitle="Goods Received Note"
+        documentNumber={purchaseOrder.orderNumber || ''}
+        documentDate={formatDate(
+          purchaseOrder.receivedDate ?? purchaseOrder.updatedAt ?? new Date(),
+        )}
+        recipient={toRecipient(purchaseOrder.supplier)}
+        items={items}
+        totals={{ subtotal: 0, total: 0 }}
+        notes={purchaseOrder.notes || ''}
+        perPageFooter={printSettings?.purchasingPerPageFooter || ''}
+        endOfDocFooter={printSettings?.purchasingEndOfDocFooter || ''}
+        showDiscount={false}
+        showPricing={false}
+        currency={currency}
+      />
+    )
+  }
+
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
       <DialogTitle>Print Options</DialogTitle>
@@ -212,7 +243,7 @@ const PurchaseOrderPrintDialog: React.FC<PurchaseOrderPrintDialogProps> = ({
           <RadioGroup
             value={printType}
             onChange={(_, value) =>
-              setPrintType(value as 'purchase_order' | 'vendor_payment')
+              setPrintType(value as 'purchase_order' | 'vendor_payment' | 'grn')
             }
             row
           >
@@ -231,6 +262,22 @@ const PurchaseOrderPrintDialog: React.FC<PurchaseOrderPrintDialogProps> = ({
                 />
               </span>
             </Tooltip>
+            <Tooltip
+              title={
+                purchaseOrder.status !== 'RECEIVED'
+                  ? 'Goods have not been received yet'
+                  : ''
+              }
+            >
+              <span>
+                <FormControlLabel
+                  value="grn"
+                  control={<Radio />}
+                  label="Goods Received Note"
+                  disabled={purchaseOrder.status !== 'RECEIVED'}
+                />
+              </span>
+            </Tooltip>
           </RadioGroup>
         </FormControl>
 
@@ -240,9 +287,11 @@ const PurchaseOrderPrintDialog: React.FC<PurchaseOrderPrintDialogProps> = ({
           </Box>
         ) : (
           <Box className="print-root" data-testid="print-root">
-            {printType === 'vendor_payment'
-              ? renderVendorPaymentContent()
-              : renderPurchaseOrderContent()}
+            {printType === 'grn'
+              ? renderGRNContent()
+              : printType === 'vendor_payment'
+                ? renderVendorPaymentContent()
+                : renderPurchaseOrderContent()}
           </Box>
         )}
       </DialogContent>

--- a/frontend/src/pages/purchasing/components/__tests__/PurchaseOrderPrintDialog.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/PurchaseOrderPrintDialog.test.tsx
@@ -397,6 +397,9 @@ describe('PurchaseOrderPrintDialog', () => {
   });
 
   it('GRN date uses receivedDate when present', async () => {
+    // Pin the format explicitly so the test does not depend on the jsdom default;
+    // afterEach clears it. formatDate() reads this same key, so assertions stay in sync.
+    localStorage.setItem('dateFormat', 'DD/MM/YYYY');
     const user = userEvent.setup();
     render(
       <PurchaseOrderPrintDialog
@@ -411,8 +414,7 @@ describe('PurchaseOrderPrintDialog', () => {
       />,
     );
     await user.click(screen.getByRole('radio', { name: /Goods Received Note/i }));
-    // Assert via formatDate (it reads localStorage.dateFormat) rather than a hardcoded
-    // string, and assert it is NOT the updatedAt date.
+    // Assert via formatDate (same format key as the component) and that it is NOT updatedAt.
     expect(screen.getByTestId('print-root')).toHaveTextContent(
       formatDate(new Date('2026-06-10')),
     );
@@ -422,6 +424,7 @@ describe('PurchaseOrderPrintDialog', () => {
   });
 
   it('GRN date falls back to updatedAt when receivedDate is absent', async () => {
+    localStorage.setItem('dateFormat', 'DD/MM/YYYY');
     const user = userEvent.setup();
     render(
       <PurchaseOrderPrintDialog

--- a/frontend/src/pages/purchasing/components/__tests__/PurchaseOrderPrintDialog.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/PurchaseOrderPrintDialog.test.tsx
@@ -8,6 +8,7 @@ import PurchaseOrderPrintDialog, {
 } from '../PurchaseOrderPrintDialog';
 
 import type { VendorPayment } from '@/types';
+import { formatDate } from '@/utils/formatters';
 
 const mockPrintData = {
   logoUrl: '',
@@ -327,5 +328,127 @@ describe('PurchaseOrderPrintDialog', () => {
     const printRoot = screen.getByTestId('print-root');
     const row = within(printRoot).getByText('Sprocket').closest('tr') as HTMLElement;
     expect(within(row).getByText(/75\.00/)).toBeInTheDocument();
+  });
+
+  it('disables Goods Received Note when the PO is not RECEIVED', () => {
+    render(
+      <PurchaseOrderPrintDialog
+        open
+        purchaseOrder={makePurchaseOrder({ status: 'READY' })}
+        payment={null}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByRole('radio', { name: /Goods Received Note/i })).toBeDisabled();
+  });
+
+  it('enables Goods Received Note when the PO is RECEIVED', () => {
+    render(
+      <PurchaseOrderPrintDialog
+        open
+        purchaseOrder={makePurchaseOrder({ status: 'RECEIVED' })}
+        payment={null}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByRole('radio', { name: /Goods Received Note/i })).toBeEnabled();
+  });
+
+  it('shows the GRN preview with received quantities and no pricing columns', async () => {
+    const user = userEvent.setup();
+    render(
+      <PurchaseOrderPrintDialog
+        open
+        purchaseOrder={makePurchaseOrder({
+          status: 'RECEIVED',
+          receivedDate: new Date('2026-06-10'),
+          items: [
+            {
+              id: 'poi-1',
+              quantity: 5,
+              receivedQuantity: 3,
+              unitPrice: 50,
+              totalAmount: 250,
+              product: { id: 'p-1', name: 'Widget' },
+            },
+          ],
+        })}
+        payment={null}
+        onClose={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole('radio', { name: /Goods Received Note/i }));
+    const printRoot = screen.getByTestId('print-root');
+    expect(printRoot).toHaveTextContent(/GOODS RECEIVED NOTE/i);
+    // Qty column shows received qty (3), not ordered (5).
+    const widgetRow = within(printRoot).getByText('Widget').closest('tr') as HTMLElement;
+    expect(within(widgetRow).getByText('3')).toBeInTheDocument();
+    // No money: unit price / amount must not appear.
+    expect(printRoot).not.toHaveTextContent(/50\.00/);
+    expect(printRoot).not.toHaveTextContent(/250\.00/);
+    // Total Quantity box present.
+    expect(printRoot).toHaveTextContent(/Total Quantity/i);
+  });
+
+  it('GRN date uses receivedDate when present', async () => {
+    const user = userEvent.setup();
+    render(
+      <PurchaseOrderPrintDialog
+        open
+        purchaseOrder={makePurchaseOrder({
+          status: 'RECEIVED',
+          receivedDate: new Date('2026-06-10'),
+          updatedAt: new Date('2026-06-30'),
+        })}
+        payment={null}
+        onClose={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole('radio', { name: /Goods Received Note/i }));
+    // Assert via formatDate (it reads localStorage.dateFormat) rather than a hardcoded
+    // string, and assert it is NOT the updatedAt date.
+    expect(screen.getByTestId('print-root')).toHaveTextContent(
+      formatDate(new Date('2026-06-10')),
+    );
+    expect(screen.getByTestId('print-root')).not.toHaveTextContent(
+      formatDate(new Date('2026-06-30')),
+    );
+  });
+
+  it('GRN date falls back to updatedAt when receivedDate is absent', async () => {
+    const user = userEvent.setup();
+    render(
+      <PurchaseOrderPrintDialog
+        open
+        purchaseOrder={makePurchaseOrder({
+          status: 'RECEIVED',
+          receivedDate: null,
+          updatedAt: new Date('2026-06-30'),
+        })}
+        payment={null}
+        onClose={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole('radio', { name: /Goods Received Note/i }));
+    expect(screen.getByTestId('print-root')).toHaveTextContent(
+      formatDate(new Date('2026-06-30')),
+    );
+  });
+
+  it('calls window.print for the GRN type', async () => {
+    const user = userEvent.setup();
+    const printSpy = vi.spyOn(window, 'print').mockImplementation(() => {});
+    render(
+      <PurchaseOrderPrintDialog
+        open
+        purchaseOrder={makePurchaseOrder({ status: 'RECEIVED' })}
+        payment={null}
+        onClose={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole('radio', { name: /Goods Received Note/i }));
+    await user.click(screen.getByRole('button', { name: /Print/i }));
+    expect(printSpy).toHaveBeenCalled();
+    printSpy.mockRestore();
   });
 });

--- a/frontend/src/pages/purchasing/components/__tests__/PurchaseOrderPrintDialog.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/PurchaseOrderPrintDialog.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import PurchaseOrderPrintDialog, {
   type PurchaseOrderPrintData,
   type PrintSupplier,
@@ -77,6 +77,9 @@ function makePurchaseOrder(
 }
 
 describe('PurchaseOrderPrintDialog', () => {
+  // formatDate reads localStorage.dateFormat; clear so a stray value can't bleed between tests.
+  afterEach(() => localStorage.clear());
+
   it('renders the Purchase Order preview by default in a print-root', () => {
     render(
       <PurchaseOrderPrintDialog
@@ -383,7 +386,10 @@ describe('PurchaseOrderPrintDialog', () => {
     // Qty column shows received qty (3), not ordered (5).
     const widgetRow = within(printRoot).getByText('Widget').closest('tr') as HTMLElement;
     expect(within(widgetRow).getByText('3')).toBeInTheDocument();
-    // No money: unit price / amount must not appear.
+    // No money: the pricing column headers must be absent (structural, not value-based).
+    expect(within(printRoot).queryByText('Unit Price')).not.toBeInTheDocument();
+    expect(within(printRoot).queryByText('Amount')).not.toBeInTheDocument();
+    // ...and the line's price/amount values do not render.
     expect(printRoot).not.toHaveTextContent(/50\.00/);
     expect(printRoot).not.toHaveTextContent(/250\.00/);
     // Total Quantity box present.

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -373,7 +373,7 @@ export interface PurchaseOrder {
   orderDate: Date;
   deletedAt?: Date | string;
   expectedDate?: Date;
-  receivedDate?: Date;
+  receivedDate?: Date | null;
   notes?: string;
   vendorPayments?: Partial<VendorPayment>[];
   createdAt: Date;


### PR DESCRIPTION
## Summary

Adds a **Goods Received Note (GRN)** print option to the Purchase Order print dialog, backed by a real persisted receipt date.

Closes #772

The print dialog now offers a third radio — **Goods Received Note** — alongside Purchase Order and Vendor Payment. It renders a goods-only receiving receipt: what physically arrived, no money.

## Design note (diverges from the original issue)

The issue proposed an Ordered-vs-Received split + signature block. That was **superseded by the existing Print Settings `grn` template**, which is the source of truth: single **Qty** column, **Total Quantity** box, no pricing, no signatures. The print output matches that template exactly (reuses `BasePrintTemplate` with `showPricing={false}` — no template changes).

| | Purchase Order | Vendor Payment | Goods Received Note |
|---|---|---|---|
| Title | PURCHASE ORDER | VENDOR PAYMENT | GOODS RECEIVED NOTE |
| Date | `orderDate` | `paymentDate` | `receivedDate ?? updatedAt` |
| Table cols | Product, Qty, Unit Price, Amount | + same | **Product, Qty** |
| Qty value | ordered | ordered | **received** (`receivedQuantity ?? quantity`) |
| Totals | Subtotal/Shipping/Total | + Paid/Balance | **Total Quantity** |

## Changes

**Backend — persist a real receipt date**
- `purchase_orders` gains a nullable `receivedDate` column (migration with idempotent `ADD/DROP COLUMN IF [NOT] EXISTS` + column comment).
- Lifecycle: set `receivedDate` on the RECEIVED transition; clear to `null` on return.
- Exposed in `PurchaseOrderResponseDto` + mapper.

**Frontend — GRN print**
- `PurchaseOrder.receivedDate` widened to `Date | null`.
- New GRN radio (disabled unless status `RECEIVED`, tooltip "Goods have not been received yet").
- `renderGRNContent()` — received qty, `showPricing={false}`, date falls back to `updatedAt` for legacy POs.

No backfill — pre-change RECEIVED POs fall back to `updatedAt`. No `PurchaseOrder` consumer reads the new column (verified: `receivedDate` readers are all on the separate `purchase-cost-history` entity).

## Test plan

- Backend: lifecycle receive sets / return clears `receivedDate`; mapper exposes value + null. All purchasing unit tests pass.
- Frontend: GRN radio disabled/enabled by status; preview shows title + received qty + Total Quantity, no pricing columns; date precedence (`receivedDate`) + fallback (`updatedAt`); print works. 18/18 pass.
- Lint + type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)