### PR TITLE
fix(inventory,sales,purchasing): consistent Add Item button label

### DIFF
--- a/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
+++ b/frontend/src/pages/purchasing/CreatePurchaseOrderPage.tsx
@@ -538,7 +538,7 @@ const CreatePurchaseOrderPage: React.FC = () => {
                   onClick={() => append(emptyItem())}
                   disabled={loading}
                 >
-                  Add Row / Add Item
+                  Add Item
                 </AppButton>
               </Box>
 

--- a/frontend/src/pages/sales/CreateSalesOrderPage.tsx
+++ b/frontend/src/pages/sales/CreateSalesOrderPage.tsx
@@ -632,7 +632,7 @@ const CreateSalesOrderPage: React.FC = () => {
                   onClick={() => append(emptyItem())}
                   disabled={isSaving}
                 >
-                  Add Row / Add Item
+                  Add Item
                 </AppButton>
               </Box>
 

--- a/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
+++ b/frontend/src/pages/sales/__tests__/CreateSalesOrderPage.test.tsx
@@ -532,7 +532,7 @@ describe('CreateSalesOrderPage — new features', () => {
       </BrowserRouter>,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /add row/i }))
+    fireEvent.click(screen.getByRole('button', { name: /add item/i }))
 
     const lastColFirstRow = document.querySelector('[data-cell="r0-c3"]')
     expect(lastColFirstRow).not.toBeNull()


### PR DESCRIPTION
## Problem
The add-item button label was inconsistent across the three transaction create forms:

| Form | Old label |
|------|-----------|
| Stock Adjustment | `Add Item` |
| Sales Order | `Add Row / Add Item` |
| Purchase Order | `Add Row / Add Item` |

## Fix
Unify all three on `Add Item`. Label-only change — row-add behavior, button variant, icon, and disabled state are untouched.

- `CreateSalesOrderPage.tsx` — `Add Row / Add Item` → `Add Item`
- `CreatePurchaseOrderPage.tsx` — `Add Row / Add Item` → `Add Item`
- `CreateSalesOrderPage.test.tsx` — updated matcher `/add row/i` → `/add item/i` (relied on the old text)

## Verification
- `npm run type-check` ✅
- `npm run lint` ✅
- `npm run test` (full frontend suite) ✅ — 1434 tests pass

Closes #866

🤖 Generated with [Claude Code](https://claude.com/claude-code)