### PR TITLE
fix(inventory): block Stocked→Service type change when stock > 0 (#804)

### DIFF
--- a/backend/src/modules/inventory/services/product.service.spec.ts
+++ b/backend/src/modules/inventory/services/product.service.spec.ts
@@ -72,6 +72,7 @@ describe('ProductService pagination removal', () => {
           provide: getRepositoryToken(Product),
           useValue: {
             createQueryBuilder: jest.fn(),
+            findOne: jest.fn(),
           },
         },
         { provide: getRepositoryToken(Category), useValue: {} },
@@ -478,6 +479,50 @@ describe('ProductService pagination removal', () => {
       expect(result.priceListItems[0].priceList?.priority).toBe(1);
     });
   });
+
+  describe('update() Stocked→Service block', () => {
+    it('rejects GOODS→SERVICE when stockQuantity > 0', async () => {
+      const product = createProduct('p1', {
+        type: ProductType.GOODS,
+        stockQuantity: 5,
+      });
+      productRepository.findOne.mockResolvedValue(product);
+
+      await expect(
+        service.update('p1', { type: ProductType.SERVICE } as any),
+      ).rejects.toThrow(BadRequestException);
+      await expect(
+        service.update('p1', { type: ProductType.SERVICE } as any),
+      ).rejects.toThrow(
+        'Reduce stock to 0 via a Stock Adjustment before converting to a Service',
+      );
+    });
+
+    it('allows GOODS→SERVICE when stockQuantity is 0', async () => {
+      const loaded = createProduct('p1', {
+        type: ProductType.GOODS,
+        stockQuantity: 0,
+      });
+      const reloaded = createProduct('p1', {
+        type: ProductType.SERVICE,
+        stockQuantity: 0,
+      });
+      // update() calls findOne twice: initial load, then reload-with-relations.
+      productRepository.findOne
+        .mockResolvedValueOnce(loaded)
+        .mockResolvedValueOnce(reloaded);
+      productRepository.update = jest.fn().mockResolvedValue({ affected: 1 });
+
+      const result = await service.update('p1', {
+        type: ProductType.SERVICE,
+      } as any);
+
+      expect(productRepository.update).toHaveBeenCalledWith('p1', {
+        type: ProductType.SERVICE,
+      });
+      expect(result.type).toBe(ProductType.SERVICE);
+    });
+  });
 });
 
 describe('checkProductDependencies', () => {
@@ -687,7 +732,7 @@ describe('permanentDelete and bulkPermanentDelete cleanup', () => {
       productId: 'product-id',
       movementType: StockMovementType.INITIAL_STOCK,
     });
-    const cleanupOrder = stockMovementRepo.delete.mock.invocationCallOrder[0];
+      const cleanupOrder = stockMovementRepo.delete.mock.invocationCallOrder[0];
     const deleteOrder = productRepo.delete.mock.invocationCallOrder[0];
     expect(cleanupOrder).toBeLessThan(deleteOrder);
   });

--- a/backend/src/modules/inventory/services/product.service.spec.ts
+++ b/backend/src/modules/inventory/services/product.service.spec.ts
@@ -732,7 +732,7 @@ describe('permanentDelete and bulkPermanentDelete cleanup', () => {
       productId: 'product-id',
       movementType: StockMovementType.INITIAL_STOCK,
     });
-      const cleanupOrder = stockMovementRepo.delete.mock.invocationCallOrder[0];
+    const cleanupOrder = stockMovementRepo.delete.mock.invocationCallOrder[0];
     const deleteOrder = productRepo.delete.mock.invocationCallOrder[0];
     expect(cleanupOrder).toBeLessThan(deleteOrder);
   });

--- a/backend/src/modules/inventory/services/product.service.ts
+++ b/backend/src/modules/inventory/services/product.service.ts
@@ -913,6 +913,18 @@ export class ProductService extends BaseCrudService<
       throw new NotFoundException(`Product with ID '${id}' not found`);
     }
 
