### PR TITLE
fix(frontend): align remaining tab tables to gold standard (DataTable)

### DIFF
--- a/frontend/src/components/accounting/JournalEntriesTab.tsx
+++ b/frontend/src/components/accounting/JournalEntriesTab.tsx
@@ -1,0 +1,72 @@
+import { Link } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
+
+import { DataTable, type Column, bold } from '@/components/common/DataTable'
+import { useGetJournalEntriesQuery } from '@/store/api/accountingApi'
+import type { JournalEntryLine } from '@/types'
+import { formatCurrency, formatDate } from '@/utils/formatters'
+
+interface JournalEntriesTabProps {
+  /** Source record type the entries are posted against. */
+  sourceType: 'sales_order' | 'purchase_order'
+  /** Source record id. */
+  orderId: string
+  /** Empty-state copy (differs per source type). */
+  emptyText: string
+}
+
+/**
+ * Shared journal-entries table for a source record (sales or purchase order).
+ * Lists posted entries with debit/credit totals, linking each entry number to
+ * the filtered journal-entries page. Backs both OrderJournalEntriesTab and
+ * PurchaseOrderJournalEntriesTab — they differ only by sourceType + copy.
+ */
+export default function JournalEntriesTab({ sourceType, orderId, emptyText }: JournalEntriesTabProps) {
+  const { data, isLoading, isError } = useGetJournalEntriesQuery({ sourceType, sourceId: orderId })
+  const entries = data?.data ?? []
+
+  const sumLines = (lines: JournalEntryLine[] | undefined, key: 'debitAmount' | 'creditAmount') =>
+    (lines ?? []).reduce((sum: number, line: JournalEntryLine) => sum + Number(line[key]), 0)
+
+  const columns: Column<(typeof entries)[number]>[] = [
+    {
+      header: 'Entry Number',
+      width: '18%',
+      render: (entry) =>
+        bold(
+          <Link
+            component={RouterLink}
+            to={`/accounting/journal-entries?sourceType=${sourceType}&sourceId=${orderId}`}
+          >
+            {entry.referenceNumber}
+          </Link>,
+        ),
+    },
+    { header: 'Date', width: '16%', render: (entry) => formatDate(entry.entryDate) },
+    { header: 'Description', width: '36%', render: (entry) => entry.description },
+    {
+      header: 'Debit',
+      align: 'right',
+      width: '15%',
+      render: (entry) => formatCurrency(sumLines(entry.lines, 'debitAmount')),
+    },
+    {
+      header: 'Credit',
+      align: 'right',
+      width: '15%',
+      render: (entry) => formatCurrency(sumLines(entry.lines, 'creditAmount')),
+    },
+  ]
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={entries}
+      getRowKey={(entry) => entry.id}
+      emptyText={emptyText}
+      isLoading={isLoading}
+      isError={isError}
+      errorText="Failed to load journal entries."
+    />
+  )
+}

--- a/frontend/src/components/accounting/JournalEntriesTab.tsx
+++ b/frontend/src/components/accounting/JournalEntriesTab.tsx
@@ -13,6 +13,8 @@ interface JournalEntriesTabProps {
   orderId: string
   /** Empty-state copy (differs per source type). */
   emptyText: string
+  /** Error-state copy. */
+  errorText?: string
 }
 
 /**
@@ -21,7 +23,12 @@ interface JournalEntriesTabProps {
  * the filtered journal-entries page. Backs both OrderJournalEntriesTab and
  * PurchaseOrderJournalEntriesTab — they differ only by sourceType + copy.
  */
