### PR TITLE
fix(sales/purchasing): exclude inactive products from order line selector

### DIFF
--- a/frontend/src/hooks/useProductSearch.test.ts
+++ b/frontend/src/hooks/useProductSearch.test.ts
@@ -52,7 +52,9 @@ describe('useProductSearch', () => {
     })
   })
 
-  it('does not send an isActive filter, so inactive products are included (regression #768)', async () => {
+  // Default (no option) intentionally omits isActive so callers like the stock
+  // adjustment page can still see inactive products. Opt-in is tested below.
+  it('does not send an isActive filter by default so callers can include inactive products', async () => {
     mockGet.mockResolvedValue(makeResponse([]))
     const { result } = renderHook(() => useProductSearch())
 
@@ -60,6 +62,17 @@ describe('useProductSearch', () => {
 
     const callConfig = mockGet.mock.calls[0][1] as { params: Record<string, unknown> }
     expect(callConfig.params).not.toHaveProperty('isActive')
+  })
+
+  it('sends isActive=true when onlyActive option is set (issue #808)', async () => {
+    mockGet.mockResolvedValue(makeResponse([]))
+    const { result } = renderHook(() => useProductSearch({ onlyActive: true }))
+
+    await act(() => result.current.loadProducts('bolt'))
+
+    expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
+      params: { sortBy: 'name', sortOrder: 'ASC', search: 'bolt', isActive: 'true' },
+    })
   })
 
   it('loadProducts replaces the list, not merges', async () => {

--- a/frontend/src/hooks/useProductSearch.ts
+++ b/frontend/src/hooks/useProductSearch.ts
@@ -23,7 +23,7 @@ const getProductsFromResponse = (response: unknown): Product[] => {
   return []
 }
 
-export function useProductSearch() {
+export function useProductSearch({ onlyActive = false }: { onlyActive?: boolean } = {}) {
   const [products, setProducts] = useState<Product[]>([])
   const latestRequestRef = useRef(0)
 
@@ -37,6 +37,11 @@ export function useProductSearch() {
         sortBy: 'name',
         sortOrder: 'ASC',
       }
+
+      if (onlyActive) {
+        params.isActive = 'true'
+      }
+
       const trimmedSearchTerm = searchTerm.trim()
 
       if (trimmedSearchTerm.length >= 1) {

--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -134,7 +134,7 @@ const CreatePurchaseOrderPage: React.FC = () => {
   const isEditMode = !!orderNumber
   const { showSuccess, showError } = useNotification()
 
-  const { products, loadProducts, seedProducts } = useProductSearch()
+  const { products, loadProducts, seedProducts } = useProductSearch({ onlyActive: true })
   const [loading, setLoading] = useState(false)
   const [loadingOrder, setLoadingOrder] = useState(false)
   const [orderToLoad, setOrderToLoad] = useState<any>(null)

--- a/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
@@ -213,7 +213,7 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
+        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm, isActive: 'true' },
       })
     })
 
@@ -251,7 +251,7 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
+        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm, isActive: 'true' },
       })
     })
 
@@ -308,7 +308,7 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
+        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm, isActive: 'true' },
       })
     })
 
@@ -339,7 +339,7 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { sortBy: 'name', sortOrder: 'ASC' },
+        params: { sortBy: 'name', sortOrder: 'ASC', isActive: 'true' },
       })
     })
 
@@ -348,7 +348,7 @@ describe('CreatePurchaseOrderPage', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
+        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm, isActive: 'true' },
       })
     })
 

--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -187,7 +187,7 @@ const CreateSalesOrderPage: React.FC = () => {
   const [triggerGetSalesOrderByNumber] = useLazyGetSalesOrderByNumberQuery()
   const isSaving = Boolean(createState.isLoading || updateState.isLoading)
 
-  const { products, loadProducts, seedProducts } = useProductSearch()
+  const { products, loadProducts, seedProducts } = useProductSearch({ onlyActive: true })
 
   const orderNumberPreview = useMemo(() => {
     if (isEditMode) return null

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -154,7 +154,7 @@ describe('CreateSalesOrderPage product search', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
+        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm, isActive: 'true' },
       })
     })
 
@@ -192,7 +192,7 @@ describe('CreateSalesOrderPage product search', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
+        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm, isActive: 'true' },
       })
     })
 
@@ -248,7 +248,7 @@ describe('CreateSalesOrderPage product search', { timeout: 60000 }, () => {
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/inventory/products', {
-        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm },
+        params: { sortBy: 'name', sortOrder: 'ASC', search: replacementSearchTerm, isActive: 'true' },
       })
     })
 


### PR DESCRIPTION
Closes #808

## Problem

Inactive products could be added to new Sales Orders and Purchase Orders — the order line product selector showed them in the dropdown.

## Root cause

`useProductSearch` never sent an `isActive` param. The backend already supports the filter end to end (`isActive` on `BaseQueryDto` → inherited by `QueryProductsDto`, applied in `ProductService.applyQueryBuilder`), so this is a frontend-only fix.

## Change

- `useProductSearch` gains an opt-in `{ onlyActive }` option; when set it sends `isActive='true'`.
- `CreateSalesOrderPage` and `CreatePurchaseOrderPage` pass `{ onlyActive: true }`.
- `CreateStockAdjustmentPage` is intentionally left unchanged — adjusting stock of inactive products (write-offs, corrections) is legitimate.

## Tests

- `useProductSearch.test.ts`: default omits `isActive`; opt-in sends `isActive: 'true'`.
- Sales + Purchasing page tests assert `isActive: 'true'` in product-search calls.
- StockAdjustment page test still asserts no `isActive` (regression guard for the carve-out).

Verification: lint ✅, type-check ✅, full test suite ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)