### PR TITLE
fix(inventory): add Adjustment Number field to stock adjustment form

### DIFF
--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import {
   Alert,
@@ -33,6 +33,7 @@ import {
   useCreateStockAdjustmentMutation,
   useUpdateStockAdjustmentMutation,
 } from '@/store/api/inventoryApi'
+import { useGetDocumentNumberSettingsQuery } from '@/store/api/settingsApi'
 import { getCurrentDate } from '@/utils/formatters'
 import { formatCurrency } from '@/utils/currency'
 import { useNotification } from '@/hooks/useNotification'
@@ -76,6 +77,22 @@ const CreateStockAdjustmentPage: React.FC = () => {
   const { data: productsData, isLoading: productsLoading } = useGetProductsQuery({ isActive: true })
   const { data: adjustment, isLoading: adjustmentLoading } = useGetStockAdjustmentQuery(id!, { skip: !id })
   const { data: sourceAdjustment, isLoading: sourceLoading } = useGetStockAdjustmentQuery(revertFrom!, { skip: !revertFrom })
+
+  const { data: docNumberSettings, isLoading: loadingDocNumbers } =
+    useGetDocumentNumberSettingsQuery()
+
+  const adjustmentNumberPreview = useMemo(() => {
+    if (isEditMode) return null
+    if (loadingDocNumbers) return 'Loading...'
+    if (!docNumberSettings) return 'Auto-generated'
+    const config = docNumberSettings.configurations?.find(
+      (c: any) => c.documentName === 'Stock Adjustment',
+    )
+    if (!config) return 'Auto-generated'
+    const yy = String(new Date().getFullYear() % 100).padStart(2, '0')
+    const seq = String(config.nextNumber).padStart(config.paddingDigits, '0')
+    return `${config.prefix}-${yy}-${seq}`
+  }, [docNumberSettings, isEditMode, loadingDocNumbers])
 
   const [createStockAdjustment, { isLoading: isCreating }] = useCreateStockAdjustmentMutation()
   const [updateStockAdjustment, { isLoading: isUpdating }] = useUpdateStockAdjustmentMutation()
@@ -254,6 +271,19 @@ const CreateStockAdjustmentPage: React.FC = () => {
                   Adjustment Information
                 </Typography>
                 <Grid container spacing={2}>
+                  <Grid size={{ xs: 12, md: 6 }}>
+                    <TextField
+                      fullWidth
+                      size="small"
+                      label="Adjustment Number"
+                      value={isEditMode ? (adjustment?.adjustmentNumber ?? '') : (adjustmentNumberPreview ?? '')}
+                      slotProps={{ input: { readOnly: true }, inputLabel: { shrink: true } }}
+                      sx={{
+                        '& .MuiInputBase-input': { fontSize: '0.875rem' },
+                        '& .MuiInputLabel-root': { fontSize: '0.875rem' },
+                      }}
+                    />
+                  </Grid>
                   <Grid size={{ xs: 12, md: 6 }}>
                     <Controller
                       name="adjustmentDate"

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -253,4 +253,66 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
       })
     })
   })
