### PR TITLE
fix(inventory): unify pagination to PagePagination (#796)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -135,4 +135,30 @@ export default tseslint.config(
       'no-restricted-syntax': 'off',
     },
   },
+  // TablePagination guard — use <PagePagination> for a consistent pagination UI.
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@mui/material',
+              importNames: ['TablePagination'],
+              message:
+                'Use <PagePagination> (components/common/PagePagination.tsx) for a consistent pagination UI. BackupList is the only sanctioned exception.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  // Known exception — BackupList intentionally keeps raw TablePagination (see tableStyles.ts opt-out).
+  {
+    files: ['src/components/backup/BackupList.tsx'],
+    rules: {
+      'no-restricted-imports': 'off',
+    },
+  },
 );

--- a/frontend/src/components/inventory/OrderHistoryTab.tsx
+++ b/frontend/src/components/inventory/OrderHistoryTab.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from 'react'
-import { TablePagination } from '@mui/material'
 import { useNavigate } from 'react-router-dom'
 
+import PagePagination from '@/components/common/PagePagination'
 import { ApiService } from '@/services/api'
 import { useNotification } from '@/hooks/useNotification'
 import { StatusChip } from '@/components/common/StatusChip'
-import { PAGINATION } from '@/constants/tableStyles'
+import { usePagination } from '@/hooks/usePagination'
 import { DataTable, type Column, bold, statusGroup, viewAction } from '@/components/common/DataTable'
 import { formatCurrency } from '@/utils/currency'
 import { formatDate } from '@/utils/formatters'
@@ -39,10 +39,9 @@ const OrderHistoryTab: React.FC<OrderHistoryTabProps> = ({ productId }) => {
     }
   }
 
+  const { page, limit, paginationProps } = usePagination()
   const [orders, setOrders] = useState<OrderHistoryItem[]>([])
   const [loading, setLoading] = useState(true)
