### PR TITLE
fix(inventory): show price list items on Product view Pricing card (#784)

### DIFF
--- a/backend/src/modules/inventory/dto/product.dto.ts
+++ b/backend/src/modules/inventory/dto/product.dto.ts
@@ -186,6 +186,24 @@ export class ProductResponseDto {
   @ApiProperty({ description: 'Last update date' })
   updatedAt: Date;
 
+  @ApiProperty({ description: 'Price list items for this product', type: [Object] })
+  priceListItems: {
+    id: string;
+    priceListId: string;
+    productId: string;
+    price: number;
+    costBasis: number | null;
+    marginPercent: number | null;
+    priceList?: {
+      id: string;
+      code: string;
+      name: string;
+      priority: number;
+      isDefault: boolean;
+      isActive: boolean;
+    };
+  }[];
+
   @ApiPropertyOptional({ description: 'Deletion date (only for soft-deleted products)' })
   deletedAt?: Date;
 }

--- a/backend/src/modules/inventory/services/product.service.spec.ts
+++ b/backend/src/modules/inventory/services/product.service.spec.ts
@@ -389,6 +389,58 @@ describe('ProductService pagination removal', () => {
       );
     });
   });
+
+  describe('findBySlug / findByBarcode relations (#784)', () => {
+    const priceList = {
+      id: 'pl-1',
+      code: 'RETAIL',
+      name: 'Retail',
+      priority: 1,
+      isDefault: true,
+      isActive: true,
+    } as any;
+
+    const productWithPriceList = createProduct('prod-1', {
+      slug: 'product-prod-1',
+      priceListItems: [
+        {
+          id: 'pli-1',
+          priceListId: 'pl-1',
+          productId: 'prod-1',
+          price: 100,
+          costBasis: 80,
+          marginPercent: 25,
+          priceList,
+        },
+      ] as any,
+    });
+
+    it('findBySlug loads priceListItems with priceList relation', async () => {
+      productRepository.findOne = jest.fn().mockResolvedValue(productWithPriceList);
+
+      const result = await service.findBySlug('product-prod-1');
+
+      expect(productRepository.findOne).toHaveBeenCalledWith({
+        where: { slug: 'product-prod-1' },
+        relations: { category: true, priceListItems: { priceList: true } },
+      });
+      expect(result.priceListItems).toHaveLength(1);
+      expect(result.priceListItems[0].priceList?.priority).toBe(1);
+    });
+
+    it('findByBarcode loads priceListItems with priceList relation', async () => {
+      productRepository.findOne = jest.fn().mockResolvedValue(productWithPriceList);
+
+      const result = await service.findByBarcode('SKU-prod-1');
+
+      expect(productRepository.findOne).toHaveBeenCalledWith({
+        where: { barcode: 'SKU-prod-1' },
+        relations: { category: true, priceListItems: { priceList: true } },
+      });
+      expect(result.priceListItems).toHaveLength(1);
+      expect(result.priceListItems[0].priceList?.priority).toBe(1);
+    });
+  });
 });
 
 describe('checkProductDependencies', () => {

--- a/backend/src/modules/inventory/services/product.service.spec.ts
+++ b/backend/src/modules/inventory/services/product.service.spec.ts
@@ -440,6 +440,43 @@ describe('ProductService pagination removal', () => {
       expect(result.priceListItems).toHaveLength(1);
       expect(result.priceListItems[0].priceList?.priority).toBe(1);
     });
+
+    it('restore reloads the product with priceListItems relation', async () => {
+      const restorable = createProduct('prod-1', {
+        barcode: null,
+        deletedAt: new Date('2026-03-10T00:00:00.000Z'),
+        priceListItems: productWithPriceList.priceListItems,
+      });
+      productRepository.findOne = jest.fn().mockResolvedValue(restorable);
+      productRepository.restore = jest.fn().mockResolvedValue(undefined);
+
+      const result = await service.restore('prod-1');
+
+      // Second findOne is the post-restore refetch returned to the client.
+      expect(productRepository.findOne).toHaveBeenNthCalledWith(2, {
+        where: { id: 'prod-1' },
+        relations: { category: true, priceListItems: { priceList: true } },
+      });
+      expect(result.priceListItems[0].priceList?.priority).toBe(1);
+    });
+
+    it('update reloads the product with priceListItems relation', async () => {
+      const existing = createProduct('prod-1', {
+        priceListItems: productWithPriceList.priceListItems,
+      });
+      productRepository.findOne = jest.fn().mockResolvedValue(existing);
+      productRepository.update = jest.fn().mockResolvedValue(undefined);
+
+      // No name/barcode change → no conflict query builders are invoked.
+      const result = await service.update('prod-1', {} as any);
+
+      // Second findOne is the reload returned to the client.
+      expect(productRepository.findOne).toHaveBeenNthCalledWith(2, {
+        where: { id: 'prod-1' },
+        relations: { category: true, priceListItems: { priceList: true } },
+      });
+      expect(result.priceListItems[0].priceList?.priority).toBe(1);
+    });
   });
 });
 

