### PR TITLE
fix(inventory): populate stock adjustment product dropdown (#838)

### DIFF
--- a/backend/src/common/dto/base-query.dto.spec.ts
+++ b/backend/src/common/dto/base-query.dto.spec.ts
@@ -1,0 +1,42 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { BaseQueryDto } from './base-query.dto';
+
+describe('BaseQueryDto sortOrder', () => {
+  it('accepts lowercase sortOrder and normalizes to uppercase', async () => {
+    const dto = plainToInstance(BaseQueryDto, { sortOrder: 'asc' });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+    expect(dto.sortOrder).toBe('ASC');
+  });
+
+  it('accepts uppercase sortOrder unchanged', async () => {
+    const dto = plainToInstance(BaseQueryDto, { sortOrder: 'DESC' });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+    expect(dto.sortOrder).toBe('DESC');
+  });
+
+  it('rejects a non-direction sortOrder value', async () => {
+    const dto = plainToInstance(BaseQueryDto, { sortOrder: 'sideways' });
+
+    const errors = await validate(dto);
+
+    expect(errors.some((e) => e.property === 'sortOrder')).toBe(true);
+  });
+
+  it('leaves sortOrder undefined when omitted', async () => {
+    const dto = plainToInstance(BaseQueryDto, {});
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+    expect(dto.sortOrder).toBeUndefined();
+  });
+});

--- a/backend/src/common/dto/base-query.dto.ts
+++ b/backend/src/common/dto/base-query.dto.ts
@@ -21,6 +21,7 @@ export class BaseQueryDto {
   sortBy?: string;
 
   @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? value.toUpperCase() : value))
   @IsIn(['ASC', 'DESC'])
   sortOrder?: 'ASC' | 'DESC';
 

--- a/frontend/src/store/api/__tests__/inventoryApi.test.ts
+++ b/frontend/src/store/api/__tests__/inventoryApi.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from 'vitest'
+import { configureStore } from '@reduxjs/toolkit'
+import { describe, expect, it, vi } from 'vitest'
 
+import api from '@/services/api'
 import { inventoryApiSlice } from '@/store/api/inventoryApi'
+
+vi.mock('@/services/api', () => ({
+  default: vi.fn(),
+}))
 
 describe('inventoryApiSlice', () => {
   it('defines core inventory endpoints', () => {
@@ -22,5 +28,27 @@ describe('inventoryApiSlice', () => {
     expect(inventoryApiSlice.endpoints.setCategoryEnabled).toBeDefined()
     expect(inventoryApiSlice.endpoints.checkProductDuplicate).toBeDefined()
     expect(inventoryApiSlice.endpoints.checkCategoryDuplicate).toBeDefined()
+  })
+})
+
+describe('getProducts params', () => {
+  it('sends uppercase sortOrder ASC by default', async () => {
+    vi.mocked(api).mockResolvedValue({ data: { data: [], meta: { total: 0 } } })
+
+    const store = configureStore({
+      reducer: { [inventoryApiSlice.reducerPath]: inventoryApiSlice.reducer },
+      middleware: (getDefaultMiddleware) =>
+        getDefaultMiddleware().concat(inventoryApiSlice.middleware),
+    })
+
+    await store.dispatch(
+      inventoryApiSlice.endpoints.getProducts.initiate(undefined),
+    )
+
+    expect(api).toHaveBeenCalledTimes(1)
+    const sentConfig = vi.mocked(api).mock.calls[0][0] as { params: Record<string, unknown> }
+    expect(sentConfig.params.sortOrder).toBe('ASC')
+    expect(sentConfig.params.isActive).toBe(true)
+    expect(sentConfig.params.sortBy).toBe('name')
   })
 })

--- a/frontend/src/store/api/inventoryApi.ts
+++ b/frontend/src/store/api/inventoryApi.ts
@@ -19,7 +19,7 @@ export const inventoryApiSlice = createApi({
     getProducts: builder.query<PaginatedResponse<Product>, Record<string, unknown> | undefined>({
       query: (params) => ({
         url: '/inventory/products',
-        params: { isActive: true, sortBy: 'name', sortOrder: 'asc', ...(params ?? {}) },
+        params: { isActive: true, sortBy: 'name', sortOrder: 'ASC', ...(params ?? {}) },
       }),
       transformResponse: normalizePaginated<Product>,
       providesTags: ['Product'],


### PR DESCRIPTION
## Problem

Creating a new stock adjustment (Inventory → Stock Adjustments → **+ New Adjustment**) showed an **empty Product dropdown**, blocking stock adjustment creation and manual testing.

Closes #838

## Root cause

`frontend/src/store/api/inventoryApi.ts` sent `sortOrder: 'asc'` (lowercase). `BaseQueryDto.sortOrder` validates with `@IsIn(['ASC', 'DESC'])` — uppercase only — so the request failed:

```
GET /inventory/products?isActive=true&sortBy=name&sortOrder=asc
→ 400 Bad Request: "sortOrder must be one of the following values: ASC, DESC"
```

RTK Query then errored, `productsData` was `undefined`, `products = []`, and the Autocomplete had no options. Other list pages didn't trip this because they send uppercase; the service layer already normalizes with `.toUpperCase()`, so the DTO was the only strict layer.

## Fix

- **Backend (root cause):** `BaseQueryDto.sortOrder` now `@Transform`s the value to uppercase before `@IsIn`, so sort direction is case-insensitive. Fixes all 6 DTOs that extend it (products, categories, purchase orders, suppliers, sales orders, customers).
- **Frontend (consistency):** `getProducts` now sends `sortOrder: 'ASC'`, matching the sibling API slices.

No entity or migration change.

## Tests

- **Backend:** `base-query.dto.spec.ts` (new) — uses `plainToInstance` so `@Transform` actually runs; covers lowercase→ASC, uppercase passthrough, invalid reject, omitted. (4 tests)
- **Frontend:** `inventoryApi.test.ts` — dispatches the real `getProducts` query through a store with mocked axios and asserts the sent params include `sortOrder: 'ASC'`. Guards the regression at the API layer (the page test mocks the query, so it can't).

## Verification

Against the running stack, `?sortOrder=asc` now returns **200** with the 3 active products (previously 400). Backend + frontend targeted suites green; full lint/type-check/test gates per repo rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)