### PR TITLE
fix(inventory): stock adjustment clear + PO/SO section alignment

### DIFF
--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -202,7 +202,13 @@ const CreateStockAdjustmentPage: React.FC = () => {
   })
 
   const handleProductSelect = (index: number, product: any) => {
-    if (!product) return
+    if (!product) {
+      setDuplicateError(null)
+      setValue(`items.${index}.productId`, '', { shouldDirty: true, shouldValidate: true })
+      setValue(`items.${index}.liveStock`, 0, { shouldDirty: true })
+      setValue(`items.${index}.unitCost`, 0, { shouldDirty: true })
+      return
+    }
     const existing = (watchedItems ?? []).find(
       (item, i) => i !== index && item.productId === product.id,
     )
@@ -211,7 +217,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
       return
     }
     setDuplicateError(null)
-    setValue(`items.${index}.productId`, product.id, { shouldDirty: true })
+    setValue(`items.${index}.productId`, product.id, { shouldDirty: true, shouldValidate: true })
     setValue(`items.${index}.liveStock`, Number(product.stockQuantity) || 0, { shouldDirty: true })
     setValue(`items.${index}.unitCost`, Number(product.baseCost) || 0, { shouldDirty: true })
   }
@@ -273,7 +279,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
             <Card>
               <CardContent>
                 <Typography variant="h6" gutterBottom>
-                  Adjustment Information
+                  Adjustment Info
                 </Typography>
                 <Grid container spacing={2}>
                   <Grid size={{ xs: 12, md: 6 }}>
@@ -327,7 +333,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
             <Card>
               <CardContent>
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-                  <Typography variant="h6">Adjustment Items</Typography>
+                  <Typography variant="h6">Line Items</Typography>
                   <AppButton
                     variant="secondary"
                     startIcon={<AddIcon />}
@@ -531,6 +537,9 @@ const CreateStockAdjustmentPage: React.FC = () => {
           <Grid size={12}>
             <Card>
               <CardContent>
+                <Typography variant="h6" gutterBottom>
+                  Additional
+                </Typography>
                 <Controller
                   name="notes"
                   control={control}

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router-dom'
 
 import CreateStockAdjustmentPage from '../CreateStockAdjustmentPage'
+import { formatCurrency } from '@/utils/currency'
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 
@@ -310,5 +311,89 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
     renderPage()
     const field = screen.getByLabelText(/adjustment number/i) as HTMLInputElement
     expect(field.value).toBe('SA-25-0042')
+  })
+
+  describe('product clear (#857)', () => {
+    it('keeps the row empty after clearing a selected product', async () => {
+      const user = userEvent.setup()
+      renderPage()
+
+      const input = screen.getByPlaceholderText('Search product...')
+      await user.click(input)
+      const listbox = await screen.findByRole('listbox')
+      await user.click(within(listbox).getByText('Alpha Widget'))
+
+      await waitFor(() => {
+        expect(input).toHaveValue('Alpha Widget')
+      })
+      // Product-derived fields seeded (stockQuantity: 10, baseCost: 5)
+      expect(screen.getByTestId('liveStock-0')).toHaveTextContent('10')
+
+      // Enter a non-zero qty change BEFORE clearing. This makes the Unit Cost assertion
+      // discriminating: if unitCost is NOT reset (stale 5), Unit Cost cell shows
+      // formatCurrency(5) and Total shows formatCurrency(15) — neither is formatCurrency(0),
+      // so the assertion below fails. Only a real unitCost reset produces a zero-currency cell.
+      const diffInput = screen.getByTestId('items.0.difference') as HTMLInputElement
+      fireEvent.change(diffInput, { target: { value: '3' } })
+      await waitFor(() => expect(diffInput.value).toBe('3'))
+
+      const zeroCurrency = formatCurrency(0)
+      const staleUnitCost = formatCurrency(5)
+
+      // Clear via the Autocomplete clear (X) button, then blur the field
+      const clearBtn = screen.getByTitle('Clear')
+      await user.click(clearBtn)
+      fireEvent.blur(input)
+
+      // No snap-back: re-query the input after blur and assert the product did not come back
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search product...')).toHaveValue('')
+      })
+      // liveStock reset
+      expect(screen.getByTestId('liveStock-0')).toHaveTextContent('0')
+      // unitCost reset — scope to THIS row so an unrelated formatCurrency(5) elsewhere can't
+      // mask a failure to reset. Stale unit cost gone from the row; a zero-currency cell present.
+      const row = diffInput.closest('tr') as HTMLElement
+      expect(within(row).queryByText(staleUnitCost)).not.toBeInTheDocument()
+      expect(within(row).getAllByText(zeroCurrency).length).toBeGreaterThan(0)
+      // qty change preserved
+      expect(diffInput.value).toBe('3')
+    })
+
+    it('blocks save for a lone cleared row instead of dropping it', async () => {
+      const user = userEvent.setup()
+      renderPage()
+
+      const input = screen.getByPlaceholderText('Search product...')
+      await user.click(input)
+      const listbox = await screen.findByRole('listbox')
+      await user.click(within(listbox).getByText('Alpha Widget'))
+      await waitFor(() => expect(input).toHaveValue('Alpha Widget'))
+
+      const diffInput = screen.getByTestId('items.0.difference') as HTMLInputElement
+      fireEvent.change(diffInput, { target: { value: '5' } })
+
+      await user.click(screen.getByTitle('Clear'))
+      await waitFor(() => expect(input).toHaveValue(''))
+      // qty change survives the product clear
+      expect(diffInput.value).toBe('5')
+
+      await user.click(screen.getByRole('button', { name: /create adjustment/i }))
+
+      // Validation blocks: mutation never fires, required error surfaces
+      await waitFor(() => {
+        expect(screen.getByText(/product is required/i)).toBeInTheDocument()
+      })
+      expect(mockCreateAdjustment).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('section alignment (#858)', () => {
+    it('renders PO/SO-aligned section headers', () => {
+      renderPage()
+      expect(screen.getByRole('heading', { name: /^adjustment info$/i })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: /^line items$/i })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: /^additional$/i })).toBeInTheDocument()
+    })
   })
 })


### PR DESCRIPTION
## Summary
Two Stock Adjustment create/edit form fixes on `CreateStockAdjustmentPage.tsx`.

**#857 — product autocomplete cannot stay cleared**
Clearing a selected product via the Autocomplete (X) snapped the old product back. `handleProductSelect` returned early on `null`, leaving stale `productId` in form state. Now the null branch resets `productId`/`liveStock`/`unitCost` (keeps user-entered qty change) with `shouldValidate: true` so the required-field state updates promptly. A cleared row stays a validation-blocking incomplete row — not silently dropped.

**#858 — align form sections with PO/SO design family**
Section-shell alignment only (adjustment domain has no shipping/discount/order-total, so no fake totals section):
- `Adjustment Information` → `Adjustment Info`
- `Adjustment Items` → `Line Items`
- added `Additional` header above notes

Columns, sticky footer, and yup schema unchanged.

## Tests
- #857: clear keeps row empty (no snap-back after blur), resets live stock + unit cost (row-scoped assertion), preserves qty change; lone cleared row blocks save via validation.
- #858: asserts `Adjustment Info` / `Line Items` / `Additional` headers render.

## Verification
- Lint ✅ · type-check ✅ · targeted (#857) 2/2 ✅
- Full frontend suite: running (per AGENTS.md)

Closes #857
Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)