### PR TITLE
fix(inventory): rebalance Products tab columns to 55/20/25 (#823)

### DIFF
--- a/frontend/src/pages/inventory/components/CategoryProductsList.tsx
+++ b/frontend/src/pages/inventory/components/CategoryProductsList.tsx
@@ -22,13 +22,13 @@ const CategoryProductsList: React.FC<CategoryProductsListProps> = ({ categoryId 
     { header: 'Name', width: '55%', render: (p) => bold(p.name) },
     {
       header: 'Qty',
-      width: '15%',
+      width: '20%',
       align: 'right',
       render: (p) => formatWholeQuantity(p.stockQuantity ?? 0),
     },
     {
       header: 'Status',
-      width: '30%',
+      width: '25%',
       render: (p) => {
         const status = getStockStatus(p.stockQuantity ?? 0, lowStockThreshold)
         return (


### PR DESCRIPTION
## Summary
Follow-up to #821. The category-view Products tab split its columns `55/15/30` (Name/Qty/Status), leaving a dead gap after the small Status chip and a tight Qty column.

Rebalances to **Name 55% / Qty 20% / Status 25%** — closes the Status gap, gives Qty more room. Name unchanged.

Closes #823

## Changes
- `CategoryProductsList.tsx` — Qty width `15% → 20%`, Status width `30% → 25%`. Two lines; no `DataTable`, API, or test changes.

## Verification
- `npx vitest run CategoryProductsList` — 9/9 pass
- `npm run lint` — clean
- `npm run type-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)