### PR TITLE
fix(backend): bump js-yaml override to 4.2.0 to clear DoS advisory

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8249,9 +8249,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/backend/package.json
+++ b/backend/package.json
@@ -100,7 +100,7 @@
     "multer": "2.2.0",
     "body-parser": "2.2.1",
     "tar": "7.5.4",
-    "js-yaml": "4.1.1",
+    "js-yaml": "4.2.0",
     "qs": "6.15.2",
     "file-type": "21.3.2",
     "path-to-regexp": "8.4.2",


### PR DESCRIPTION
## Summary
- Bumps the pinned `js-yaml` override in `backend/package.json` from `4.1.1` to `4.2.0`.
- Clears all 20 moderate `npm audit` findings, which all traced to a single advisory: **GHSA-h67p-54hq-rp68** (js-yaml quadratic-complexity DoS in merge-key handling).
- Semver-minor, API-compatible bump.

## Verification
- `npm ls js-yaml` — all paths resolve to 4.2.0.
- `npm audit` — 0 vulnerabilities.
- js-yaml merge-key parse smoke — passes on 4.2.0.
- Backend Jest suite — green.
- `npm run build` — clean.
- Swagger YAML route (`/api/docs-yaml`) smoke — serves.

## Notes
- npm's suggested "fix available" downgrades (jest@25, ts-jest@27, swagger@5) are rollback traps and were not used; installed majors are current.
- js-yaml 4.2.0 adds `maxMergeSeqLength` (default 20). No merge-key YAML in this repo, so no behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)