### PR TITLE
fix(inventory): stock adjustment date field follows regional settings

### DIFF
--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -22,6 +22,8 @@ import {
 import AddIcon from '@mui/icons-material/Add'
 import DeleteIcon from '@mui/icons-material/Delete'
 import { useForm, useFieldArray, Controller } from 'react-hook-form'
+import { DatePicker } from '@mui/x-date-pickers'
+import { parseISO, format, isValid } from 'date-fns'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 
@@ -34,7 +36,7 @@ import {
   useUpdateStockAdjustmentMutation,
 } from '@/store/api/inventoryApi'
 import { useGetDocumentNumberSettingsQuery } from '@/store/api/settingsApi'
-import { getCurrentDate } from '@/utils/formatters'
+import { getCurrentDate, toMuiDatePickerFormat } from '@/utils/formatters'
 import { formatCurrency } from '@/utils/currency'
 import { useNotification } from '@/hooks/useNotification'
 import { useUnsavedChangesGuard } from '@/hooks/useUnsavedChangesGuard'
@@ -93,6 +95,9 @@ const CreateStockAdjustmentPage: React.FC = () => {
     const seq = String(config.nextNumber).padStart(config.paddingDigits, '0')
     return `${config.prefix}-${yy}-${seq}`
   }, [docNumberSettings, isEditMode, loadingDocNumbers])
+
+  const storedFormat = useMemo(() => localStorage.getItem('dateFormat') || 'DD/MM/YYYY', [])
+  const pickerFormat = useMemo(() => toMuiDatePickerFormat(storedFormat), [storedFormat])
 
   const [createStockAdjustment, { isLoading: isCreating }] = useCreateStockAdjustmentMutation()
   const [updateStockAdjustment, { isLoading: isUpdating }] = useUpdateStockAdjustmentMutation()
