### PR TITLE
fix(inventory): default stock adjustments list to newest-first by date

### DIFF
--- a/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
@@ -41,8 +41,8 @@ export default function StockAdjustmentsPage() {
   const navigate = useNavigate()
   const [page, setPage] = useState(1)
   const [limit, setLimit] = useState<number>(PAGINATION.defaultPageSize)
-  const [sortBy, setSortBy] = useState('adjustmentNumber')
-  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
+  const [sortBy, setSortBy] = useState('adjustmentDate')
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
   const [completeTarget, setCompleteTarget] = useState<string | null>(null)
   const [revertTarget, setRevertTarget] = useState<string | null>(null)
 
@@ -122,7 +122,7 @@ export default function StockAdjustmentsPage() {
       handlers={handlers}
       hasActiveFilters={hasActiveFilters}
       searchInputRef={searchInputRef}
-      sort={{ field: 'adjustmentNumber', sortBy, sortOrder, onSort: handleSort }}
+      sort={{ field: 'adjustmentDate', sortBy, sortOrder, onSort: handleSort }}
       isFetching={isFetching}
       error={error ? 'Failed to load stock adjustments.' : null}
       tableSlot={(

--- a/frontend/src/pages/inventory/__tests__/StockAdjustmentsPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/StockAdjustmentsPage.test.tsx
@@ -3,11 +3,12 @@ import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, expect, it, vi } from 'vitest'
 
-const { completeSpy, unwrapMock, showSuccessSpy, showErrorSpy } = vi.hoisted(() => ({
+const { completeSpy, unwrapMock, showSuccessSpy, showErrorSpy, getAdjustmentsSpy } = vi.hoisted(() => ({
   completeSpy: vi.fn(),
   unwrapMock: vi.fn(),
   showSuccessSpy: vi.fn(),
   showErrorSpy: vi.fn(),
+  getAdjustmentsSpy: vi.fn(),
 }))
 
 vi.mock('@/store/api/inventoryApi', async (importOriginal) => {
@@ -17,7 +18,10 @@ vi.mock('@/store/api/inventoryApi', async (importOriginal) => {
   ]
   return {
     ...actual,
-    useGetStockAdjustmentsQuery: () => ({ data: { data: mockRows }, isFetching: false, error: undefined }),
+    useGetStockAdjustmentsQuery: (params: unknown) => {
+      getAdjustmentsSpy(params)
+      return { data: { data: mockRows }, isFetching: false, error: undefined }
+    },
     useGetCategoriesQuery: () => ({ data: [] }),
     useCompleteStockAdjustmentMutation: () => [completeSpy, {}],
     // The item-count popover (StockAdjustmentItemsPopover) uses this lazy query;
@@ -57,6 +61,7 @@ beforeEach(() => {
   unwrapMock.mockReset()
   showSuccessSpy.mockReset()
   showErrorSpy.mockReset()
+  getAdjustmentsSpy.mockReset()
   completeSpy.mockReturnValue({ unwrap: unwrapMock })
 })
 
@@ -94,5 +99,14 @@ it('keeps non-zero fractional digits when tidying the error message', async () =
 
   await waitFor(() =>
     expect(showErrorSpy).toHaveBeenCalledWith('Insufficient stock. Available: 1.5, Requested: 15'),
+  )
+})
+
+it('defaults the list sort to newest-first by adjustment date', () => {
+  renderPage()
+
+  expect(getAdjustmentsSpy).toHaveBeenNthCalledWith(
+    1,
+    expect.objectContaining({ sortBy: 'adjustmentDate', sortOrder: 'DESC' }),
   )
 })


### PR DESCRIPTION
## Problem
Stock Adjustments list defaulted to `adjustmentNumber` ascending → oldest-first, contradicting the redesign spec which expects newest-first by Date. Recent activity was hard to find.

## Fix
Frontend-only. `StockAdjustmentsPage` initialized its sort state to `adjustmentNumber`/`asc` and sent that to the API on every load. Changed the initial sort state and the sort-config `field` to `adjustmentDate`/`desc`. Backend already supports `adjustmentDate` sorting — no backend change, no migration.

- `StockAdjustmentsPage.tsx:44-45,125` — sort default `adjustmentNumber`/`asc` → `adjustmentDate`/`desc`
- `StockAdjustmentsPage.test.tsx` — refactored the `useGetStockAdjustmentsQuery` mock to a param-capturing spy; added a test asserting the initial query uses `sortBy: 'adjustmentDate'`, `sortOrder: 'DESC'`

## Verification
- `npm run lint` ✅
- `npm run type-check` ✅
- Full frontend suite: 201 files / 1425 tests pass ✅

Closes #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)