### PR TITLE
fix(inventory): split Products tab Stock column into Qty + Status (#821)

### DIFF
--- a/frontend/src/pages/inventory/components/CategoryProductsList.test.tsx
+++ b/frontend/src/pages/inventory/components/CategoryProductsList.test.tsx
@@ -118,4 +118,23 @@ describe('CategoryProductsList', () => {
     renderList()
     expect(screen.getByText('Low Stock')).toBeInTheDocument()
   })
+
+  it('renders Qty and Status as separate columns in separate cells', () => {
+    mockUseGetCategoryProductsQuery.mockReturnValue({
+      data: { data: [makeProduct({ name: 'Widget', stockQuantity: 5 })] },
+      isLoading: false,
+      isError: false,
+    })
+    renderList()
+
+    expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Qty' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Status' })).toBeInTheDocument()
+
+    const qtyCell = screen.getByText('5').closest('td')
+    const statusCell = screen.getByText('Low Stock').closest('td')
+    expect(qtyCell).not.toBeNull()
+    expect(statusCell).not.toBeNull()
+    expect(qtyCell).not.toBe(statusCell)
+  })
 })

--- a/frontend/src/pages/inventory/components/CategoryProductsList.tsx
+++ b/frontend/src/pages/inventory/components/CategoryProductsList.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Box, Typography } from '@mui/material'
 
 import { DataTable, type Column, bold } from '@/components/common/DataTable'
 import { StatusChip } from '@/components/common/StatusChip'
@@ -20,18 +19,24 @@ const CategoryProductsList: React.FC<CategoryProductsListProps> = ({ categoryId 
   const lowStockThreshold = regionalSettings?.lowStockThreshold ?? 10
 
   const columns: Column<CategoryProduct>[] = [
-    { header: 'Name', width: '70%', render: (p) => bold(p.name) },
+    { header: 'Name', width: '55%', render: (p) => bold(p.name) },
     {
-      header: 'Stock',
+      header: 'Qty',
+      width: '15%',
+      align: 'right',
+      render: (p) => formatWholeQuantity(p.stockQuantity ?? 0),
+    },
+    {
+      header: 'Status',
       width: '30%',
       render: (p) => {
-        const stock = p.stockQuantity ?? 0
-        const status = getStockStatus(stock, lowStockThreshold)
+        const status = getStockStatus(p.stockQuantity ?? 0, lowStockThreshold)
         return (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <Typography variant="body2">{formatWholeQuantity(stock)}</Typography>
-            <StatusChip status={status} variant="outlined" sx={{ fontSize: '0.7rem', fontWeight: 500, height: 20 }} />
-          </Box>
+          <StatusChip
+            status={status}
+            variant="outlined"
+            sx={{ fontSize: '0.7rem', fontWeight: 500, height: 20 }}
+          />
         )
       },
     },


### PR DESCRIPTION
## Summary
Categories page Products tab (Sec 4) had stock quantity and the status chip crammed into one "Stock" column, with an unbalanced 70/30 Name/Stock split.

Splits the single column into three: **Name** (55%), **Qty** (15%, right-aligned), **Status** (30%). Quantity and the status chip now each get their own cell.

Closes #821

## Changes
- `CategoryProductsList.tsx` — 3-column layout; removed unused `Box`/`Typography` imports. Uses existing `DataTable` `width`/`align` support — no `DataTable` change.
- `CategoryProductsList.test.tsx` — asserts 3 column headers and that Qty value + Status chip render in separate `<td>` cells.

## Verification
- 9/9 tests pass
- `npm run lint` clean
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)