### PR TITLE
fix(inventory): stock adjustments empty state reads 'No adjustments found'

### DIFF
--- a/frontend/src/components/common/EntityTable.test.tsx
+++ b/frontend/src/components/common/EntityTable.test.tsx
@@ -153,4 +153,24 @@ describe('EntityTable', () => {
 
     expect(screen.getByText('Searching...')).toBeInTheDocument()
   })
+
+  it('uses emptyLabel for the empty state when provided', () => {
+    render(
+      <EntityTable
+        rows={[]}
+        columns={columns}
+        loading={false}
+        total={0}
+        label="Stock Adjustments"
+        emptyLabel="adjustments"
+        selectedId={undefined}
+        focusedIndex={-1}
+        onSelect={vi.fn()}
+        listRef={{ current: null }}
+      />,
+    )
+
+    expect(screen.getByText('No adjustments found')).toBeInTheDocument()
+    expect(screen.queryByText('No Stock Adjustments found')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/common/EntityTable.tsx
+++ b/frontend/src/components/common/EntityTable.tsx
@@ -30,6 +30,7 @@ export interface EntityTableProps<T extends { id: string }> {
   loading: boolean
   total: number
   label: string
+  emptyLabel?: string
   selectedId?: string
   focusedIndex: number
   onSelect: (row: T) => void
@@ -112,6 +113,7 @@ function EntityTable<T extends { id: string }>({
   loading,
   total,
   label,
+  emptyLabel,
   selectedId,
   focusedIndex,
   onSelect,
@@ -217,7 +219,7 @@ function EntityTable<T extends { id: string }>({
                             variant="body2"
                             sx={{ color: 'text.secondary', textAlign: 'center', py: 2 }}
                           >
-                            No {label} found
+                            No {emptyLabel ?? label} found
                           </Typography>
                         </TableCell>
                       </TableRow>

--- a/frontend/src/pages/inventory/components/StockAdjustmentList.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentList.tsx
@@ -51,6 +51,7 @@ export default function StockAdjustmentList({ rows, total, loading, paginationSl
       loading={loading}
       total={total}
       label="Stock Adjustments"
+      emptyLabel="adjustments"
       headers={['Adjustment Number', 'Date', 'Status', 'Item Count', 'Total Value', 'Actions']}
       showHeader={false}
       focusedIndex={-1}

--- a/frontend/src/pages/inventory/components/__tests__/StockAdjustmentList.test.tsx
+++ b/frontend/src/pages/inventory/components/__tests__/StockAdjustmentList.test.tsx
@@ -77,7 +77,16 @@ it('does NOT navigate when the icon is clicked (stopPropagation)', () => {
   expect(h.navigateMock).not.toHaveBeenCalled()
 })
 
-// NOTE: the "click outside closes the popover without navigating to the row's
+it('shows "No adjustments found" when there are no rows', () => {
+  render(
+    <MemoryRouter>
+      <StockAdjustmentList rows={[] as any} total={0} loading={false} paginationSlot={null} />
+    </MemoryRouter>,
+  )
+  expect(screen.getByText('No adjustments found')).toBeInTheDocument()
+})
+
+  // NOTE: the "click outside closes the popover without navigating to the row's
 // View page" behavior relies on the MUI Popover's viewport-covering backdrop
 // catching the dismiss click. That is real-browser overlay hit-testing which
 // jsdom does not model (it dispatches synthetic clicks straight at a node,

--- a/frontend/src/pages/inventory/components/__tests__/StockAdjustmentList.test.tsx
+++ b/frontend/src/pages/inventory/components/__tests__/StockAdjustmentList.test.tsx
@@ -77,16 +77,7 @@ it('does NOT navigate when the icon is clicked (stopPropagation)', () => {
   expect(h.navigateMock).not.toHaveBeenCalled()
 })
 
-it('shows "No adjustments found" when there are no rows', () => {
-  render(
-    <MemoryRouter>
-      <StockAdjustmentList rows={[] as any} total={0} loading={false} paginationSlot={null} />
-    </MemoryRouter>,
-  )
-  expect(screen.getByText('No adjustments found')).toBeInTheDocument()
-})
-
-  // NOTE: the "click outside closes the popover without navigating to the row's
+// NOTE: the "click outside closes the popover without navigating to the row's
 // View page" behavior relies on the MUI Popover's viewport-covering backdrop
 // catching the dismiss click. That is real-browser overlay hit-testing which
 // jsdom does not model (it dispatches synthetic clicks straight at a node,
@@ -122,4 +113,13 @@ it('shows a spinner (not an empty list) before the first fetch settles', async (
   await waitFor(() => expect(screen.getByRole('progressbar')).toBeInTheDocument())
   // No empty "Total:" footer while loading.
   expect(screen.queryByText(/Total:/)).not.toBeInTheDocument()
+})
+
+it('shows "No adjustments found" when there are no rows', () => {
+  render(
+    <MemoryRouter>
+      <StockAdjustmentList rows={[] as any} total={0} loading={false} paginationSlot={null} />
+    </MemoryRouter>,
+  )
+  expect(screen.getByText('No adjustments found')).toBeInTheDocument()
 })


### PR DESCRIPTION
## Problem
Stock Adjustments list empty state rendered `No Stock Adjustments found` via the generic `EntityTable` label. Redesign spec expects `No adjustments found`.

Root cause: `EntityTable`'s single `label` prop drove both the header title (`{label} ({total})`) and the empty message (`No {label} found`), so no single value satisfied both.

## Fix
- Add optional `emptyLabel?: string` to `EntityTable`, defaulting to `label`. Empty state renders `No {emptyLabel ?? label} found`; header keeps using `label`.
- `StockAdjustmentList` passes `emptyLabel="adjustments"` while keeping `label="Stock Adjustments"`.
- Backwards-compatible — the other 15 `EntityTable` consumers are untouched.

## Result
- Empty state: `No adjustments found`
- Header title: `Stock Adjustments` (unchanged)

## Out of scope
Filtered-empty copy (`No adjustments match filters`) — needs filter-awareness plumbing into `EntityTable`; separate work.

## Testing
- `EntityTable` test: `emptyLabel` overrides empty-state text (+ negative assert)
- `StockAdjustmentList` test: `No adjustments found` renders for empty list
- `cd frontend && npm run lint && npm run type-check && npm run test` — all green (597 tests)

Closes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)