### PR TITLE
fix: Add pagination to Customer and Supplier profile tabs (#798)

### DIFF
--- a/backend/src/modules/purchasing/controllers/supplier.controller.ts
+++ b/backend/src/modules/purchasing/controllers/supplier.controller.ts
@@ -31,6 +31,7 @@ import {
   SupplierListResponseDto,
 } from '../dto';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { BaseQueryDto } from '@/common/dto/base-query.dto';
 
 @ApiTags('Suppliers')
 @Controller('purchasing/suppliers')
@@ -160,8 +161,9 @@ export class SupplierController {
   @ApiResponse({ status: 200, description: 'Purchase orders retrieved successfully' })
   async getSupplierPurchaseOrders(
     @Param('id', ParseUUIDPipe) id: string,
-  ): Promise<{ data: any[]; total: number }> {
-    return await this.supplierService.getSupplierPurchaseOrders(id);
+    @Query() query: BaseQueryDto,
+  ): Promise<{ data: any[]; meta: { total: number } }> {
+    return await this.supplierService.getSupplierPurchaseOrders(id, query);
   }
 
   @Get(':id/payments')
@@ -169,8 +171,9 @@ export class SupplierController {
   @ApiResponse({ status: 200, description: 'Payments retrieved successfully' })
   async getSupplierPayments(
     @Param('id', ParseUUIDPipe) id: string,
-  ): Promise<{ data: any[]; total: number }> {
-    return await this.supplierService.getSupplierPayments(id);
+    @Query() query: BaseQueryDto,
+  ): Promise<{ data: any[]; meta: { total: number } }> {
+    return await this.supplierService.getSupplierPayments(id, query);
   }
 
   @Get(':id')

--- a/backend/src/modules/purchasing/services/supplier.service.spec.ts
+++ b/backend/src/modules/purchasing/services/supplier.service.spec.ts
@@ -203,16 +203,16 @@ describe('SupplierService', () => {
       expect(result).toEqual({ data: [{ id: 'po1' }], meta: { total: 80 } });
     });
 
-    it('defaults page/limit when omitted (no NaN skip)', async () => {
+    it('omits skip/take when page/limit are absent (full set)', async () => {
       const findAndCount = purchaseOrderRepository.findAndCount as jest.Mock;
-      findAndCount.mockResolvedValue([[], 0]);
+      findAndCount.mockResolvedValue([[{ id: 'po1' }], 80]);
 
-      await service.getSupplierPurchaseOrders('sup-1');
+      const result = await service.getSupplierPurchaseOrders('sup-1');
 
       const arg = findAndCount.mock.calls[0][0];
-      expect(arg.skip).toBe(0);
-      expect(Number.isNaN(arg.skip)).toBe(false);
-      expect(arg.take).toBeGreaterThan(0);
+      expect(arg.skip).toBeUndefined();
+      expect(arg.take).toBeUndefined();
+      expect(result).toEqual({ data: [{ id: 'po1' }], meta: { total: 80 } });
     });
   });
 
@@ -226,6 +226,18 @@ describe('SupplierService', () => {
       expect(findAndCount).toHaveBeenCalledWith(
         expect.objectContaining({ where: { supplierId: 'sup-1' }, skip: 10, take: 10 }),
       );
+      expect(result).toEqual({ data: [{ id: 'vp1' }], meta: { total: 60 } });
+    });
+
+    it('omits skip/take when page/limit are absent (full set)', async () => {
+      const findAndCount = vendorPaymentRepository.findAndCount as jest.Mock;
+      findAndCount.mockResolvedValue([[{ id: 'vp1' }], 60]);
+
+      const result = await service.getSupplierPayments('sup-1');
+
+      const arg = findAndCount.mock.calls[0][0];
+      expect(arg.skip).toBeUndefined();
+      expect(arg.take).toBeUndefined();
       expect(result).toEqual({ data: [{ id: 'vp1' }], meta: { total: 60 } });
     });
   });

--- a/backend/src/modules/purchasing/services/supplier.service.spec.ts
+++ b/backend/src/modules/purchasing/services/supplier.service.spec.ts
@@ -12,6 +12,8 @@ import { UserRole } from '../../../database/entities/user.entity';
 describe('SupplierService', () => {
   let service: SupplierService;
   let supplierRepository: jest.Mocked<Repository<Supplier>>;
+  let purchaseOrderRepository: jest.Mocked<Repository<PurchaseOrder>>;
+  let vendorPaymentRepository: jest.Mocked<Repository<VendorPayment>>;
 
   const createSupplier = (id: string, overrides: Partial<Supplier> = {}): Supplier =>
     ({
@@ -78,6 +80,8 @@ describe('SupplierService', () => {
 
     service = module.get(SupplierService);
     supplierRepository = module.get(getRepositoryToken(Supplier));
+    purchaseOrderRepository = module.get(getRepositoryToken(PurchaseOrder));
+    vendorPaymentRepository = module.get(getRepositoryToken(VendorPayment));
   });
 
   describe('findAll', () => {
@@ -183,6 +187,46 @@ describe('SupplierService', () => {
         route: '/purchasing/suppliers/sup-1',
       });
       expect(results[0].score).toBe(122);
+    });
+  });
+
+  describe('getSupplierPurchaseOrders', () => {
+    it('applies skip/take and returns meta.total', async () => {
+      const findAndCount = purchaseOrderRepository.findAndCount as jest.Mock;
+      findAndCount.mockResolvedValue([[{ id: 'po1' }], 80]);
+
+      const result = await service.getSupplierPurchaseOrders('sup-1', { page: 2, limit: 25 } as any);
+
+      expect(findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { supplierId: 'sup-1' }, skip: 25, take: 25 }),
+      );
+      expect(result).toEqual({ data: [{ id: 'po1' }], meta: { total: 80 } });
+    });
+
+    it('defaults page/limit when omitted (no NaN skip)', async () => {
+      const findAndCount = purchaseOrderRepository.findAndCount as jest.Mock;
+      findAndCount.mockResolvedValue([[], 0]);
+
+      await service.getSupplierPurchaseOrders('sup-1');
+
+      const arg = findAndCount.mock.calls[0][0];
+      expect(arg.skip).toBe(0);
+      expect(Number.isNaN(arg.skip)).toBe(false);
+      expect(arg.take).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getSupplierPayments', () => {
+    it('applies skip/take and returns meta.total', async () => {
+      const findAndCount = vendorPaymentRepository.findAndCount as jest.Mock;
+      findAndCount.mockResolvedValue([[{ id: 'vp1' }], 60]);
+
+      const result = await service.getSupplierPayments('sup-1', { page: 2, limit: 10 } as any);
+
+      expect(findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { supplierId: 'sup-1' }, skip: 10, take: 10 }),
+      );
+      expect(result).toEqual({ data: [{ id: 'vp1' }], meta: { total: 60 } });
     });
   });
 });

