### PR TITLE
fix(inventory): correct Service→Stocked type-change warning copy

### DIFF
--- a/frontend/src/pages/inventory/CreateProductPage.tsx
+++ b/frontend/src/pages/inventory/CreateProductPage.tsx
@@ -808,7 +808,7 @@ const CreateProductPage: React.FC = () => {
                 ? 'Reduce stock to 0 via a Stock Adjustment before converting to a Service'
                 : pendingType === 'Service'
                 ? 'Switching to Service will stop stock tracking. Existing stock data for this product will no longer be used.'
-                : 'Switching to Stocked Product will start stock tracking from the entered quantity.'}
+                : 'Switching to Stocked Product will start stock tracking at 0. You must set quantity afterward via Stock Adjustments.'}
             </DialogContentText>
           </DialogContent>
           <DialogActions>

--- a/frontend/src/pages/inventory/__tests__/CreateProductPage.typechange.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateProductPage.typechange.test.tsx
@@ -129,7 +129,6 @@ describe('CreateProductPage type change', () => {
   })
 
   it('shows "start at 0 / Stock Adjustments" copy on Service→Stocked in edit mode', async () => {
-    productState.stockQuantity = 0
     productState.type = 'Service'
     const user = userEvent.setup()
     renderEdit()

--- a/frontend/src/pages/inventory/__tests__/CreateProductPage.typechange.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateProductPage.typechange.test.tsx
@@ -7,13 +7,13 @@ import { describe, expect, it, vi } from 'vitest'
 
 const { mockNavigate, mockUpdateProduct, mockFetchProductBySlug, productState } =
   vi.hoisted(() => {
-    const productState = { stockQuantity: 5 }
+    const productState = { stockQuantity: 5, type: 'Stocked Product' as 'Stocked Product' | 'Service' }
     return {
       mockNavigate: vi.fn(),
       mockUpdateProduct: vi.fn(() => ({ unwrap: () => Promise.resolve({ id: 'p1' }) })),
       mockFetchProductBySlug: vi.fn(() => ({
         unwrap: () => Promise.resolve({
-          id: 'p1', slug: 'widget', name: 'Widget', type: 'Stocked Product',
+          id: 'p1', slug: 'widget', name: 'Widget', type: productState.type,
           categoryId: 'c1', baseCost: 10, stockQuantity: productState.stockQuantity,
           isActive: true, priceListItems: [],
         }),
@@ -88,6 +88,7 @@ function renderEdit() {
 describe('CreateProductPage type change', () => {
   it('blocks Stocked→Service when stock > 0 (no Confirm, type unchanged)', async () => {
     productState.stockQuantity = 5
+    productState.type = 'Stocked Product'
     const user = userEvent.setup()
     renderEdit()
 
@@ -110,6 +111,7 @@ describe('CreateProductPage type change', () => {
 
   it('warns (with Confirm) on Stocked→Service when stock is 0', async () => {
     productState.stockQuantity = 0
+    productState.type = 'Stocked Product'
     const user = userEvent.setup()
     renderEdit()
 
@@ -124,5 +126,24 @@ describe('CreateProductPage type change', () => {
     // Confirm applies the conversion: dialog closes and the type field becomes Service.
     await user.click(screen.getByRole('button', { name: /^Confirm$/i }))
     await waitFor(() => expect(screen.getByDisplayValue('Service')).toBeInTheDocument())
+  })
+
+  it('shows "start at 0 / Stock Adjustments" copy on Service→Stocked in edit mode', async () => {
+    productState.stockQuantity = 0
+    productState.type = 'Service'
+    const user = userEvent.setup()
+    renderEdit()
+
+    await waitFor(() => expect(screen.getByDisplayValue('Widget')).toBeInTheDocument())
+
+    const typeSelect = screen.getByLabelText(/Product Type/i)
+    await user.click(typeSelect)
+    await user.click(await screen.findByRole('option', { name: 'Stocked Product' }))
+
+    expect(
+      await screen.findByText(
+        /start stock tracking at 0\. You must set quantity afterward via Stock Adjustments\./i,
+      ),
+    ).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

The Edit Product form's Service→Stocked type-change confirmation dialog showed misleading copy:

> "Switching to Stocked Product will start stock tracking from the entered quantity."

In edit mode the quantity field is disabled/readonly — stock starts at 0 and quantity is set afterward via Stock Adjustments. The dialog is edit-mode-only (gated on `isEditMode`, `CreateProductPage.tsx:525`), so the old string was unreachable in create mode and is replaced outright per spec #775 (X6):

> "Switching to Stocked Product will start stock tracking at 0. You must set quantity afterward via Stock Adjustments."

## Changes

- `CreateProductPage.tsx`: replace the Service→Stocked dialog string.
- `CreateProductPage.typechange.test.tsx`: thread product `type` through the test fixture; add edit-mode Service→Stocked regression test asserting the new copy; reset fixture `type` in existing tests to prevent order leakage.

## Testing

- 3 type-change tests PASS (2 existing Stocked→Service + new Service→Stocked).
- Broader `CreateProductPage.test.tsx` PASS.
- `npm run type-check` PASS.

Closes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)