### PR TITLE
fix(sales,purchasing,inventory): match line-item row height to header

### DIFF
--- a/frontend/src/components/transactions/OrderLineItemRow.tsx
+++ b/frontend/src/components/transactions/OrderLineItemRow.tsx
@@ -126,7 +126,7 @@ export default function OrderLineItemRow({
                     sx={{
                       '& .MuiInputBase-input': {
                         textAlign: 'left !important',
-                        padding: '6px 8px !important',
+                        padding: '2px 8px !important',
                         fontSize: '0.875rem',
                       },
                     }}
@@ -265,7 +265,7 @@ export default function OrderLineItemRow({
                 disabled={isSaving}
                 sx={{
                   width: '60px',
-                  '& .MuiInputBase-input': { fontSize: '0.875rem', padding: '6px 4px' },
+                  '& .MuiInputBase-input': { fontSize: '0.875rem', padding: '2px 4px' },
                 }}
                 slotProps={{
                   select: {

--- a/frontend/src/components/transactions/transactionTableStyles.ts
+++ b/frontend/src/components/transactions/transactionTableStyles.ts
@@ -19,8 +19,10 @@ export const LINE_ITEM_TABLE_SX = (theme: Theme): SxProps<Theme> => ({
     '&.Mui-focused fieldset': { border: `1px solid ${theme.palette.primary.main}` },
     backgroundColor: 'transparent',
     fontSize: '0.875rem',
+    minHeight: 29,
+    height: 29,
   },
-  '& .MuiTextField-root .MuiInputBase-input': { padding: '6px 8px' },
+  '& .MuiTextField-root .MuiInputBase-input': { padding: '2px 8px' },
   '& .MuiAutocomplete-root .MuiOutlinedInput-root': {
     paddingTop: 0,
     paddingBottom: 0,

--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -405,7 +405,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
                                     sx={{
                                       '& .MuiInputBase-input': {
                                         textAlign: 'left !important',
-                                        padding: '6px 8px !important',
+                                        padding: '2px 8px !important',
                                         fontSize: '0.875rem',
                                       },
                                     }}


### PR DESCRIPTION
## Problem

Line-item field rows in Create SO / PO / SA were taller than the table header (measured 40px field vs 35px header). Body rows hold `TextField` inputs whose intrinsic outlined-input height exceeded the plain-text header cell.

## Fix

- Shrink input vertical padding `6px → 2px` in the shared row style + product Autocomplete overrides (SO/PO/SA) and the discount-type select.
- Add a central input height clamp (`MuiOutlinedInput-root` height 29px) in `LINE_ITEM_TABLE_SX` so all fields resolve to header height.
- Horizontal padding unchanged.

## Files

- `transactionTableStyles.ts` — input padding + central height clamp (all 3 forms)
- `OrderLineItemRow.tsx` — product Autocomplete + discountType select padding (SO/PO)
- `CreateStockAdjustmentPage.tsx` — product Autocomplete padding (SA)

## Verify

- [ ] Rebuild frontend, visually confirm field rows == header height in Create SO/PO/SA
- [x] Full frontend test suite — 200 files, 1434 tests, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)