@@ -289,19 +294,25 @@ const CreateStockAdjustmentPage: React.FC = () => {
                       name="adjustmentDate"
                       control={control}
                       render={({ field }) => (
-                        <TextField
-                          {...field}
+                        <DatePicker
                           label="Adjustment Date"
-                          type="date"
-                          required
-                          fullWidth
-                          size="small"
-                          error={!!errors.adjustmentDate}
-                          helperText={errors.adjustmentDate?.message}
-                          slotProps={{ inputLabel: { shrink: true } }}
-                          sx={{
-                            '& .MuiInputBase-input': { fontSize: '0.875rem' },
-                            '& .MuiInputLabel-root': { fontSize: '0.875rem' },
+                          value={field.value ? parseISO(field.value) : null}
+                          format={pickerFormat}
+                          onChange={(date) =>
+                            field.onChange(date && isValid(date) ? format(date, 'yyyy-MM-dd') : '')
+                          }
+                          slotProps={{
+                            textField: {
+                              required: true,
+                              fullWidth: true,
+                              size: 'small',
+                              error: !!errors.adjustmentDate,
+                              helperText: errors.adjustmentDate?.message,
+                              sx: {
+                                '& .MuiInputBase-input': { fontSize: '0.875rem' },
+                                '& .MuiInputLabel-root': { fontSize: '0.875rem' },
+                              },
+                            },
                           }}
                         />
                       )}

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -5,6 +5,8 @@ import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router-dom'
 
 import CreateStockAdjustmentPage from '../CreateStockAdjustmentPage'
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 
 const {
   mockNavigate,
@@ -76,8 +78,18 @@ const stableAllProducts = Object.freeze({
   isLoading: false,
 })
 
+const renderPage = () =>
+  render(
+    <BrowserRouter>
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <CreateStockAdjustmentPage />
+      </LocalizationProvider>
+    </BrowserRouter>,
+  )
+
 describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
   beforeEach(() => {
+    localStorage.clear()
     vi.clearAllMocks()
     mockParams.mockReturnValue({})
     mockSearchParams.mockReturnValue([new URLSearchParams(), vi.fn()])
@@ -93,22 +105,34 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
   })
 
   it('renders the page header in create mode', () => {
-    render(
-      <BrowserRouter>
-        <CreateStockAdjustmentPage />
-      </BrowserRouter>,
-    )
+    renderPage()
     expect(screen.getByRole('heading', { name: /create stock adjustment/i })).toBeInTheDocument()
+  })
+
+  it('renders the Adjustment Date in the regional format (DD/MM/YYYY)', async () => {
+    localStorage.setItem('dateFormat', 'DD/MM/YYYY')
+    mockParams.mockReturnValue({ id: 'adj-1' })
+    mockAdjustmentQuery.mockReturnValue({
+      data: {
+        id: 'adj-1',
+        adjustmentNumber: 'SA-25-0042',
+        adjustmentDate: '2026-07-01',
+        notes: '',
+        items: [],
+      },
+      isLoading: false,
+    })
+    renderPage()
+    await waitFor(() => {
+      const dateField = screen.getByDisplayValue('01/07/2026')
+      expect(dateField).toBeInTheDocument()
+    })
   })
 
   describe('duplicate product guard', () => {
     it('blocks adding a product already in the items table', async () => {
       const user = userEvent.setup()
-      render(
-        <BrowserRouter>
-          <CreateStockAdjustmentPage />
-        </BrowserRouter>,
-      )
+      renderPage()
 
       const inputs = screen.getAllByPlaceholderText('Search product...')
       await user.click(inputs[0])
@@ -140,11 +164,7 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
         isLoading: false,
       })
       mockProductsQuery.mockReturnValue(stableSingleProduct)
-      render(
-        <BrowserRouter>
-          <CreateStockAdjustmentPage />
-        </BrowserRouter>,
-      )
+      renderPage()
 
       const input = screen.getByPlaceholderText('Search product...')
       await user.click(input)
@@ -197,11 +217,7 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
       })
       mockProductsQuery.mockReturnValue(stableRevertProducts)
 
-      render(
-        <BrowserRouter>
-          <CreateStockAdjustmentPage />
-        </BrowserRouter>,
-      )
+      renderPage()
 
       await waitFor(() => {
         const diffInput = screen.getByTestId('items.0.difference') as HTMLInputElement
@@ -238,11 +254,7 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
         return stableAdjNull
       })
 
-      render(
-        <BrowserRouter>
-          <CreateStockAdjustmentPage />
-        </BrowserRouter>,
-      )
+      renderPage()
 
       await waitFor(() => {
         expect(mockAdjustmentQuery).toHaveBeenCalledWith('abc-123')
@@ -255,11 +267,7 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
   })
 
   it('renders a read-only Adjustment Number field in create mode', () => {
-    render(
-      <BrowserRouter>
-        <CreateStockAdjustmentPage />
-      </BrowserRouter>,
-    )
+    renderPage()
     const field = screen.getByLabelText(/adjustment number/i) as HTMLInputElement
     expect(field).toBeInTheDocument()
     expect(field).toHaveAttribute('readonly')
@@ -274,11 +282,7 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
       },
       isLoading: false,
     })
-    render(
-      <BrowserRouter>
-        <CreateStockAdjustmentPage />
-      </BrowserRouter>,
-    )
+    renderPage()
     const yy = String(new Date().getFullYear() % 100).padStart(2, '0')
     const field = screen.getByLabelText(/adjustment number/i) as HTMLInputElement
     expect(field.value).toBe(`SA-${yy}-0007`)
@@ -286,11 +290,7 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
 
   it('falls back to Auto-generated when settings are unavailable', () => {
     mockDocNumberSettings.mockReturnValue({ data: undefined, isLoading: false })
-    render(
-      <BrowserRouter>
-        <CreateStockAdjustmentPage />
-      </BrowserRouter>,
-    )
+    renderPage()
     const field = screen.getByLabelText(/adjustment number/i) as HTMLInputElement
     expect(field.value).toBe('Auto-generated')
   })
@@ -307,11 +307,7 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
       },
       isLoading: false,
     })
-    render(
-      <BrowserRouter>
-        <CreateStockAdjustmentPage />
-      </BrowserRouter>,
-    )
+    renderPage()
     const field = screen.getByLabelText(/adjustment number/i) as HTMLInputElement
     expect(field.value).toBe('SA-25-0042')
   })


### PR DESCRIPTION
## Summary

The Stock Adjustments create form's **Adjustment Date** field used a native `<TextField type="date">`, locked to ISO `YYYY-MM-DD` display and ignoring the regional `dateFormat` setting. Swapped it for an MUI `<DatePicker>` that follows the user's regional format, reusing the canonical in-repo pattern from `FilterPeriod.tsx`.

Form state and submit payload stay a `YYYY-MM-DD` string end-to-end — only the input UI and displayed format change.

## Changes

- Replaced native date `TextField` with `<DatePicker>` (`@mui/x-date-pickers`, `LocalizationProvider` already global in `main.tsx`).
- `pickerFormat` derived from `localStorage` `dateFormat` via `toMuiDatePickerFormat` (local read; no new export from `formatters.ts`).
- `parseISO` / `format` convert `string ↔ Date` at the field boundary; `isValid(date)` guard prevents `format(InvalidDate)` from throwing on partial typed input (maps to `''`, yup `required` then fires).
- Dropped `slotProps.inputLabel.shrink` (DatePicker manages shrink itself).
- Test: added `renderPage` helper wrapping `LocalizationProvider` (all render sites), `localStorage.clear()` in `beforeEach`, and an async regional-format assertion.

## Verification

- `npm run lint` ✓
- `npm run type-check` ✓
- Full frontend suite: **201 files / 1436 tests passed** ✓

Closes #855

🤖 Generated with [Claude Code](https://claude.com/claude-code)