### PR TITLE
feat(inventory): move Import button beside New Product (#777)

### DIFF
--- a/frontend/src/components/common/PageHeader.tsx
+++ b/frontend/src/components/common/PageHeader.tsx
@@ -88,6 +88,7 @@ export default function PageHeader({
 
         {hasActions && (
           <Box
+            data-testid="page-header-actions"
             sx={{
               display: 'flex',
               alignItems: 'center',

--- a/frontend/src/components/common/__tests__/PageHeader.test.tsx
+++ b/frontend/src/components/common/__tests__/PageHeader.test.tsx
@@ -64,6 +64,20 @@ describe('PageHeader', () => {
   it('does not render actions box when neither action is provided', () => {
     renderWithTheme(<PageHeader title="Sales Orders" />)
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('page-header-actions')).not.toBeInTheDocument()
+  })
+
+  it('groups both actions inside the page-header-actions container', () => {
+    renderWithTheme(
+      <PageHeader
+        title="T"
+        secondaryAction={{ label: 'Import', onClick: vi.fn() }}
+        primaryAction={{ label: 'New Product', onClick: vi.fn() }}
+      />,
+    )
+    const actions = screen.getByTestId('page-header-actions')
+    expect(actions).toContainElement(screen.getByRole('button', { name: 'Import' }))
+    expect(actions).toContainElement(screen.getByRole('button', { name: 'New Product' }))
   })
 
   it('renders only primary button when only primaryAction is provided', () => {

--- a/frontend/src/pages/inventory/ProductsPage.tsx
+++ b/frontend/src/pages/inventory/ProductsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Box, Link } from '@mui/material'
+import { Box } from '@mui/material'
 import { useNavigate } from 'react-router-dom'
 
 import PagePagination from '@/components/common/PagePagination'
@@ -121,6 +121,7 @@ export default function ProductsPage() {
       title="Products"
       subtitle="Manage your product catalog, prices, and stock levels."
       primaryAction={{ label: 'New Product', onClick: () => navigate('/inventory/products/create') }}
+      secondaryAction={{ label: 'Import', onClick: () => setImportOpen(true) }}
       filterConfig={filterConfig}
       draftFilters={draftFilters}
       handlers={handlers}
@@ -132,11 +133,6 @@ export default function ProductsPage() {
       onErrorClose={() => setPageError(null)}
       tableSlot={(
         <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
-          <Box sx={{ mb: 1 }}>
-            <Link component="button" type="button" variant="body2" onClick={() => setImportOpen(true)}>
-              Import
-            </Link>
-          </Box>
           <ProductList
             products={products}
             loading={isLoading || isFetching}

--- a/frontend/src/pages/inventory/__tests__/ProductsPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/ProductsPage.test.tsx
@@ -1,5 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -34,6 +35,16 @@ vi.mock('@/store/api/settingsApi', async (importOriginal) => {
   return {
     ...actual,
     useGetRegionalSettingsQuery: () => ({ data: { lowStockThreshold: 10 } }),
+  }
+})
+
+const { navigateSpy } = vi.hoisted(() => ({ navigateSpy: vi.fn() }))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => navigateSpy,
   }
 })
 
@@ -100,10 +111,35 @@ afterEach(() => {
 })
 
 describe('ProductsPage', () => {
-  it('renders the page header and Import link', () => {
+  it('renders the page header and Import action', () => {
     renderPage()
     expect(screen.getByText('Products')).toBeInTheDocument()
-    expect(screen.getByText('Import')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Import' })).toBeInTheDocument()
+  })
+
+  it('renders Import before New Product (grouped header actions)', () => {
+    renderPage()
+    const importButton = screen.getByRole('button', { name: 'Import' })
+    const newProductButton = screen.getByRole('button', { name: 'New Product' })
+    expect(importButton.parentElement).toBe(newProductButton.parentElement)
+    expect(
+      importButton.compareDocumentPosition(newProductButton)
+        & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+  })
+
+  it('opens the import dialog when Import is clicked', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Import' }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('navigates to create page when New Product is clicked', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'New Product' }))
+    expect(navigateSpy).toHaveBeenCalledWith('/inventory/products/create')
   })
 
   it('sends isActive: undefined when the status filter is All', () => {

--- a/frontend/src/pages/inventory/__tests__/ProductsPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/ProductsPage.test.tsx
@@ -121,7 +121,15 @@ describe('ProductsPage', () => {
     renderPage()
     const importButton = screen.getByRole('button', { name: 'Import' })
     const newProductButton = screen.getByRole('button', { name: 'New Product' })
-    expect(importButton.parentElement).toBe(newProductButton.parentElement)
+    // Grouped: both live in one header action container. Anchor on Import's
+    // parent and assert it contains New Product, rather than identical
+    // parentElement. This survives a future wrapper around New Product (e.g. a
+    // tooltip span) while still proving grouping; a wrapper around Import itself
+    // would still need this anchor revisited.
+    const container = importButton.parentElement
+    expect(container).not.toBeNull()
+    expect(container?.contains(newProductButton)).toBe(true)
+    // And Import comes BEFORE New Product in DOM order.
     expect(
       importButton.compareDocumentPosition(newProductButton)
         & Node.DOCUMENT_POSITION_FOLLOWING,

--- a/frontend/src/pages/inventory/__tests__/ProductsPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/ProductsPage.test.tsx
@@ -121,14 +121,13 @@ describe('ProductsPage', () => {
     renderPage()
     const importButton = screen.getByRole('button', { name: 'Import' })
     const newProductButton = screen.getByRole('button', { name: 'New Product' })
-    // Grouped: both live in one header action container. Anchor on Import's
-    // parent and assert it contains New Product, rather than identical
-    // parentElement. This survives a future wrapper around New Product (e.g. a
-    // tooltip span) while still proving grouping; a wrapper around Import itself
-    // would still need this anchor revisited.
-    const container = importButton.parentElement
-    expect(container).not.toBeNull()
-    expect(container?.contains(newProductButton)).toBe(true)
+    // Grouped: both buttons live inside the single header action container.
+    // Anchor on the named container (not either button's parentElement) so the
+    // test survives a future per-button wrapper (e.g. tooltip span) on either
+    // Import or New Product while still proving they are grouped together.
+    const actions = screen.getByTestId('page-header-actions')
+    expect(actions).toContainElement(importButton)
+    expect(actions).toContainElement(newProductButton)
     // And Import comes BEFORE New Product in DOM order.
     expect(
       importButton.compareDocumentPosition(newProductButton)


### PR DESCRIPTION
Closes #777

## What

Moves the Products page **Import** action from a text link above the table into the header, beside **New Product**, grouping all creation actions together: `[ Import ] [ New Product ]`.

## How

Reuses the existing `secondaryAction` slot on `SimpleListPage` → `PageHeader` (renders an outlined button immediately left of the primary action). No new components; shared `PageHeader` gains only a `data-testid="page-header-actions"` test seam (no behavior/layout change).

## Changes

- `ProductsPage.tsx` — add `secondaryAction` Import, remove old in-table `<Link>` and unused import
- `PageHeader.tsx` — `data-testid="page-header-actions"` on the actions container
- Tests — Import now a header button; grouping (anchored on the named container, wrapper-proof for both buttons) + DOM-order + dialog-open + New Product navigation; PageHeader suite locks the new seam

## Verification

- `npm run lint` ✅
- `npm run type-check` ✅
- Targeted: `ProductsPage.test.tsx` 6/6, `PageHeader.test.tsx` 26/26 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)