### PR TITLE
fix(categories): status filter excludes wrong-status ancestors (#819)

### DIFF
--- a/frontend/src/pages/inventory/CategoriesPage.tsx
+++ b/frontend/src/pages/inventory/CategoriesPage.tsx
@@ -62,11 +62,11 @@ export default function CategoriesPage() {
         ? true
         : appliedFilters.status === 'active' ? c.isEnabled : !c.isEnabled
 
-    if (statusActive) {
+    if (appliedFilters.status !== null) {
       return categories.filter((c) => matchesSearch(c) && matchesStatus(c))
     }
     return filterWithAncestors(categories, (c) => matchesSearch(c) && matchesStatus(c))
-  }, [categories, appliedFilters, statusActive])
+  }, [categories, appliedFilters])
 
   return (
     <SimpleListPage

--- a/frontend/src/pages/inventory/CategoriesPage.tsx
+++ b/frontend/src/pages/inventory/CategoriesPage.tsx
@@ -52,14 +52,21 @@ export default function CategoriesPage() {
     includeProductCount: true,
   })
 
+  const statusActive = appliedFilters.status !== null
+
   const visibleCategories = useMemo(() => {
-    return filterWithAncestors(categories, (c) => {
-      if (appliedFilters.search && !c.name.toLowerCase().includes(appliedFilters.search.toLowerCase())) return false
-      if (appliedFilters.status === 'active' && !c.isEnabled) return false
-      if (appliedFilters.status === 'inactive' && c.isEnabled) return false
-      return true
-    })
-  }, [categories, appliedFilters])
+    const matchesSearch = (c: Category) =>
+      !appliedFilters.search || c.name.toLowerCase().includes(appliedFilters.search.toLowerCase())
+    const matchesStatus = (c: Category) =>
+      appliedFilters.status === null
+        ? true
+        : appliedFilters.status === 'active' ? c.isEnabled : !c.isEnabled
+
+    if (statusActive) {
+      return categories.filter((c) => matchesSearch(c) && matchesStatus(c))
+    }
+    return filterWithAncestors(categories, (c) => matchesSearch(c) && matchesStatus(c))
+  }, [categories, appliedFilters, statusActive])
 
   return (
     <SimpleListPage
@@ -81,6 +88,7 @@ export default function CategoriesPage() {
             sortBy={sortBy}
             sortOrder={sortOrder}
             onSort={handleSort}
+            flat={statusActive}
           />
         </Box>
       )}

--- a/frontend/src/pages/inventory/__tests__/CategoriesPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CategoriesPage.test.tsx
@@ -2,20 +2,18 @@ import { render, screen } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import userEvent from '@testing-library/user-event'
 
 import CategoriesPage from '../CategoriesPage'
 
+const fixtureRef: { data: any[] } = { data: [] }
 vi.mock('@/store/api/inventoryApi', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/store/api/inventoryApi')>()
   return {
     ...actual,
     useGetCategoriesQuery: () => ({
-      data: [],
-      isLoading: false,
-      isFetching: false,
-      error: undefined,
-      refetch: vi.fn(),
+      data: fixtureRef.data, isLoading: false, isFetching: false, error: undefined, refetch: vi.fn(),
     }),
   }
 })
@@ -28,7 +26,14 @@ vi.mock('react-router-dom', async (importOriginal) => {
   }
 })
 
-vi.mock('../components/CategoryList', () => ({ default: () => <div>CategoryList</div> }))
+const listProps: { categories?: any[]; flat?: boolean } = {}
+vi.mock('../components/CategoryList', () => ({
+  default: (props: any) => {
+    listProps.categories = props.categories
+    listProps.flat = props.flat
+    return <div data-testid="category-list" />
+  },
+}))
 
 function renderPage() {
   const store = configureStore({ reducer: { empty: (s = null) => s } })
@@ -41,10 +46,82 @@ function renderPage() {
   )
 }
 