+
+  it('renders a read-only Adjustment Number field in create mode', () => {
+    render(
+      <BrowserRouter>
+        <CreateStockAdjustmentPage />
+      </BrowserRouter>,
+    )
+    const field = screen.getByLabelText(/adjustment number/i) as HTMLInputElement
+    expect(field).toBeInTheDocument()
+    expect(field).toHaveAttribute('readonly')
+  })
+
+  it('shows the SA-YY-NNNN preview from document number settings in create mode', () => {
+    mockDocNumberSettings.mockReturnValue({
+      data: {
+        configurations: [
+          { documentName: 'Stock Adjustment', prefix: 'SA', nextNumber: 7, paddingDigits: 4 },
+        ],
+      },
+      isLoading: false,
+    })
+    render(
+      <BrowserRouter>
+        <CreateStockAdjustmentPage />
+      </BrowserRouter>,
+    )
+    const yy = String(new Date().getFullYear() % 100).padStart(2, '0')
+    const field = screen.getByLabelText(/adjustment number/i) as HTMLInputElement
+    expect(field.value).toBe(`SA-${yy}-0007`)
+  })
+
+  it('falls back to Auto-generated when settings are unavailable', () => {
+    mockDocNumberSettings.mockReturnValue({ data: undefined, isLoading: false })
+    render(
+      <BrowserRouter>
+        <CreateStockAdjustmentPage />
+      </BrowserRouter>,
+    )
+    const field = screen.getByLabelText(/adjustment number/i) as HTMLInputElement
+    expect(field.value).toBe('Auto-generated')
+  })
+
+  it('shows the loaded adjustmentNumber in edit mode', () => {
+    mockParams.mockReturnValue({ id: 'adj-1' })
+    mockAdjustmentQuery.mockReturnValue({
+      data: {
+        id: 'adj-1',
+        adjustmentNumber: 'SA-25-0042',
+        adjustmentDate: '2026-07-01',
+        notes: '',
+        items: [],
+      },
+      isLoading: false,
+    })
+    render(
+      <BrowserRouter>
+        <CreateStockAdjustmentPage />
+      </BrowserRouter>,
+    )
+    const field = screen.getByLabelText(/adjustment number/i) as HTMLInputElement
+    expect(field.value).toBe('SA-25-0042')
+  })
 })

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -16,6 +16,7 @@ const {
   mockShowSuccess,
   mockProductsQuery,
   mockAdjustmentQuery,
+  mockDocNumberSettings,
 } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
   mockParams: vi.fn(() => ({})),
@@ -26,6 +27,7 @@ const {
   mockShowSuccess: vi.fn(),
   mockProductsQuery: vi.fn(),
   mockAdjustmentQuery: vi.fn(),
+  mockDocNumberSettings: vi.fn(),
 }))
 
 vi.mock('react-router-dom', async () => {
@@ -55,6 +57,10 @@ vi.mock('@/store/api/inventoryApi', () => ({
   useUpdateStockAdjustmentMutation: () => [mockUpdateAdjustment, { isLoading: false }],
 }))
 
+vi.mock('@/store/api/settingsApi', () => ({
+  useGetDocumentNumberSettingsQuery: () => mockDocNumberSettings(),
+}))
+
 const baseProduct1 = Object.freeze({
   id: 'p1', name: 'Alpha Widget', stockQuantity: 10, baseCost: 5,
 })
@@ -77,6 +83,7 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
     mockSearchParams.mockReturnValue([new URLSearchParams(), vi.fn()])
     mockProductsQuery.mockReturnValue(stableAllProducts)
     mockAdjustmentQuery.mockReturnValue(stableAdjNull)
+    mockDocNumberSettings.mockReturnValue({ data: undefined, isLoading: false })
     mockCreateAdjustment.mockReturnValue({
       unwrap: vi.fn().mockResolvedValue({ id: 'adj-new', adjustmentNumber: 'SA-001' }),
     })


### PR DESCRIPTION
## Summary

Fixes the Stock Adjustment create/edit form missing a Document Number field (QA checklist item 6.4).

Adds a read-only **Adjustment Number** field to the "Adjustment Information" card, mirroring the Sales Order / Purchase Order pattern:

- **Edit mode** → shows the loaded `adjustment.adjustmentNumber`.
- **Create mode** (incl. `revertFrom`) → shows a `SA-YY-NNNN` preview computed from document-number settings, with `Loading...` / `Auto-generated` fallbacks.

Reuses the shared `useGetDocumentNumberSettingsQuery` hook and the `'Stock Adjustment'` config key (same mechanism the backend uses to generate the number).

## Changes

- `CreateStockAdjustmentPage.tsx` — hook + `useMemo` preview + read-only `TextField`.
- `CreateStockAdjustmentPage.test.tsx` — `settingsApi` mock in the `vi.hoisted` block + 4 tests (create field, preview, fallback, edit).

## Verification

- `npm run type-check` ✅
- `npm run lint` ✅
- Targeted test: 9/9 pass (5 existing + 4 new)
- Full `npm run test` suite: in progress at PR-open time

Closes #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)
