### PR TITLE
fix(categories): full-width two-column Category form layout

### DIFF
--- a/frontend/src/pages/inventory/CategoryFormPage.tsx
+++ b/frontend/src/pages/inventory/CategoryFormPage.tsx
@@ -166,8 +166,8 @@ const CategoryFormPage: React.FC = () => {
 
       <form noValidate onSubmit={handleSubmit(onSubmit)}>
         <Grid container spacing={3}>
-          <Grid size={{ xs: 12, md: 8 }}>
-            <Card>
+          <Grid size={{ xs: 12, md: 6 }} sx={{ display: 'flex', flexDirection: 'column' }}>
+            <Card sx={{ flex: 1 }}>
               <CardContent>
                 <Typography variant="h6" gutterBottom>Category Information</Typography>
                 <Grid container spacing={2}>
@@ -215,27 +215,43 @@ const CategoryFormPage: React.FC = () => {
                       )}
                     />
                   </Grid>
-
-                  <Grid size={12}>
-                    <Controller
-                      name="description"
-                      control={control}
-                      render={({ field }) => (
-                        <TextField
-                          {...field}
-                          value={field.value || ''}
-                          label="Description"
-                          multiline
-                          rows={3}
-                          fullWidth
-                          size="small"
-                          disabled={isSaving}
-                          sx={fieldSx}
-                        />
-                      )}
-                    />
-                  </Grid>
                 </Grid>
+              </CardContent>
+            </Card>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }} sx={{ display: 'flex', flexDirection: 'column' }}>
+            <Card sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
+              <CardContent sx={{ display: 'flex', flexDirection: 'column', height: '100%', boxSizing: 'border-box' }}>
+                <Typography variant="h6" gutterBottom>Description</Typography>
+                <Box sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', mt: 1 }}>
+                  <Controller
+                    name="description"
+                    control={control}
+                    render={({ field }) => (
+                      <TextField
+                        {...field}
+                        value={field.value || ''}
+                        label="Description"
+                        multiline
+                        minRows={4}
+                        fullWidth
+                        size="small"
+                        disabled={isSaving}
+                        sx={{
+                          flexGrow: 1,
+                          '& .MuiInputBase-root': { height: '100%', alignItems: 'flex-start' },
+                          '& .MuiInputBase-input': {
+                            fontSize: '0.875rem',
+                            height: '100% !important',
+                            overflow: 'auto !important',
+                          },
+                          '& .MuiInputLabel-root': { fontSize: '0.875rem' },
+                        }}
+                      />
+                    )}
+                  />
+                </Box>
               </CardContent>
             </Card>
           </Grid>


### PR DESCRIPTION
## Summary
Category Create/Edit form wrapped its single card in `Grid size={{ xs: 12, md: 8 }}`, leaving ~4 empty columns on the right at md+ viewports.

Replaced with a full-width two-column layout (mirrors `CreateProductPage`):
- **Left card** `md: 6` (`flex: 1`) — Name + Parent Category
- **Right card** `md: 6` — Description textarea, flex-stretched to equal height (mirrors Product Notes mechanics: `minRows={4}` + flex-driven height, no fixed `rows`)
- Action row unchanged

Pure layout change — no controller names, validation schema, duplicate check, submit path, or unsaved-changes guard touched.

## Verification
- ✅ Tests: 2/2 pass (`CategoryFormPage.test.tsx`)
- ✅ `npm run type-check`: pass
- ✅ `npm run lint`: 0 warnings

Closes #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)