### PR TITLE
feat(inventory): add clickable product summary popover to stock adjustment list

### DIFF
--- a/frontend/src/pages/inventory/__tests__/StockAdjustmentsPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/StockAdjustmentsPage.test.tsx
@@ -20,6 +20,9 @@ vi.mock('@/store/api/inventoryApi', async (importOriginal) => {
     useGetStockAdjustmentsQuery: () => ({ data: { data: mockRows }, isFetching: false, error: undefined }),
     useGetCategoriesQuery: () => ({ data: [] }),
     useCompleteStockAdjustmentMutation: () => [completeSpy, {}],
+    // The item-count popover (StockAdjustmentItemsPopover) uses this lazy query;
+    // stub it so the unwrapped page render doesn't require a Redux <Provider>.
+    useLazyGetStockAdjustmentQuery: () => [vi.fn(), { data: undefined, isFetching: false, isError: false, isUninitialized: true }],
   }
 })
 

--- a/frontend/src/pages/inventory/components/StockAdjustmentItemsPopover.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentItemsPopover.tsx
@@ -58,6 +58,9 @@ export default function StockAdjustmentItemsPopover({ adjustment }: Props) {
         anchorEl={anchorEl}
         onClose={handleClose}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        // Stop the dismiss/backdrop click from bubbling to the row's onClick
+        // (which navigates to the View page). Mirrors RowActionMenu.
+        onClick={(e) => e.stopPropagation()}
       >
         <Box sx={{ p: 2, minWidth: 220 }}>
           {isLoading && (

--- a/frontend/src/pages/inventory/components/StockAdjustmentItemsPopover.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentItemsPopover.tsx
@@ -1,0 +1,99 @@
+import { useState, type MouseEvent } from 'react'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import CircularProgress from '@mui/material/CircularProgress'
+import IconButton from '@mui/material/IconButton'
+import Popover from '@mui/material/Popover'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
+
+import { useLazyGetStockAdjustmentQuery } from '@/store/api/inventoryApi'
+import { formatNumber } from '@/utils/formatters'
+import type { StockAdjustment } from '@/types'
+
+interface Props {
+  adjustment: StockAdjustment
+}
+
+export default function StockAdjustmentItemsPopover({ adjustment }: Props) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+  const [trigger, { data, isFetching, isError }] = useLazyGetStockAdjustmentQuery()
+
+  const count = adjustment.itemCount
+  const label = count === 1 ? '1 item' : `${formatNumber(count)} items`
+
+  if (count === 0) {
+    return <span>{formatNumber(count)}</span>
+  }
+
+  const handleOpen = (event: MouseEvent<HTMLElement>) => {
+    event.stopPropagation()
+    setAnchorEl(event.currentTarget)
+    trigger(adjustment.id, true)
+  }
+
+  const handleClose = () => setAnchorEl(null)
+
+  const handleRetry = () => trigger(adjustment.id, true)
+
+  const items = data?.items ?? []
+
+  return (
+    <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
+      <span>{label}</span>
+      <IconButton
+        size="small"
+        aria-label="Show products"
+        onClick={handleOpen}
+      >
+        <InfoOutlinedIcon fontSize="small" />
+      </IconButton>
+      <Popover
+        open={Boolean(anchorEl)}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      >
+        <Box sx={{ p: 2, minWidth: 220 }} onClick={(e) => e.stopPropagation()}>
+          {isFetching && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 1 }}>
+              <CircularProgress size={20} />
+            </Box>
+          )}
+          {isError && (
+            <Stack spacing={1} sx={{ alignItems: 'flex-start' }}>
+              <Typography variant="body2" color="error">
+                Failed to load products.
+              </Typography>
+              <Button size="small" onClick={handleRetry}>Retry</Button>
+            </Stack>
+          )}
+          {!isFetching && !isError && (
+            <>
+              <Stack spacing={0.5}>
+                {items.map((item) => (
+                  <Box
+                    key={item.id}
+                    sx={{ display: 'flex', justifyContent: 'space-between', gap: 2 }}
+                  >
+                    <Typography variant="body2">{item.product.name}</Typography>
+                    <Typography
+                      variant="body2"
+                      sx={{ color: item.difference > 0 ? 'success.main' : 'error.main', fontWeight: 600 }}
+                    >
+                      {item.difference > 0 ? '+' : ''}{formatNumber(item.difference)}
+                    </Typography>
+                  </Box>
+                ))}
+              </Stack>
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+                Total: {label}
+              </Typography>
+            </>
+          )}
+        </Box>
+      </Popover>
+    </Box>
+  )
+}