-export default function JournalEntriesTab({ sourceType, orderId, emptyText }: JournalEntriesTabProps) {
+export default function JournalEntriesTab({
+  sourceType,
+  orderId,
+  emptyText,
+  errorText = 'Failed to load journal entries.',
+}: JournalEntriesTabProps) {
   const { data, isLoading, isError } = useGetJournalEntriesQuery({ sourceType, sourceId: orderId })
   const entries = data?.data ?? []
 
@@ -66,7 +73,7 @@ export default function JournalEntriesTab({ sourceType, orderId, emptyText }: Jo
       emptyText={emptyText}
       isLoading={isLoading}
       isError={isError}
-      errorText="Failed to load journal entries."
+      errorText={errorText}
     />
   )
 }

--- a/frontend/src/components/accounting/__tests__/JournalEntriesTab.test.tsx
+++ b/frontend/src/components/accounting/__tests__/JournalEntriesTab.test.tsx
@@ -1,0 +1,77 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import JournalEntriesTab from '../JournalEntriesTab'
+
+const { mockGetJournalEntries } = vi.hoisted(() => ({
+  mockGetJournalEntries: vi.fn(),
+}))
+
+vi.mock('@/store/api/accountingApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store/api/accountingApi')>()
+  return { ...actual, useGetJournalEntriesQuery: mockGetJournalEntries }
+})
+
+function makeEntry(overrides = {}) {
+  return {
+    id: 'je1',
+    referenceNumber: 'JE-900',
+    entryDate: '2026-03-01',
+    description: 'Entry description',
+    status: 'POSTED',
+    isDraft: false,
+    isPosted: true,
+    isReversed: false,
+    fiscalPeriodId: 'fp1',
+    lines: [
+      { id: 'l1', journalEntryId: 'je1', accountId: 'a1', debitAmount: 40, creditAmount: 0, createdAt: '2026-03-01', updatedAt: '2026-03-01' },
+      { id: 'l2', journalEntryId: 'je1', accountId: 'a2', debitAmount: 0, creditAmount: 40, createdAt: '2026-03-01', updatedAt: '2026-03-01' },
+    ],
+    ...overrides,
+  }
+}
+
+function renderTab(props: { sourceType: 'sales_order' | 'purchase_order'; orderId: string; emptyText: string }) {
+  const store = configureStore({ reducer: { accounting: (state = {}) => state } })
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <JournalEntriesTab {...props} />
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('JournalEntriesTab (shared)', () => {
+  it('shows the provided empty text', () => {
+    mockGetJournalEntries.mockReturnValue({ data: { data: [], meta: { total: 0 } }, isLoading: false })
+    renderTab({ sourceType: 'sales_order', orderId: 'o1', emptyText: 'Nothing here' })
+    expect(screen.getByText('Nothing here')).toBeInTheDocument()
+  })
+
+  it('queries with the given sourceType and orderId', () => {
+    mockGetJournalEntries.mockReturnValue({ data: { data: [], meta: { total: 0 } }, isLoading: false })
+    renderTab({ sourceType: 'purchase_order', orderId: 'po-9', emptyText: 'Nothing' })
+    expect(mockGetJournalEntries).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceType: 'purchase_order', sourceId: 'po-9' }),
+    )
+  })
+
+  it('links the entry number to the source-filtered journal-entries page', () => {
+    mockGetJournalEntries.mockReturnValue({ data: { data: [makeEntry()], meta: { total: 1 } }, isLoading: false })
+    renderTab({ sourceType: 'sales_order', orderId: 'o1', emptyText: 'Nothing' })
+    const link = screen.getByRole('link', { name: 'JE-900' })
+    expect(link).toHaveAttribute('href', '/accounting/journal-entries?sourceType=sales_order&sourceId=o1')
+  })
+
+  it('renders a gold-standard grey header (DataTable)', () => {
+    mockGetJournalEntries.mockReturnValue({ data: { data: [makeEntry()], meta: { total: 1 } }, isLoading: false })
+    const { container } = renderTab({ sourceType: 'sales_order', orderId: 'o1', emptyText: 'Nothing' })
+    const headerCell = container.querySelector('.MuiTableCell-head')
+    expect(headerCell).not.toBeNull()
+    expect(headerCell).toHaveStyle({ backgroundColor: 'rgb(250, 250, 250)' })
+  })
+})

