### PR TITLE
fix(inventory): stock adjustments filtered empty state reads 'No adjustments match filters'

### DIFF
--- a/frontend/src/components/common/EntityTable.test.tsx
+++ b/frontend/src/components/common/EntityTable.test.tsx
@@ -173,4 +173,67 @@ describe('EntityTable', () => {
     expect(screen.getByText('No adjustments found')).toBeInTheDocument()
     expect(screen.queryByText('No Stock Adjustments found')).not.toBeInTheDocument()
   })
+
+  it('shows filtered empty state when hasActiveFilters and emptyFilteredLabel provided', () => {
+    render(
+      <EntityTable
+        rows={[]}
+        columns={columns}
+        loading={false}
+        total={0}
+        label="Stock Adjustments"
+        emptyFilteredLabel="adjustments"
+        hasActiveFilters={true}
+        selectedId={undefined}
+        focusedIndex={-1}
+        onSelect={vi.fn()}
+        listRef={{ current: null }}
+      />,
+    )
+
+    expect(screen.getByText('No adjustments match filters')).toBeInTheDocument()
+    expect(screen.queryByText('No adjustments found')).not.toBeInTheDocument()
+  })
+
+  it('shows unfiltered empty state when hasActiveFilters is false', () => {
+    render(
+      <EntityTable
+        rows={[]}
+        columns={columns}
+        loading={false}
+        total={0}
+        label="Stock Adjustments"
+        emptyLabel="adjustments"
+        emptyFilteredLabel="adjustments"
+        hasActiveFilters={false}
+        selectedId={undefined}
+        focusedIndex={-1}
+        onSelect={vi.fn()}
+        listRef={{ current: null }}
+      />,
+    )
+
+    expect(screen.getByText('No adjustments found')).toBeInTheDocument()
+    expect(screen.queryByText('No adjustments match filters')).not.toBeInTheDocument()
+  })
+
+  it('falls back to emptyLabel for filtered copy when emptyFilteredLabel is omitted', () => {
+    render(
+      <EntityTable
+        rows={[]}
+        columns={columns}
+        loading={false}
+        total={0}
+        label="Stock Adjustments"
+        emptyLabel="adjustments"
+        hasActiveFilters={true}
+        selectedId={undefined}
+        focusedIndex={-1}
+        onSelect={vi.fn()}
+        listRef={{ current: null }}
+      />,
+    )
+
+    expect(screen.getByText('No adjustments match filters')).toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/common/EntityTable.tsx
+++ b/frontend/src/components/common/EntityTable.tsx
@@ -31,6 +31,8 @@ export interface EntityTableProps<T extends { id: string }> {
   total: number
   label: string
   emptyLabel?: string
+  emptyFilteredLabel?: string
+  hasActiveFilters?: boolean
   selectedId?: string
   focusedIndex: number
   onSelect: (row: T) => void
@@ -114,6 +116,8 @@ function EntityTable<T extends { id: string }>({
   total,
   label,
   emptyLabel,
+  emptyFilteredLabel,
+  hasActiveFilters,
   selectedId,
   focusedIndex,
   onSelect,
@@ -123,6 +127,13 @@ function EntityTable<T extends { id: string }>({
   headers,
   paginationSlot,
 }: EntityTableProps<T>) {
+  const emptyName = hasActiveFilters
+    ? emptyFilteredLabel ?? emptyLabel ?? label
+    : emptyLabel ?? label
+  const emptyMessage = hasActiveFilters
+    ? `No ${emptyName} match filters`
+    : `No ${emptyName} found`
+
   return (
     <Paper sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       {showHeader && (
@@ -219,7 +230,7 @@ function EntityTable<T extends { id: string }>({
                             variant="body2"
                             sx={{ color: 'text.secondary', textAlign: 'center', py: 2 }}
                           >
-                            No {emptyLabel ?? label} found
+                            {emptyMessage}
                           </Typography>
                         </TableCell>
                       </TableRow>

--- a/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentsPage.tsx
@@ -131,6 +131,7 @@ export default function StockAdjustmentsPage() {
             rows={pageRows}
             total={total}
             loading={isFetching}
+            hasActiveFilters={hasActiveFilters}
             paginationSlot={(
               <PagePagination
                 total={total}

--- a/frontend/src/pages/inventory/components/StockAdjustmentList.tsx
+++ b/frontend/src/pages/inventory/components/StockAdjustmentList.tsx
@@ -14,11 +14,12 @@ interface Props {
   total: number
   loading: boolean
   paginationSlot: ReactNode
+  hasActiveFilters: boolean
   onComplete?: (a: StockAdjustment) => void
   onRevert?: (a: StockAdjustment) => void
 }
 
-export default function StockAdjustmentList({ rows, total, loading, paginationSlot, onComplete, onRevert }: Props) {
+export default function StockAdjustmentList({ rows, total, loading, paginationSlot, hasActiveFilters, onComplete, onRevert }: Props) {
   const navigate = useNavigate()
 
   const columns: ColumnConfig<StockAdjustment>[] = [
@@ -52,6 +53,8 @@ export default function StockAdjustmentList({ rows, total, loading, paginationSl
       total={total}
       label="Stock Adjustments"
       emptyLabel="adjustments"
+      emptyFilteredLabel="adjustments"
+      hasActiveFilters={hasActiveFilters}
       headers={['Adjustment Number', 'Date', 'Status', 'Item Count', 'Total Value', 'Actions']}
       showHeader={false}
       focusedIndex={-1}

--- a/frontend/src/pages/inventory/components/__tests__/StockAdjustmentList.test.tsx
+++ b/frontend/src/pages/inventory/components/__tests__/StockAdjustmentList.test.tsx
@@ -33,7 +33,7 @@ const rows = [
 ]
 
 const renderList = () =>
-  render(<MemoryRouter><StockAdjustmentList rows={rows as any} total={3} loading={false} paginationSlot={null} /></MemoryRouter>)
+  render(<MemoryRouter><StockAdjustmentList rows={rows as any} total={3} loading={false} paginationSlot={null} hasActiveFilters={false} /></MemoryRouter>)
 
 beforeEach(() => {
   h.triggerMock.mockReset()
@@ -115,11 +115,20 @@ it('shows a spinner (not an empty list) before the first fetch settles', async (
   expect(screen.queryByText(/Total:/)).not.toBeInTheDocument()
 })
 
-it('shows "No adjustments found" when there are no rows', () => {
+it('shows "No adjustments found" when there are no rows and no active filters', () => {
   render(
     <MemoryRouter>
-      <StockAdjustmentList rows={[] as any} total={0} loading={false} paginationSlot={null} />
+      <StockAdjustmentList rows={[] as any} total={0} loading={false} paginationSlot={null} hasActiveFilters={false} />
     </MemoryRouter>,
   )
   expect(screen.getByText('No adjustments found')).toBeInTheDocument()
+})
+
+it('shows "No adjustments match filters" when there are no rows and filters are active', () => {
+  render(
+    <MemoryRouter>
+      <StockAdjustmentList rows={[] as any} total={0} loading={false} paginationSlot={null} hasActiveFilters={true} />
+    </MemoryRouter>,
+  )
+  expect(screen.getByText('No adjustments match filters')).toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary
Stock adjustments list now shows `No adjustments match filters` when filters are active and no rows match, instead of the generic `No adjustments found` empty-state copy.

Closes #851

## Changes
- **`EntityTable`**: added optional `hasActiveFilters` & `emptyFilteredLabel` props. Empty state renders `No {name} match filters` when filters active, else `No {name} found`. Both props optional — existing callers unchanged (undefined `hasActiveFilters` → old copy).
- **`StockAdjustmentList`**: added required `hasActiveFilters` prop; passes `hasActiveFilters` + `emptyFilteredLabel="adjustments"` to `EntityTable`.
- **`StockAdjustmentsPage`**: wires `hasActiveFilters` (from `useFilterBar`) into the list.

Empty-name fallback: `hasActiveFilters ? (emptyFilteredLabel ?? emptyLabel ?? label) : (emptyLabel ?? label)`.

## Testing
- `EntityTable.test.tsx`: 3 new tests — filtered state, unfiltered state, `emptyFilteredLabel` fallback.
- `StockAdjustmentList.test.tsx`: empty-state split into unfiltered + filtered cases.
- Gate: `lint` ✓, `type-check` ✓, `npm run test` ✓ (20/20 in touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)