### PR TITLE
fix(inventory): allow clearing Qty Change on stock adjustment form

### DIFF
--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -45,7 +45,7 @@ import { useUnsavedChangesGuard } from '@/hooks/useUnsavedChangesGuard'
 interface ItemRow {
   productId: string
   liveStock: number
-  difference: number
+  difference: number | '' | '-'
   unitCost: number
 }
 
@@ -62,7 +62,13 @@ const schema = yup.object({
     yup.object({
       productId: yup.string().required('Product is required'),
       liveStock: yup.number().required(),
-      difference: yup.number().required('Quantity change is required').notOneOf([0], 'Quantity change cannot be zero'),
+      difference: yup
+        .number()
+        .transform((value, originalValue) =>
+          originalValue === '' || originalValue === '-' ? undefined : value,
+        )
+        .required('Quantity change is required')
+        .notOneOf([0], 'Quantity change cannot be zero'),
       unitCost: yup.number().required(),
     }),
   ).min(1, 'At least one item is required'),
@@ -232,7 +238,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
     setPageError(null)
     try {
       const items = data.items
-        .filter((item) => item.productId && item.difference !== 0)
+        .filter((item) => item.productId && (Number(item.difference) || 0) !== 0)
         .map((item) => ({
           productId: item.productId,
           oldQuantity: Number(item.liveStock),
@@ -437,7 +443,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
                                   onChange={(e) => {
                                     const raw = e.target.value
                                     if (raw === '' || raw === '-') {
-                                      diffField.onChange(raw === '-' ? raw : 0)
+                                      diffField.onChange(raw)
                                       return
                                     }
                                     const num = Number(raw)
@@ -466,8 +472,8 @@ const CreateStockAdjustmentPage: React.FC = () => {
                         <TableCell align="center" sx={{ padding: '2px 8px !important' }}>
                           <Typography variant="body2" sx={{ fontWeight: 600 }}>
                             {formatCurrency(
-                              Math.abs(watchedItems?.[index]?.difference ?? 0) *
-                                (watchedItems?.[index]?.unitCost ?? 0),
+                              Math.abs(Number(watchedItems?.[index]?.difference) || 0) *
+                                (Number(watchedItems?.[index]?.unitCost) || 0),
                             )}
                           </Typography>
                         </TableCell>

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -192,6 +192,69 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
     })
   })
 
+  describe('clear Qty Change (#864)', () => {
+    // Products come from the beforeEach default (stableAllProducts, which
+    // already includes 'Low Stock Widget'). Don't re-mock products after render:
+    // the useGetProductsQuery hook already ran during renderPage().
+    const selectFirstProduct = async (user: ReturnType<typeof userEvent.setup>) => {
+      const input = screen.getByPlaceholderText('Search product...')
+      await user.click(input)
+      const listbox = await screen.findByRole('listbox')
+      await user.click(within(listbox).getByText('Low Stock Widget'))
+      await waitFor(() => expect(input).toHaveValue('Low Stock Widget'))
+    }
+
+    it('lets the user clear the field to empty instead of snapping back to 0', async () => {
+      const user = userEvent.setup()
+      renderPage()
+      await selectFirstProduct(user)
+
+      const diffInput = screen.getByTestId('items.0.difference') as HTMLInputElement
+      fireEvent.change(diffInput, { target: { value: '5' } })
+      await waitFor(() => expect(diffInput.value).toBe('5'))
+
+      fireEvent.change(diffInput, { target: { value: '' } })
+      await waitFor(() => expect(diffInput.value).toBe(''))
+    })
+
+    it('accepts a lone minus without breaking the row (smoke test)', async () => {
+      const user = userEvent.setup()
+      renderPage()
+      await selectFirstProduct(user)
+
+      const diffInput = screen.getByTestId('items.0.difference') as HTMLInputElement
+      fireEvent.change(diffInput, { target: { value: '-' } })
+      await waitFor(() => expect(diffInput.value).toBe('-'))
+
+      // Weak smoke test only: it asserts the row does not render the literal
+      // string "NaN". It does NOT prove step 6's guard, because formatCurrency
+      // maps NaN -> "RM 0.00", so the total cell reads "RM 0.00" whether the
+      // code uses Math.abs('-') (NaN) or Math.abs(Number('-') || 0) (0). The
+      // real protection for step 6 is the type-check in Step 9: Math.abs('-')
+      // is a TS error under the `number | '' | '-'` type, forcing the guard.
+      const row = diffInput.closest('tr') as HTMLElement
+      expect(within(row).queryByText(/NaN/)).not.toBeInTheDocument()
+    })
+
+    it('blocks submit when Qty Change is left empty', async () => {
+      const user = userEvent.setup()
+      renderPage()
+      await selectFirstProduct(user)
+
+      const diffInput = screen.getByTestId('items.0.difference') as HTMLInputElement
+      fireEvent.change(diffInput, { target: { value: '' } })
+      await waitFor(() => expect(diffInput.value).toBe(''))
+
+      await user.click(screen.getByRole('button', { name: /create adjustment/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText(/quantity change is required/i)).toBeInTheDocument()
+      })
+      // Validation blocked submit — mutation never fired.
+      expect(mockCreateAdjustment).not.toHaveBeenCalled()
+    })
+  })
+
   describe('revert prefill', () => {
     it('prefills negative qty changes from a completed source when ?revertFrom is set', async () => {
       mockSearchParams.mockReturnValue([new URLSearchParams('revertFrom=source-1'), vi.fn()])


### PR DESCRIPTION
## Problem
On the Stock Adjustment create/edit form, the `Qty Change` field could not be cleared back to empty after typing a value — deleting the number snapped it back to `0`, blocking normal editing (#864).

## Root cause
The `difference` field `onChange` coerced empty input to `0`, so `displayValue` always rendered `"0"` and the field never emptied.

## Fix (single file: `CreateStockAdjustmentPage.tsx`)
- Widen `ItemRow.difference` type to `number | '' | '-'` so transient states are representable.
- onChange: write `''`/`'-'` through instead of coercing to `0`.
- Yup schema: `.transform()` maps `''`/`'-'` → `undefined` so `.required('Quantity change is required')` fires on empty submit; `.notOneOf([0])` unchanged.
- Guard the row-total display and the submit filter with `Number(...) || 0` so transient strings never produce `NaN` or leak into the payload.

## Behavior
- During typing: field can be cleared or hold a lone `-` — no snap-back to `0`.
- On submit: empty → "Quantity change is required"; `0` → "Quantity change cannot be zero"; real numbers pass through.

## Tests
Three new cases in `CreateStockAdjustmentPage.test.tsx`: clear-to-empty (no snap-back), lone-minus smoke test, submit-blocks-empty (asserts mutation never fires).

## Verification
`npm run lint` clean · `npm run type-check` clean · focal file 16/16 pass · full suite clean.

Closes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)