### PR TITLE
fix(inventory): inline Create/Edit Product form footer

### DIFF
--- a/frontend/src/pages/inventory/CreateProductPage.tsx
+++ b/frontend/src/pages/inventory/CreateProductPage.tsx
@@ -769,30 +769,19 @@ const CreateProductPage: React.FC = () => {
                 </CardContent>
               </Card>
             </Grid>
+            <Grid size={12}>
+              <Box sx={{ display: 'flex', gap: 2, justifyContent: 'flex-end' }}>
+                <AppButton variant="secondary" onClick={handleCancel} disabled={loading}>Cancel</AppButton>
+                <AppButton
+                  variant="primary"
+                  type="submit"
+                  disabled={loading || hasNameDuplicate || hasBarcodeDuplicate}
+                >
+                  {loading ? (isEditMode ? 'Updating...' : 'Creating...') : (isEditMode ? 'Update Product' : 'Create Product')}
+                </AppButton>
+              </Box>
+            </Grid>
           </Grid>
-
-          <Box
-            sx={{
-              position: 'sticky',
-              bottom: 0,
-              bgcolor: 'background.paper',
-              borderTop: 1,
-              borderColor: 'divider',
-              py: 2,
-              display: 'flex',
-              gap: 2,
-              justifyContent: 'flex-end',
-            }}
-          >
-            <AppButton variant="secondary" onClick={handleCancel} disabled={loading}>Cancel</AppButton>
-            <AppButton
-              variant="primary"
-              type="submit"
-              disabled={loading || hasNameDuplicate || hasBarcodeDuplicate}
-            >
-              {loading ? (isEditMode ? 'Updating...' : 'Creating...') : (isEditMode ? 'Update Product' : 'Create Product')}
-            </AppButton>
-          </Box>
         </form>
         {UnsavedChangesDialog}
 


### PR DESCRIPTION
## Summary
Replaces the sticky grey footer on the Create/Edit Product form with an inline, full-width action row, matching the `CreateSalesOrderPage` pattern.

- Removed the sticky footer `Box` (`position: sticky`, `bgcolor: 'background.paper'`, `borderTop`) placed after the outer `<Grid container>`.
- Added a `<Grid size={12}>` action row as the last child *inside* the outer container, so the Cancel / Create (Update) buttons span the full form width with no grey bar.
- Button handlers, disable logic, and labels unchanged — no behavior change.

## Verification
- `npm run lint` ✅
- `npm run type-check` ✅
- `npx vitest run` on `CreateProductPage.test.tsx` + `CreateProductPage.typechange.test.tsx` (4 tests) ✅
- Manual visual check: footer buttons inline, right-aligned, full width, no sticky grey bar.

Existing tests select the action buttons only by role/name (main test) or don't touch the footer (typechange test); since roles/names/labels are unchanged they pass as a behavior-regression guard. This styling change has no automated style-assertion seam, so it's verified visually.

Closes #780

🤖 Generated with [Claude Code](https://claude.com/claude-code)