--- a/frontend/src/pages/inventory/components/StockAdjustmentItemsPopover.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentItemsPopover.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 export default function StockAdjustmentItemsPopover({ adjustment }: Props) {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
-  const [trigger, { data, isFetching, isError }] = useLazyGetStockAdjustmentQuery()
+  const [trigger, { data, isFetching, isError, isUninitialized }] = useLazyGetStockAdjustmentQuery()
 
   const count = adjustment.itemCount
   const label = count === 1 ? '1 item' : `${formatNumber(count)} items`
@@ -38,6 +38,10 @@ export default function StockAdjustmentItemsPopover({ adjustment }: Props) {
   const handleRetry = () => trigger(adjustment.id, true)
 
   const items = data?.items ?? []
+  // Show the spinner until the first fetch settles: before the initial trigger
+  // resolves, isFetching can briefly be false, which would otherwise flash an
+  // empty product list.
+  const isLoading = isFetching || isUninitialized
 
   return (
     <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
@@ -55,13 +59,13 @@ export default function StockAdjustmentItemsPopover({ adjustment }: Props) {
         onClose={handleClose}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
       >
-        <Box sx={{ p: 2, minWidth: 220 }} onClick={(e) => e.stopPropagation()}>
-          {isFetching && (
+        <Box sx={{ p: 2, minWidth: 220 }}>
+          {isLoading && (
             <Box sx={{ display: 'flex', justifyContent: 'center', py: 1 }}>
               <CircularProgress size={20} />
             </Box>
           )}
-          {isError && (
+          {isError && !isLoading && (
             <Stack spacing={1} sx={{ alignItems: 'flex-start' }}>
               <Typography variant="body2" color="error">
                 Failed to load products.
@@ -69,7 +73,7 @@ export default function StockAdjustmentItemsPopover({ adjustment }: Props) {
               <Button size="small" onClick={handleRetry}>Retry</Button>
             </Stack>
           )}
-          {!isFetching && !isError && (
+          {!isLoading && !isError && (
             <>
               <Stack spacing={0.5}>
                 {items.map((item) => (
@@ -80,7 +84,15 @@ export default function StockAdjustmentItemsPopover({ adjustment }: Props) {
                     <Typography variant="body2">{item.product.name}</Typography>
                     <Typography
                       variant="body2"
-                      sx={{ color: item.difference > 0 ? 'success.main' : 'error.main', fontWeight: 600 }}
+                      sx={{
+                        color:
+                          item.difference > 0
+                            ? 'success.main'
+                            : item.difference < 0
+                              ? 'error.main'
+                              : 'text.secondary',
+                        fontWeight: 600,
+                      }}
                     >
                       {item.difference > 0 ? '+' : ''}{formatNumber(item.difference)}
                     </Typography>

--- a/frontend/src/pages/inventory/components/StockAdjustmentList.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentList.tsx
@@ -7,6 +7,7 @@ import { StatusChip } from '@/components/common/StatusChip'
 import { formatCurrency } from '@/utils/currency'
 import { formatDate, formatNumber } from '@/utils/formatters'
 import type { StockAdjustment } from '@/types'
+import StockAdjustmentItemsPopover from './StockAdjustmentItemsPopover'
 
 interface Props {
   rows: StockAdjustment[]
@@ -24,7 +25,7 @@ export default function StockAdjustmentList({ rows, total, loading, paginationSl
     { key: 'adjustmentNumber', width: '30%', render: (a) => a.adjustmentNumber },
     { key: 'date', width: '16%', render: (a) => formatDate(a.adjustmentDate) },
     { key: 'status', width: '14%', raw: true, render: (a) => <StatusChip status={a.status} /> },
-    { key: 'itemCount', width: '14%', render: (a) => formatNumber(a.itemCount) },
+    { key: 'itemCount', width: '14%', raw: true, render: (a) => <StockAdjustmentItemsPopover adjustment={a} /> },
     { key: 'totalValue', width: '18%', render: (a) => formatCurrency(a.totalValue) },
     {
       key: 'actions', width: '8%', raw: true,

--- a/frontend/src/pages/inventory/components/__tests__/StockAdjustmentList.test.tsx
+++ b/frontend/src/pages/inventory/components/__tests__/StockAdjustmentList.test.tsx
@@ -6,7 +6,7 @@ import StockAdjustmentList from '../StockAdjustmentList'
 const h = vi.hoisted(() => ({
   triggerMock: vi.fn(),
   navigateMock: vi.fn(),
-  lazyState: { data: undefined as any, isFetching: false, isError: false },
+  lazyState: { data: undefined as any, isFetching: false, isError: false, isUninitialized: false },
 }))
 
 vi.mock('@/store/api/inventoryApi', () => ({
@@ -41,6 +41,7 @@ beforeEach(() => {
   h.lazyState.data = detail
   h.lazyState.isFetching = false
   h.lazyState.isError = false
+  h.lazyState.isUninitialized = false
 })
 
 it('renders adjustment numbers and status chips', () => {
@@ -93,4 +94,15 @@ it('shows a retry button on error that re-triggers the fetch', async () => {
   h.triggerMock.mockClear()
   fireEvent.click(retry)
   expect(h.triggerMock).toHaveBeenCalledWith('a1', true)
+})
+
+it('shows a spinner (not an empty list) before the first fetch settles', async () => {
+  // Uninitialized: trigger fired but not yet resolved — no data, not error.
+  h.lazyState.data = undefined
+  h.lazyState.isUninitialized = true
+  renderList()
+  fireEvent.click(screen.getAllByRole('button', { name: /show products/i })[0])
+  await waitFor(() => expect(screen.getByRole('progressbar')).toBeInTheDocument())
+  // No empty "Total:" footer while loading.
+  expect(screen.queryByText(/Total:/)).not.toBeInTheDocument()
 })

--- a/frontend/src/pages/inventory/components/__tests__/StockAdjustmentList.test.tsx
+++ b/frontend/src/pages/inventory/components/__tests__/StockAdjustmentList.test.tsx
@@ -77,6 +77,14 @@ it('does NOT navigate when the icon is clicked (stopPropagation)', () => {
   expect(h.navigateMock).not.toHaveBeenCalled()
 })
 
+// NOTE: the "click outside closes the popover without navigating to the row's
+// View page" behavior relies on the MUI Popover's viewport-covering backdrop
+// catching the dismiss click. That is real-browser overlay hit-testing which
+// jsdom does not model (it dispatches synthetic clicks straight at a node,
+// ignoring the portal-rendered backdrop). So this is verified manually in the
+// browser, not here. The guard itself is the `onClick={(e) => e.stopPropagation()}`
+// on the <Popover> in StockAdjustmentItemsPopover (mirrors RowActionMenu).
+
 it('closes the popover on Escape', async () => {
   renderList()
   fireEvent.click(screen.getAllByRole('button', { name: /show products/i })[0])

--- a/frontend/src/pages/inventory/components/__tests__/StockAdjustmentList.test.tsx
+++ b/frontend/src/pages/inventory/components/__tests__/StockAdjustmentList.test.tsx
@@ -1,15 +1,96 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import { vi } from 'vitest'
 import StockAdjustmentList from '../StockAdjustmentList'
+
+const h = vi.hoisted(() => ({
+  triggerMock: vi.fn(),
+  navigateMock: vi.fn(),
+  lazyState: { data: undefined as any, isFetching: false, isError: false },
+}))
+
+vi.mock('@/store/api/inventoryApi', () => ({
+  useLazyGetStockAdjustmentQuery: () => [h.triggerMock, h.lazyState],
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<any>('react-router-dom')
+  return { ...actual, useNavigate: () => h.navigateMock }
+})
+
+const detail = {
+  id: 'a1',
+  items: [
+    { id: 'i1', product: { id: 'p1', name: 'Widget A' }, difference: 2 },
+    { id: 'i2', product: { id: 'p2', name: 'Cable X' }, difference: -1 },
+  ],
+}
 
 const rows = [
   { id: 'a1', adjustmentNumber: 'SA-000001', adjustmentDate: '2026-06-29', status: 'draft', itemCount: 2, totalValue: 100 },
   { id: 'a2', adjustmentNumber: 'SA-000002', adjustmentDate: '2026-06-28', status: 'completed', itemCount: 1, totalValue: 50 },
+  { id: 'a3', adjustmentNumber: 'SA-000003', adjustmentDate: '2026-06-27', status: 'draft', itemCount: 0, totalValue: 0 },
 ]
 
+const renderList = () =>
+  render(<MemoryRouter><StockAdjustmentList rows={rows as any} total={3} loading={false} paginationSlot={null} /></MemoryRouter>)
+
+beforeEach(() => {
+  h.triggerMock.mockReset()
+  h.navigateMock.mockReset()
+  h.lazyState.data = detail
+  h.lazyState.isFetching = false
+  h.lazyState.isError = false
+})
+
 it('renders adjustment numbers and status chips', () => {
-  render(<MemoryRouter><StockAdjustmentList rows={rows as any} total={2} loading={false} paginationSlot={null} /></MemoryRouter>)
+  renderList()
   expect(screen.getByText('SA-000001')).toBeInTheDocument()
-  expect(screen.getByText('Draft')).toBeInTheDocument()
+  expect(screen.getAllByText('Draft')).toHaveLength(2)
   expect(screen.getByText('Completed')).toBeInTheDocument()
+})
+
+it('pluralizes item count: plural, singular, and zero without icon', () => {
+  renderList()
+  expect(screen.getByText('2 items')).toBeInTheDocument()
+  expect(screen.getByText('1 item')).toBeInTheDocument()
+  expect(screen.getByText('0')).toBeInTheDocument()
+  expect(screen.getAllByRole('button', { name: /show products/i })).toHaveLength(2)
+})
+
+it('opens popover on icon click and shows product names with signed diffs', async () => {
+  renderList()
+  const icon = screen.getAllByRole('button', { name: /show products/i })[0]
+  fireEvent.click(icon)
+  expect(h.triggerMock).toHaveBeenCalledWith('a1', true)
+  await waitFor(() => expect(screen.getByText('Widget A')).toBeInTheDocument())
+  expect(screen.getByText('Cable X')).toBeInTheDocument()
+  expect(screen.getByText('+2')).toBeInTheDocument()
+  expect(screen.getByText('-1')).toBeInTheDocument()
+})
+
+it('does NOT navigate when the icon is clicked (stopPropagation)', () => {
+  renderList()
+  const icon = screen.getAllByRole('button', { name: /show products/i })[0]
+  fireEvent.click(icon)
+  expect(h.navigateMock).not.toHaveBeenCalled()
+})
+
+it('closes the popover on Escape', async () => {
+  renderList()
+  fireEvent.click(screen.getAllByRole('button', { name: /show products/i })[0])
+  await waitFor(() => expect(screen.getByText('Widget A')).toBeInTheDocument())
+  fireEvent.keyDown(screen.getByText('Widget A'), { key: 'Escape', code: 'Escape' })
+  await waitFor(() => expect(screen.queryByText('Widget A')).not.toBeInTheDocument())
+})
+
+it('shows a retry button on error that re-triggers the fetch', async () => {
+  h.lazyState.data = undefined
+  h.lazyState.isError = true
+  renderList()
+  fireEvent.click(screen.getAllByRole('button', { name: /show products/i })[0])
+  const retry = await screen.findByRole('button', { name: /retry/i })
+  h.triggerMock.mockClear()
+  fireEvent.click(retry)
+  expect(h.triggerMock).toHaveBeenCalledWith('a1', true)
 })


### PR DESCRIPTION
## Summary

Adds a clickable info icon to the Item Count column on the Stock Adjustments list. Clicking it opens a popover listing each product and its signed quantity change, so users can identify what's in an adjustment without opening the View page.

Closes #840

## Approach

Frontend-only. New self-contained `StockAdjustmentItemsPopover` component:
- Renders the item-count cell as `N items ⓘ` (singular `1 item`; `0` → count only, no icon)
- On icon click: opens the popover immediately, then lazy-fetches the adjustment via the existing View endpoint (`useLazyGetStockAdjustmentQuery`, `preferCacheValue: true` so cached rows don't refetch)
- Shows product name + signed diff (green increase / red decrease / neutral for zero), plus a total footer
- Loading / error+retry / data render branches are mutually exclusive
- Icon click calls `stopPropagation()` so the row's navigate-to-View doesn't fire

No backend, DTO, or migration changes — reuses `GET /inventory/stock-adjustments/:id`. The compact list DTO is intentionally left unwidened (see design doc); if first-open latency becomes a problem, a lightweight preview endpoint is the documented fallback.

## Accessibility
- Click/tap based (not hover), `aria-label="Show products"`, keyboard-openable
- MUI `Popover` closes on Escape and outside click; repositions within viewport (desktop + mobile)

## Testing
7 tests: pluralization + zero-no-icon, popover open + product/signed-diff display, icon-does-not-navigate (regression), Escape close, retry on error, spinner-before-first-fetch (no empty-list flash).

Verification: 7/7 tests pass, `tsc --noEmit` clean, `eslint --max-warnings 0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)