### PR TITLE
fix(accounting): fiscal-period end date inclusive on post (#836)

### DIFF
--- a/backend/src/modules/accounting/services/journal-entry.service.spec.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.spec.ts
@@ -803,6 +803,33 @@ describe('JournalEntryService', () => {
       expect(journalEntryRepository.save).toHaveBeenCalled();
     });
 
+    it('should post an entry dated on the last day of the period even with a time component', async () => {
+      // Regression: an entryDate carrying a time-of-day (e.g. created via `new Date()`
+      // late on the period's end date) must not be treated as "after" the period end,
+      // which is stored as a date-only value (midnight).
+      const entryWithLines = {
+        ...mockJournalEntry,
+        entryDate: new Date('2026-01-31T19:32:31Z'),
+        fiscalPeriod: {
+          ...mockFiscalPeriod,
+          startDate: new Date('2026-01-01'),
+          endDate: new Date('2026-01-31'),
+        },
+        lines: [mockJournalEntryLine1, mockJournalEntryLine2],
+        isBalanced: true,
+      };
+      journalEntryRepository.findOne.mockResolvedValue(entryWithLines as JournalEntry);
+      fiscalPeriodService.checkPeriodOpen.mockResolvedValue(true);
+      journalEntryRepository.save.mockResolvedValue({
+        ...entryWithLines,
+        status: JournalEntryStatus.POSTED,
+      } as JournalEntry);
+
+      const result = await service.postEntry('entry-1');
+
+      expect(result.status).toBe(JournalEntryStatus.POSTED);
+    });
+
     it('should throw BadRequestException if entry is not balanced', async () => {
       const unbalancedEntry = {
         ...mockJournalEntry,

--- a/backend/src/modules/accounting/services/journal-entry.service.ts
+++ b/backend/src/modules/accounting/services/journal-entry.service.ts
@@ -515,10 +515,16 @@ export class JournalEntryService {
       );
     }
 
-    // Validate entry date falls within fiscal period
+    // Validate entry date falls within fiscal period. Compare date-only:
+    // entryDate may carry a time-of-day (e.g. created via `new Date()`), while the
+    // period bounds are stored as date-only. Normalize all to start-of-day so an
+    // entry on the period's last day is not wrongly rejected (matches validatePeriod).
     const entryDate = new Date(entry.entryDate);
     const periodStart = new Date(entry.fiscalPeriod.startDate);
     const periodEnd = new Date(entry.fiscalPeriod.endDate);
+    entryDate.setUTCHours(0, 0, 0, 0);
+    periodStart.setUTCHours(0, 0, 0, 0);
+    periodEnd.setUTCHours(0, 0, 0, 0);
 
     if (entryDate < periodStart || entryDate > periodEnd) {
       throw new BadRequestException(
@@ -792,10 +798,15 @@ export class JournalEntryService {
       );
     }
 
-    // Validate entry date falls within period
+    // Validate entry date falls within period. Compare date-only (the entry date may
+    // carry a time-of-day while the period bounds are date-only) so an entry on the
+    // period's last day is not wrongly rejected (matches validatePeriod).
     const date = new Date(entryDate);
     const periodStart = new Date(period.startDate);
     const periodEnd = new Date(period.endDate);
+    date.setUTCHours(0, 0, 0, 0);
+    periodStart.setUTCHours(0, 0, 0, 0);
+    periodEnd.setUTCHours(0, 0, 0, 0);
 
     if (date < periodStart || date > periodEnd) {
       throw new BadRequestException(


### PR DESCRIPTION
## Summary
Accounting posts (PO receive, sales fulfillment, payments, stock adjustments — anything routed through journal-entry validation) failed on the **last day** of a fiscal period:

```
400 POST /purchasing/orders/:id/receive
Error: Entry date 2026-06-30 is outside fiscal period range (2026-06-01 to 2026-06-30)
```

## Root cause
`journal-entry.service.ts` compared an `entryDate` that may carry a time-of-day (PO receive sets `receiveDate = new Date()`) against **date-only** fiscal-period bounds, with no normalization. An afternoon entry on the end date is later than the end-date's midnight, so `entryDate > periodEnd` → wrongly rejected. Only manifests on the period's final day — which is why CI was green on 2026-06-29 and red on 2026-06-30. The sibling `fiscalPeriodService.validatePeriod` already normalizes (via `setHours`), so the two diverged within one request.

## Fix
Normalize `entryDate` and both period bounds to **UTC start-of-day** before comparing, at both check sites (`postEntry`, `validateFiscalPeriod`). UTC (not local `setHours`) because date-only DB values parse as UTC midnight and CI/dev run different timezones — local normalization is itself timezone-fragile.

## Tests
- New regression unit test: an entry dated on the period's last day **with a time component** posts successfully (failed before, passes after).
- Backend: lint ✓, full unit suite ✓ (1206 tests). E2E (the originally-failing `purchasing.e2e-spec.ts`) verified by CI.

Closes #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)