--- a/backend/src/modules/inventory/services/product.service.ts
+++ b/backend/src/modules/inventory/services/product.service.ts
@@ -644,7 +644,7 @@ export class ProductService extends BaseCrudService<
     // Fetch the restored product
     const restoredProduct = await this.productRepository.findOne({
       where: { id },
-      relations: { category: true },
+      relations: { category: true, priceListItems: { priceList: true } },
     });
 
     // Log audit trail for restore
@@ -1022,10 +1022,10 @@ export class ProductService extends BaseCrudService<
       updateData,
     );
 
-    // Reload the product with category relation to ensure fresh data
+    // Reload the product with category and price list relations to ensure fresh data
     const productWithCategory = await this.productRepository.findOne({
       where: { id },
-      relations: { category: true },
+      relations: { category: true, priceListItems: { priceList: true } },
     });
 
     // Log audit trail for update

--- a/backend/src/modules/inventory/services/product.service.ts
+++ b/backend/src/modules/inventory/services/product.service.ts
@@ -475,7 +475,7 @@ export class ProductService extends BaseCrudService<
   async findByBarcode(barcode: string): Promise<ProductResponseDto> {
     const product = await this.productRepository.findOne({
       where: { barcode },
-      relations: { category: true },
+      relations: { category: true, priceListItems: { priceList: true } },
     });
 
     if (!product) {
@@ -488,7 +488,7 @@ export class ProductService extends BaseCrudService<
   async findBySlug(slug: string): Promise<ProductResponseDto> {
     const product = await this.productRepository.findOne({
       where: { slug },
-      relations: { category: true },
+      relations: { category: true, priceListItems: { priceList: true } },
     });
 
     if (!product) {
@@ -1509,6 +1509,7 @@ export class ProductService extends BaseCrudService<
                 id: item.priceList.id,
                 code: item.priceList.code,
                 name: item.priceList.name,
+                priority: item.priceList.priority,
                 isDefault: item.priceList.isDefault,
                 isActive: item.priceList.isActive,
               }


### PR DESCRIPTION
## Summary

Product view (slug route) → Overview tab → Pricing card showed Cost Price but **no price list items**, even for products with price lists assigned.

Root cause: `findBySlug` loaded only the `category` relation, so `toResponseDto` mapped an empty `priceListItems` array. The same omission affected `findByBarcode`, `restore`, and `update` — every client-facing path that returns a `ProductResponseDto` from a refetch. Separately, `toResponseDto` mapped the nested `priceList` object but omitted `priority`, so the frontend's priority sort was silently a no-op for this response.

## Changes

- **`product.service.ts`**
  - Add `priceListItems: { priceList: true }` to the client-facing refetches: `findBySlug`, `findByBarcode`, `restore` (post-restore reload), `update` (reload). Mirrors existing `findOne`.
  - Map `priceList.priority` in `toResponseDto` so the frontend priority sort works.
  - Internal-only queries (pre-restore validation fetch, update pre-fetch, `bulkRestore`, stats aggregation) intentionally keep `category`-only — they don't return the product DTO, so the extra join would be wasted.
- **`product.dto.ts`** — declare `priceListItems` (incl. nested `priceList.priority`) on `ProductResponseDto` to make the API contract explicit.
- **`product.service.spec.ts`** — 4 tests asserting the relation is loaded (and priority mapped) in `findBySlug`, `findByBarcode`, `restore`, `update`.

No frontend code change — `ProductOverviewTab.tsx` already sorts by `priceList.priority`; it was correct once the API returns the field.

## Testing

- `npm run lint` — clean
- `npm run test` — **1136/1136 passing**

Closes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)