### PR TITLE
fix(inventory,accounting): surface Complete errors + fiscal-period end date inclusive (#833, #836)

### DIFF
--- a/backend/src/modules/accounting/services/journal-entry.service.spec.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.spec.ts
@@ -803,6 +803,33 @@ describe('JournalEntryService', () => {
       expect(journalEntryRepository.save).toHaveBeenCalled();
     });
 
+    it('should post an entry dated on the last day of the period even with a time component', async () => {
+      // Regression: an entryDate carrying a time-of-day (e.g. created via `new Date()`
+      // late on the period's end date) must not be treated as "after" the period end,
+      // which is stored as a date-only value (midnight).
+      const entryWithLines = {
+        ...mockJournalEntry,
+        entryDate: new Date('2026-01-31T19:32:31Z'),
+        fiscalPeriod: {
+          ...mockFiscalPeriod,
+          startDate: new Date('2026-01-01'),
+          endDate: new Date('2026-01-31'),
+        },
+        lines: [mockJournalEntryLine1, mockJournalEntryLine2],
+        isBalanced: true,
+      };
+      journalEntryRepository.findOne.mockResolvedValue(entryWithLines as JournalEntry);
+      fiscalPeriodService.checkPeriodOpen.mockResolvedValue(true);
+      journalEntryRepository.save.mockResolvedValue({
+        ...entryWithLines,
+        status: JournalEntryStatus.POSTED,
+      } as JournalEntry);
+
+      const result = await service.postEntry('entry-1');
+
+      expect(result.status).toBe(JournalEntryStatus.POSTED);
+    });
+
     it('should throw BadRequestException if entry is not balanced', async () => {
       const unbalancedEntry = {
         ...mockJournalEntry,

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -515,10 +515,16 @@ export class JournalEntryService {
       );
     }
 
-    // Validate entry date falls within fiscal period
+    // Validate entry date falls within fiscal period. Compare date-only:
+    // entryDate may carry a time-of-day (e.g. created via `new Date()`), while the
+    // period bounds are stored as date-only. Normalize all to start-of-day so an
+    // entry on the period's last day is not wrongly rejected (matches validatePeriod).
     const entryDate = new Date(entry.entryDate);
     const periodStart = new Date(entry.fiscalPeriod.startDate);
     const periodEnd = new Date(entry.fiscalPeriod.endDate);
+    entryDate.setUTCHours(0, 0, 0, 0);
+    periodStart.setUTCHours(0, 0, 0, 0);
+    periodEnd.setUTCHours(0, 0, 0, 0);
 
     if (entryDate < periodStart || entryDate > periodEnd) {
       throw new BadRequestException(
@@ -792,10 +798,15 @@ export class JournalEntryService {
       );
     }
 
-    // Validate entry date falls within period
+    // Validate entry date falls within period. Compare date-only (the entry date may
+    // carry a time-of-day while the period bounds are date-only) so an entry on the
+    // period's last day is not wrongly rejected (matches validatePeriod).
     const date = new Date(entryDate);
     const periodStart = new Date(period.startDate);
     const periodEnd = new Date(period.endDate);
+    date.setUTCHours(0, 0, 0, 0);
+    periodStart.setUTCHours(0, 0, 0, 0);
+    periodEnd.setUTCHours(0, 0, 0, 0);
 
     if (date < periodStart || date > periodEnd) {
       throw new BadRequestException(

--- a/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
@@ -32,6 +32,11 @@ const filterConfig: FilterBarConfig<StockAdjustmentFilters> = {
   defaults: { search: '', period: { key: null, from: null, to: null }, status: null, categoryId: null },
 }
 
+// Backend stock errors embed quantities like "1.0000" / "1.5000". Trim
+// trailing-zero decimals for readability in the toast: 1.0000 → 1, 1.5000 → 1.5.
+const tidyDecimals = (message: string): string =>
+  message.replace(/(\d+)\.(\d*?)0+(?=\D|$)/g, (_, intPart, frac) => (frac ? `${intPart}.${frac}` : intPart))
+
 export default function StockAdjustmentsPage() {
   const navigate = useNavigate()
   const [page, setPage] = useState(1)
@@ -97,7 +102,7 @@ export default function StockAdjustmentsPage() {
       showSuccess(`Stock adjustment ${name} completed`)
       setCompleteTarget(null)
     } catch (error) {
-      showError(rtkErrorMessage(error, 'Failed to complete stock adjustment'))
+      showError(tidyDecimals(rtkErrorMessage(error, 'Failed to complete stock adjustment')))
     }
   }, [completeTarget, completeTargetRow, completeAdjustment, showSuccess, showError])
 

--- a/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
@@ -9,6 +9,8 @@ import { useCompleteStockAdjustmentMutation, useGetStockAdjustmentsQuery } from 
 import { PAGINATION } from '@/constants/tableStyles'
 import type { FilterBarConfig, PeriodValue } from '@/types/filterBar.types'
 import { getPeriodDateRange, getStartOfWeek } from '@/utils/dateRange'
+import { useNotification } from '@/hooks/useNotification'
+import { rtkErrorMessage } from '@/utils/errorMessage'
 
 import StockAdjustmentList from './components/StockAdjustmentList'
 import StockAdjustmentsDialogs from './components/StockAdjustmentsDialogs'
@@ -42,6 +44,7 @@ export default function StockAdjustmentsPage() {
   const searchInputRef = useRef<HTMLInputElement | null>(null)
   const { appliedFilters, draftFilters, handlers, hasActiveFilters } = useFilterBar(filterConfig)
   const [completeAdjustment] = useCompleteStockAdjustmentMutation()
+  const { showSuccess, showError } = useNotification()
 
   const weekStartsOn = getStartOfWeek()
 
@@ -88,14 +91,15 @@ export default function StockAdjustmentsPage() {
 
   const handleConfirmComplete = useCallback(async () => {
     if (!completeTarget) return
+    const name = completeTargetRow?.adjustmentNumber ?? ''
     try {
       await completeAdjustment(completeTarget).unwrap()
-    } catch {
-      // error handled by api layer
-    } finally {
+      showSuccess(`Stock adjustment ${name} completed`)
       setCompleteTarget(null)
+    } catch (error) {
+      showError(rtkErrorMessage(error, 'Failed to complete stock adjustment'))
     }
-  }, [completeTarget, completeAdjustment])
+  }, [completeTarget, completeTargetRow, completeAdjustment, showSuccess, showError])
 
   const handleConfirmRevert = useCallback(() => {
     if (!revertTarget) return

--- a/frontend/src/pages/inventory/__tests__/StockAdjustmentsPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/StockAdjustmentsPage.test.tsx
@@ -77,7 +77,19 @@ it('surfaces backend error and keeps the dialog open when completion fails', asy
   await clickConfirm(user)
 
   await waitFor(() =>
-    expect(showErrorSpy).toHaveBeenCalledWith('Insufficient stock. Available: 1.0000, Requested: 15'),
+    expect(showErrorSpy).toHaveBeenCalledWith('Insufficient stock. Available: 1, Requested: 15'),
   )
   expect(screen.getByText('Complete Stock Adjustment?')).toBeInTheDocument()
+})
+
+it('keeps non-zero fractional digits when tidying the error message', async () => {
+  const user = userEvent.setup()
+  unwrapMock.mockRejectedValue({ data: { message: 'Insufficient stock. Available: 1.5000, Requested: 15' } })
+  renderPage()
+  await openCompleteDialog(user)
+  await clickConfirm(user)
+
+  await waitFor(() =>
+    expect(showErrorSpy).toHaveBeenCalledWith('Insufficient stock. Available: 1.5, Requested: 15'),
+  )
 })

--- a/frontend/src/pages/inventory/__tests__/StockAdjustmentsPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/StockAdjustmentsPage.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, expect, it, vi } from 'vitest'
+
+const { completeSpy, unwrapMock, showSuccessSpy, showErrorSpy } = vi.hoisted(() => ({
+  completeSpy: vi.fn(),
+  unwrapMock: vi.fn(),
+  showSuccessSpy: vi.fn(),
+  showErrorSpy: vi.fn(),
+}))
+
+vi.mock('@/store/api/inventoryApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/store/api/inventoryApi')>()
+  const mockRows = [
+    { id: 'a1', adjustmentNumber: 'SA-000001', adjustmentDate: '2026-06-29', status: 'draft', itemCount: 2, totalValue: 100 },
+  ]
+  return {
+    ...actual,
+    useGetStockAdjustmentsQuery: () => ({ data: { data: mockRows }, isFetching: false, error: undefined }),
+    useGetCategoriesQuery: () => ({ data: [] }),
+    useCompleteStockAdjustmentMutation: () => [completeSpy, {}],
+  }
+})
+
+vi.mock('@/hooks/useNotification', () => ({
+  useNotification: () => ({
+    showSuccess: showSuccessSpy,
+    showError: showErrorSpy,
+    showWarning: vi.fn(),
+    showInfo: vi.fn(),
+  }),
+}))
+
+import StockAdjustmentsPage from '../StockAdjustmentsPage'
+
+function renderPage() {
+  return render(<MemoryRouter><StockAdjustmentsPage /></MemoryRouter>)
+}
+
+async function openCompleteDialog(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByLabelText('row actions'))
+  await user.click(screen.getByText('Complete'))
+  await waitFor(() => expect(screen.getByText('Complete Stock Adjustment?')).toBeInTheDocument())
+}
+
+function clickConfirm(user: ReturnType<typeof userEvent.setup>) {
+  const confirm = screen.getAllByText('Complete').find((el) => el.closest('button'))
+  return user.click(confirm!)
+}
+
+beforeEach(() => {
+  completeSpy.mockReset()
+  unwrapMock.mockReset()
+  showSuccessSpy.mockReset()
+  showErrorSpy.mockReset()
+  completeSpy.mockReturnValue({ unwrap: unwrapMock })
+})
+
+it('completes a draft adjustment and shows a success toast', async () => {
+  const user = userEvent.setup()
+  unwrapMock.mockResolvedValue({})
+  renderPage()
+  await openCompleteDialog(user)
+  await clickConfirm(user)
+
+  await waitFor(() => expect(completeSpy).toHaveBeenCalledWith('a1'))
+  expect(showSuccessSpy).toHaveBeenCalledWith('Stock adjustment SA-000001 completed')
+  await waitFor(() => expect(screen.queryByText('Complete Stock Adjustment?')).not.toBeInTheDocument())
+})
+
+it('surfaces backend error and keeps the dialog open when completion fails', async () => {
+  const user = userEvent.setup()
+  unwrapMock.mockRejectedValue({ data: { message: 'Insufficient stock. Available: 1.0000, Requested: 15' } })
+  renderPage()
+  await openCompleteDialog(user)
+  await clickConfirm(user)
+
+  await waitFor(() =>
+    expect(showErrorSpy).toHaveBeenCalledWith('Insufficient stock. Available: 1.0000, Requested: 15'),
+  )
+  expect(screen.getByText('Complete Stock Adjustment?')).toBeInTheDocument()
+})


### PR DESCRIPTION
Two related fixes (the second was uncovered while getting this PR's CI green).

## 1. Surface Complete errors on stock adjustment list (#833)
Clicking **Complete** on a draft stock adjustment then confirming did nothing visible — the dialog closed, the row stayed draft, no error. Root cause: `handleConfirmComplete` swallowed the backend error in an empty `catch {}`.

- `StockAdjustmentsPage.tsx`: wire `useNotification` + `rtkErrorMessage`. Success → success toast + close; failure → error toast (decimals tidied, e.g. `1.0000`→`1`) and the dialog **stays open**.
- New page-level tests: success path, error path (regression), decimal-tidy.

## 2. Fiscal-period end date inclusive on accounting post (#836)
CI surfaced a **pre-existing** backend bug (verified independently against unmodified `main`): accounting posts (PO receive, etc.) failed on the **last day** of a fiscal period:

```
400 POST /purchasing/orders/:id/receive
Error: Entry date 2026-06-30 is outside fiscal period range (2026-06-01 to 2026-06-30)
```

`journal-entry.service.ts` compared an `entryDate` carrying a time-of-day (PO receive uses `new Date()`) against **date-only** period bounds without normalizing — an afternoon entry on the end date parsed as later than the end-date midnight. Manifests only on the period's final day (green 06-29, red 06-30).

- Normalize `entryDate` and both bounds to **UTC** start-of-day at both check sites (`postEntry`, `validateFiscalPeriod`). UTC (not local `setHours`) because date-only DB values are UTC midnight and CI/dev timezones differ.
- New regression unit test: last-day entry with a time component posts.

## Verification
- Frontend: lint ✓, type-check ✓, full `npm run test` ✓.
- Backend: lint ✓, full unit suite ✓ (1206). E2E (previously-red `purchasing.e2e-spec.ts`) green in CI on this branch.

Closes #833
Closes #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)