+function makeCat(p: any) {
+  return {
+    id: p.id, name: p.name, slug: p.name.toLowerCase(), isEnabled: p.isEnabled ?? true,
+    level: p.level ?? 0, parentId: p.parentId ?? null, fullPath: p.name,
+    isRoot: (p.level ?? 0) === 0, hasChildren: false, isActive: true,
+    createdAt: '', updatedAt: '', productCount: 0,
+  }
+}
+
+const HARDWARE = makeCat({ id: 'h', name: 'Hardware', isEnabled: true, level: 0 })
+const SCREWS = makeCat({ id: 's', name: 'Screws', parentId: 'h', isEnabled: false, level: 1 })
+const PAINT = makeCat({ id: 'p', name: 'Paint', isEnabled: true, level: 0 })
+
 describe('CategoriesPage', () => {
   it('renders New Category action and no View Deleted', async () => {
     renderPage()
     expect(await screen.findByText('New Category')).toBeInTheDocument()
     expect(screen.queryByText(/View Deleted/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('CategoriesPage status filter', () => {
+  beforeEach(() => {
+    fixtureRef.data = [HARDWARE, SCREWS, PAINT]
+    listProps.categories = undefined
+    listProps.flat = undefined
+  })
+
+  async function selectStatus(label: string) {
+    const user = userEvent.setup()
+    await user.click(screen.getByLabelText('Status'))
+    await user.click(await screen.findByRole('option', { name: label }))
+  }
+
+  it('Inactive shows only inactive rows and does not leak active ancestor', async () => {
+    renderPage()
+    await selectStatus('Inactive')
+    const names = listProps.categories!.map((c) => c.name)
+    expect(names).toEqual(['Screws'])
+    expect(names).not.toContain('Hardware')
+    expect(listProps.flat).toBe(true)
+  })
+
+  it('Active shows only active rows', async () => {
+    renderPage()
+    await selectStatus('Active')
+    const names = listProps.categories!.map((c) => c.name).sort()
+    expect(names).toEqual(['Hardware', 'Paint'])
+    expect(listProps.categories!.map((c) => c.name)).not.toContain('Screws')
+    expect(listProps.flat).toBe(true)
+  })
+
+  it('no status filter keeps ancestor injection (search keeps non-matching parent)', async () => {
+    renderPage()
+    const user = userEvent.setup()
+    await user.type(screen.getByPlaceholderText('Search categories by name...'), 'Screws')
+    await screen.findByTestId('category-list')
+    await vi.waitFor(() => {
+      const names = listProps.categories!.map((c) => c.name)
+      expect(names).toContain('Screws')
+      expect(names).toContain('Hardware')
+    })
+    expect(listProps.flat).toBe(false)
+  })
+
+  it('clearing the status filter restores tree behavior (flat=false)', async () => {
+    renderPage()
+    await selectStatus('Inactive')
+    expect(listProps.flat).toBe(true)
+    const user = userEvent.setup()
+    await user.click(screen.getByLabelText('Status'))
+    await user.click(await screen.findByRole('option', { name: 'All' }))
+    await vi.waitFor(() => {
+      expect(listProps.flat).toBe(false)
+      const names = listProps.categories!.map((c) => c.name).sort()
+      expect(names).toEqual(['Hardware', 'Paint', 'Screws'])
+    })
   })
 })

--- a/frontend/src/pages/inventory/components/CategoryList.flat.test.tsx
+++ b/frontend/src/pages/inventory/components/CategoryList.flat.test.tsx
@@ -1,0 +1,83 @@
+import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+import CategoryList from './CategoryList'
+import type { Category } from '@/types'
+
+const captured: { rows?: any[]; columns?: any[] } = {}
+vi.mock('@/components/common/EntityTable', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    captured.rows = props.rows
+    captured.columns = props.columns
+    return <div data-testid="entity-table" />
+  },
+}))
+
+vi.mock('@/store/api/inventoryApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store/api/inventoryApi')>()
+  return { ...actual, useSetCategoryEnabledMutation: () => [vi.fn(), { isLoading: false }] }
+})
+
+vi.mock('@/hooks/useNotification', () => ({
+  useNotification: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
+}))
+
+function cat(partial: Partial<Category>): Category {
+  return {
+    id: partial.id!, name: partial.name!, slug: partial.slug ?? partial.name!.toLowerCase(),
+    isEnabled: partial.isEnabled ?? true, level: partial.level ?? 0, parentId: partial.parentId ?? null,
+    fullPath: partial.name!, isRoot: (partial.level ?? 0) === 0, hasChildren: false,
+    isActive: true, createdAt: '', updatedAt: '', productCount: partial.productCount ?? 0,
+  } as Category
+}
+
+function renderList(categories: Category[], extra: Partial<React.ComponentProps<typeof CategoryList>> = {}) {
+  const store = configureStore({ reducer: { empty: (s = null) => s } })
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <CategoryList categories={categories} sortBy="name" sortOrder="asc" onSort={vi.fn()} {...extra} />
+      </MemoryRouter>
+    </Provider>,
+  )
+}
+
+describe('CategoryList flat mode', () => {
+  beforeEach(() => { captured.rows = undefined; captured.columns = undefined })
+
+  it('flat mode sorts rows by name asc', () => {
+    renderList([cat({ id: 'b', name: 'Beta' }), cat({ id: 'a', name: 'Alpha' })], { flat: true })
+    expect(captured.rows!.map((r) => r.name)).toEqual(['Alpha', 'Beta'])
+  })
+
+  it('flat mode honors descending order', () => {
+    renderList([cat({ id: 'a', name: 'Alpha' }), cat({ id: 'b', name: 'Beta' })], { flat: true, sortOrder: 'desc' })
+    expect(captured.rows!.map((r) => r.name)).toEqual(['Beta', 'Alpha'])
+  })
+
+  it('flat mode renders an orphan whose parent is absent', () => {
+    renderList([cat({ id: 'child', name: 'Orphan', parentId: 'missing', level: 1 })], { flat: true })
+    expect(captured.rows!.map((r) => r.name)).toEqual(['Orphan'])
+  })
+
+  it('flat mode renders name cell with no indentation (sx.pl === 0)', () => {
+    renderList([cat({ id: 'child', name: 'Deep', parentId: 'missing', level: 2 })], { flat: true })
+    const nameCol = captured.columns!.find((c) => c.key === 'name')
+    const el = nameCol.render(captured.rows![0]) as React.ReactElement
+    expect((el.props as any).sx.pl).toBe(0)
+  })
+
+  it('tree mode keeps level indentation (sx.pl === level * 3)', () => {
+    const parent = cat({ id: 'p', name: 'Parent', level: 0 })
+    const child = cat({ id: 'c', name: 'Child', parentId: 'p', level: 1 })
+    renderList([parent, child])
+    const nameCol = captured.columns!.find((c) => c.key === 'name')
+    const childRow = captured.rows!.find((r) => r.id === 'c')!
+    const el = nameCol.render(childRow) as React.ReactElement
+    expect((el.props as any).sx.pl).toBe(3)
+  })
+})

