### PR TITLE
feat(inventory/orders): align stock adjustment form + unify order date, fixes

### DIFF
--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -331,16 +331,9 @@ const CreateStockAdjustmentPage: React.FC = () => {
           <Grid size={12}>
             <Card>
               <CardContent>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-                  <Typography variant="h6">Line Items</Typography>
-                  <AppButton
-                    variant="secondary"
-                    startIcon={<AddIcon />}
-                    onClick={() => append({ productId: '', liveStock: 0, difference: 0, unitCost: 0 })}
-                  >
-                    Add Item
-                  </AppButton>
-                </Box>
+                <Typography variant="h6" gutterBottom>
+                  Line Items
+                </Typography>
 
                 {duplicateError && (
                   <Alert severity="warning" sx={{ mb: 2 }} onClose={() => setDuplicateError(null)}>
@@ -523,6 +516,16 @@ const CreateStockAdjustmentPage: React.FC = () => {
                     </TableBody>
                   </Table>
                 </TableContainer>
+
+                <Box sx={{ mt: 2 }}>
+                  <AppButton
+                    variant="secondary"
+                    startIcon={<AddIcon />}
+                    onClick={() => append({ productId: '', liveStock: 0, difference: 0, unitCost: 0 })}
+                  >
+                    Add Item
+                  </AppButton>
+                </Box>
 
                 {errors.items && !Array.isArray(errors.items) && (
                   <Alert severity="error" sx={{ mt: 1 }}>

--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -361,6 +361,9 @@ const CreateStockAdjustmentPage: React.FC = () => {
                         backgroundColor: theme.palette.grey[50],
                         fontWeight: 600,
                       },
+                      '& .MuiTableBody-root .MuiTableRow-root:hover': {
+                        backgroundColor: theme.palette.action.hover,
+                      },
                       '& .MuiTextField-root .MuiOutlinedInput-root': {
                         '& fieldset': { border: 'none' },
                         '&:hover fieldset': { border: `1px solid ${theme.palette.primary.main}` },

--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -570,21 +570,9 @@ const CreateStockAdjustmentPage: React.FC = () => {
           )}
 
           <Grid size={12}>
-            <Box
-              sx={{
-                position: 'sticky',
-                bottom: 0,
-                backgroundColor: 'background.paper',
-                borderTop: `1px solid ${theme.palette.divider}`,
-                py: 2,
-                px: 3,
-                display: 'flex',
-                gap: 2,
-                justifyContent: 'flex-end',
-              }}
-            >
+            <Box sx={{ display: 'flex', gap: 2, justifyContent: 'flex-end' }}>
               <AppButton
-                variant="outlined"
+                variant="secondary"
                 onClick={() => navigate('/inventory/stock-adjustments')}
                 disabled={isSaving}
               >

--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -67,6 +67,11 @@ const schema = yup.object({
   ).min(1, 'At least one item is required'),
 })
 
+const fieldSx = {
+  '& .MuiInputBase-input': { fontSize: '0.875rem' },
+  '& .MuiInputLabel-root': { fontSize: '0.875rem' },
+}
+
 const CreateStockAdjustmentPage: React.FC = () => {
   const theme = useTheme()
   const navigate = useNavigate()
@@ -289,10 +294,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
                       label="Adjustment Number"
                       value={isEditMode ? (adjustment?.adjustmentNumber ?? '') : (adjustmentNumberPreview ?? '')}
                       slotProps={{ input: { readOnly: true }, inputLabel: { shrink: true } }}
-                      sx={{
-                        '& .MuiInputBase-input': { fontSize: '0.875rem' },
-                        '& .MuiInputLabel-root': { fontSize: '0.875rem' },
-                      }}
+                      sx={fieldSx}
                     />
                   </Grid>
                   <Grid size={{ xs: 12, md: 6 }}>
@@ -314,10 +316,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
                               size: 'small',
                               error: !!errors.adjustmentDate,
                               helperText: errors.adjustmentDate?.message,
-                              sx: {
-                                '& .MuiInputBase-input': { fontSize: '0.875rem' },
-                                '& .MuiInputLabel-root': { fontSize: '0.875rem' },
-                              },
+                              sx: fieldSx,
                             },
                           }}
                         />
@@ -550,10 +549,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
                       multiline
                       rows={3}
                       fullWidth
-                      sx={{
-                        '& .MuiInputBase-input': { fontSize: '0.875rem' },
-                        '& .MuiInputLabel-root': { fontSize: '0.875rem' },
-                      }}
+                      sx={fieldSx}
                     />
                   )}
                 />

--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -22,6 +22,8 @@ import {
 import AddIcon from '@mui/icons-material/Add'
 import DeleteIcon from '@mui/icons-material/Delete'
 import { yupResolver } from '@hookform/resolvers/yup'
+import { DatePicker } from '@mui/x-date-pickers'
+import { parseISO, format, isValid } from 'date-fns'
 import { Controller, useFieldArray, useForm } from 'react-hook-form'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import * as yup from 'yup'
@@ -40,7 +42,7 @@ import {
   useUpdatePurchaseOrderMutation,
 } from '@/store/api/purchasingApi'
 import { useGetDocumentNumberSettingsQuery } from '@/store/api/settingsApi'
-import { formatCurrency, getCurrentDate } from '@/utils/formatters'
+import { formatCurrency, getCurrentDate, toMuiDatePickerFormat } from '@/utils/formatters'
 import { rtkErrorMessage } from '@/utils/errorMessage'
 
 interface PurchaseOrderItem {
@@ -149,6 +151,9 @@ const CreatePurchaseOrderPage: React.FC = () => {
   const [createPurchaseOrder] = useCreatePurchaseOrderMutation()
   const [updatePurchaseOrder] = useUpdatePurchaseOrderMutation()
   const [fetchPurchaseOrderByNumber] = useLazyGetPurchaseOrderByNumberQuery()
+
+  const storedFormat = useMemo(() => localStorage.getItem('dateFormat') || 'DD/MM/YYYY', [])
+  const pickerFormat = useMemo(() => toMuiDatePickerFormat(storedFormat), [storedFormat])
 
   const orderNumberPreview = useMemo(() => {
     if (isEditMode) return null
@@ -399,18 +404,24 @@ const CreatePurchaseOrderPage: React.FC = () => {
                       name="orderDate"
                       control={control}
                       render={({ field }) => (
-                        <TextField
-                          {...field}
-                          fullWidth
-                          size="small"
+                        <DatePicker
                           label="Order Date"
-                          type="date"
-                          required
+                          value={field.value ? parseISO(field.value) : null}
+                          format={pickerFormat}
                           disabled={loading}
-                          error={!!errors.orderDate}
-                          helperText={errors.orderDate?.message}
-                          slotProps={{ inputLabel: { shrink: true } }}
-                          sx={fieldSx}
+                          onChange={(date) =>
+                            field.onChange(date && isValid(date) ? format(date, 'yyyy-MM-dd') : '')
+                          }
+                          slotProps={{
+                            textField: {
+                              required: true,
+                              fullWidth: true,
+                              size: 'small',
+                              error: !!errors.orderDate,
+                              helperText: errors.orderDate?.message,
+                              sx: fieldSx,
+                            },
+                          }}
                         />
                       )}
                     />

--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -299,7 +299,15 @@ const CreatePurchaseOrderPage: React.FC = () => {
 
   const handleProductSelect = useCallback(
     (index: number, product: any) => {
-      if (!product) return
+      if (!product) {
+        // Clearing the product (X button) must erase the row's product —
+        // follow the Stock Adjustment pattern instead of no-op leaving it stale.
+        setValue(`items.${index}.productId`, '', { shouldDirty: true, shouldValidate: true })
+        setValue(`items.${index}.product`, undefined, { shouldDirty: true })
+        setValue(`items.${index}.unitPrice`, 0, { shouldDirty: true })
+        setValue(`items.${index}.totalPrice`, 0, { shouldDirty: true })
+        return
+      }
       seedProducts([product])
       const price = Number(product.baseCost || 0)
       const qty = Number(watchedItems[index]?.quantity) || 1

--- a/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
+++ b/frontend/src/pages/purchasing/__tests__/CreatePurchaseOrderPage.test.tsx
@@ -1,8 +1,16 @@
 import '@testing-library/jest-dom/vitest'
+import type { ReactElement } from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render as rtlRender, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BrowserRouter, MemoryRouter } from 'react-router-dom'
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
+
+// Wrap every render in LocalizationProvider — the Order Date field uses a
+// MUI X DatePicker, which throws without a localization context.
+const render = (ui: ReactElement) =>
+  rtlRender(<LocalizationProvider dateAdapter={AdapterDateFns}>{ui}</LocalizationProvider>)
 
 import CreatePurchaseOrderPage from '../CreatePurchaseOrderPage'
 

--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -361,7 +361,15 @@ const CreateSalesOrderPage: React.FC = () => {
 
   const handleProductSelect = useCallback(
     (index: number, product: any) => {
-      if (!product) return
+      if (!product) {
+        // Clearing the product (X button) must erase the row's product —
+        // follow the Stock Adjustment pattern instead of no-op leaving it stale.
+        setValue(`items.${index}.productId`, '', { shouldDirty: true, shouldValidate: true })
+        setValue(`items.${index}.product`, undefined, { shouldDirty: true })
+        setValue(`items.${index}.unitPrice`, 0, { shouldDirty: true })
+        setValue(`items.${index}.totalPrice`, 0, { shouldDirty: true })
+        return
+      }
       seedProducts([product])
       const price = getProductPrice(product, selectedCustomer)
       const qty = Number(watchedItems[index]?.quantity) || 1
@@ -828,7 +836,7 @@ function LineItemRow({
           name={`items.${index}.productId`}
           control={control}
           render={({ field }) => (
-            <>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
               <Autocomplete
                 options={products}
                 getOptionLabel={(option) => option?.name || ''}
@@ -842,6 +850,7 @@ function LineItemRow({
                 size="small"
                 disabled={isSaving}
                 onKeyDown={getKeyHandler(index, 0)}
+                sx={{ flex: 1 }}
                 renderInput={(params) => (
                   <TextField
                     {...params}
@@ -863,14 +872,12 @@ function LineItemRow({
                 }}
               />
               {watchedItem?.product && (
-                <Box sx={{ mt: 0.5 }}>
-                  <StockIndicatorChip
-                    stockQuantity={Number(watchedItem.product.stockQuantity ?? 0)}
-                    quantity={Number(watchedItem.quantity ?? 0)}
-                  />
-                </Box>
+                <StockIndicatorChip
+                  stockQuantity={Number(watchedItem.product.stockQuantity ?? 0)}
+                  quantity={Number(watchedItem.quantity ?? 0)}
+                />
               )}
-            </>
+            </Box>
           )}
         />
       </TableCell>

--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -23,6 +23,8 @@ import {
 import AddIcon from '@mui/icons-material/Add'
 import DeleteIcon from '@mui/icons-material/Delete'
 import { yupResolver } from '@hookform/resolvers/yup'
+import { DatePicker } from '@mui/x-date-pickers'
+import { parseISO, format, isValid } from 'date-fns'
 import { Controller, useFieldArray, useForm } from 'react-hook-form'
 import { useStore } from 'react-redux'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
@@ -46,7 +48,7 @@ import { patchSalesOrderCaches } from '@/store/api/salesOrderCache'
 import { useGetDocumentNumberSettingsQuery } from '@/store/api/settingsApi'
 import { setSelectedOrder } from '@/store/slices/salesSlice'
 import type { RootState } from '@/store'
-import { formatCurrency, getCurrentDate } from '@/utils/formatters'
+import { formatCurrency, getCurrentDate, toMuiDatePickerFormat } from '@/utils/formatters'
 import { rtkErrorMessage } from '@/utils/errorMessage'
 import { getStockOffenders } from '@/utils/stockStatus'
 import { getOrderActionMetas } from './utils/orderActions'
@@ -188,6 +190,9 @@ const CreateSalesOrderPage: React.FC = () => {
   const isSaving = Boolean(createState.isLoading || updateState.isLoading)
 
   const { products, loadProducts, seedProducts } = useProductSearch({ onlyActive: true })
+
+  const storedFormat = useMemo(() => localStorage.getItem('dateFormat') || 'DD/MM/YYYY', [])
+  const pickerFormat = useMemo(() => toMuiDatePickerFormat(storedFormat), [storedFormat])
 
   const orderNumberPreview = useMemo(() => {
     if (isEditMode) return null
@@ -469,18 +474,24 @@ const CreateSalesOrderPage: React.FC = () => {
                       name="orderDate"
                       control={control}
                       render={({ field }) => (
-                        <TextField
-                          {...field}
-                          fullWidth
-                          size="small"
+                        <DatePicker
                           label="Order Date"
-                          type="date"
-                          required
+                          value={field.value ? parseISO(field.value) : null}
+                          format={pickerFormat}
                           disabled={isSaving}
-                          error={!!errors.orderDate}
-                          helperText={errors.orderDate?.message}
-                          slotProps={{ inputLabel: { shrink: true } }}
-                          sx={fieldSx}
+                          onChange={(date) =>
+                            field.onChange(date && isValid(date) ? format(date, 'yyyy-MM-dd') : '')
+                          }
+                          slotProps={{
+                            textField: {
+                              required: true,
+                              fullWidth: true,
+                              size: 'small',
+                              error: !!errors.orderDate,
+                              helperText: errors.orderDate?.message,
+                              sx: fieldSx,
+                            },
+                          }}
                         />
                       )}
                     />

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -1,8 +1,16 @@
 import '@testing-library/jest-dom/vitest'
+import type { ReactElement } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor, within, act } from '@testing-library/react'
+import { fireEvent, render as rtlRender, screen, waitFor, within, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BrowserRouter, MemoryRouter, Route, Routes } from 'react-router-dom'
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
+
+// Wrap every render in LocalizationProvider — the Order Date field uses a
+// MUI X DatePicker, which throws without a localization context.
+const render = (ui: ReactElement) =>
+  rtlRender(<LocalizationProvider dateAdapter={AdapterDateFns}>{ui}</LocalizationProvider>)
 
 import CreateSalesOrderPage from '../CreateSalesOrderPage'
 
@@ -720,7 +728,9 @@ describe('CreateSalesOrderPage — edit mode', { timeout: 60000 }, () => {
     // Section 1 — Order Info
     await waitFor(() => {
       expect(screen.getByDisplayValue('SO-26-001')).toBeInTheDocument()
-      expect(screen.getByDisplayValue('2026-03-15')).toBeInTheDocument()
+      // Order Date renders via MUI X DatePicker in the user's regional format
+      // (default DD/MM/YYYY), not the raw ISO yyyy-MM-dd of a native date input.
+      expect(screen.getByDisplayValue('15/03/2026')).toBeInTheDocument()
       expect(screen.getByRole('combobox', { name: /customer/i })).toHaveValue('Test Customer')
     })
 


### PR DESCRIPTION
## Summary

Aligns the Stock Adjustment create/edit form with the Purchase Order / Sales Order form family (#860), then unifies date handling and fixes two order-form bugs found while comparing the three pages.

Closes #860

## Changes

**Stock Adjustment cosmetic alignment (#860)**
- Share a `fieldSx` const (matches PO/SO) for Number/Date/Notes fields
- Move the `Add Item` button below the line-item table (plain `h6` header)
- Add line-item row-hover parity
- Replace the sticky footer with a normal in-flow action row; Cancel `outlined`→`secondary`

**Regional date field unification**
- PO and SO Order Date now use the MUI X `DatePicker` with `toMuiDatePickerFormat(dateFormat)` — the same regional-format pattern Stock Adjustment already used — instead of a native `<input type="date">` that ignored the user's date-format setting. All three order forms now honor the configured format.

**Order-form fixes**
- PO/SO: clearing the product Autocomplete (X button) previously no-oped, leaving the stale product on the row. Now erases the product and resets unit price / total, following the Stock Adjustment pattern.
- SO: the `StockIndicatorChip` now sits inline (right of the product input) instead of stacked below it.

## Notes
- Investigated a reported SA-vs-PO line-item row height difference: the two rows render with byte-identical CSS classes; the perceived gap was an empty-vs-filled state artifact, not a code divergence. No change made.

## Verification
- `npm run lint` — clean
- `npm run type-check` — clean
- Purchase Order + Sales Order + Stock Adjustment form tests pass (test render helpers wrapped in `LocalizationProvider` for the DatePicker; SO edit-mode date assertion updated to the regional display)

🤖 Generated with [Claude Code](https://claude.com/claude-code)