### PR TITLE
fix(inventory): remove invalid Cancelled status from stock adjustment filter

### DIFF
--- a/frontend/src/components/filters/FilterStockAdjustmentStatus.tsx
+++ b/frontend/src/components/filters/FilterStockAdjustmentStatus.tsx
@@ -3,7 +3,6 @@ import { FilterSelect } from './FilterSelect'
 const STOCK_ADJUSTMENT_STATUS_OPTIONS = [
   { value: 'draft', label: 'Draft' },
   { value: 'completed', label: 'Completed' },
-  { value: 'cancelled', label: 'Cancelled' },
 ]
 
 interface Props {

--- a/frontend/src/components/filters/__tests__/FilterStockAdjustmentStatus.test.tsx
+++ b/frontend/src/components/filters/__tests__/FilterStockAdjustmentStatus.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { FilterStockAdjustmentStatus } from '../FilterStockAdjustmentStatus'
+
+describe('FilterStockAdjustmentStatus', () => {
+  it('renders with Status label', () => {
+    render(<FilterStockAdjustmentStatus field="status" value={null} onChange={vi.fn()} />)
+    expect(screen.getByLabelText(/status/i)).toBeInTheDocument()
+  })
+
+  it('shows exactly All, Draft, and Completed options', async () => {
+    render(<FilterStockAdjustmentStatus field="status" value={null} onChange={vi.fn()} />)
+    await userEvent.click(screen.getByRole('combobox'))
+    // FilterSelect renders the empty "All" MenuItem plus the option list.
+    const optionNames = screen.getAllByRole('option').map((o) => o.textContent)
+    expect(optionNames).toEqual(['All', 'Draft', 'Completed'])
+  })
+})

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -141,7 +141,7 @@ export interface StockAdjustment {
   id: string;
   adjustmentNumber: string;
   adjustmentDate: Date;
-  status: 'draft' | 'completed' | 'cancelled';
+  status: 'draft' | 'completed';
   notes?: string;
   itemCount: number;
   totalValue: number;

--- a/frontend/src/utils/filterBar.url.test.ts
+++ b/frontend/src/utils/filterBar.url.test.ts
@@ -373,3 +373,30 @@ describe('compare field type — getManagedParamKeys', () => {
     expect(keys.filter((k) => k.startsWith('sales_compareWith'))).toHaveLength(1)
   })
 })
+
+describe('parseFilters — stock-adjustment-status field', () => {
+  interface SaFilters {
+    search: string
+    status: string | null
+  }
+
+  const saConfig: FilterBarConfig<SaFilters> = {
+    search: { placeholder: 'Search...' },
+    fields: [
+      { field: 'status', label: 'Status', type: 'stock-adjustment-status' },
+    ],
+    defaults: { search: '', status: null },
+  }
+
+  it('rejects cancelled and returns null', () => {
+    expect(parseFilters(new URLSearchParams('status=cancelled'), saConfig).status).toBeNull()
+  })
+
+  it('accepts draft', () => {
+    expect(parseFilters(new URLSearchParams('status=draft'), saConfig).status).toBe('draft')
+  })
+
+  it('accepts completed', () => {
+    expect(parseFilters(new URLSearchParams('status=completed'), saConfig).status).toBe('completed')
+  })
+})

--- a/frontend/src/utils/filterBar.url.ts
+++ b/frontend/src/utils/filterBar.url.ts
@@ -203,7 +203,7 @@ export function parseFilters<TFilters extends object>(
         const VALID_ROLE = ['admin', 'manager', 'sales_staff', 'inventory_staff', 'procurement_staff']
         result[fieldKey] = VALID_ROLE.includes(raw) ? raw : (defaultValue ?? null)
       } else if (field.type === 'stock-adjustment-status') {
-        const VALID_STOCK_ADJUSTMENT_STATUS = ['draft', 'completed', 'cancelled']
+        const VALID_STOCK_ADJUSTMENT_STATUS = ['draft', 'completed']
         result[fieldKey] = VALID_STOCK_ADJUSTMENT_STATUS.includes(raw) ? raw : (defaultValue ?? null)
       } else if (field.type === 'order-status') {
         const VALID_ORDER_STATUS = fieldKey === 'status'


### PR DESCRIPTION
## Summary
Stock adjustments only support `draft` and `completed` (backend enum `StockAdjustmentStatus`), but the frontend carried a phantom `cancelled` in three places. Removed it from every path so the frontend matches the backend enum.

## Changes
- **`FilterStockAdjustmentStatus.tsx`** — drop the `Cancelled` dropdown option (the visible bug).
- **`filterBar.url.ts`** — narrow `VALID_STOCK_ADJUSTMENT_STATUS` to `['draft', 'completed']`, so `?status=cancelled` in the URL no longer slips past the allow-list to the API (second entry point into the same invalid state).
- **`types/index.ts`** — narrow `StockAdjustment.status` to `'draft' | 'completed'`.

Left `StatusChip/statusColors.ts` untouched — its `cancelled` color is valid for sales orders, purchase orders, and payments.

## Tests
- Dropdown renders exactly `All`, `Draft`, `Completed`.
- URL parsing for `stock-adjustment-status` rejects `cancelled` → `null`, and still accepts `draft` / `completed`.

## Verification
`npm run lint` ✓, `npm run type-check` ✓, affected test files pass (35/35).

Closes #842

🤖 Generated with [Claude Code](https://claude.com/claude-code)