--- a/frontend/src/pages/inventory/components/CategoryList.tsx
+++ b/frontend/src/pages/inventory/components/CategoryList.tsx
@@ -16,6 +16,14 @@ interface CategoryListProps {
   sortBy: string
   sortOrder: 'asc' | 'desc'
   onSort: (field: string) => void
+  flat?: boolean
+}
+
+function compareCategories(a: Category, b: Category, sortBy: string, order: 'asc' | 'desc'): number {
+  const v = sortBy === 'productCount'
+    ? (a.productCount ?? 0) - (b.productCount ?? 0)
+    : a.name.localeCompare(b.name)
+  return order === 'asc' ? v : -v
 }
 
 function flattenTree(cats: Category[], sortBy: string, order: 'asc' | 'desc'): Category[] {
@@ -25,27 +33,23 @@ function flattenTree(cats: Category[], sortBy: string, order: 'asc' | 'desc'): C
     if (!byParent.has(key)) byParent.set(key, [])
     byParent.get(key)!.push(c)
   }
-  const cmp = (a: Category, b: Category) => {
-    const v = sortBy === 'productCount'
-      ? (a.productCount ?? 0) - (b.productCount ?? 0)
-      : a.name.localeCompare(b.name)
-    return order === 'asc' ? v : -v
-  }
   const out: Category[] = []
   const walk = (parentId: string | null) => {
-    const kids = (byParent.get(parentId) ?? []).slice().sort(cmp)
+    const kids = (byParent.get(parentId) ?? []).slice().sort((a, b) => compareCategories(a, b, sortBy, order))
     for (const k of kids) { out.push(k); walk(k.id) }
   }
   walk(null)
   return out
 }
 