+    // Y6 (#775/#804): block Stocked→Service conversion while stock remains.
+    // Avoids silently zeroing stock without an audit trail.
+    if (
+      updateProductDto.type === ProductType.SERVICE &&
+      product.type === ProductType.GOODS &&
+      Number(product.stockQuantity) > 0
+    ) {
+      throw new BadRequestException(
+        'Reduce stock to 0 via a Stock Adjustment before converting to a Service',
+      );
+    }
+
     // Check for name conflicts if name is being changed (case-insensitive)
     if (
       updateProductDto.name &&

--- a/frontend/src/pages/inventory/CreateProductPage.tsx
+++ b/frontend/src/pages/inventory/CreateProductPage.tsx
@@ -364,6 +364,10 @@ const CreateProductPage: React.FC = () => {
     return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   }
 
+  const currentStockQuantity = Number(watch('stockQuantity') ?? 0)
+  const isBlockedConversion =
+    pendingType === 'Service' && currentStockQuantity > 0
+
   return (
     <>
       {/* Header */}
@@ -800,24 +804,32 @@ const CreateProductPage: React.FC = () => {
           <DialogTitle>Change product type?</DialogTitle>
           <DialogContent>
             <DialogContentText>
-              {pendingType === 'Service'
+              {isBlockedConversion
+                ? 'Reduce stock to 0 via a Stock Adjustment before converting to a Service'
+                : pendingType === 'Service'
                 ? 'Switching to Service will stop stock tracking. Existing stock data for this product will no longer be used.'
                 : 'Switching to Stocked Product will start stock tracking from the entered quantity.'}
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <AppButton variant="secondary" onClick={() => setPendingType(null)}>Cancel</AppButton>
-            <AppButton
-              variant="primary"
-              onClick={() => {
-                if (pendingType) {
-                  setValue('type', pendingType, { shouldDirty: true })
-                }
-                setPendingType(null)
-              }}
-            >
-              Confirm
-            </AppButton>
+            {isBlockedConversion ? (
+              <AppButton variant="primary" onClick={() => setPendingType(null)}>Close</AppButton>
+            ) : (
+              <>
+                <AppButton variant="secondary" onClick={() => setPendingType(null)}>Cancel</AppButton>
+                <AppButton
+                  variant="primary"
+                  onClick={() => {
+                    if (pendingType) {
+                      setValue('type', pendingType, { shouldDirty: true })
+                    }
+                    setPendingType(null)
+                  }}
+                >
+                  Confirm
+                </AppButton>
+              </>
+            )}
           </DialogActions>
         </Dialog>
         </>

--- a/frontend/src/pages/inventory/__tests__/CreateProductPage.typechange.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateProductPage.typechange.test.tsx
@@ -120,6 +120,9 @@ describe('CreateProductPage type change', () => {
     await user.click(await screen.findByRole('option', { name: 'Service' }))
 
     expect(await screen.findByText(/stop stock tracking/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /^Confirm$/i })).toBeInTheDocument()
+
+    // Confirm applies the conversion: dialog closes and the type field becomes Service.
+    await user.click(screen.getByRole('button', { name: /^Confirm$/i }))
+    await waitFor(() => expect(screen.getByDisplayValue('Service')).toBeInTheDocument())
   })
 })

--- a/frontend/src/pages/inventory/__tests__/CreateProductPage.typechange.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateProductPage.typechange.test.tsx
@@ -5,17 +5,22 @@ import { Provider } from 'react-redux'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
 
-const { mockNavigate, mockUpdateProduct, mockFetchProductBySlug } =
-  vi.hoisted(() => ({
-    mockNavigate: vi.fn(),
-    mockUpdateProduct: vi.fn(() => ({ unwrap: () => Promise.resolve({ id: 'p1' }) })),
-    mockFetchProductBySlug: vi.fn(() => ({
-      unwrap: () => Promise.resolve({
-        id: 'p1', slug: 'widget', name: 'Widget', type: 'Stocked Product',
-        categoryId: 'c1', baseCost: 10, stockQuantity: 5, isActive: true, priceListItems: [],
-      }),
-    })),
-  }))
+const { mockNavigate, mockUpdateProduct, mockFetchProductBySlug, productState } =
+  vi.hoisted(() => {
+    const productState = { stockQuantity: 5 }
+    return {
+      mockNavigate: vi.fn(),
+      mockUpdateProduct: vi.fn(() => ({ unwrap: () => Promise.resolve({ id: 'p1' }) })),
+      mockFetchProductBySlug: vi.fn(() => ({
+        unwrap: () => Promise.resolve({
+          id: 'p1', slug: 'widget', name: 'Widget', type: 'Stocked Product',
+          categoryId: 'c1', baseCost: 10, stockQuantity: productState.stockQuantity,
+          isActive: true, priceListItems: [],
+        }),
+      })),
+      productState,
+    }
+  })
 
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-router-dom')>()
@@ -81,7 +86,30 @@ function renderEdit() {
 }
 
 describe('CreateProductPage type change', () => {
-  it('confirms before changing type from Stocked Product to Service in edit mode', async () => {
+  it('blocks Stocked→Service when stock > 0 (no Confirm, type unchanged)', async () => {
+    productState.stockQuantity = 5
+    const user = userEvent.setup()
+    renderEdit()
+
+    await waitFor(() => expect(screen.getByDisplayValue('Widget')).toBeInTheDocument())
+
+    const typeSelect = screen.getByLabelText(/Product Type/i)
+    await user.click(typeSelect)
+    await user.click(await screen.findByRole('option', { name: 'Service' }))
+
+    expect(
+      await screen.findByText(/Reduce stock to 0 via a Stock Adjustment before converting to a Service/i),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^Confirm$/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^Close$/i })).toBeInTheDocument()
+
+    // Close dialog, then verify type field unchanged
+    await user.click(screen.getByRole('button', { name: /^Close$/i }))
+    expect(screen.getByDisplayValue('Stocked Product')).toBeInTheDocument()
+  })
+
+  it('warns (with Confirm) on Stocked→Service when stock is 0', async () => {
+    productState.stockQuantity = 0
     const user = userEvent.setup()
     renderEdit()
 
@@ -92,5 +120,6 @@ describe('CreateProductPage type change', () => {
     await user.click(await screen.findByRole('option', { name: 'Service' }))
 
     expect(await screen.findByText(/stop stock tracking/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^Confirm$/i })).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Closes #804

## Problem
Edit Product allowed Stocked→Service conversion even when stock > 0. Spec #775 (Y6) requires blocking it — converting would silently strand stock without an audit trail.

## Fix
**Backend** (`product.service.ts` `update()`): guard throws `BadRequestException('Reduce stock to 0 via a Stock Adjustment before converting to a Service')` when `type → Service`, current `type === Stocked Product`, and `Number(product.stockQuantity) > 0`. This is the real invariant — not bypassable via API.

**Frontend** (`CreateProductPage.tsx`): type-change dialog computes `isBlockedConversion` from `watch('stockQuantity')`. When blocked → shows the same message + Close-only button (no Confirm), type stays Stocked. When allowed (stock 0, or Service→Stocked) → existing Confirm/Cancel flow unchanged.

Out of scope: X6 Service→Stocked copy (separate issue).

## Tests
- Backend: rejects GOODS→SERVICE with stock>0; permits with stock=0 (real success path asserted).
- Frontend: blocks with stock>0 (no Confirm, type unchanged); warns with stock=0 (Confirm present).

All 4 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)