--- a/backend/src/modules/purchasing/services/supplier.service.ts
+++ b/backend/src/modules/purchasing/services/supplier.service.ts
@@ -747,25 +747,37 @@ export class SupplierService extends BaseCrudService<
     }
   }
 
-  async getSupplierPurchaseOrders(supplierId: string): Promise<{ data: PurchaseOrder[]; total: number }> {
+  async getSupplierPurchaseOrders(
+    supplierId: string,
+    query: { page?: number; limit?: number } = {},
+  ): Promise<{ data: PurchaseOrder[]; meta: { total: number } }> {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 25;
     const [data, total] = await this.purchaseOrderRepository.findAndCount({
       where: { supplierId },
       order: { orderNumber: 'ASC' },
-      take: 50,
+      skip: (page - 1) * limit,
+      take: limit,
     });
 
-    return { data, total };
+    return { data, meta: { total } };
   }
 
-  async getSupplierPayments(supplierId: string): Promise<{ data: VendorPayment[]; total: number }> {
+  async getSupplierPayments(
+    supplierId: string,
+    query: { page?: number; limit?: number } = {},
+  ): Promise<{ data: VendorPayment[]; meta: { total: number } }> {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 25;
     const [data, total] = await this.vendorPaymentRepository.findAndCount({
       where: { supplierId },
       relations: { paymentMethodEntity: true, purchaseOrder: true },
       order: { paymentNumber: 'ASC' },
-      take: 50,
+      skip: (page - 1) * limit,
+      take: limit,
     });
 
-    return { data, total };
+    return { data, meta: { total } };
   }
 
   /**

--- a/backend/src/modules/purchasing/services/supplier.service.ts
+++ b/backend/src/modules/purchasing/services/supplier.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, NotFoundException, BadRequestException, ConflictException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, FindOptionsWhere, Like, In, Between } from 'typeorm';
+import { Repository, FindOptionsWhere, FindManyOptions, Like, In, Between } from 'typeorm';
 import { BaseCrudService } from '../../../common/services/base-crud.service';
 import {
   Supplier,
@@ -751,14 +751,18 @@ export class SupplierService extends BaseCrudService<
     supplierId: string,
     query: { page?: number; limit?: number } = {},
   ): Promise<{ data: PurchaseOrder[]; meta: { total: number } }> {
-    const page = query.page ?? 1;
-    const limit = query.limit ?? 25;
-    const [data, total] = await this.purchaseOrderRepository.findAndCount({
+    const { page, limit } = query;
+    const options: FindManyOptions<PurchaseOrder> = {
       where: { supplierId },
       order: { orderNumber: 'ASC' },
-      skip: (page - 1) * limit,
-      take: limit,
-    });
+    };
+    // Paginate only when both page and limit are provided; absent => full set
+    // (consistent with PaymentService.findAll). Defends any non-UI caller.
+    if (page && limit) {
+      options.skip = (page - 1) * limit;
+      options.take = limit;
+    }
+    const [data, total] = await this.purchaseOrderRepository.findAndCount(options);
 
     return { data, meta: { total } };
   }
@@ -767,15 +771,17 @@ export class SupplierService extends BaseCrudService<
     supplierId: string,
     query: { page?: number; limit?: number } = {},
   ): Promise<{ data: VendorPayment[]; meta: { total: number } }> {
-    const page = query.page ?? 1;
-    const limit = query.limit ?? 25;
-    const [data, total] = await this.vendorPaymentRepository.findAndCount({
+    const { page, limit } = query;
+    const options: FindManyOptions<VendorPayment> = {
       where: { supplierId },
       relations: { paymentMethodEntity: true, purchaseOrder: true },
       order: { paymentNumber: 'ASC' },
-      skip: (page - 1) * limit,
-      take: limit,
-    });
+    };
+    if (page && limit) {
+      options.skip = (page - 1) * limit;
+      options.take = limit;
+    }
+    const [data, total] = await this.vendorPaymentRepository.findAndCount(options);
 
     return { data, meta: { total } };
   }

--- a/backend/src/modules/sales/services/payment.service.spec.ts
+++ b/backend/src/modules/sales/services/payment.service.spec.ts
@@ -128,6 +128,45 @@ describe('PaymentService', () => {
 
       expect(result.data).toHaveLength(1);
     });
+
+    it('applies skip/take when page and limit are provided', async () => {
+      const skip = jest.fn().mockReturnThis();
+      const take = jest.fn().mockReturnThis();
+      jest.spyOn(paymentRepository, 'createQueryBuilder').mockReturnValue({
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        skip,
+        take,
+        getManyAndCount: jest.fn().mockResolvedValue([[], 100]),
+      } as any);
+
+      const result = await service.findAll({ page: 3, limit: 20 } as any);
+
+      expect(skip).toHaveBeenCalledWith(40);
+      expect(take).toHaveBeenCalledWith(20);
+      expect(result.meta.total).toBe(100);
+    });
+
+    it('does NOT apply skip/take when page/limit are absent', async () => {
+      const skip = jest.fn().mockReturnThis();
+      const take = jest.fn().mockReturnThis();
+      jest.spyOn(paymentRepository, 'createQueryBuilder').mockReturnValue({
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        skip,
+        take,
+        getManyAndCount: jest.fn().mockResolvedValue([[], 5]),
+      } as any);
+
+      await service.findAll({} as any);
+
+      expect(skip).not.toHaveBeenCalled();
+      expect(take).not.toHaveBeenCalled();
+    });
   });
 
   describe('create', () => {

--- a/backend/src/modules/sales/services/payment.service.ts
+++ b/backend/src/modules/sales/services/payment.service.ts
@@ -176,6 +176,8 @@ export class PaymentService extends BaseCrudService<
       sortBy = 'paymentDate',
       sortOrder = 'DESC',
       status,
+      page,
+      limit,
     } = query;
 
     const where: FindOptionsWhere<Payment> = {};
@@ -205,6 +207,10 @@ export class PaymentService extends BaseCrudService<
         '(payment.paymentNumber ILIKE :search OR customer.name ILIKE :search)',
         { search: `%${search}%` },
       );
+    }
+
+    if (page && limit) {
+      queryBuilder.skip((page - 1) * limit).take(limit);
     }
 
     const [payments, total] = await queryBuilder.getManyAndCount();

--- a/frontend/src/pages/purchasing/components/SupplierPaymentsTab.tsx
+++ b/frontend/src/pages/purchasing/components/SupplierPaymentsTab.tsx
@@ -1,6 +1,8 @@
 import { useNavigate } from 'react-router-dom'
 
+import PagePagination from '@/components/common/PagePagination'
 import { DataTable, type Column, bold, viewAction } from '@/components/common/DataTable'
+import { usePagination } from '@/hooks/usePagination'
 import { useGetSupplierPaymentsQuery } from '@/store/api/purchasingApi'
 import { formatCurrency } from '@/utils/currency'
 import { formatDate } from '@/utils/formatters'
@@ -11,8 +13,10 @@ interface SupplierPaymentsTabProps {
 
 export default function SupplierPaymentsTab({ supplierId }: SupplierPaymentsTabProps) {
   const navigate = useNavigate()
-  const { data, isLoading } = useGetSupplierPaymentsQuery(supplierId)
+  const { page, limit, paginationProps } = usePagination()
+  const { data, isLoading } = useGetSupplierPaymentsQuery({ supplierId, page, limit })
   const payments = data?.data ?? []
+  const total = data?.meta?.total ?? 0
 
   const columns: Column<(typeof payments)[number]>[] = [
     { header: 'Payment #', width: '18%', render: (p) => bold(p.paymentNumber) },
@@ -41,6 +45,7 @@ export default function SupplierPaymentsTab({ supplierId }: SupplierPaymentsTabP
       getRowKey={(p) => p.id}
       emptyText="No payments yet for this supplier."
       isLoading={isLoading}
+      footer={<PagePagination total={total} {...paginationProps} />}
     />
   )
 }

--- a/frontend/src/pages/purchasing/components/SupplierPurchaseOrdersTab.tsx
+++ b/frontend/src/pages/purchasing/components/SupplierPurchaseOrdersTab.tsx
@@ -1,24 +1,12 @@
-import {
-  Box,
-  Button,
-  CircularProgress,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Typography,
-} from '@mui/material'
 import { useNavigate } from 'react-router-dom'
 
-import { TABLE_STYLES } from '@/constants/tableStyles'
+import PagePagination from '@/components/common/PagePagination'
+import { StatusChip } from '@/components/common/StatusChip'
+import { DataTable, type Column, bold, viewAction } from '@/components/common/DataTable'
+import { usePagination } from '@/hooks/usePagination'
 import { useGetSupplierPurchaseOrdersQuery } from '@/store/api/purchasingApi'
 import { formatCurrency } from '@/utils/currency'
 import { formatDate } from '@/utils/formatters'
-
-import { StatusChip } from '@/components/common/StatusChip'
 
 interface SupplierPurchaseOrdersTabProps {
   supplierId: string
@@ -26,63 +14,37 @@ interface SupplierPurchaseOrdersTabProps {
 
 export default function SupplierPurchaseOrdersTab({ supplierId }: SupplierPurchaseOrdersTabProps) {
   const navigate = useNavigate()
-  const { data, isLoading } = useGetSupplierPurchaseOrdersQuery(supplierId)
+  const { page, limit, paginationProps } = usePagination()
+  const { data, isLoading } = useGetSupplierPurchaseOrdersQuery({ supplierId, page, limit })
   const orders = data?.data ?? []
+  const total = data?.meta?.total ?? 0
 
-  if (isLoading) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-        <CircularProgress />
-      </Box>
-    )
-  }
-
-  if (orders.length === 0) {
-    return (
-      <Typography sx={{ color: 'text.secondary', py: 4, textAlign: 'center' }}>
-        No purchase orders yet for this supplier.
-      </Typography>
-    )
-  }
+  const columns: Column<(typeof orders)[number]>[] = [
+    { header: 'PO #', width: '20%', render: (o) => bold(o.orderNumber) },
+    { header: 'Date', width: '20%', render: (o) => formatDate(o.orderDate) },
+    { header: 'Status', width: '20%', render: (o) => <StatusChip status={o.status} /> },
+    {
+      header: 'Total',
+      align: 'right',
+      width: '20%',
+      render: (o) => formatCurrency(o.totalAmount ?? o.total ?? 0),
+    },
+    {
+      header: 'Action',
+      align: 'right',
+      width: '20%',
+      render: (o) => viewAction(() => navigate(`/purchasing/orders/${o.orderNumber}/view`)),
+    },
+  ]
 
   return (
-    <TableContainer component={Paper} variant="outlined">
-      <Table size={TABLE_STYLES.size}>
-        <TableHead>
-          <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600, backgroundColor: 'grey.50' } }}>
-            <TableCell sx={{ width: '20%' }}>PO #</TableCell>
-            <TableCell sx={{ width: '20%' }}>Date</TableCell>
-            <TableCell sx={{ width: '20%' }}>Status</TableCell>
-            <TableCell align="right" sx={{ width: '20%' }}>Total</TableCell>
-            <TableCell align="right" sx={{ width: '20%' }}>Action</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {orders.map((order) => (
-            <TableRow key={order.id} hover>
-              <TableCell>
-                <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                  {order.orderNumber}
-                </Typography>
-              </TableCell>
-              <TableCell>{formatDate(order.orderDate)}</TableCell>
-              <TableCell>
-                <StatusChip status={order.status} />
-              </TableCell>
-              <TableCell align="right">{formatCurrency(order.totalAmount ?? order.total ?? 0)}</TableCell>
-              <TableCell align="right">
-                <Button
-                  size="small"
-                  variant="text"
-                  onClick={() => navigate(`/purchasing/orders/${order.orderNumber}/view`)}
-                >
-                  View
-                </Button>
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
+    <DataTable
+      columns={columns}
+      rows={orders}
+      getRowKey={(o) => o.id}
+      emptyText="No purchase orders yet for this supplier."
+      isLoading={isLoading}
+      footer={<PagePagination total={total} {...paginationProps} />}
+    />
   )
 }

--- a/frontend/src/pages/purchasing/components/__tests__/SupplierPaymentsTab.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/SupplierPaymentsTab.test.tsx
@@ -58,4 +58,25 @@ describe('SupplierPaymentsTab', () => {
     renderTab()
     expect(screen.getByRole('button', { name: /view/i })).toBeDisabled()
   })
+
+  it('passes supplierId, page and limit to the query', () => {
+    mockQuery.mockReturnValue({ data: { data: [], meta: { total: 0 } }, isLoading: false })
+    renderTab()
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ supplierId: 's1', page: 1, limit: expect.any(Number) }),
+    )
+  })
+
+  it('renders the footer total', () => {
+    mockQuery.mockReturnValue({
+      data: {
+        data: [{ id: 'vp1', paymentNumber: 'VP-001', paymentDate: '2026-01-01', amount: 250, paymentMethodEntity: { id: 'm1', name: 'Bank', isActive: true } }],
+        meta: { total: 55 },
+      },
+      isLoading: false,
+    })
+    renderTab()
+    expect(screen.getByText('VP-001')).toBeInTheDocument()
+    expect(screen.getByText(/of 55 records/)).toBeInTheDocument()
+  })
 })

--- a/frontend/src/pages/purchasing/components/__tests__/SupplierPurchaseOrdersTab.test.tsx
+++ b/frontend/src/pages/purchasing/components/__tests__/SupplierPurchaseOrdersTab.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import SupplierPurchaseOrdersTab from '../SupplierPurchaseOrdersTab'
+
+const { mockQuery } = vi.hoisted(() => ({ mockQuery: vi.fn() }))
+
+vi.mock('@/store/api/purchasingApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store/api/purchasingApi')>()
+  return { ...actual, useGetSupplierPurchaseOrdersQuery: mockQuery }
+})
+
+function renderTab(supplierId: string) {
+  const store = configureStore({ reducer: { p: (s = {}) => s } })
+  return render(
+    <Provider store={store}>
+      <MemoryRouter><SupplierPurchaseOrdersTab supplierId={supplierId} /></MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('SupplierPurchaseOrdersTab', () => {
+  it('passes supplierId, page and limit to the query', () => {
+    mockQuery.mockReturnValue({ data: { data: [], meta: { total: 0 } }, isLoading: false })
+    renderTab('sup-1')
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ supplierId: 'sup-1', page: 1, limit: expect.any(Number) }),
+    )
+  })
+
+  it('renders rows and the footer total', () => {
+    mockQuery.mockReturnValue({
+      data: { data: [{ id: 'po1', orderNumber: 'PO-001', orderDate: '2026-01-01', status: 'pending', totalAmount: 500 }], meta: { total: 73 } },
+      isLoading: false,
+    })
+    renderTab('sup-1')
+    expect(screen.getByText('PO-001')).toBeInTheDocument()
+    expect(screen.getByText(/of 73 records/)).toBeInTheDocument()
+  })
+
+  it('shows empty state', () => {
+    mockQuery.mockReturnValue({ data: { data: [], meta: { total: 0 } }, isLoading: false })
+    renderTab('sup-1')
+    expect(screen.getByText(/No purchase orders yet/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/sales/components/CustomerOrdersTab.tsx
+++ b/frontend/src/pages/sales/components/CustomerOrdersTab.tsx
@@ -1,7 +1,9 @@
 import { useNavigate } from 'react-router-dom'
 
+import PagePagination from '@/components/common/PagePagination'
 import { StatusChip } from '@/components/common/StatusChip'
 import { DataTable, type Column, bold, viewAction } from '@/components/common/DataTable'
+import { usePagination } from '@/hooks/usePagination'
 import { useGetSalesOrdersQuery } from '@/store/api/salesApi'
 import { formatCurrency } from '@/utils/currency'
 import { formatDate } from '@/utils/formatters'
@@ -12,8 +14,10 @@ interface CustomerOrdersTabProps {
 
 export default function CustomerOrdersTab({ customerId }: CustomerOrdersTabProps) {
   const navigate = useNavigate()
-  const { data, isLoading } = useGetSalesOrdersQuery({ customerId })
+  const { page, limit, paginationProps } = usePagination()
+  const { data, isLoading } = useGetSalesOrdersQuery({ customerId, page, limit })
   const orders = data?.data ?? []
+  const total = data?.meta?.total ?? 0
 
   const columns: Column<(typeof orders)[number]>[] = [
     { header: 'Order #', width: '18%', render: (o) => bold(o.orderNumber) },
@@ -39,6 +43,7 @@ export default function CustomerOrdersTab({ customerId }: CustomerOrdersTabProps
       getRowKey={(o) => o.id}
       emptyText="No orders yet for this customer."
       isLoading={isLoading}
+      footer={<PagePagination total={total} {...paginationProps} />}
     />
   )
 }

--- a/frontend/src/pages/sales/components/CustomerPaymentsTab.tsx
+++ b/frontend/src/pages/sales/components/CustomerPaymentsTab.tsx
@@ -1,4 +1,6 @@
+import PagePagination from '@/components/common/PagePagination'
 import { DataTable, type Column, bold } from '@/components/common/DataTable'
+import { usePagination } from '@/hooks/usePagination'
 import { useGetPaymentsQuery } from '@/store/api/salesApi'
 import { formatCurrency } from '@/utils/currency'
 import { formatDate } from '@/utils/formatters'
@@ -8,10 +10,16 @@ interface CustomerPaymentsTabProps {
 }
 
 export default function CustomerPaymentsTab({ customerId }: CustomerPaymentsTabProps) {
-  const { data, isLoading } = useGetPaymentsQuery({ customerId })
-  const payments = [...(data?.data ?? [])].sort((a, b) =>
-    (a.paymentNumber ?? '').localeCompare(b.paymentNumber ?? '', undefined, { numeric: true }),
-  )
+  const { page, limit, paginationProps } = usePagination()
+  const { data, isLoading } = useGetPaymentsQuery({
+    customerId,
+    page,
+    limit,
+    sortBy: 'paymentNumber',
+    sortOrder: 'ASC',
+  })
+  const payments = data?.data ?? []
+  const total = data?.meta?.total ?? 0
 
   const columns: Column<(typeof payments)[number]>[] = [
     { header: 'Payment #', width: '20%', render: (p) => bold(p.paymentNumber) },
@@ -28,6 +36,7 @@ export default function CustomerPaymentsTab({ customerId }: CustomerPaymentsTabP
       getRowKey={(p) => p.id}
       emptyText="No payments yet for this customer."
       isLoading={isLoading}
+      footer={<PagePagination total={total} {...paginationProps} />}
     />
   )
 }

--- a/frontend/src/pages/sales/components/__tests__/CustomerOrdersTab.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/CustomerOrdersTab.test.tsx
@@ -103,7 +103,29 @@ describe('CustomerOrdersTab', () => {
     mockGetSalesOrders.mockReturnValue({ data: { data: [], meta: { total: 0 } }, isLoading: false })
     renderTab('customer-abc')
     expect(mockGetSalesOrders).toHaveBeenCalledWith(
-      expect.objectContaining({ customerId: 'customer-abc' }),
+      expect.objectContaining({ customerId: 'customer-abc', page: 1, limit: expect.any(Number) }),
     )
+  })
+
+  it('renders the pagination footer with the total', () => {
+    mockGetSalesOrders.mockReturnValue({
+      data: {
+        data: [{
+          id: 'o1',
+          orderNumber: 'SO-001',
+          orderDate: '2026-01-15',
+          isCompleted: true,
+          isFulfilled: false,
+          totalAmount: 1500,
+          customerId: 'c1',
+          createdAt: '2026-01-15',
+          updatedAt: '2026-01-15',
+        }],
+        meta: { total: 42 },
+      },
+      isLoading: false,
+    })
+    renderTab('c1')
+    expect(screen.getByText(/of 42 records/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/sales/components/__tests__/CustomerPaymentsTab.test.tsx
+++ b/frontend/src/pages/sales/components/__tests__/CustomerPaymentsTab.test.tsx
@@ -91,11 +91,41 @@ describe('CustomerPaymentsTab', () => {
     expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(1);
   });
 
-  it('passes customerId to query', () => {
+  it('passes customerId, page, limit and lexical sort to the query', () => {
     mockGetPayments.mockReturnValue({ data: { data: [], meta: { total: 0 } }, isLoading: false });
     renderTab('cust-99');
     expect(mockGetPayments).toHaveBeenCalledWith(
-      expect.objectContaining({ customerId: 'cust-99' }),
+      expect.objectContaining({
+        customerId: 'cust-99',
+        page: 1,
+        limit: expect.any(Number),
+        sortBy: 'paymentNumber',
+        sortOrder: 'ASC',
+      }),
     );
+  });
+
+  it('renders the pagination footer with the total', () => {
+    mockGetPayments.mockReturnValue({
+      data: {
+        data: [
+          {
+            id: 'p1',
+            paymentNumber: 'PAY-001',
+            paymentDate: '2026-01-25',
+            amount: 1000,
+            paymentMethodEntity: { id: 'pm1', name: 'Cash', isActive: true },
+            status: 'completed',
+            customerId: 'c1',
+            createdAt: '2026-01-25',
+            updatedAt: '2026-01-25',
+          },
+        ],
+        meta: { total: 17 },
+      },
+      isLoading: false,
+    });
+    renderTab('c1');
+    expect(screen.getByText(/of 17 records/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/store/api/purchasingApi.ts
+++ b/frontend/src/store/api/purchasingApi.ts
@@ -84,13 +84,25 @@ export const purchasingApiSlice = createApi({
       transformResponse: (response: any) => normalizeNamedCollection<Supplier>(response, 'data'),
       providesTags: ['DeletedSupplier'],
     }),
-    getSupplierPurchaseOrders: builder.query<{ data: PurchaseOrder[]; total: number }, string>({
-      query: (id) => ({ url: `/purchasing/suppliers/${id}/purchase-orders` }),
-      providesTags: (_result, _error, id) => [{ type: 'Supplier', id }],
+    getSupplierPurchaseOrders: builder.query<
+      PaginatedResponse<PurchaseOrder>,
+      { supplierId: string; page: number; limit: number }
+    >({
+      query: ({ supplierId, page, limit }) => ({
+        url: `/purchasing/suppliers/${supplierId}/purchase-orders`,
+        params: { page, limit },
+      }),
+      providesTags: (_result, _error, { supplierId }) => [{ type: 'Supplier', id: supplierId }],
     }),
-    getSupplierPayments: builder.query<{ data: VendorPayment[]; total: number }, string>({
-      query: (id) => ({ url: `/purchasing/suppliers/${id}/payments` }),
-      providesTags: (_result, _error, id) => [{ type: 'Supplier', id }],
+    getSupplierPayments: builder.query<
+      PaginatedResponse<VendorPayment>,
+      { supplierId: string; page: number; limit: number }
+    >({
+      query: ({ supplierId, page, limit }) => ({
+        url: `/purchasing/suppliers/${supplierId}/payments`,
+        params: { page, limit },
+      }),
+      providesTags: (_result, _error, { supplierId }) => [{ type: 'Supplier', id: supplierId }],
     }),
     restoreSupplier: builder.mutation<Supplier, string>({
       query: (id) => ({ url: `/purchasing/suppliers/${id}/restore`, method: 'POST' }),


### PR DESCRIPTION
Closes #798

## Summary

Adds server-side \`PagePagination\` to the four Customer/Supplier profile tabs that previously loaded every record at once, matching the Products-list pattern. Also fixes a silent row-truncation bug in the two supplier endpoints (they hardcoded \`take: 50\`).

| Tab | Before | After |
|-----|--------|-------|
| Customer Orders | all rows | paged (server-side) |
| Customer Payments | all rows, client-side sort | paged + lexical SQL sort |
| Supplier Purchase Orders | capped at 50, raw \`<Table>\` | paged, \`DataTable\` |
| Supplier Vendor Payments | capped at 50 | paged |

## Backend changes

- **\`PaymentService.findAll\`** — applies \`skip\`/\`take\` **only when both \`page\` and \`limit\` are present**. Absent ⇒ full set, preserving the contract \`DashboardPage\` relies on (it feeds the entire payments array into the stats aggregator). A blanket default limit would have silently truncated the dashboard.
- **\`SupplierService.getSupplierPurchaseOrders\` / \`getSupplierPayments\`** — replaced hardcoded \`take: 50\` with the same conditional \`skip\`/\`take\`; controller accepts \`BaseQueryDto\` (\`page\`/\`limit\`). All four endpoints now return the uniform \`{ data, meta: { total } }\` shape.

## Frontend changes

- All four tabs converge on one pattern: \`usePagination()\` → query with \`{ ...filter, page, limit }\` → \`DataTable\` with \`footer={<PagePagination total={total} {...paginationProps} />}\`.
- \`CustomerPaymentsTab\`: dropped the client-side \`paymentNumber\` sort; ordering moves to the backend (\`sortBy: 'paymentNumber'\`, \`sortOrder: 'ASC'\` — lexical, consistent with every other paymentNumber-ordered view; payment numbers are zero-padded so order is unchanged in practice).
- \`SupplierPurchaseOrdersTab\`: rewrote the hand-rolled \`<Table>\` to \`DataTable\` (−~50 lines), removing the last raw-table outlier.
- Supplier RTK queries take \`{ supplierId, page, limit }\` and the \`PaginatedResponse\` shape.

## Out of scope

- SO/PO **detail** payments & journal-entry tabs (sub-records of one order — intentionally unpaginated, per #798).
- Pre-existing default caps on other list endpoints surfaced during review: dashboard sales-orders \`limit=1000\` under-count (**#799**) and the umbrella conditional-pagination refactor (**#800**). Filed separately to keep this PR scoped to the four tabs.

## Testing

- Backend (jest): \`PaymentService.findAll\` — \`skip\`/\`take\` applied with params, **not** applied (full set) when absent; \`SupplierService\` — \`skip\`/\`take\` with params, omitted (full set) when absent.
- Frontend (vitest): each tab asserts query receives \`page\`/\`limit\` and the footer shows "Showing X–Y of Z records"; existing nav/empty/loading tests preserved.
- Dashboard test confirms the unpaginated caller shape is unchanged.
- Backend build, frontend type-check, lint — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)