--- a/frontend/src/components/common/DataTable/DataTable.tsx
+++ b/frontend/src/components/common/DataTable/DataTable.tsx
@@ -92,7 +92,7 @@ export function DataTable<T>({
   if (sticky) {
     return (
       <>
-        <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
+        <TableContainer component={Paper} variant="outlined" sx={{ flex: 1, overflow: 'auto' }}>
           {container}
         </TableContainer>
         {footer}

--- a/frontend/src/components/common/DataTable/__tests__/DataTable.test.tsx
+++ b/frontend/src/components/common/DataTable/__tests__/DataTable.test.tsx
@@ -49,6 +49,14 @@ describe('DataTable', () => {
     expect(screen.getByText('Boom')).toBeInTheDocument()
   })
 
+  it('wraps a populated sticky table in an outlined Paper card', () => {
+    const { container } = render(
+      <DataTable columns={columns} rows={rows} getRowKey={(r) => r.id} emptyText="Nothing" sticky />,
+    )
+    expect(container.querySelector('.MuiPaper-outlined')).not.toBeNull()
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+  })
+
   it('renders a footer below the table', () => {
     render(
       <DataTable

--- a/frontend/src/components/inventory/OrderHistoryTab.tsx
+++ b/frontend/src/components/inventory/OrderHistoryTab.tsx
@@ -102,14 +102,14 @@ const OrderHistoryTab: React.FC<OrderHistoryTabProps> = ({ productId }) => {
   }
 
   const columns: Column<OrderHistoryItem>[] = [
-    { header: 'Type', render: (o) => getOrderTypeLabel(o.type) },
-    { header: 'Order #', render: (o) => bold(o.orderNumber) },
-    { header: 'Customer/Vendor', render: (o) => o.customerOrVendor },
-    { header: 'Date', render: (o) => formatDate(o.date) },
-    { header: 'Order Status', render: (o) => renderStatus(o) },
-    { header: 'Quantity', align: 'right', render: (o) => Math.floor(o.quantity) },
-    { header: 'Sub-Total', align: 'right', render: (o) => bold(formatCurrency(o.subTotal)) },
-    { header: 'Action', align: 'right', render: (o) => viewAction(() => goToOrder(o)) },
+    { header: 'Type', width: '12%', render: (o) => getOrderTypeLabel(o.type) },
+    { header: 'Order #', width: '12%', render: (o) => bold(o.orderNumber) },
+    { header: 'Customer/Vendor', width: '18%', render: (o) => o.customerOrVendor },
+    { header: 'Date', width: '12%', render: (o) => formatDate(o.date) },
+    { header: 'Order Status', width: '16%', render: (o) => renderStatus(o) },
+    { header: 'Quantity', align: 'right', width: '10%', render: (o) => Math.floor(o.quantity) },
+    { header: 'Sub-Total', align: 'right', width: '12%', render: (o) => bold(formatCurrency(o.subTotal)) },
+    { header: 'Action', align: 'right', width: '8%', render: (o) => viewAction(() => goToOrder(o)) },
   ]
 
   return (

--- a/frontend/src/pages/inventory/components/StockMovementsTab.tsx
+++ b/frontend/src/pages/inventory/components/StockMovementsTab.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { TablePagination } from '@mui/material'
 import { useNavigate } from 'react-router-dom'
 
-import { DataTable, type Column, viewAction } from '@/components/common/DataTable'
+import { DataTable, type Column, bold, viewAction } from '@/components/common/DataTable'
 import { useLazyGetPurchaseOrderQuery } from '@/store/api/purchasingApi'
 import { useLazyGetSalesOrderQuery } from '@/store/api/salesApi'
 import { useGetStockMovementsQuery } from '@/store/api/inventoryApi'
@@ -46,7 +46,7 @@ export default function StockMovementsTab({ productId }: { productId: string }) 
   const columns: Column<StockMovement>[] = [
     { header: 'Date', width: '14%', render: (m) => formatDate(m.movementDate) },
     { header: 'Type', width: '16%', render: (m) => getMovementLabel(m.movementType) },
-    { header: 'Reference', width: '16%', render: (m) => getReferenceLabel(m.referenceType) },
+    { header: 'Reference', width: '16%', render: (m) => bold(m.referenceNumber ?? getReferenceLabel(m.referenceType)) },
     {
       header: 'Qty Change',
       align: 'right',

--- a/frontend/src/pages/inventory/components/__tests__/StockMovementsTab.test.tsx
+++ b/frontend/src/pages/inventory/components/__tests__/StockMovementsTab.test.tsx
@@ -142,6 +142,18 @@ describe('StockMovementsTab', () => {
     expect(mockNavigate).not.toHaveBeenCalled()
   })
 
+  it('shows the reference document number when present, in bold', () => {
+    movements = [makeMovement({ referenceType: 'purchase_order', referenceId: 'po-uuid', referenceNumber: 'PO-7' })]
+    renderTab()
+    expect(screen.getByText('PO-7')).toBeInTheDocument()
+  })
+
+  it('falls back to the reference type label when no referenceNumber', () => {
+    movements = [makeMovement({ referenceType: 'sales_order', referenceId: 'so-uuid', referenceNumber: undefined })]
+    renderTab()
+    expect(screen.getByText('Sales Order')).toBeInTheDocument()
+  })
+
   it('renders the empty state when there are no movements', () => {
     movements = []
     renderTab()

--- a/frontend/src/pages/purchasing/components/PurchaseOrderJournalEntriesTab.tsx
+++ b/frontend/src/pages/purchasing/components/PurchaseOrderJournalEntriesTab.tsx
@@ -1,64 +1,15 @@
-import { Link } from '@mui/material'
-import { Link as RouterLink } from 'react-router-dom'
-
-import { DataTable, type Column, bold } from '@/components/common/DataTable'
-import { useGetJournalEntriesQuery } from '@/store/api/accountingApi'
-import type { JournalEntryLine } from '@/types'
-import { formatCurrency, formatDate } from '@/utils/formatters'
+import JournalEntriesTab from '@/components/accounting/JournalEntriesTab'
 
 interface PurchaseOrderJournalEntriesTabProps {
   orderId: string
 }
 
 export default function PurchaseOrderJournalEntriesTab({ orderId }: PurchaseOrderJournalEntriesTabProps) {
-  const { data, isLoading, isError } = useGetJournalEntriesQuery({
-    sourceType: 'purchase_order',
-    sourceId: orderId,
-  })
-  const entries = data?.data ?? []
-
-  const sumLines = (lines: JournalEntryLine[] | undefined, key: 'debitAmount' | 'creditAmount') =>
-    (lines ?? []).reduce((sum: number, line: JournalEntryLine) => sum + Number(line[key]), 0)
-
-  const columns: Column<(typeof entries)[number]>[] = [
-    {
-      header: 'Entry Number',
-      width: '18%',
-      render: (entry) =>
-        bold(
-          <Link
-            component={RouterLink}
-            to={`/accounting/journal-entries?sourceType=purchase_order&sourceId=${orderId}`}
-          >
-            {entry.referenceNumber}
-          </Link>,
-        ),
-    },
-    { header: 'Date', width: '16%', render: (entry) => formatDate(entry.entryDate) },
-    { header: 'Description', width: '36%', render: (entry) => entry.description },
-    {
-      header: 'Debit',
-      align: 'right',
-      width: '15%',
-      render: (entry) => formatCurrency(sumLines(entry.lines, 'debitAmount')),
-    },
-    {
-      header: 'Credit',
-      align: 'right',
-      width: '15%',
-      render: (entry) => formatCurrency(sumLines(entry.lines, 'creditAmount')),
-    },
-  ]
-
   return (
-    <DataTable
-      columns={columns}
-      rows={entries}
-      getRowKey={(entry) => entry.id}
+    <JournalEntriesTab
+      sourceType="purchase_order"
+      orderId={orderId}
       emptyText="No journal entries created for this purchase order."
-      isLoading={isLoading}
-      isError={isError}
-      errorText="Failed to load journal entries."
     />
   )
 }

--- a/frontend/src/pages/purchasing/components/PurchaseOrderJournalEntriesTab.tsx
+++ b/frontend/src/pages/purchasing/components/PurchaseOrderJournalEntriesTab.tsx
@@ -1,7 +1,7 @@
-import { Box, CircularProgress, Link, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from '@mui/material'
+import { Link } from '@mui/material'
 import { Link as RouterLink } from 'react-router-dom'
 
-import { TABLE_STYLES } from '@/constants/tableStyles'
+import { DataTable, type Column, bold } from '@/components/common/DataTable'
 import { useGetJournalEntriesQuery } from '@/store/api/accountingApi'
 import type { JournalEntryLine } from '@/types'
 import { formatCurrency, formatDate } from '@/utils/formatters'
@@ -11,66 +11,54 @@ interface PurchaseOrderJournalEntriesTabProps {
 }
 
 export default function PurchaseOrderJournalEntriesTab({ orderId }: PurchaseOrderJournalEntriesTabProps) {
-  const { data, isLoading, isError } = useGetJournalEntriesQuery({ sourceType: 'purchase_order', sourceId: orderId })
+  const { data, isLoading, isError } = useGetJournalEntriesQuery({
+    sourceType: 'purchase_order',
+    sourceId: orderId,
+  })
   const entries = data?.data ?? []
 
-  if (isLoading) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-        <CircularProgress />
-      </Box>
-    )
-  }
+  const sumLines = (lines: JournalEntryLine[] | undefined, key: 'debitAmount' | 'creditAmount') =>
+    (lines ?? []).reduce((sum: number, line: JournalEntryLine) => sum + Number(line[key]), 0)
 
-  if (isError) {
-    return (
-      <Typography sx={{ color: 'text.secondary', py: 4, textAlign: 'center' }}>
-        Failed to load journal entries.
-      </Typography>
-    )
-  }
-
-  if (entries.length === 0) {
-    return (
-      <Typography sx={{ color: 'text.secondary', py: 4, textAlign: 'center' }}>
-        No journal entries created for this purchase order.
-      </Typography>
-    )
-  }
+  const columns: Column<(typeof entries)[number]>[] = [
+    {
+      header: 'Entry Number',
+      width: '18%',
+      render: (entry) =>
+        bold(
+          <Link
+            component={RouterLink}
+            to={`/accounting/journal-entries?sourceType=purchase_order&sourceId=${orderId}`}
+          >
+            {entry.referenceNumber}
+          </Link>,
+        ),
+    },
+    { header: 'Date', width: '16%', render: (entry) => formatDate(entry.entryDate) },
+    { header: 'Description', width: '36%', render: (entry) => entry.description },
+    {
+      header: 'Debit',
+      align: 'right',
+      width: '15%',
+      render: (entry) => formatCurrency(sumLines(entry.lines, 'debitAmount')),
+    },
+    {
+      header: 'Credit',
+      align: 'right',
+      width: '15%',
+      render: (entry) => formatCurrency(sumLines(entry.lines, 'creditAmount')),
+    },
+  ]
 
   return (
-    <TableContainer component={Paper} variant="outlined">
-      <Table size={TABLE_STYLES.size}>
-        <TableHead>
-          <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600 } }}>
-            <TableCell>Entry Number</TableCell>
-            <TableCell>Date</TableCell>
-            <TableCell>Description</TableCell>
-            <TableCell align="right">Debit</TableCell>
-            <TableCell align="right">Credit</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {entries.map((entry) => {
-            const totalDebit = (entry.lines ?? []).reduce((sum: number, line: JournalEntryLine) => sum + Number(line.debitAmount), 0)
-            const totalCredit = (entry.lines ?? []).reduce((sum: number, line: JournalEntryLine) => sum + Number(line.creditAmount), 0)
-
-            return (
-              <TableRow key={entry.id} hover>
-                <TableCell>
-                  <Link component={RouterLink} to={`/accounting/journal-entries?sourceType=purchase_order&sourceId=${orderId}`}>
-                    {entry.referenceNumber}
-                  </Link>
-                </TableCell>
-                <TableCell>{formatDate(entry.entryDate)}</TableCell>
-                <TableCell>{entry.description}</TableCell>
-                <TableCell align="right">{formatCurrency(totalDebit)}</TableCell>
-                <TableCell align="right">{formatCurrency(totalCredit)}</TableCell>
-              </TableRow>
-            )
-          })}
-        </TableBody>
-      </Table>
-    </TableContainer>
+    <DataTable
+      columns={columns}
+      rows={entries}
+      getRowKey={(entry) => entry.id}
+      emptyText="No journal entries created for this purchase order."
+      isLoading={isLoading}
+      isError={isError}
+      errorText="Failed to load journal entries."
+    />
   )
 }

--- a/frontend/src/pages/purchasing/components/__tests__/PurchaseOrderJournalEntriesTab.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/PurchaseOrderJournalEntriesTab.test.tsx
@@ -1,0 +1,90 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import PurchaseOrderJournalEntriesTab from '../PurchaseOrderJournalEntriesTab'
+
+const { mockGetJournalEntries } = vi.hoisted(() => ({
+  mockGetJournalEntries: vi.fn(),
+}))
+
+vi.mock('@/store/api/accountingApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store/api/accountingApi')>()
+  return { ...actual, useGetJournalEntriesQuery: mockGetJournalEntries }
+})
+
+function makeEntry(overrides = {}) {
+  return {
+    id: 'je1',
+    referenceNumber: 'JE-501',
+    entryDate: '2026-02-10',
+    description: 'Purchase order PO-26-009',
+    status: 'POSTED',
+    isDraft: false,
+    isPosted: true,
+    isReversed: false,
+    fiscalPeriodId: 'fp1',
+    lines: [
+      { id: 'l1', journalEntryId: 'je1', accountId: 'a1', debitAmount: 75, creditAmount: 0, createdAt: '2026-02-10', updatedAt: '2026-02-10' },
+      { id: 'l2', journalEntryId: 'je1', accountId: 'a2', debitAmount: 0, creditAmount: 75, createdAt: '2026-02-10', updatedAt: '2026-02-10' },
+    ],
+    ...overrides,
+  }
+}
+
+function renderTab(orderId: string) {
+  const store = configureStore({ reducer: { accounting: (state = {}) => state } })
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <PurchaseOrderJournalEntriesTab orderId={orderId} />
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('PurchaseOrderJournalEntriesTab', () => {
+  it('shows loading state', () => {
+    mockGetJournalEntries.mockReturnValue({ data: undefined, isLoading: true })
+    renderTab('o1')
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no entries', () => {
+    mockGetJournalEntries.mockReturnValue({ data: { data: [], meta: { total: 0 } }, isLoading: false })
+    renderTab('o1')
+    expect(screen.getByText(/No journal entries/)).toBeInTheDocument()
+  })
+
+  it('renders entry number as a link with the purchase_order href', () => {
+    mockGetJournalEntries.mockReturnValue({ data: { data: [makeEntry()], meta: { total: 1 } }, isLoading: false })
+    renderTab('o1')
+    const link = screen.getByRole('link', { name: 'JE-501' })
+    expect(link).toHaveAttribute('href', '/accounting/journal-entries?sourceType=purchase_order&sourceId=o1')
+  })
+
+  it('renders description and debit/credit totals', () => {
+    mockGetJournalEntries.mockReturnValue({ data: { data: [makeEntry()], meta: { total: 1 } }, isLoading: false })
+    renderTab('o1')
+    expect(screen.getByText('Purchase order PO-26-009')).toBeInTheDocument()
+    expect(screen.getAllByText('RM 75.00').length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('passes purchase_order sourceType and sourceId to query', () => {
+    mockGetJournalEntries.mockReturnValue({ data: { data: [], meta: { total: 0 } }, isLoading: false })
+    renderTab('order-77')
+    expect(mockGetJournalEntries).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceType: 'purchase_order', sourceId: 'order-77' }),
+    )
+  })
+
+  it('renders a gold-standard grey header (DataTable)', () => {
+    mockGetJournalEntries.mockReturnValue({ data: { data: [makeEntry()], meta: { total: 1 } }, isLoading: false })
+    const { container } = renderTab('o1')
+    const headerCell = container.querySelector('.MuiTableCell-head')
+    expect(headerCell).not.toBeNull()
+    expect(headerCell).toHaveStyle({ backgroundColor: 'rgb(250, 250, 250)' })
+  })
+})

--- a/frontend/src/pages/sales/components/OrderJournalEntriesTab.tsx
+++ b/frontend/src/pages/sales/components/OrderJournalEntriesTab.tsx
@@ -1,64 +1,15 @@
-import { Link } from '@mui/material'
-import { Link as RouterLink } from 'react-router-dom'
-
-import { DataTable, type Column, bold } from '@/components/common/DataTable'
-import { useGetJournalEntriesQuery } from '@/store/api/accountingApi'
-import type { JournalEntryLine } from '@/types'
-import { formatCurrency, formatDate } from '@/utils/formatters'
+import JournalEntriesTab from '@/components/accounting/JournalEntriesTab'
 
 interface OrderJournalEntriesTabProps {
   orderId: string
 }
 
 export default function OrderJournalEntriesTab({ orderId }: OrderJournalEntriesTabProps) {
-  const { data, isLoading, isError } = useGetJournalEntriesQuery({
-    sourceType: 'sales_order',
-    sourceId: orderId,
-  })
-  const entries = data?.data ?? []
-
-  const sumLines = (lines: JournalEntryLine[] | undefined, key: 'debitAmount' | 'creditAmount') =>
-    (lines ?? []).reduce((sum: number, line: JournalEntryLine) => sum + Number(line[key]), 0)
-
-  const columns: Column<(typeof entries)[number]>[] = [
-    {
-      header: 'Entry Number',
-      width: '18%',
-      render: (entry) =>
-        bold(
-          <Link
-            component={RouterLink}
-            to={`/accounting/journal-entries?sourceType=sales_order&sourceId=${orderId}`}
-          >
-            {entry.referenceNumber}
-          </Link>,
-        ),
-    },
-    { header: 'Date', width: '16%', render: (entry) => formatDate(entry.entryDate) },
-    { header: 'Description', width: '36%', render: (entry) => entry.description },
-    {
-      header: 'Debit',
-      align: 'right',
-      width: '15%',
-      render: (entry) => formatCurrency(sumLines(entry.lines, 'debitAmount')),
-    },
-    {
-      header: 'Credit',
-      align: 'right',
-      width: '15%',
-      render: (entry) => formatCurrency(sumLines(entry.lines, 'creditAmount')),
-    },
-  ]
-
   return (
-    <DataTable
-      columns={columns}
-      rows={entries}
-      getRowKey={(entry) => entry.id}
+    <JournalEntriesTab
+      sourceType="sales_order"
+      orderId={orderId}
       emptyText="No journal entries created for this sales order."
-      isLoading={isLoading}
-      isError={isError}
-      errorText="Failed to load journal entries."
     />
   )
 }

--- a/frontend/src/pages/sales/components/OrderJournalEntriesTab.tsx
+++ b/frontend/src/pages/sales/components/OrderJournalEntriesTab.tsx
@@ -1,19 +1,7 @@
-import {
-  Box,
-  CircularProgress,
-  Link,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Typography,
-} from '@mui/material'
+import { Link } from '@mui/material'
 import { Link as RouterLink } from 'react-router-dom'
 
-import { TABLE_STYLES } from '@/constants/tableStyles'
+import { DataTable, type Column, bold } from '@/components/common/DataTable'
 import { useGetJournalEntriesQuery } from '@/store/api/accountingApi'
 import type { JournalEntryLine } from '@/types'
 import { formatCurrency, formatDate } from '@/utils/formatters'
@@ -23,66 +11,54 @@ interface OrderJournalEntriesTabProps {
 }
 
 export default function OrderJournalEntriesTab({ orderId }: OrderJournalEntriesTabProps) {
-  const { data, isLoading, isError } = useGetJournalEntriesQuery({ sourceType: 'sales_order', sourceId: orderId })
+  const { data, isLoading, isError } = useGetJournalEntriesQuery({
+    sourceType: 'sales_order',
+    sourceId: orderId,
+  })
   const entries = data?.data ?? []
 
-  if (isLoading) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-        <CircularProgress />
-      </Box>
-    )
-  }
+  const sumLines = (lines: JournalEntryLine[] | undefined, key: 'debitAmount' | 'creditAmount') =>
+    (lines ?? []).reduce((sum: number, line: JournalEntryLine) => sum + Number(line[key]), 0)
 
-  if (isError) {
-    return (
-      <Typography sx={{ color: 'text.secondary', py: 4, textAlign: 'center' }}>
-        Failed to load journal entries.
-      </Typography>
-    )
-  }
-
-  if (entries.length === 0) {
-    return (
-      <Typography sx={{ color: 'text.secondary', py: 4, textAlign: 'center' }}>
-        No journal entries created for this sales order.
-      </Typography>
-    )
-  }
+  const columns: Column<(typeof entries)[number]>[] = [
+    {
+      header: 'Entry Number',
+      width: '18%',
+      render: (entry) =>
+        bold(
+          <Link
+            component={RouterLink}
+            to={`/accounting/journal-entries?sourceType=sales_order&sourceId=${orderId}`}
+          >
+            {entry.referenceNumber}
+          </Link>,
+        ),
+    },
+    { header: 'Date', width: '16%', render: (entry) => formatDate(entry.entryDate) },
+    { header: 'Description', width: '36%', render: (entry) => entry.description },
+    {
+      header: 'Debit',
+      align: 'right',
+      width: '15%',
+      render: (entry) => formatCurrency(sumLines(entry.lines, 'debitAmount')),
+    },
+    {
+      header: 'Credit',
+      align: 'right',
+      width: '15%',
+      render: (entry) => formatCurrency(sumLines(entry.lines, 'creditAmount')),
+    },
+  ]
 
   return (
-    <TableContainer component={Paper} variant="outlined">
-      <Table size={TABLE_STYLES.size}>
-        <TableHead>
-          <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600 } }}>
-            <TableCell>Entry Number</TableCell>
-            <TableCell>Date</TableCell>
-            <TableCell>Description</TableCell>
-            <TableCell align="right">Debit</TableCell>
-            <TableCell align="right">Credit</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {entries.map((entry) => {
-            const totalDebit = (entry.lines ?? []).reduce((sum: number, line: JournalEntryLine) => sum + Number(line.debitAmount), 0)
-            const totalCredit = (entry.lines ?? []).reduce((sum: number, line: JournalEntryLine) => sum + Number(line.creditAmount), 0)
-
-            return (
-              <TableRow key={entry.id} hover>
-                <TableCell>
-                  <Link component={RouterLink} to={`/accounting/journal-entries?sourceType=sales_order&sourceId=${orderId}`}>
-                    {entry.referenceNumber}
-                  </Link>
-                </TableCell>
-                <TableCell>{formatDate(entry.entryDate)}</TableCell>
-                <TableCell>{entry.description}</TableCell>
-                <TableCell align="right">{formatCurrency(totalDebit)}</TableCell>
-                <TableCell align="right">{formatCurrency(totalCredit)}</TableCell>
-              </TableRow>
-            )
-          })}
-        </TableBody>
-      </Table>
-    </TableContainer>
+    <DataTable
+      columns={columns}
+      rows={entries}
+      getRowKey={(entry) => entry.id}
+      emptyText="No journal entries created for this sales order."
+      isLoading={isLoading}
+      isError={isError}
+      errorText="Failed to load journal entries."
+    />
   )
 }

--- a/frontend/src/pages/sales/components/OrderPaymentsTab.tsx
+++ b/frontend/src/pages/sales/components/OrderPaymentsTab.tsx
@@ -1,18 +1,8 @@
-import {
-  Box,
-  CircularProgress,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Typography,
-} from '@mui/material'
+import { Box, Typography } from '@mui/material'
 
-import { TABLE_STYLES } from '@/constants/tableStyles'
+import { DataTable, type Column } from '@/components/common/DataTable'
 import { useGetSalesOrderPaymentsQuery } from '@/store/api/salesApi'
+import type { SalesOrderPayment } from '@/types'
 import { formatCurrency, formatDate } from '@/utils/formatters'
 
 interface OrderPaymentsTabProps {
@@ -23,81 +13,61 @@ interface OrderPaymentsTabProps {
 export default function OrderPaymentsTab({ orderId, totalAmount }: OrderPaymentsTabProps) {
   const { data: payments = [], isLoading, isError } = useGetSalesOrderPaymentsQuery(orderId)
 
-  if (isLoading) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-        <CircularProgress />
-      </Box>
-    )
-  }
-
-  if (isError) {
-    return (
-      <Typography sx={{ color: 'text.secondary', py: 4, textAlign: 'center' }}>
-        Failed to load payments.
-      </Typography>
-    )
-  }
-
-  if (payments.length === 0) {
-    return (
-      <Typography sx={{ color: 'text.secondary', py: 4, textAlign: 'center' }}>
-        No payments recorded for this sales order.
-      </Typography>
-    )
-  }
-
   const totalPaid = payments.reduce((sum, payment) => sum + Number(payment.amount), 0)
   const balance = totalAmount - totalPaid
 
-  return (
-    <Box>
-      <TableContainer component={Paper} variant="outlined">
-        <Table size={TABLE_STYLES.size}>
-          <TableHead>
-            <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600 } }}>
-              <TableCell>Payment Date</TableCell>
-              <TableCell>Payment Method</TableCell>
-              <TableCell>Reference Number</TableCell>
-              <TableCell align="right">Amount</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {payments.map((payment) => (
-              <TableRow key={payment.id} hover>
-                <TableCell>{formatDate(payment.paymentDate)}</TableCell>
-                <TableCell>{payment.paymentMethod?.name ?? '—'}</TableCell>
-                <TableCell>{payment.referenceNumber ?? '—'}</TableCell>
-                <TableCell
-                  align="right"
-                  data-testid={`payment-amount-${payment.id}`}
-                  sx={{ color: Number(payment.amount) < 0 ? 'error.main' : 'text.primary' }}
-                >
-                  {formatCurrency(payment.amount)}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
+  const columns: Column<SalesOrderPayment>[] = [
+    { header: 'Payment Date', width: '22%', render: (p) => formatDate(p.paymentDate) },
+    { header: 'Payment Method', width: '28%', render: (p) => p.paymentMethod?.name ?? '—' },
+    { header: 'Reference Number', width: '28%', render: (p) => p.referenceNumber ?? '—' },
+    {
+      header: 'Amount',
+      align: 'right',
+      width: '22%',
+      render: (p) => (
+        <Typography
+          variant="body2"
+          component="span"
+          data-testid={`payment-amount-${p.id}`}
+          sx={{ color: Number(p.amount) < 0 ? 'error.main' : 'text.primary' }}
+        >
+          {formatCurrency(p.amount)}
+        </Typography>
+      ),
+    },
+  ]
 
+  const summary =
+    payments.length > 0 ? (
       <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
         <Box sx={{ minWidth: 240 }}>
           {[
-            { label: 'Total Paid', value: formatCurrency(totalPaid), bold: true },
-            { label: 'Balance', value: formatCurrency(balance), bold: true },
-          ].map(({ label, value, bold }) => (
+            { label: 'Total Paid', value: formatCurrency(totalPaid) },
+            { label: 'Balance', value: formatCurrency(balance) },
+          ].map(({ label, value }) => (
             <Box key={label} sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
-              <Typography variant="body2" sx={{ fontWeight: bold ? 600 : 400 }}>
+              <Typography variant="body2" sx={{ fontWeight: 600 }}>
                 {label}
               </Typography>
-              <Typography variant="body2" sx={{ fontWeight: bold ? 600 : 400 }}>
+              <Typography variant="body2" sx={{ fontWeight: 600 }}>
                 {value}
               </Typography>
             </Box>
           ))}
         </Box>
       </Box>
-    </Box>
+    ) : undefined
+
+  return (
+    <DataTable
+      columns={columns}
+      rows={payments}
+      getRowKey={(p) => p.id}
+      emptyText="No payments recorded for this sales order."
+      isLoading={isLoading}
+      isError={isError}
+      errorText="Failed to load payments."
+      footer={summary}
+    />
   )
 }

--- a/frontend/src/pages/sales/components/__tests__/OrderJournalEntriesTab.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/OrderJournalEntriesTab.test.tsx
@@ -77,6 +77,14 @@ describe('OrderJournalEntriesTab', () => {
     expect(screen.getByText('Sales order SO-26-001')).toBeInTheDocument()
   })
 
+  it('renders a gold-standard grey header (DataTable)', () => {
+    mockGetJournalEntries.mockReturnValue({ data: { data: [makeEntry()], meta: { total: 1 } }, isLoading: false })
+    const { container } = renderTab('o1')
+    const headerCell = container.querySelector('.MuiTableCell-head')
+    expect(headerCell).not.toBeNull()
+    expect(headerCell).toHaveStyle({ backgroundColor: 'rgb(250, 250, 250)' })
+  })
+
   it('passes correct sourceType and sourceId to query', () => {
     mockGetJournalEntries.mockReturnValue({ data: { data: [], meta: { total: 0 } }, isLoading: false })
     renderTab('order-99')

--- a/frontend/src/pages/sales/components/__tests__/OrderPaymentsTab.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/OrderPaymentsTab.test.tsx
@@ -95,4 +95,12 @@ describe('OrderPaymentsTab', () => {
     renderTab('order-99', 100)
     expect(mockGetSalesOrderPayments).toHaveBeenCalledWith('order-99')
   })
+
+  it('renders a gold-standard grey header (DataTable)', () => {
+    mockGetSalesOrderPayments.mockReturnValue({ data: [makePayment()], isLoading: false })
+    const { container } = renderTab('o1', 200)
+    const headerCell = container.querySelector('.MuiTableCell-head')
+    expect(headerCell).not.toBeNull()
+    expect(headerCell).toHaveStyle({ backgroundColor: 'rgb(250, 250, 250)' })
+  })
 })


### PR DESCRIPTION
Closes #790.

Migrates the 3 remaining raw-MUI tab tables onto the shared `DataTable`, fixes `DataTable` so sticky tables get the outlined-Paper card border (the real shared gap — the two sticky consumers `StockMovementsTab` and `OrderHistoryTab` were rendering borderless), and adds width/`bold()` polish so all five remaining tab tables match the Customer Orders gold standard (plus the shared `DataTable` component fix that backs them).

## Changes
- **DataTable** sticky branch → outlined Paper card (fixes both sticky consumers at the source)
- **OrderPaymentsTab**, **OrderJournalEntriesTab**, **PurchaseOrderJournalEntriesTab** → migrated to `DataTable`
- **OrderHistoryTab** → explicit column widths (sum 100%)
- **StockMovementsTab** → bold Reference identifier (`referenceNumber`, fallback to type label)
- New test for **PurchaseOrderJournalEntriesTab** (had none)

## Verification
- Type-check: 0 errors
- Tests: 6 files, 40/40 passed
- Lint: 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)