-export default function CategoryList({ categories, sortBy, sortOrder }: CategoryListProps) {
+export default function CategoryList({ categories, sortBy, sortOrder, flat = false }: CategoryListProps) {
   const navigate = useNavigate()
   const { showSuccess, showError } = useNotification()
   const [setCategoryEnabled, { isLoading: toggling }] = useSetCategoryEnabledMutation()
   const [pendingToggle, setPendingToggle] = useState<Category | null>(null)
-  const flat = flattenTree(categories, sortBy, sortOrder)
+  const rows = flat
+    ? categories.slice().sort((a, b) => compareCategories(a, b, sortBy, sortOrder))
+    : flattenTree(categories, sortBy, sortOrder)
 
   const confirmToggle = async () => {
     if (!pendingToggle) return
@@ -72,7 +76,7 @@ export default function CategoryList({ categories, sortBy, sortOrder }: Category
         <Typography
           variant="body2"
           sx={{
-            pl: c.level * 3,
+            pl: flat ? 0 : c.level * 3,
             fontWeight: 400,
             fontSize: '0.8rem',
             lineHeight: 1.2,
@@ -116,10 +120,10 @@ export default function CategoryList({ categories, sortBy, sortOrder }: Category
   return (
     <>
       <EntityTable
-        rows={flat}
+        rows={rows}
         columns={columns}
         loading={false}
-        total={flat.length}
+        total={rows.length}
         label="Categories"
         showHeader={false}
         headers={['Name', 'Product Count', 'Status', 'Actions']}


### PR DESCRIPTION
## Problem

Selecting "Inactive" on the Categories page still showed active categories. `filterWithAncestors` was applied on every filter path, so filtering for an inactive child (e.g. `Screws`) also injected its active parent (`Hardware`) into the list.

## Fix

When the Status filter is set, filter **strictly** by status (no ancestor injection) and render a **flat** list. Ancestor injection is retained for the search-only path so deep search matches keep their parent context.

### Task 1 — `CategoryList` flat mode
- Added `flat?: boolean` prop.
- Extracted `compareCategories` to module scope so flat mode honors `sortBy`/`sortOrder`.
- Flat mode sorts via `categories.slice().sort()`, bypassing the tree-walk so strict status matches whose parent was filtered out are not dropped.
- Indentation `pl: 0` in flat mode.

### Task 2 — `CategoriesPage` strict filtering
- `statusActive` branches the memo: when set, strict filter (no `filterWithAncestors`) and `flat={statusActive}` to `CategoryList`.

## Tests
- New `CategoryList.flat.test.tsx`: sort asc/desc, orphan preservation, flat indentation, tree-indentation regression guard.
- `CategoriesPage.test.tsx`: Inactive strict, Active strict, search ancestor injection retained, clear-status restores tree.
- 14 tests pass (3 suites); `npm run type-check` clean. No backend changes.

Closes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)