### PR TITLE
fix(inventory): set explicit category list column widths (#817)

### DIFF
--- a/frontend/src/pages/inventory/components/CategoryList.tsx
+++ b/frontend/src/pages/inventory/components/CategoryList.tsx
@@ -66,6 +66,7 @@ export default function CategoryList({ categories, sortBy, sortOrder }: Category
   const columns: ColumnConfig<Category>[] = [
     {
       key: 'name',
+      width: '48%',
       raw: true,
       render: (c) => (
         <Typography
@@ -84,12 +85,12 @@ export default function CategoryList({ categories, sortBy, sortOrder }: Category
     },
     {
       key: 'productCount',
-      width: '20%',
+      width: '22%',
       render: (c) => `${c.productCount ?? 0} items`,
     },
     {
       key: 'status',
-      width: '12%',
+      width: '15%',
       raw: true,
       render: (c) => <StatusChip status={c.isEnabled ? 'active' : 'inactive'} />,
     },


### PR DESCRIPTION
## Summary

Category list Name column had no explicit width, leaving it squeezed against the fixed-width columns (Product Count 20% + Status 12% + Actions 10% = 42%).

Set explicit widths per issue #817:
- **Name** — 48% (new)
- **Product Count** — 22% (was 20%)
- **Status** — 15% (was 12%)
- **Actions** — 10% (unchanged)

## Notes

Widths are layout **hints** — `EntityTable` does not set `table-layout: fixed`, so content can still affect column sizing. No `EntityTable` change needed; it already passes `width` through to `TableCell`.

## Testing

- `cd frontend && npm run type-check` — clean
- Visual verification of category list table

Closes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)