### PR TITLE
fix(inventory): hide already-selected products in stock adjustment autocomplete

### DIFF
--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -213,6 +213,14 @@ const CreateStockAdjustmentPage: React.FC = () => {
     return (Number(item.liveStock) || 0) + (Number(item.difference) || 0) < 0
   })
 
+  const selectedProductIds = useMemo(
+    () =>
+      new Set(
+        (watchedItems ?? []).map((item) => item.productId).filter(Boolean),
+      ),
+    [watchedItems],
+  )
+
   const handleProductSelect = (index: number, product: any) => {
     if (!product) {
       setDuplicateError(null)
@@ -389,7 +397,11 @@ const CreateStockAdjustmentPage: React.FC = () => {
                             control={control}
                             render={({ field: pdField }) => (
                               <Autocomplete
-                                options={products}
+                                options={products.filter(
+                                  (p: any) =>
+                                    p.id === pdField.value ||
+                                    !selectedProductIds.has(p.id),
+                                )}
                                 getOptionLabel={(option: any) => option?.name || ''}
                                 isOptionEqualToValue={(option: any, value: any) => option.id === value.id}
                                 value={products.find((p: any) => p.id === pdField.value) || null}

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -130,8 +130,8 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
     })
   })
 
-  describe('duplicate product guard', () => {
-    it('blocks adding a product already in the items table', async () => {
+  describe('product exclusion', () => {
+    it('hides an already-selected product from other rows', async () => {
       const user = userEvent.setup()
       renderPage()
 
@@ -149,11 +149,10 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
       const inputs2 = screen.getAllByPlaceholderText('Search product...')
       await user.click(inputs2[1])
       const listbox2 = await screen.findByRole('listbox')
-      await user.click(within(listbox2).getByText('Alpha Widget'))
 
-      await waitFor(() => {
-        expect(screen.getByText(/already in the items list/i)).toBeInTheDocument()
-      })
+      // Alpha Widget (taken in row 1) is absent; other products still present
+      expect(within(listbox2).queryByText('Alpha Widget')).not.toBeInTheDocument()
+      expect(within(listbox2).getByText('Beta Gadget')).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## Summary
Stock Adjustment create/edit form no longer shows products already picked in another row.

- `CreateStockAdjustmentPage.tsx`: added `selectedProductIds` memo (Set<string> from `watchedItems`); filter each row's `Autocomplete` options to exclude products chosen in *other* rows, keeping the current row's own selection visible (`p.id === pdField.value`).
- `handleProductSelect` duplicate guard preserved as a backup check.
- Test: replaced the now-invalid duplicate-guard UI test with `hides an already-selected product from other rows` (asserts Alpha Widget absent in row 2, Beta Gadget present).

## Test
16 tests pass in the file; type-check + lint clean.

Closes #869

🤖 Generated with [Claude Code](https://claude.com/claude-code)