-  const [page, setPage] = useState(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
   const [total, setTotal] = useState(0)
 
   useEffect(() => {
@@ -50,7 +49,7 @@ const OrderHistoryTab: React.FC<OrderHistoryTabProps> = ({ productId }) => {
       try {
         setLoading(true)
         const response = (await ApiService.get(`/inventory/products/${productId}/order-history`, {
-          params: { page: page + 1, limit: rowsPerPage },
+          params: { page, limit },
         })) as any
         const data = response.data?.data || response.data || []
         const meta = response.data?.meta || response.meta || {}
@@ -66,7 +65,7 @@ const OrderHistoryTab: React.FC<OrderHistoryTabProps> = ({ productId }) => {
     if (productId) {
       fetchOrderHistory()
     }
-  }, [productId, page, rowsPerPage, showError])
+  }, [productId, page, limit, showError])
 
   const getOrderTypeLabel = (type: string): string =>
     type === 'sales_order' ? 'Sales Order' : 'Purchase Order'
@@ -122,19 +121,7 @@ const OrderHistoryTab: React.FC<OrderHistoryTabProps> = ({ productId }) => {
       isLoading={loading}
       sticky
       footer={
-        <TablePagination
-          rowsPerPageOptions={PAGINATION.options}
-          component="div"
-          count={total}
-          rowsPerPage={rowsPerPage}
-          page={page}
-          onPageChange={(_, newPage) => setPage(newPage)}
-          onRowsPerPageChange={(e) => {
-            setRowsPerPage(parseInt(e.target.value, 10))
-            setPage(0)
-          }}
-          size="small"
-        />
+        <PagePagination total={total} {...paginationProps} />
       }
     />
   )

--- a/frontend/src/hooks/usePagination.test.ts
+++ b/frontend/src/hooks/usePagination.test.ts
@@ -1,0 +1,42 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+
+import { usePagination } from './usePagination'
+import { PAGINATION } from '@/constants/tableStyles'
+
+describe('usePagination', () => {
+  it('starts on page 1 with the default limit', () => {
+    const { result } = renderHook(() => usePagination())
+    expect(result.current.page).toBe(1)
+    expect(result.current.limit).toBe(PAGINATION.defaultPageSize)
+  })
+
+  it('honors an explicit initial limit', () => {
+    const { result } = renderHook(() => usePagination(50))
+    expect(result.current.limit).toBe(50)
+  })
+
+  it('setLimit changes limit and resets page to 1', () => {
+    const { result } = renderHook(() => usePagination())
+    act(() => result.current.setPage(4))
+    expect(result.current.page).toBe(4)
+    act(() => result.current.setLimit(100))
+    expect(result.current.limit).toBe(100)
+    expect(result.current.page).toBe(1)
+  })
+
+  it('reset returns to page 1', () => {
+    const { result } = renderHook(() => usePagination())
+    act(() => result.current.setPage(7))
+    act(() => result.current.reset())
+    expect(result.current.page).toBe(1)
+  })
+
+  it('paginationProps.onLimitChange also resets the page', () => {
+    const { result } = renderHook(() => usePagination())
+    act(() => result.current.setPage(3))
+    act(() => result.current.paginationProps.onLimitChange(25))
+    expect(result.current.page).toBe(1)
+    expect(result.current.limit).toBe(25)
+  })
+})

--- a/frontend/src/hooks/usePagination.ts
+++ b/frontend/src/hooks/usePagination.ts
@@ -1,0 +1,22 @@
+import { useCallback, useMemo, useState } from 'react'
+
+import { PAGINATION } from '@/constants/tableStyles'
+
+export function usePagination(initialLimit: number = PAGINATION.defaultPageSize) {
+  const [page, setPage] = useState(1)
+  const [limit, setLimitState] = useState(initialLimit)
+
+  const setLimit = useCallback((l: number) => {
+    setLimitState(l)
+    setPage(1)
+  }, [])
+
+  const reset = useCallback(() => setPage(1), [])
+
+  const paginationProps = useMemo(
+    () => ({ page, limit, onPageChange: setPage, onLimitChange: setLimit }),
+    [page, limit, setLimit],
+  )
+
+  return { page, limit, setPage, setLimit, reset, paginationProps }
+}

--- a/frontend/src/pages/audit-logs/components/LogsTab.tsx
+++ b/frontend/src/pages/audit-logs/components/LogsTab.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import {
   Paper, Table, TableBody, TableCell, TableContainer, TableHead,
-  TablePagination, TableRow, CircularProgress, Typography, Alert,
+  TableRow, CircularProgress, Typography, Alert,
 } from '@mui/material'
-import { PAGINATION } from '@/constants/tableStyles'
+import PagePagination from '@/components/common/PagePagination'
 import type { AuditLog } from '@/types'
 import LogRow from './LogRow'
 
@@ -64,14 +64,12 @@ const LogsTab: React.FC<LogsTabProps> = ({
             </TableBody>
           </Table>
         </TableContainer>
-        <TablePagination
-          rowsPerPageOptions={PAGINATION.options}
-          component="div"
-          count={total}
-          rowsPerPage={limit}
-          page={page - 1}
-          onPageChange={(_e, p) => onPageChange(p + 1)}
-          onRowsPerPageChange={(e) => onLimitChange(parseInt(e.target.value, 10))}
+        <PagePagination
+          total={total}
+          page={page}
+          limit={limit}
+          onPageChange={onPageChange}
+          onLimitChange={onLimitChange}
         />
       </Paper>
     </>

--- a/frontend/src/pages/inventory/HistoricalInventoryReport.tsx
+++ b/frontend/src/pages/inventory/HistoricalInventoryReport.tsx
@@ -15,7 +15,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   CircularProgress,
   Stack,
   useTheme,
@@ -27,6 +26,8 @@ import {
   DialogActions,
   IconButton,
 } from '@mui/material'
+import PagePagination from '@/components/common/PagePagination'
+import { usePagination } from '@/hooks/usePagination'
 import { alpha } from '@mui/material/styles'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
 import { default as ExcelIcon } from '@mui/icons-material/TableChart'
@@ -43,7 +44,7 @@ import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { escapeHtml } from '@/utils/security'
 import { printReport } from '@/utils/printReport'
 import { exportReportExcel } from '@/utils/exportReport'
-import { PAGINATION, TABLE_STYLES } from '@/constants/tableStyles'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 import { useGetProductsQuery, useGetCategoriesQuery } from '@/store/api/inventoryApi'
 import { printColors } from '@/styles/printTokens'
@@ -94,8 +95,7 @@ const HistoricalInventoryReport: React.FC = () => {
   const [reportTitle, setReportTitle] = useState<string>('Historical Inventory Report')
 
   // Pagination
-  const [page, setPage] = useState<number>(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, reset, setLimit, paginationProps } = usePagination()
 
   const { data: productsResponse } = useGetProductsQuery({ limit: 10000 })
   const products = productsResponse?.data ?? []
@@ -104,7 +104,7 @@ const HistoricalInventoryReport: React.FC = () => {
 
   const handleGenerateReport = async () => {
     setLoading(true)
-    setPage(0)
+    reset()
 
     try {
       const params = new URLSearchParams()
@@ -134,8 +134,8 @@ const HistoricalInventoryReport: React.FC = () => {
     setGroupBy('none')
     setSortBy1('productName')
     setReportTitle('Historical Inventory Report')
-    setPage(0)
-    setRowsPerPage(25)
+    reset()
+    setLimit(25)
   }
 
   const handleProductClick = (productId: string, event: React.MouseEvent) => {
@@ -439,16 +439,9 @@ const HistoricalInventoryReport: React.FC = () => {
 
   const totals = calculateTotals()
   const sortedData = getSortedData()
-  const paginatedData = sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+  const paginatedData = sortedData.slice((page - 1) * limit, (page - 1) * limit + limit)
 
-  const handleChangePage = (_: unknown, newPage: number) => {
-    setPage(newPage)
-  }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10))
-    setPage(0)
-  }
 
   return (
     <>
@@ -924,15 +917,7 @@ const HistoricalInventoryReport: React.FC = () => {
               {/* Pagination */}
               {reportData.length > 0 && (
                 <Box sx={{ borderTop: TABLE_STYLES.cell.border, flexShrink: 0 }}>
-                  <TablePagination
-                    component="div"
-                    count={sortedData.length}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    rowsPerPage={rowsPerPage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    rowsPerPageOptions={PAGINATION.options}
-                  />
+                  <PagePagination total={sortedData.length} {...paginationProps} />
                 </Box>
               )}
             </Paper>

--- a/frontend/src/pages/inventory/HistoricalInventoryReport.tsx
+++ b/frontend/src/pages/inventory/HistoricalInventoryReport.tsx
@@ -134,7 +134,6 @@ const HistoricalInventoryReport: React.FC = () => {
     setGroupBy('none')
     setSortBy1('productName')
     setReportTitle('Historical Inventory Report')
-    reset()
     setLimit(25)
   }
 

--- a/frontend/src/pages/inventory/InventorySummaryReport.tsx
+++ b/frontend/src/pages/inventory/InventorySummaryReport.tsx
@@ -16,7 +16,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   CircularProgress,
   Stack,
   useTheme,
@@ -28,6 +27,8 @@ import {
   DialogActions,
   IconButton,
 } from '@mui/material'
+import PagePagination from '@/components/common/PagePagination'
+import { usePagination } from '@/hooks/usePagination'
 import { alpha } from '@mui/material/styles'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
 import { default as ExcelIcon } from '@mui/icons-material/TableChart'
@@ -44,7 +45,7 @@ import { formatCurrency, formatDateTime } from '@/utils/formatters'
 import { escapeHtml } from '@/utils/security'
 import { printReport } from '@/utils/printReport'
 import { exportReportExcel } from '@/utils/exportReport'
-import { PAGINATION, TABLE_STYLES } from '@/constants/tableStyles'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 import { useGetEffectivePriceListsQuery } from '@/store/api/priceListApi'
 import { printColors } from '@/styles/printTokens'
@@ -97,8 +98,7 @@ const InventorySummaryReport: React.FC = () => {
   const [reportTitle, setReportTitle] = useState<string>('Inventory Summary Report')
 
   // Pagination
-  const [page, setPage] = useState<number>(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, reset, setLimit, paginationProps } = usePagination()
 
   useEffect(() => {
     // Load products
@@ -144,7 +144,7 @@ const InventorySummaryReport: React.FC = () => {
 
   const handleGenerateReport = async () => {
     setLoading(true)
-    setPage(0)
+    reset()
 
     try {
       const params = new URLSearchParams()
@@ -176,8 +176,8 @@ const InventorySummaryReport: React.FC = () => {
     setGroupBy('none')
     setSortBy1('productName')
     setReportTitle('Inventory Summary Report')
-    setPage(0)
-    setRowsPerPage(25)
+    reset()
+    setLimit(25)
   }
 
   const handleProductClick = (productId: string, event: React.MouseEvent) => {
@@ -547,16 +547,9 @@ const InventorySummaryReport: React.FC = () => {
   }
 
   const sortedData = getSortedData()
-  const paginatedData = sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+  const paginatedData = sortedData.slice((page - 1) * limit, (page - 1) * limit + limit)
 
-  const handleChangePage = (_: unknown, newPage: number) => {
-    setPage(newPage)
-  }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10))
-    setPage(0)
-  }
 
   return (
     <>
@@ -1056,15 +1049,7 @@ const InventorySummaryReport: React.FC = () => {
               {/* Pagination */}
               {reportData.length > 0 && (
                 <Box sx={{ borderTop: TABLE_STYLES.cell.border, flexShrink: 0 }}>
-                  <TablePagination
-                    component="div"
-                    count={sortedData.length}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    rowsPerPage={rowsPerPage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    rowsPerPageOptions={PAGINATION.options}
-                  />
+                  <PagePagination total={sortedData.length} {...paginationProps} />
                 </Box>
               )}
             </Paper>

--- a/frontend/src/pages/inventory/InventorySummaryReport.tsx
+++ b/frontend/src/pages/inventory/InventorySummaryReport.tsx
@@ -176,7 +176,6 @@ const InventorySummaryReport: React.FC = () => {
     setGroupBy('none')
     setSortBy1('productName')
     setReportTitle('Inventory Summary Report')
-    reset()
     setLimit(25)
   }
 

--- a/frontend/src/pages/inventory/MovementSummaryReport.tsx
+++ b/frontend/src/pages/inventory/MovementSummaryReport.tsx
@@ -130,7 +130,6 @@ const MovementSummaryReport: React.FC = () => {
     setGroupBy('none')
     setSortBy1('productName')
     setReportTitle('Inventory Movement Summary Report')
-    reset()
     setLimit(25)
   }
 

--- a/frontend/src/pages/inventory/MovementSummaryReport.tsx
+++ b/frontend/src/pages/inventory/MovementSummaryReport.tsx
@@ -16,7 +16,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   CircularProgress,
   Stack,
   useTheme,
@@ -28,6 +27,8 @@ import {
   DialogActions,
   IconButton,
 } from '@mui/material'
+import PagePagination from '@/components/common/PagePagination'
+import { usePagination } from '@/hooks/usePagination'
 import { alpha } from '@mui/material/styles'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
 import { default as ExcelIcon } from '@mui/icons-material/TableChart'
@@ -44,7 +45,7 @@ import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { escapeHtml } from '@/utils/security'
 import { printReport } from '@/utils/printReport'
 import { exportReportExcel } from '@/utils/exportReport'
-import { PAGINATION, TABLE_STYLES } from '@/constants/tableStyles'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 import { useGetProductsQuery, useGetCategoriesQuery } from '@/store/api/inventoryApi'
 import { printColors } from '@/styles/printTokens'
@@ -88,8 +89,7 @@ const MovementSummaryReport: React.FC = () => {
   const [reportTitle, setReportTitle] = useState<string>('Inventory Movement Summary Report')
 
   // Pagination
-  const [page, setPage] = useState<number>(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, reset, setLimit, paginationProps } = usePagination()
 
   const { data: productsResponse } = useGetProductsQuery({ limit: 10000 })
   const products = productsResponse?.data ?? []
@@ -98,7 +98,7 @@ const MovementSummaryReport: React.FC = () => {
 
   const handleGenerateReport = async () => {
     setLoading(true)
-    setPage(0)
+    reset()
 
     try {
       const params = new URLSearchParams()
@@ -130,8 +130,8 @@ const MovementSummaryReport: React.FC = () => {
     setGroupBy('none')
     setSortBy1('productName')
     setReportTitle('Inventory Movement Summary Report')
-    setPage(0)
-    setRowsPerPage(25)
+    reset()
+    setLimit(25)
   }
 
   const handleProductClick = (productId: string, event: React.MouseEvent) => {
@@ -437,16 +437,9 @@ const MovementSummaryReport: React.FC = () => {
 
   const totals = calculateTotals()
   const sortedData = getSortedData()
-  const paginatedData = sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+  const paginatedData = sortedData.slice((page - 1) * limit, (page - 1) * limit + limit)
 
-  const handleChangePage = (_: unknown, newPage: number) => {
-    setPage(newPage)
-  }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10))
-    setPage(0)
-  }
 
   return (
     <>
@@ -924,15 +917,7 @@ const MovementSummaryReport: React.FC = () => {
               {/* Pagination */}
               {reportData.length > 0 && (
                 <Box sx={{ borderTop: TABLE_STYLES.cell.border, flexShrink: 0 }}>
-                  <TablePagination
-                    component="div"
-                    count={sortedData.length}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    rowsPerPage={rowsPerPage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    rowsPerPageOptions={PAGINATION.options}
-                  />
+                  <PagePagination total={sortedData.length} {...paginationProps} />
                 </Box>
               )}
             </Paper>

--- a/frontend/src/pages/inventory/PriceListReport.tsx
+++ b/frontend/src/pages/inventory/PriceListReport.tsx
@@ -15,7 +15,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   CircularProgress,
   Stack,
   useTheme,
@@ -27,6 +26,8 @@ import {
   DialogActions,
   IconButton,
 } from '@mui/material'
+import PagePagination from '@/components/common/PagePagination'
+import { usePagination } from '@/hooks/usePagination'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
 import { default as ExcelIcon } from '@mui/icons-material/TableChart'
 import { default as RefreshIcon } from '@mui/icons-material/Refresh'
@@ -42,7 +43,7 @@ import { formatCurrency, formatDateTime } from '@/utils/formatters'
 import { escapeHtml } from '@/utils/security'
 import { printReport } from '@/utils/printReport'
 import { exportReportExcel } from '@/utils/exportReport'
-import { PAGINATION, TABLE_STYLES } from '@/constants/tableStyles'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 import { printColors } from '@/styles/printTokens'
 import { PRINT_STYLES } from '@/styles/printStyles'
@@ -94,8 +95,7 @@ const PriceListReport: React.FC = () => {
   const [reportTitle, setReportTitle] = useState<string>('Product Price List Report')
 
   // Pagination
-  const [page, setPage] = useState<number>(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, reset, setLimit, paginationProps } = usePagination()
 
   const { data: productsResponse } = useGetProductsQuery({ limit: 10000 })
   const products = productsResponse?.data ?? []
@@ -123,7 +123,7 @@ const PriceListReport: React.FC = () => {
 
   const handleGenerateReport = async () => {
     setLoading(true)
-    setPage(0)
+    reset()
 
     try {
       const params = new URLSearchParams()
@@ -161,8 +161,8 @@ const PriceListReport: React.FC = () => {
     setGroupBy('none')
     setSortBy1('productName')
     setReportTitle('Product Price List Report')
-    setPage(0)
-    setRowsPerPage(25)
+    reset()
+    setLimit(25)
   }
 
   const handleProductClick = (productId: string, event: React.MouseEvent) => {
@@ -453,16 +453,9 @@ const PriceListReport: React.FC = () => {
   }
 
   const sortedData = getSortedData()
-  const paginatedData = sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+  const paginatedData = sortedData.slice((page - 1) * limit, (page - 1) * limit + limit)
 
-  const handleChangePage = (_: unknown, newPage: number) => {
-    setPage(newPage)
-  }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10))
-    setPage(0)
-  }
 
   return (
     <>
@@ -873,15 +866,7 @@ const PriceListReport: React.FC = () => {
               {/* Pagination */}
               {reportData.length > 0 && (
                 <Box sx={{ borderTop: TABLE_STYLES.cell.border, flexShrink: 0 }}>
-                  <TablePagination
-                    component="div"
-                    count={sortedData.length}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    rowsPerPage={rowsPerPage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    rowsPerPageOptions={PAGINATION.options}
-                  />
+                  <PagePagination total={sortedData.length} {...paginationProps} />
                 </Box>
               )}
             </Paper>

--- a/frontend/src/pages/inventory/PriceListReport.tsx
+++ b/frontend/src/pages/inventory/PriceListReport.tsx
@@ -161,7 +161,6 @@ const PriceListReport: React.FC = () => {
     setGroupBy('none')
     setSortBy1('productName')
     setReportTitle('Product Price List Report')
-    reset()
     setLimit(25)
   }
 

--- a/frontend/src/pages/inventory/ProductCostReport.tsx
+++ b/frontend/src/pages/inventory/ProductCostReport.tsx
@@ -15,7 +15,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   CircularProgress,
   Stack,
   useTheme,
@@ -27,6 +26,8 @@ import {
   DialogActions,
   IconButton,
 } from '@mui/material'
+import PagePagination from '@/components/common/PagePagination'
+import { usePagination } from '@/hooks/usePagination'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
 import { default as ExcelIcon } from '@mui/icons-material/TableChart'
 import { default as RefreshIcon } from '@mui/icons-material/Refresh'
@@ -42,7 +43,7 @@ import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { escapeHtml } from '@/utils/security'
 import { printReport } from '@/utils/printReport'
 import { exportReportExcel } from '@/utils/exportReport'
-import { PAGINATION, TABLE_STYLES } from '@/constants/tableStyles'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 import { useGetProductsQuery, useGetCategoriesQuery } from '@/store/api/inventoryApi'
 import { printColors } from '@/styles/printTokens'
@@ -90,8 +91,7 @@ const ProductCostReport: React.FC = () => {
   const [reportTitle, setReportTitle] = useState<string>('Product Cost Report')
 
   // Pagination
-  const [page, setPage] = useState<number>(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, reset, setLimit, paginationProps } = usePagination()
 
   const { data: productsResponse } = useGetProductsQuery({ limit: 10000 })
   const products = productsResponse?.data ?? []
@@ -100,7 +100,7 @@ const ProductCostReport: React.FC = () => {
 
   const handleGenerateReport = async () => {
     setLoading(true)
-    setPage(0)
+    reset()
 
     try {
       const params = new URLSearchParams()
@@ -130,8 +130,8 @@ const ProductCostReport: React.FC = () => {
     setGroupBy('productName')
     setSortBy1('productName')
     setReportTitle('Product Cost Report')
-    setPage(0)
-    setRowsPerPage(25)
+    reset()
+    setLimit(25)
   }
 
   const handleProductClick = (productId: string, event: React.MouseEvent) => {
@@ -444,16 +444,9 @@ const ProductCostReport: React.FC = () => {
   }
 
   const sortedData = getSortedData()
-  const paginatedData = sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+  const paginatedData = sortedData.slice((page - 1) * limit, (page - 1) * limit + limit)
 
-  const handleChangePage = (_: unknown, newPage: number) => {
-    setPage(newPage)
-  }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10))
-    setPage(0)
-  }
 
   return (
     <>
@@ -901,15 +894,7 @@ const ProductCostReport: React.FC = () => {
               {/* Pagination */}
               {reportData.length > 0 && (
                 <Box sx={{ borderTop: TABLE_STYLES.cell.border, flexShrink: 0 }}>
-                  <TablePagination
-                    component="div"
-                    count={sortedData.length}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    rowsPerPage={rowsPerPage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    rowsPerPageOptions={PAGINATION.options}
-                  />
+                  <PagePagination total={sortedData.length} {...paginationProps} />
                 </Box>
               )}
             </Paper>

--- a/frontend/src/pages/inventory/ProductCostReport.tsx
+++ b/frontend/src/pages/inventory/ProductCostReport.tsx
@@ -130,7 +130,6 @@ const ProductCostReport: React.FC = () => {
     setGroupBy('productName')
     setSortBy1('productName')
     setReportTitle('Product Cost Report')
-    reset()
     setLimit(25)
   }
 

--- a/frontend/src/pages/inventory/components/StockMovementsTab.tsx
+++ b/frontend/src/pages/inventory/components/StockMovementsTab.tsx
@@ -1,26 +1,24 @@
-import { useState } from 'react'
-import { TablePagination } from '@mui/material'
 import { useNavigate } from 'react-router-dom'
 
+import PagePagination from '@/components/common/PagePagination'
 import { DataTable, type Column, bold, viewAction } from '@/components/common/DataTable'
+import { usePagination } from '@/hooks/usePagination'
 import { useLazyGetPurchaseOrderQuery } from '@/store/api/purchasingApi'
 import { useLazyGetSalesOrderQuery } from '@/store/api/salesApi'
 import { useGetStockMovementsQuery } from '@/store/api/inventoryApi'
 import type { StockMovement } from '@/types'
 import { formatDate, formatNumber } from '@/utils/formatters'
-import { PAGINATION } from '@/constants/tableStyles'
 
 import { getMovementLabel, getMovementNavTarget, getReferenceLabel } from '../utils/stockMovementDisplay'
 
 export default function StockMovementsTab({ productId }: { productId: string }) {
   const navigate = useNavigate()
-  const [page, setPage] = useState(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, paginationProps } = usePagination()
 
   const { data, isLoading } = useGetStockMovementsQuery({
     productId,
-    page: page + 1,
-    limit: rowsPerPage,
+    page,
+    limit,
   })
   const movements = data?.data ?? []
   const total = data?.meta?.total ?? 0
@@ -76,19 +74,7 @@ export default function StockMovementsTab({ productId }: { productId: string }) 
       isLoading={isLoading}
       sticky
       footer={
-        <TablePagination
-          rowsPerPageOptions={PAGINATION.options}
-          component="div"
-          count={total}
-          rowsPerPage={rowsPerPage}
-          page={page}
-          onPageChange={(_, newPage) => setPage(newPage)}
-          onRowsPerPageChange={(e) => {
-            setRowsPerPage(parseInt(e.target.value, 10))
-            setPage(0)
-          }}
-          size="small"
-        />
+        <PagePagination total={total} {...paginationProps} />
       }
     />
   )

--- a/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
@@ -190,7 +190,6 @@ const PurchaseOrderDetailsReport: React.FC = () => {
     setGroupBy('none')
     setSortBy1('productName')
     setReportTitle('Purchase Order Details Report')
-    reset()
     setLimit(25)
   }
 

--- a/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderDetailsReport.tsx
@@ -17,7 +17,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   CircularProgress,
   Stack,
   useTheme,
@@ -36,6 +35,8 @@ import {
   OutlinedInput,
   Divider,
 } from '@mui/material'
+import PagePagination from '@/components/common/PagePagination'
+import { usePagination } from '@/hooks/usePagination'
 import { alpha } from '@mui/material/styles'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
 import { default as ExcelIcon } from '@mui/icons-material/TableChart'
@@ -56,7 +57,7 @@ import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { escapeHtml } from '@/utils/security'
 import { printReport } from '@/utils/printReport'
 import { exportReportExcel } from '@/utils/exportReport'
-import { PAGINATION, TABLE_STYLES } from '@/constants/tableStyles'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import api from '@/services/api'
 
 interface PurchaseOrderDetail {
@@ -107,8 +108,7 @@ const PurchaseOrderDetailsReport: React.FC = () => {
   const [reportTitle, setReportTitle] = useState<string>('Purchase Order Details Report')
 
   // Pagination
-  const [page, setPage] = useState<number>(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, reset, setLimit, paginationProps } = usePagination()
 
   useEffect(() => {
     // Load suppliers
@@ -151,7 +151,7 @@ const PurchaseOrderDetailsReport: React.FC = () => {
 
   const handleGenerateReport = async () => {
     setLoading(true)
-    setPage(0)
+    reset()
 
     try {
       const params = new URLSearchParams()
@@ -190,8 +190,8 @@ const PurchaseOrderDetailsReport: React.FC = () => {
     setGroupBy('none')
     setSortBy1('productName')
     setReportTitle('Purchase Order Details Report')
-    setPage(0)
-    setRowsPerPage(25)
+    reset()
+    setLimit(25)
   }
 
   const handleProductClick = (productId: string, event: React.MouseEvent) => {
@@ -550,16 +550,9 @@ const PurchaseOrderDetailsReport: React.FC = () => {
   }
 
   const sortedData = getSortedData()
-  const paginatedData = sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+  const paginatedData = sortedData.slice((page - 1) * limit, (page - 1) * limit + limit)
 
-  const handleChangePage = (_: unknown, newPage: number) => {
-    setPage(newPage)
-  }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10))
-    setPage(0)
-  }
 
   return (
     <>
@@ -1154,15 +1147,7 @@ const PurchaseOrderDetailsReport: React.FC = () => {
               {/* Pagination */}
               {reportData.length > 0 && (
                 <Box sx={{ borderTop: TABLE_STYLES.cell.border, flexShrink: 0 }}>
-                  <TablePagination
-                    component="div"
-                    count={sortedData.length}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    rowsPerPage={rowsPerPage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    rowsPerPageOptions={PAGINATION.options}
-                  />
+                  <PagePagination total={sortedData.length} {...paginationProps} />
                 </Box>
               )}
             </Paper>

--- a/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
@@ -16,7 +16,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   CircularProgress,
   Stack,
   useTheme,
@@ -28,6 +27,8 @@ import {
   DialogActions,
   IconButton,
 } from '@mui/material'
+import PagePagination from '@/components/common/PagePagination'
+import { usePagination } from '@/hooks/usePagination'
 import { alpha } from '@mui/material/styles'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
 import { default as ExcelIcon } from '@mui/icons-material/TableChart'
@@ -48,7 +49,7 @@ import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { escapeHtml } from '@/utils/security'
 import { printReport } from '@/utils/printReport'
 import { exportReportExcel } from '@/utils/exportReport'
-import { PAGINATION, TABLE_STYLES } from '@/constants/tableStyles'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import api from '@/services/api'
 
 interface PurchaseOrderStatus {
@@ -96,8 +97,7 @@ const PurchaseOrderStatusReport: React.FC = () => {
   const [reportTitle, setReportTitle] = useState<string>('Purchase Order Status Report')
 
   // Pagination
-  const [page, setPage] = useState<number>(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, reset, setLimit, paginationProps } = usePagination()
 
   useEffect(() => {
     // Load suppliers
@@ -140,7 +140,7 @@ const PurchaseOrderStatusReport: React.FC = () => {
 
   const handleGenerateReport = async () => {
     setLoading(true)
-    setPage(0)
+    reset()
 
     try {
       const params = new URLSearchParams()
@@ -173,8 +173,8 @@ const PurchaseOrderStatusReport: React.FC = () => {
     setGroupBy('none')
     setSortBy1('productName')
     setReportTitle('Purchase Order Status Report')
-    setPage(0)
-    setRowsPerPage(25)
+    reset()
+    setLimit(25)
   }
 
   const handleProductClick = (productId: string, event: React.MouseEvent) => {
@@ -530,16 +530,9 @@ const PurchaseOrderStatusReport: React.FC = () => {
   }
 
   const sortedData = getSortedData()
-  const paginatedData = sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+  const paginatedData = sortedData.slice((page - 1) * limit, (page - 1) * limit + limit)
 
-  const handleChangePage = (_: unknown, newPage: number) => {
-    setPage(newPage)
-  }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10))
-    setPage(0)
-  }
 
   return (
     <>
@@ -1094,15 +1087,7 @@ const PurchaseOrderStatusReport: React.FC = () => {
               {/* Pagination */}
               {reportData.length > 0 && (
                 <Box sx={{ borderTop: TABLE_STYLES.cell.border, flexShrink: 0 }}>
-                  <TablePagination
-                    component="div"
-                    count={sortedData.length}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    rowsPerPage={rowsPerPage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    rowsPerPageOptions={PAGINATION.options}
-                  />
+                  <PagePagination total={sortedData.length} {...paginationProps} />
                 </Box>
               )}
             </Paper>

--- a/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderStatusReport.tsx
@@ -173,7 +173,6 @@ const PurchaseOrderStatusReport: React.FC = () => {
     setGroupBy('none')
     setSortBy1('productName')
     setReportTitle('Purchase Order Status Report')
-    reset()
     setLimit(25)
   }
 

--- a/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
@@ -16,13 +16,14 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   CircularProgress,
   Stack,
   useTheme,
   useMediaQuery,
   Chip,
 } from '@mui/material'
+import PagePagination from '@/components/common/PagePagination'
+import { usePagination } from '@/hooks/usePagination'
 import { alpha } from '@mui/material/styles'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
 import { default as ExcelIcon } from '@mui/icons-material/TableChart'
@@ -37,7 +38,7 @@ import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { escapeHtml } from '@/utils/security'
 import { printReport } from '@/utils/printReport'
 import { exportReportExcel } from '@/utils/exportReport'
-import { PAGINATION, TABLE_STYLES } from '@/constants/tableStyles'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import api from '@/services/api'
 
 interface PurchaseOrderSummaryReport {
@@ -74,8 +75,7 @@ const PurchaseOrderSummary: React.FC = () => {
   const [reportTitle, setReportTitle] = useState<string>('Purchase Order Summary Report')
 
   // Pagination
-  const [page, setPage] = useState<number>(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, reset, setLimit, paginationProps } = usePagination()
 
   useEffect(() => {
     // Load suppliers
@@ -90,7 +90,7 @@ const PurchaseOrderSummary: React.FC = () => {
 
   // Reset to first page when filters or display options change
   useEffect(() => {
-    setPage(0)
+    reset()
   }, [groupBy, sortBy1, status, paymentStatus, selectedSupplier])
 
   // Reset sortBy1 if the selected column is removed from selectedColumns
@@ -103,7 +103,7 @@ const PurchaseOrderSummary: React.FC = () => {
 
   const handleGenerateReport = async () => {
     setLoading(true)
-    setPage(0) // Reset to first page when generating new report
+    reset() // Reset to first page when generating new report
 
     try {
       // Build query parameters
@@ -138,8 +138,8 @@ const PurchaseOrderSummary: React.FC = () => {
     setGroupBy('none')
     setSortBy1('orderNumber')
     setReportTitle('Purchase Order Summary Report')
-    setPage(0)
-    setRowsPerPage(25)
+    reset()
+    setLimit(25)
   }
 
   const handleExportExcel = async () => {
@@ -407,16 +407,9 @@ const PurchaseOrderSummary: React.FC = () => {
   }
 
   const sortedData = getSortedData()
-  const paginatedData = sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+  const paginatedData = sortedData.slice((page - 1) * limit, (page - 1) * limit + limit)
 
-  const handleChangePage = (_: unknown, newPage: number) => {
-    setPage(newPage)
-  }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10))
-    setPage(0)
-  }
 
   return (
     <>
@@ -960,15 +953,7 @@ const PurchaseOrderSummary: React.FC = () => {
               {/* Pagination */}
               {reportData.length > 0 && (
                 <Box sx={{ borderTop: TABLE_STYLES.cell.border, flexShrink: 0 }}>
-                  <TablePagination
-                    component="div"
-                    count={sortedData.length}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    rowsPerPage={rowsPerPage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    rowsPerPageOptions={PAGINATION.options}
-                  />
+                  <PagePagination total={sortedData.length} {...paginationProps} />
                 </Box>
               )}
             </Paper>

--- a/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
+++ b/frontend/src/pages/purchasing/PurchaseOrderSummary.tsx
@@ -138,7 +138,6 @@ const PurchaseOrderSummary: React.FC = () => {
     setGroupBy('none')
     setSortBy1('orderNumber')
     setReportTitle('Purchase Order Summary Report')
-    reset()
     setLimit(25)
   }
 

--- a/frontend/src/pages/sales/CustomerOrderHistory.tsx
+++ b/frontend/src/pages/sales/CustomerOrderHistory.tsx
@@ -15,7 +15,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   CircularProgress,
   Stack,
   useTheme,
@@ -28,6 +27,8 @@ import {
   IconButton,
   Divider,
 } from '@mui/material'
+import PagePagination from '@/components/common/PagePagination'
+import { usePagination } from '@/hooks/usePagination'
 import { alpha } from '@mui/material/styles'
 import { AppButton } from '@/components/common/AppButton'
 import { StatusChip } from '@/components/common/StatusChip'
@@ -47,7 +48,7 @@ import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { escapeHtml } from '@/utils/security'
 import { printReport } from '@/utils/printReport'
 import { exportReportExcel } from '@/utils/exportReport'
-import { PAGINATION, TABLE_STYLES } from '@/constants/tableStyles'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 
 interface CustomerOrderHistory {
@@ -100,8 +101,7 @@ const CustomerOrderHistory: React.FC = () => {
   const [reportTitle, setReportTitle] = useState<string>('Customer Order History')
 
   // Pagination
-  const [page, setPage] = useState<number>(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, reset, setLimit, paginationProps } = usePagination()
 
   useEffect(() => {
     // Load customers with authentication
@@ -134,12 +134,12 @@ const CustomerOrderHistory: React.FC = () => {
 
   // Reset to first page when filters or display options change
   useEffect(() => {
-    setPage(0)
+    reset()
   }, [groupBy, sortBy1, inventoryStatus, paymentStatus, selectedCategory, selectedProducts])
 
   const handleGenerateReport = async () => {
     setLoading(true)
-    setPage(0) // Reset to first page when generating new report
+    reset() // Reset to first page when generating new report
 
     try {
       // Build query parameters
@@ -319,8 +319,8 @@ const CustomerOrderHistory: React.FC = () => {
     setReportTitle('Customer Order History')
 
     // Reset pagination
-    setPage(0)
-    setRowsPerPage(25)
+    reset()
+    setLimit(25)
   }
 
   const handleExportExcel = async () => {
@@ -628,17 +628,10 @@ const CustomerOrderHistory: React.FC = () => {
   const sortedData = getSortedData()
 
   // Apply pagination to sorted data
-  const paginatedData = sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+  const paginatedData = sortedData.slice((page - 1) * limit, (page - 1) * limit + limit)
 
   // Pagination handlers
-  const handleChangePage = (_: unknown, newPage: number) => {
-    setPage(newPage)
-  }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10))
-    setPage(0)
-  }
 
   return (
     <>
@@ -1252,15 +1245,7 @@ const CustomerOrderHistory: React.FC = () => {
               {/* Pagination */}
               {reportData.length > 0 && (
                 <Box sx={{ borderTop: TABLE_STYLES.cell.border, flexShrink: 0 }}>
-                  <TablePagination
-                    component="div"
-                    count={sortedData.length}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    rowsPerPage={rowsPerPage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    rowsPerPageOptions={PAGINATION.options}
-                  />
+                  <PagePagination total={sortedData.length} {...paginationProps} />
                 </Box>
               )}
             </Paper>

--- a/frontend/src/pages/sales/CustomerOrderHistory.tsx
+++ b/frontend/src/pages/sales/CustomerOrderHistory.tsx
@@ -319,7 +319,6 @@ const CustomerOrderHistory: React.FC = () => {
     setReportTitle('Customer Order History')
 
     // Reset pagination
-    reset()
     setLimit(25)
   }
 

--- a/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
@@ -144,7 +144,6 @@ const CustomerPaymentByOrder: React.FC = () => {
     setReportTitle('Customer Payment by Order')
 
     // Reset pagination
-    reset()
     setLimit(25)
   }
 

--- a/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentByOrder.tsx
@@ -15,7 +15,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   CircularProgress,
   Stack,
   useTheme,
@@ -24,6 +23,8 @@ import {
   FormControlLabel,
   Checkbox,
 } from '@mui/material'
+import PagePagination from '@/components/common/PagePagination'
+import { usePagination } from '@/hooks/usePagination'
 import { alpha } from '@mui/material/styles'
 import { AppButton } from '@/components/common/AppButton'
 import { StatusChip } from '@/components/common/StatusChip'
@@ -38,7 +39,7 @@ import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { escapeHtml } from '@/utils/security'
 import { printReport } from '@/utils/printReport'
 import { exportReportExcel } from '@/utils/exportReport'
-import { PAGINATION, TABLE_STYLES } from '@/constants/tableStyles'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 
 interface CustomerPaymentByOrder {
@@ -79,8 +80,7 @@ const CustomerPaymentByOrder: React.FC = () => {
   const [reportTitle, setReportTitle] = useState<string>('Customer Payment by Order')
 
   // Pagination
-  const [page, setPage] = useState<number>(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, reset, setLimit, paginationProps } = usePagination()
 
   useEffect(() => {
     // Load customers with authentication
@@ -95,12 +95,12 @@ const CustomerPaymentByOrder: React.FC = () => {
 
   // Reset to first page when filters or display options change
   useEffect(() => {
-    setPage(0)
+    reset()
   }, [showOnlyOwing, groupBy, sortBy1])
 
   const handleGenerateReport = async () => {
     setLoading(true)
-    setPage(0) // Reset to first page when generating new report
+    reset() // Reset to first page when generating new report
 
     try {
       // Build query parameters
@@ -144,8 +144,8 @@ const CustomerPaymentByOrder: React.FC = () => {
     setReportTitle('Customer Payment by Order')
 
     // Reset pagination
-    setPage(0)
-    setRowsPerPage(25)
+    reset()
+    setLimit(25)
   }
 
   const handleExportExcel = async () => {
@@ -419,17 +419,10 @@ const CustomerPaymentByOrder: React.FC = () => {
   const sortedData = getSortedData()
 
   // Apply pagination to sorted data
-  const paginatedData = sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+  const paginatedData = sortedData.slice((page - 1) * limit, (page - 1) * limit + limit)
 
   // Pagination handlers
-  const handleChangePage = (_: unknown, newPage: number) => {
-    setPage(newPage)
-  }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10))
-    setPage(0)
-  }
 
   return (
     <>
@@ -976,15 +969,7 @@ const CustomerPaymentByOrder: React.FC = () => {
               {/* Pagination */}
               {reportData.length > 0 && (
                 <Box sx={{ borderTop: TABLE_STYLES.cell.border, flexShrink: 0 }}>
-                  <TablePagination
-                    component="div"
-                    count={sortedData.length}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    rowsPerPage={rowsPerPage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    rowsPerPageOptions={PAGINATION.options}
-                  />
+                  <PagePagination total={sortedData.length} {...paginationProps} />
                 </Box>
               )}
             </Paper>

--- a/frontend/src/pages/sales/CustomerPaymentDetails.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentDetails.tsx
@@ -15,12 +15,13 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   CircularProgress,
   Stack,
   useTheme,
   useMediaQuery,
 } from '@mui/material'
+import PagePagination from '@/components/common/PagePagination'
+import { usePagination } from '@/hooks/usePagination'
 import { alpha } from '@mui/material/styles'
 import { AppButton } from '@/components/common/AppButton'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
@@ -34,7 +35,7 @@ import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { escapeHtml } from '@/utils/security'
 import { printReport } from '@/utils/printReport'
 import { exportReportExcel } from '@/utils/exportReport'
-import { PAGINATION, TABLE_STYLES } from '@/constants/tableStyles'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 
 interface CustomerPaymentDetail {
@@ -76,8 +77,7 @@ const CustomerPaymentDetails: React.FC = () => {
   const [reportTitle, setReportTitle] = useState<string>('Customer Payment Details')
 
   // Pagination
-  const [page, setPage] = useState<number>(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, reset, setLimit, paginationProps } = usePagination()
 
   useEffect(() => {
     // Load customers with authentication
@@ -92,12 +92,12 @@ const CustomerPaymentDetails: React.FC = () => {
 
   // Reset to first page when filters or display options change
   useEffect(() => {
-    setPage(0)
+    reset()
   }, [groupBy, sortBy1])
 
   const handleGenerateReport = async () => {
     setLoading(true)
-    setPage(0) // Reset to first page when generating new report
+    reset() // Reset to first page when generating new report
 
     try {
       // Build query parameters
@@ -136,8 +136,8 @@ const CustomerPaymentDetails: React.FC = () => {
     setReportTitle('Customer Payment Details')
 
     // Reset pagination
-    setPage(0)
-    setRowsPerPage(25)
+    reset()
+    setLimit(25)
   }
 
   const handleExportExcel = async () => {
@@ -398,17 +398,10 @@ const CustomerPaymentDetails: React.FC = () => {
   const sortedData = getSortedData()
 
   // Apply pagination to sorted data
-  const paginatedData = sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+  const paginatedData = sortedData.slice((page - 1) * limit, (page - 1) * limit + limit)
 
   // Pagination handlers
-  const handleChangePage = (_: unknown, newPage: number) => {
-    setPage(newPage)
-  }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10))
-    setPage(0)
-  }
 
   return (
     <>
@@ -853,15 +846,7 @@ const CustomerPaymentDetails: React.FC = () => {
               {/* Pagination */}
               {reportData.length > 0 && (
                 <Box sx={{ borderTop: TABLE_STYLES.cell.border, flexShrink: 0 }}>
-                  <TablePagination
-                    component="div"
-                    count={sortedData.length}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    rowsPerPage={rowsPerPage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    rowsPerPageOptions={PAGINATION.options}
-                  />
+                  <PagePagination total={sortedData.length} {...paginationProps} />
                 </Box>
               )}
             </Paper>

--- a/frontend/src/pages/sales/CustomerPaymentDetails.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentDetails.tsx
@@ -136,7 +136,6 @@ const CustomerPaymentDetails: React.FC = () => {
     setReportTitle('Customer Payment Details')
 
     // Reset pagination
-    reset()
     setLimit(25)
   }
 

--- a/frontend/src/pages/sales/CustomerPaymentSummary.tsx
+++ b/frontend/src/pages/sales/CustomerPaymentSummary.tsx
@@ -15,7 +15,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   CircularProgress,
   Stack,
   useTheme,
@@ -32,12 +31,14 @@ import { default as RefreshIcon } from '@mui/icons-material/Refresh'
 import { default as GenerateIcon } from '@mui/icons-material/PlayArrow'
 import { default as PaymentSummaryIcon } from '@mui/icons-material/AccountBalanceWallet'
 import PageHeader from '@/components/common/PageHeader'
+import PagePagination from '@/components/common/PagePagination'
+import { usePagination } from '@/hooks/usePagination'
 import { printColors } from '@/styles/printTokens'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { escapeHtml } from '@/utils/security'
 import { printReport } from '@/utils/printReport'
 import { exportReportExcel } from '@/utils/exportReport'
-import { PAGINATION, TABLE_STYLES } from '@/constants/tableStyles'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import api from '@/services/api'
 
 interface CustomerPaymentSummary {
@@ -79,8 +80,7 @@ const CustomerPaymentSummary: React.FC = () => {
   const [reportTitle, setReportTitle] = useState<string>('Customer Payment Summary')
 
   // Pagination
-  const [page, setPage] = useState<number>(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, reset, paginationProps } = usePagination()
 
   useEffect(() => {
     // Load customers
@@ -95,12 +95,12 @@ const CustomerPaymentSummary: React.FC = () => {
 
   // Reset to first page when Show Only Owing changes
   useEffect(() => {
-    setPage(0)
+    reset()
   }, [showOnlyOwing])
 
   const handleGenerateReport = async () => {
     setLoading(true)
-    setPage(0) // Reset to first page when generating new report
+    reset() // Reset to first page when generating new report
 
     try {
       // Build query parameters
@@ -142,8 +142,8 @@ const CustomerPaymentSummary: React.FC = () => {
     setReportTitle('Customer Payment Summary')
 
     // Reset pagination
-    setPage(0)
-    setRowsPerPage(25)
+    reset()
+    paginationProps.onLimitChange(25)
   }
 
   const handleExportExcel = async () => {
@@ -380,17 +380,7 @@ const CustomerPaymentSummary: React.FC = () => {
   const sortedData = getSortedData()
 
   // Apply pagination to sorted data
-  const paginatedData = sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-
-  // Pagination handlers
-  const handleChangePage = (_: unknown, newPage: number) => {
-    setPage(newPage)
-  }
-
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10))
-    setPage(0)
-  }
+  const paginatedData = sortedData.slice((page - 1) * limit, (page - 1) * limit + limit)
 
   return (
     <>
@@ -802,15 +792,7 @@ const CustomerPaymentSummary: React.FC = () => {
               {/* Pagination */}
               {reportData.length > 0 && (
                 <Box sx={{ borderTop: TABLE_STYLES.cell.border, flexShrink: 0 }}>
-                  <TablePagination
-                    component="div"
-                    count={sortedData.length}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    rowsPerPage={rowsPerPage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    rowsPerPageOptions={PAGINATION.options}
-                  />
+                  <PagePagination total={sortedData.length} {...paginationProps} />
                 </Box>
               )}
             </Paper>

--- a/frontend/src/pages/sales/ProductCustomerReport.tsx
+++ b/frontend/src/pages/sales/ProductCustomerReport.tsx
@@ -306,7 +306,6 @@ const ProductCustomerReport: React.FC = () => {
     setReportTitle('Product Customer Report')
 
     // Reset pagination
-    reset()
     setLimit(25)
   }
 

--- a/frontend/src/pages/sales/ProductCustomerReport.tsx
+++ b/frontend/src/pages/sales/ProductCustomerReport.tsx
@@ -15,7 +15,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   CircularProgress,
   Stack,
   useTheme,
@@ -27,6 +26,8 @@ import {
   DialogActions,
   IconButton,
 } from '@mui/material'
+import PagePagination from '@/components/common/PagePagination'
+import { usePagination } from '@/hooks/usePagination'
 import { alpha } from '@mui/material/styles'
 import { AppButton } from '@/components/common/AppButton'
 import { StatusChip } from '@/components/common/StatusChip'
@@ -47,7 +48,7 @@ import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { escapeHtml } from '@/utils/security'
 import { printReport } from '@/utils/printReport'
 import { exportReportExcel } from '@/utils/exportReport'
-import { PAGINATION, TABLE_STYLES } from '@/constants/tableStyles'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 
 interface ProductCustomerReport {
@@ -98,8 +99,7 @@ const ProductCustomerReport: React.FC = () => {
   const [reportTitle, setReportTitle] = useState<string>('Product Customer Report')
 
   // Pagination
-  const [page, setPage] = useState<number>(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, reset, setLimit, paginationProps } = usePagination()
 
   useEffect(() => {
     // Load categories with authentication
@@ -123,12 +123,12 @@ const ProductCustomerReport: React.FC = () => {
 
   // Reset to first page when filters or display options change
   useEffect(() => {
-    setPage(0)
+    reset()
   }, [groupBy, sortBy1, inventoryStatus, paymentStatus, selectedCategory, selectedProducts])
 
   const handleGenerateReport = async () => {
     setLoading(true)
-    setPage(0) // Reset to first page when generating new report
+    reset() // Reset to first page when generating new report
 
     try {
       // Build query parameters
@@ -306,8 +306,8 @@ const ProductCustomerReport: React.FC = () => {
     setReportTitle('Product Customer Report')
 
     // Reset pagination
-    setPage(0)
-    setRowsPerPage(25)
+    reset()
+    setLimit(25)
   }
 
   const handleExportExcel = async () => {
@@ -595,17 +595,10 @@ const ProductCustomerReport: React.FC = () => {
   const sortedData = getSortedData()
 
   // Apply pagination to sorted data
-  const paginatedData = sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+  const paginatedData = sortedData.slice((page - 1) * limit, (page - 1) * limit + limit)
 
   // Pagination handlers
-  const handleChangePage = (_: unknown, newPage: number) => {
-    setPage(newPage)
-  }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10))
-    setPage(0)
-  }
 
   return (
     <>
@@ -1200,15 +1193,7 @@ const ProductCustomerReport: React.FC = () => {
               {/* Pagination */}
               {reportData.length > 0 && (
                 <Box sx={{ borderTop: TABLE_STYLES.cell.border, flexShrink: 0 }}>
-                  <TablePagination
-                    component="div"
-                    count={sortedData.length}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    rowsPerPage={rowsPerPage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    rowsPerPageOptions={PAGINATION.options}
-                  />
+                  <PagePagination total={sortedData.length} {...paginationProps} />
                 </Box>
               )}
             </Paper>

--- a/frontend/src/pages/sales/SalesByProductDetails.tsx
+++ b/frontend/src/pages/sales/SalesByProductDetails.tsx
@@ -16,7 +16,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   CircularProgress,
   Stack,
   useTheme,
@@ -35,6 +34,8 @@ import {
   Divider,
   OutlinedInput,
 } from '@mui/material'
+import PagePagination from '@/components/common/PagePagination'
+import { usePagination } from '@/hooks/usePagination'
 import { alpha } from '@mui/material/styles'
 import { AppButton } from '@/components/common/AppButton'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
@@ -54,7 +55,7 @@ import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { escapeHtml } from '@/utils/security'
 import { printReport } from '@/utils/printReport'
 import { exportReportExcel } from '@/utils/exportReport'
-import { PAGINATION, TABLE_STYLES } from '@/constants/tableStyles'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import api from '@/services/api'
 
 interface ProductDetail {
@@ -104,8 +105,7 @@ const SalesByProductDetails: React.FC = () => {
   const [reportTitle, setReportTitle] = useState<string>('Sales by Product Details')
 
   // Pagination
-  const [page, setPage] = useState<number>(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, reset, setLimit, paginationProps } = usePagination()
 
   useEffect(() => {
     // Load products
@@ -141,7 +141,7 @@ const SalesByProductDetails: React.FC = () => {
 
   const handleGenerateReport = async () => {
     setLoading(true)
-    setPage(0) // Reset to first page when generating new report
+    reset() // Reset to first page when generating new report
 
     try {
       // Build query parameters
@@ -186,8 +186,8 @@ const SalesByProductDetails: React.FC = () => {
     setReportTitle('Sales by Product Details')
 
     // Reset pagination
-    setPage(0)
-    setRowsPerPage(25)
+    reset()
+    setLimit(25)
   }
 
   const handleExportExcel = async () => {
@@ -663,7 +663,7 @@ const SalesByProductDetails: React.FC = () => {
   const groupedData = getGroupedData()
 
   // Apply pagination to sorted data
-  const paginatedData = sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+  const paginatedData = sortedData.slice((page - 1) * limit, (page - 1) * limit + limit)
 
   // Calculate subtotals for each group
   const calculateGroupSubtotal = (items: ProductDetail[]) => {
@@ -684,14 +684,7 @@ const SalesByProductDetails: React.FC = () => {
   }
 
   // Pagination handlers
-  const handleChangePage = (_: unknown, newPage: number) => {
-    setPage(newPage)
-  }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10))
-    setPage(0)
-  }
 
   return (
     <>
@@ -1289,15 +1282,7 @@ const SalesByProductDetails: React.FC = () => {
               {/* Pagination - only show when not grouped */}
               {!groupedData && reportData.length > 0 && (
                 <Box sx={{ borderTop: TABLE_STYLES.cell.border, flexShrink: 0 }}>
-                  <TablePagination
-                    component="div"
-                    count={sortedData.length}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    rowsPerPage={rowsPerPage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    rowsPerPageOptions={PAGINATION.options}
-                  />
+                  <PagePagination total={sortedData.length} {...paginationProps} />
                 </Box>
               )}
             </Paper>

--- a/frontend/src/pages/sales/SalesByProductDetails.tsx
+++ b/frontend/src/pages/sales/SalesByProductDetails.tsx
@@ -186,7 +186,6 @@ const SalesByProductDetails: React.FC = () => {
     setReportTitle('Sales by Product Details')
 
     // Reset pagination
-    reset()
     setLimit(25)
   }
 

--- a/frontend/src/pages/sales/SalesByProductSummary.tsx
+++ b/frontend/src/pages/sales/SalesByProductSummary.tsx
@@ -16,7 +16,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   CircularProgress,
   Stack,
   useTheme,
@@ -35,6 +34,8 @@ import {
   Divider,
   OutlinedInput,
 } from '@mui/material'
+import PagePagination from '@/components/common/PagePagination'
+import { usePagination } from '@/hooks/usePagination'
 import { alpha } from '@mui/material/styles'
 import { AppButton } from '@/components/common/AppButton'
 import { default as PdfIcon } from '@mui/icons-material/PictureAsPdf'
@@ -54,7 +55,7 @@ import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { escapeHtml } from '@/utils/security'
 import { printReport } from '@/utils/printReport'
 import { exportReportExcel } from '@/utils/exportReport'
-import { PAGINATION, TABLE_STYLES } from '@/constants/tableStyles'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import { ApiService } from '@/services/api'
 
 interface ProductSummary {
@@ -101,8 +102,7 @@ const SalesByProductSummary: React.FC = () => {
   const [reportTitle, setReportTitle] = useState<string>('Sales by Product Summary')
 
   // Pagination
-  const [page, setPage] = useState<number>(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, reset, setLimit, paginationProps } = usePagination()
 
   useEffect(() => {
     // Load products with authentication
@@ -138,7 +138,7 @@ const SalesByProductSummary: React.FC = () => {
 
   const handleGenerateReport = async () => {
     setLoading(true)
-    setPage(0) // Reset to first page when generating new report
+    reset() // Reset to first page when generating new report
 
     try {
       // Build query parameters
@@ -184,8 +184,8 @@ const SalesByProductSummary: React.FC = () => {
     setReportTitle('Sales by Product Summary')
 
     // Reset pagination
-    setPage(0)
-    setRowsPerPage(25)
+    reset()
+    setLimit(25)
   }
 
   const handleExportExcel = async () => {
@@ -619,7 +619,7 @@ const SalesByProductSummary: React.FC = () => {
   const groupedData = getGroupedData()
 
   // Apply pagination to sorted data
-  const paginatedData = sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+  const paginatedData = sortedData.slice((page - 1) * limit, (page - 1) * limit + limit)
 
   // Calculate subtotals for each category group
   const calculateCategorySubtotal = (items: ProductSummary[]) => {
@@ -646,14 +646,7 @@ const SalesByProductSummary: React.FC = () => {
   }
 
   // Pagination handlers
-  const handleChangePage = (_: unknown, newPage: number) => {
-    setPage(newPage)
-  }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10))
-    setPage(0)
-  }
 
   return (
     <>
@@ -1295,15 +1288,7 @@ const SalesByProductSummary: React.FC = () => {
               {/* Pagination - only show when not grouped */}
               {!groupedData && reportData.length > 0 && (
                 <Box sx={{ borderTop: TABLE_STYLES.cell.border, flexShrink: 0 }}>
-                  <TablePagination
-                    component="div"
-                    count={sortedData.length}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    rowsPerPage={rowsPerPage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    rowsPerPageOptions={PAGINATION.options}
-                  />
+                  <PagePagination total={sortedData.length} {...paginationProps} />
                 </Box>
               )}
             </Paper>

--- a/frontend/src/pages/sales/SalesByProductSummary.tsx
+++ b/frontend/src/pages/sales/SalesByProductSummary.tsx
@@ -184,7 +184,6 @@ const SalesByProductSummary: React.FC = () => {
     setReportTitle('Sales by Product Summary')
 
     // Reset pagination
-    reset()
     setLimit(25)
   }
 

--- a/frontend/src/pages/sales/SalesOrderProfitReport.tsx
+++ b/frontend/src/pages/sales/SalesOrderProfitReport.tsx
@@ -15,13 +15,14 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   CircularProgress,
   Stack,
   useTheme,
   useMediaQuery,
   Chip,
 } from '@mui/material'
+import PagePagination from '@/components/common/PagePagination'
+import { usePagination } from '@/hooks/usePagination'
 import { alpha } from '@mui/material/styles'
 import { AppButton } from '@/components/common/AppButton'
 import { StatusChip } from '@/components/common/StatusChip'
@@ -37,7 +38,7 @@ import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { escapeHtml } from '@/utils/security'
 import { printReport } from '@/utils/printReport'
 import { exportReportExcel } from '@/utils/exportReport'
-import { PAGINATION, TABLE_STYLES } from '@/constants/tableStyles'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import api from '@/services/api'
 
 interface SalesOrderProfit {
@@ -74,8 +75,7 @@ const SalesOrderProfitReport: React.FC = () => {
   const [reportTitle, setReportTitle] = useState<string>('Sales Order Profit Report')
 
   // Pagination
-  const [page, setPage] = useState<number>(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, reset, setLimit, paginationProps } = usePagination()
 
   useEffect(() => {
     // Load customers using authenticated API
@@ -96,7 +96,7 @@ const SalesOrderProfitReport: React.FC = () => {
 
   const handleGenerateReport = async () => {
     setLoading(true)
-    setPage(0) // Reset to first page when generating new report
+    reset() // Reset to first page when generating new report
 
     try {
       // Build query parameters
@@ -140,8 +140,8 @@ const SalesOrderProfitReport: React.FC = () => {
     setReportTitle('Sales Order Profit Report')
 
     // Reset pagination
-    setPage(0)
-    setRowsPerPage(25)
+    reset()
+    setLimit(25)
   }
 
   const handleExportExcel = async () => {
@@ -418,17 +418,10 @@ const SalesOrderProfitReport: React.FC = () => {
   const sortedData = getSortedData()
 
   // Apply pagination to sorted data
-  const paginatedData = sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+  const paginatedData = sortedData.slice((page - 1) * limit, (page - 1) * limit + limit)
 
   // Pagination handlers
-  const handleChangePage = (_: unknown, newPage: number) => {
-    setPage(newPage)
-  }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10))
-    setPage(0)
-  }
 
   return (
     <>
@@ -977,15 +970,7 @@ const SalesOrderProfitReport: React.FC = () => {
               {/* Pagination */}
               {reportData.length > 0 && (
                 <Box sx={{ borderTop: TABLE_STYLES.cell.border, flexShrink: 0 }}>
-                  <TablePagination
-                    component="div"
-                    count={sortedData.length}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    rowsPerPage={rowsPerPage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    rowsPerPageOptions={PAGINATION.options}
-                  />
+                  <PagePagination total={sortedData.length} {...paginationProps} />
                 </Box>
               )}
             </Paper>

--- a/frontend/src/pages/sales/SalesOrderProfitReport.tsx
+++ b/frontend/src/pages/sales/SalesOrderProfitReport.tsx
@@ -140,7 +140,6 @@ const SalesOrderProfitReport: React.FC = () => {
     setReportTitle('Sales Order Profit Report')
 
     // Reset pagination
-    reset()
     setLimit(25)
   }
 

--- a/frontend/src/pages/sales/SalesOrderSummary.tsx
+++ b/frontend/src/pages/sales/SalesOrderSummary.tsx
@@ -155,7 +155,6 @@ const SalesOrderSummary: React.FC = () => {
     setReportTitle('Sales Order Summary')
 
     // Reset pagination
-    reset()
     setLimit(25)
   }
 

--- a/frontend/src/pages/sales/SalesOrderSummary.tsx
+++ b/frontend/src/pages/sales/SalesOrderSummary.tsx
@@ -15,13 +15,14 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   CircularProgress,
   Stack,
   useTheme,
   useMediaQuery,
   Chip,
 } from '@mui/material'
+import PagePagination from '@/components/common/PagePagination'
+import { usePagination } from '@/hooks/usePagination'
 import { alpha } from '@mui/material/styles'
 import { AppButton } from '@/components/common/AppButton'
 import { StatusChip } from '@/components/common/StatusChip'
@@ -36,7 +37,7 @@ import { formatCurrency, formatDate, formatDateTime } from '@/utils/formatters'
 import { escapeHtml } from '@/utils/security'
 import { printReport } from '@/utils/printReport'
 import { exportReportExcel } from '@/utils/exportReport'
-import { PAGINATION, TABLE_STYLES } from '@/constants/tableStyles'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import api from '@/services/api'
 
 interface SalesOrderSummary {
@@ -75,8 +76,7 @@ const SalesOrderSummary: React.FC = () => {
   const [reportTitle, setReportTitle] = useState<string>('Sales Order Summary')
 
   // Pagination
-  const [page, setPage] = useState<number>(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, reset, setLimit, paginationProps } = usePagination()
 
   useEffect(() => {
     // Load customers using authenticated API
@@ -93,7 +93,7 @@ const SalesOrderSummary: React.FC = () => {
 
   const handleGenerateReport = async () => {
     setLoading(true)
-    setPage(0) // Reset to first page when generating new report
+    reset() // Reset to first page when generating new report
 
     try {
       // Build query parameters using authenticated API
@@ -155,8 +155,8 @@ const SalesOrderSummary: React.FC = () => {
     setReportTitle('Sales Order Summary')
 
     // Reset pagination
-    setPage(0)
-    setRowsPerPage(25)
+    reset()
+    setLimit(25)
   }
 
   const handleExportExcel = async () => {
@@ -459,17 +459,10 @@ const SalesOrderSummary: React.FC = () => {
   const sortedData = getSortedData()
 
   // Apply pagination to sorted data
-  const paginatedData = sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+  const paginatedData = sortedData.slice((page - 1) * limit, (page - 1) * limit + limit)
 
   // Pagination handlers
-  const handleChangePage = (_: unknown, newPage: number) => {
-    setPage(newPage)
-  }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10))
-    setPage(0)
-  }
 
   return (
     <>
@@ -980,15 +973,7 @@ const SalesOrderSummary: React.FC = () => {
               {/* Pagination */}
               {reportData.length > 0 && (
                 <Box sx={{ borderTop: TABLE_STYLES.cell.border, flexShrink: 0 }}>
-                  <TablePagination
-                    component="div"
-                    count={sortedData.length}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    rowsPerPage={rowsPerPage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    rowsPerPageOptions={PAGINATION.options}
-                  />
+                  <PagePagination total={sortedData.length} {...paginationProps} />
                 </Box>
               )}
             </Paper>

--- a/frontend/src/pages/settings/PriceListsPage.tsx
+++ b/frontend/src/pages/settings/PriceListsPage.tsx
@@ -11,7 +11,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   Alert,
   CircularProgress,
   Chip,
@@ -24,8 +23,8 @@ import { default as StarIcon } from '@mui/icons-material/Star'
 import { default as StarBorderIcon } from '@mui/icons-material/StarBorder'
 import { default as ViewIcon } from '@mui/icons-material/Visibility'
 import { useNavigate } from 'react-router-dom'
-import { PAGINATION } from '@/constants/tableStyles'
 import PageHeader from '@/components/common/PageHeader'
+import PagePagination from '@/components/common/PagePagination'
 import GenericOverviewPage from '@/components/common/GenericOverviewPage'
 import { StatusChip } from '@/components/common/StatusChip'
 import { FilterBar } from '@/components/filters'
@@ -130,12 +129,12 @@ const PriceListsPage: React.FC = () => {
   })
 
   // Handlers
-  const handlePageChange = (_event: unknown, newPage: number) => {
-    dispatch(setPagination({ page: newPage + 1 }))
+  const handlePageChange = (newPage: number) => {
+    dispatch(setPagination({ page: newPage }))
   }
 
-  const handleRowsPerPageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    dispatch(setPagination({ limit: parseInt(event.target.value, 10), page: 1 }))
+  const handleLimitChange = (newLimit: number) => {
+    dispatch(setPagination({ limit: newLimit, page: 1 }))
   }
 
   const handleAddPriceList = () => {
@@ -582,14 +581,12 @@ const PriceListsPage: React.FC = () => {
             </TableBody>
           </Table>
         </TableContainer>
-        <TablePagination
-          rowsPerPageOptions={PAGINATION.options}
-          component="div"
-          count={total}
-          rowsPerPage={pagination.limit}
-          page={pagination.page - 1}
+        <PagePagination
+          total={total}
+          page={pagination.page}
+          limit={pagination.limit}
           onPageChange={handlePageChange}
-          onRowsPerPageChange={handleRowsPerPageChange}
+          onLimitChange={handleLimitChange}
         />
       </Paper>
       {/* Price List Form Dialog */}

--- a/frontend/src/pages/settings/UserManagementPage.tsx
+++ b/frontend/src/pages/settings/UserManagementPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import {
   Box,
   Typography,
@@ -11,7 +11,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TablePagination,
   Alert,
   CircularProgress,
   Chip,
@@ -21,6 +20,8 @@ import { default as EditIcon } from '@mui/icons-material/Edit'
 import { default as DeleteIcon } from '@mui/icons-material/Delete'
 import { default as UnlockIcon } from '@mui/icons-material/LockOpen'
 import { ListSkeleton } from '@/components/common/ListSkeleton'
+import PagePagination from '@/components/common/PagePagination'
+import { usePagination } from '@/hooks/usePagination'
 import { FilterBar } from '@/components/filters'
 import PageHeader from '@/components/common/PageHeader'
 import { StatusChip } from '@/components/common/StatusChip'
@@ -38,7 +39,7 @@ import {
 import type { User } from '@/types'
 import UserFormDialog from '@/components/settings/UserFormDialog'
 import ConfirmationDialog from '@/components/common/ConfirmationDialog'
-import { PAGINATION, TABLE_STYLES } from '@/constants/tableStyles'
+import { TABLE_STYLES } from '@/constants/tableStyles'
 import { formatDateTime } from '@/utils/formatters'
 import type { FilterBarConfig } from '@/types/filterBar.types'
 
@@ -53,8 +54,7 @@ const UserManagementPage: React.FC = () => {
   const { showSuccess, showError } = useNotification()
 
   // State
-  const [page, setPage] = useState(0)
-  const [rowsPerPage, setRowsPerPage] = useState<number>(PAGINATION.defaultPageSize)
+  const { page, limit, reset, paginationProps } = usePagination()
 
   // Dialog states
   const [formDialogOpen, setFormDialogOpen] = useState(false)
@@ -87,13 +87,13 @@ const UserManagementPage: React.FC = () => {
 
   const userQueryParams = useMemo(
     () => ({
-      page: page + 1,
-      limit: rowsPerPage,
+      page,
+      limit,
       search: appliedFilters.search || undefined,
       role: appliedFilters.role ?? undefined,
       status: appliedFilters.status ?? undefined,
     }),
-    [appliedFilters, page, rowsPerPage],
+    [appliedFilters, page, limit],
   )
   const { data: usersResponse, isLoading, isFetching, error, refetch: refetchUsers } =
     useGetUsersQuery(userQueryParams)
@@ -103,35 +103,31 @@ const UserManagementPage: React.FC = () => {
   const [updateUser] = useUpdateUserMutation()
   const users = usersResponse?.data ?? []
   const totalCount = usersResponse?.meta?.total ?? 0
-  const resetPage = useCallback(() => {
-    setPage(0)
-  }, [])
-
   const filterHandlers = useMemo(
     () => ({
       ...handlers,
       onSearchChange: (value: string) => {
-        resetPage()
+        reset()
         handlers.onSearchChange(value)
       },
       onSearchCommit: () => {
-        resetPage()
+        reset()
         handlers.onSearchCommit()
       },
       onQuickFilterChange: (field: keyof UserFilters, value: unknown) => {
-        resetPage()
+        reset()
         handlers.onQuickFilterChange(field, value)
       },
       onClearField: (field: keyof UserFilters) => {
-        resetPage()
+        reset()
         handlers.onClearField(field)
       },
       onClearAll: () => {
-        resetPage()
+        reset()
         handlers.onClearAll()
       },
     }),
-    [handlers, resetPage],
+    [handlers, reset],
   )
 
   // Check if user is admin
@@ -143,15 +139,6 @@ const UserManagementPage: React.FC = () => {
   }, [currentUser, showError])
 
   // Handlers
-  const handlePageChange = (_event: unknown, newPage: number) => {
-    setPage(newPage)
-  }
-
-  const handleRowsPerPageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10))
-    setPage(0)
-  }
-
   const handleAddUser = () => {
     setSelectedUser(null)
     setFormDialogOpen(true)
@@ -622,15 +609,7 @@ const UserManagementPage: React.FC = () => {
             </TableContainer>
           </Box>
         )}
-        <TablePagination
-          rowsPerPageOptions={PAGINATION.options}
-          component="div"
-          count={totalCount}
-          rowsPerPage={rowsPerPage}
-          page={page}
-          onPageChange={handlePageChange}
-          onRowsPerPageChange={handleRowsPerPageChange}
-        />
+        <PagePagination total={totalCount} {...paginationProps} />
       </Paper>
       {/* User Form Dialog */}
       <UserFormDialog


### PR DESCRIPTION
## Summary

Replaces raw MUI `TablePagination` with the shared `PagePagination` component across all app tables **except `BackupList`** (documented opt-out), so every paginated table matches the Products-list UX: "Showing X–Y of N records", an `N / page` dropdown, and numbered page buttons.

Issue #796 named two tabs (Stock Movements, Order History); scope was expanded to the full sweep for consistency.

## Changes

- **New `usePagination` hook** (`src/hooks/usePagination.ts`) — owns 1-indexed page/limit state and the reset-to-1 invariants (on limit change and via `reset()`), used by all local-state conversions. 5 unit tests.
- **Group A — 17 client-side reports** — swapped to the hook + `PagePagination`; slice math converted 0-indexed → `(page-1)*limit`.
- **Group B — Stock Movements & Order History tabs** (the #796 files) — server-side; page state now 1-indexed, query sends `page` directly (dropped the `+1`).
- **Group C1 — UserManagementPage** — local hook; `resetPage`/5 filter handlers → `reset()`; query drops `+1` (page/limit API, no skip).
- **Group C2 — PriceListsPage** — keeps its Redux (`priceListSlice`) ownership and filter resets; just maps Redux state onto `PagePagination`.
- **Group D — LogsTab** — parent-owned 1-based props mapped straight through (no hook, no index conversion).
- **ESLint guard** — `no-restricted-imports` bans raw `TablePagination` (`error`), with a `BackupList` override.

`BackupList` keeps its raw `TablePagination` (sanctioned `[5,10,25,50]`/10 opt-out in `tableStyles.ts`).

Net: **25 files, −237 lines** (boilerplate removed).

## Verification

- `npm run type-check` — pass
- `npm run lint` — pass (zero warnings; guard verified to fire on a probe reintroduction, BackupList exempt)
- `rg "<TablePagination" src` → only `BackupList.tsx`
- `rg "setPage\(0\)" src` → only `BackupList.tsx`
- 24 tests across 5 test files — pass

**Not yet done:** runtime smoke (page-forward/back + page-size, esp. Group C server-side page advancement). Recommend a click-through before merge.

Closes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)