### PR TITLE
fix(inventory): exclude service products from stock UI

### DIFF
--- a/backend/src/modules/inventory/services/stock-adjustment.service.spec.ts
+++ b/backend/src/modules/inventory/services/stock-adjustment.service.spec.ts
@@ -4,7 +4,7 @@ import { getRepositoryToken, getDataSourceToken } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
 import { StockAdjustmentService } from './stock-adjustment.service';
 import { StockAdjustment, StockAdjustmentItem, StockAdjustmentStatus } from '../../../database/entities/stock-adjustment.entity';
-import { Product } from '../../../database/entities/product.entity';
+import { Product, ProductType } from '../../../database/entities/product.entity';
 import { User } from '../../../database/entities/user.entity';
 import { StockMovementService } from './stock-movement.service';
 import { SettingsService } from '../../settings/settings.service';
@@ -21,6 +21,8 @@ describe('StockAdjustmentService', () => {
   let auditLogService: jest.Mocked<AuditLogService>;
   let dataSource: jest.Mocked<DataSource>;
   let stockMovementRepository: jest.Mocked<Repository<StockMovement>>;
+  let productRepository: jest.Mocked<Repository<Product>>;
+  let stockAdjustmentItemRepository: jest.Mocked<Repository<StockAdjustmentItem>>;
 
   const createMockStockAdjustment = (status: StockAdjustmentStatus = StockAdjustmentStatus.DRAFT): Partial<StockAdjustment> => ({
     id: '123e4567-e89b-12d3-a456-426614174000',
@@ -103,11 +105,14 @@ describe('StockAdjustmentService', () => {
           useValue: {
             save: jest.fn(),
             create: jest.fn(),
+            delete: jest.fn(),
           },
         },
         {
           provide: getRepositoryToken(Product),
-          useValue: {},
+          useValue: {
+            findBy: jest.fn(),
+          },
         },
         {
           provide: getRepositoryToken(User),
@@ -156,6 +161,8 @@ describe('StockAdjustmentService', () => {
     stockMovementService = module.get(StockMovementService);
     auditLogService = module.get(AuditLogService);
     stockMovementRepository = module.get(getRepositoryToken(StockMovement));
+    productRepository = module.get(getRepositoryToken(Product));
+    stockAdjustmentItemRepository = module.get(getRepositoryToken(StockAdjustmentItem));
   });
 
   it('should be defined', () => {
@@ -354,7 +361,37 @@ describe('StockAdjustmentService', () => {
     });
   });
 
-  describe('updateNotes', () => {
+  describe('service product rejection', () => {
+  const serviceProduct = { id: 'svc-1', type: ProductType.SERVICE, baseCost: 5 } as any
+
+  it('create() rejects service products', async () => {
+    productRepository.findBy.mockResolvedValue([serviceProduct])
+    await expect(
+      service.create({ adjustmentDate: '2026-07-05', items: [{ productId: 'svc-1', oldQuantity: 0, newQuantity: 1, difference: 1 }] } as any),
+    ).rejects.toThrow('Service products are not valid for stock adjustments')
+  })
+
+  it('update() rejects service products', async () => {
+    stockAdjustmentRepository.findOne.mockResolvedValue({ id: 'sa-1', isEditable: () => true, items: [] } as any)
+    productRepository.findBy.mockResolvedValue([serviceProduct])
+    await expect(
+      service.update('sa-1', { items: [{ productId: 'svc-1', oldQuantity: 0, newQuantity: 1, difference: 1 }] } as any),
+    ).rejects.toThrow('Service products are not valid for stock adjustments')
+  })
+
+  it('update() rejection does not reach the delete/save path', async () => {
+    stockAdjustmentRepository.findOne.mockResolvedValue({ id: 'sa-1', isEditable: () => true, items: [] } as any)
+    productRepository.findBy.mockResolvedValue([serviceProduct])
+    await expect(
+      service.update('sa-1', { items: [{ productId: 'svc-1', oldQuantity: 0, newQuantity: 1, difference: 1 }] } as any),
+    ).rejects.toThrow()
+    expect(stockAdjustmentItemRepository.delete).not.toHaveBeenCalled()
+    expect(stockAdjustmentItemRepository.save).not.toHaveBeenCalled()
+    expect(stockAdjustmentRepository.save).not.toHaveBeenCalled()
+  })
+})
+
+describe('updateNotes', () => {
     it('updates notes on a completed adjustment without changing status/items', async () => {
       const adjustment: any = { id: 'a1', adjustmentNumber: 'SA-1', status: 'completed', notes: 'old', items: [] };
       jest.spyOn(stockAdjustmentRepository, 'findOne').mockResolvedValue(adjustment);

--- a/backend/src/modules/inventory/services/stock-adjustment.service.ts
+++ b/backend/src/modules/inventory/services/stock-adjustment.service.ts
@@ -14,7 +14,7 @@ import {
   StockAdjustmentItem,
   StockAdjustmentStatus,
 } from '../../../database/entities/stock-adjustment.entity';
-import { Product } from '../../../database/entities/product.entity';
+import { Product, ProductType } from '../../../database/entities/product.entity';
 import { User } from '../../../database/entities/user.entity';
 import {
   CreateStockAdjustmentDto,
@@ -75,6 +75,14 @@ export class StockAdjustmentService extends BaseCrudService<
   protected async afterDelete(adjustment: StockAdjustment): Promise<void> {
     if (adjustment.status !== StockAdjustmentStatus.DRAFT) {
       throw new BadRequestException('Only draft adjustments can be deleted');
+    }
+  }
+
+  private assertNoServiceProducts(products: Product[]): void {
+    if (products.some(p => p.type === ProductType.SERVICE)) {
+      throw new BadRequestException(
+        'Service products are not valid for stock adjustments',
+      );
     }
   }
 
@@ -144,6 +152,7 @@ export class StockAdjustmentService extends BaseCrudService<
     if (products.length !== productIds.length) {
       throw new BadRequestException('One or more products not found');
     }
+    this.assertNoServiceProducts(products);
 
     // Generate SA number
     const adjustmentNumber = await this.generateSANumber();
@@ -371,17 +380,18 @@ export class StockAdjustmentService extends BaseCrudService<
     if (updateDto.items) {
       this.assertNoDuplicateProducts(updateDto.items);
 
-      // Remove old items
-      await this.stockAdjustmentItemRepository.delete({
-        stockAdjustmentId: id,
-      });
-
-      // Verify all products exist
+      // Verify all products exist and are not services BEFORE mutating anything
       const productIds = updateDto.items.map(item => item.productId);
       const products = await this.productRepository.findBy({ id: In(productIds) });
       if (products.length !== productIds.length) {
         throw new BadRequestException('One or more products not found');
       }
+      this.assertNoServiceProducts(products);
+
+      // Safe to remove old items now that validation passed
+      await this.stockAdjustmentItemRepository.delete({
+        stockAdjustmentId: id,
+      });
 
       // Create new items
       let totalValue = 0;

--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -88,7 +88,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
   const isEditMode = !!id
   const { showSuccess, showError } = useNotification()
 
-  const { data: productsData, isLoading: productsLoading } = useGetProductsQuery({ isActive: true })
+  const { data: productsData, isLoading: productsLoading } = useGetProductsQuery({ isActive: true, type: 'Stocked Product' })
   const { data: adjustment, isLoading: adjustmentLoading } = useGetStockAdjustmentQuery(id!, { skip: !id })
   const { data: sourceAdjustment, isLoading: sourceLoading } = useGetStockAdjustmentQuery(revertFrom!, { skip: !revertFrom })
 

--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -79,6 +79,11 @@ const fieldSx = {
   '& .MuiInputLabel-root': { fontSize: '0.875rem' },
 }
 
+const calculateQtyAfter = (
+  liveStock: number | string,
+  difference: number | string,
+): number => (Number(liveStock) || 0) + (Number(difference) || 0)
+
 const CreateStockAdjustmentPage: React.FC = () => {
   const theme = useTheme()
   const navigate = useNavigate()
@@ -210,7 +215,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
 
   const hasNegativeStock = (watchedItems ?? []).some((item) => {
     if (!item.productId) return false
-    return (Number(item.liveStock) || 0) + (Number(item.difference) || 0) < 0
+    return calculateQtyAfter(item.liveStock, item.difference) < 0
   })
 
   const selectedProductIds = useMemo(
@@ -369,12 +374,15 @@ const CreateStockAdjustmentPage: React.FC = () => {
                 <Table size="small" sx={LINE_ITEM_TABLE_SX(theme)}>
                   <TableHead>
                     <TableRow>
-                      <TableCell sx={{ width: '30%', minWidth: 200 }}>Product</TableCell>
+                      <TableCell sx={{ width: '25%', minWidth: 200 }}>Product</TableCell>
                       <TableCell align="center" sx={{ width: '12%', minWidth: 80 }}>
                         Current Stock
                       </TableCell>
                       <TableCell align="center" sx={{ width: '12%', minWidth: 80 }}>
                         Qty Change
+                      </TableCell>
+                      <TableCell align="center" sx={{ width: '12%', minWidth: 80 }}>
+                        Qty After
                       </TableCell>
                       <TableCell align="center" sx={{ width: '12%', minWidth: 80 }}>
                         Unit Cost
@@ -475,6 +483,26 @@ const CreateStockAdjustmentPage: React.FC = () => {
                               )
                             }}
                           />
+                        </TableCell>
+                        <TableCell align="center" sx={{ padding: '2px 8px !important' }}>
+                          {(() => {
+                            const qtyAfter = calculateQtyAfter(
+                              watchedItems?.[index]?.liveStock ?? 0,
+                              watchedItems?.[index]?.difference ?? 0,
+                            )
+                            return (
+                              <Typography
+                                variant="body2"
+                                data-testid={`qtyAfter-${index}`}
+                                sx={{
+                                  fontWeight: 600,
+                                  color: qtyAfter < 0 ? 'error.main' : 'text.primary',
+                                }}
+                              >
+                                {qtyAfter}
+                              </Typography>
+                            )
+                          })()}
                         </TableCell>
                         <TableCell align="center" sx={{ padding: '2px 8px !important' }}>
                           <Typography variant="body2" sx={{ color: 'text.secondary' }}>

--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -485,24 +485,25 @@ const CreateStockAdjustmentPage: React.FC = () => {
                           />
                         </TableCell>
                         <TableCell align="center" sx={{ padding: '2px 8px !important' }}>
-                          {(() => {
-                            const qtyAfter = calculateQtyAfter(
+                          <Typography
+                            variant="body2"
+                            data-testid={`qtyAfter-${index}`}
+                            sx={{
+                              fontWeight: 600,
+                              color:
+                                calculateQtyAfter(
+                                  watchedItems?.[index]?.liveStock ?? 0,
+                                  watchedItems?.[index]?.difference ?? 0,
+                                ) < 0
+                                  ? 'error.main'
+                                  : 'text.primary',
+                            }}
+                          >
+                            {calculateQtyAfter(
                               watchedItems?.[index]?.liveStock ?? 0,
                               watchedItems?.[index]?.difference ?? 0,
-                            )
-                            return (
-                              <Typography
-                                variant="body2"
-                                data-testid={`qtyAfter-${index}`}
-                                sx={{
-                                  fontWeight: 600,
-                                  color: qtyAfter < 0 ? 'error.main' : 'text.primary',
-                                }}
-                              >
-                                {qtyAfter}
-                              </Typography>
-                            )
-                          })()}
+                            )}
+                          </Typography>
                         </TableCell>
                         <TableCell align="center" sx={{ padding: '2px 8px !important' }}>
                           <Typography variant="body2" sx={{ color: 'text.secondary' }}>

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -457,6 +457,28 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
     })
   })
 
+  describe('Qty After column', () => {
+    it('shows Qty After = current stock + qty change', async () => {
+      const user = userEvent.setup()
+      renderPage()
+
+      const input = screen.getByPlaceholderText('Search product...')
+      await user.click(input)
+      const listbox = await screen.findByRole('listbox')
+      await user.click(within(listbox).getByText('Alpha Widget'))
+
+      await waitFor(() => {
+        expect(input).toHaveValue('Alpha Widget')
+      })
+
+      const diff = screen.getByTestId('items.0.difference')
+      fireEvent.change(diff, { target: { value: '-3' } })
+      await waitFor(() => {
+        expect(screen.getByTestId('qtyAfter-0')).toHaveTextContent('7')
+      })
+    })
+  })
+
   describe('section alignment (#858)', () => {
     it('renders PO/SO-aligned section headers', () => {
       renderPage()

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -130,6 +130,13 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
     })
   })
 
+  it('requests only stocked products (excludes services)', () => {
+    renderPage()
+    expect(mockProductsQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ isActive: true, type: 'Stocked Product' }),
+    )
+  })
+
   describe('product exclusion', () => {
     it('hides an already-selected product from other rows', async () => {
       const user = userEvent.setup()

--- a/frontend/src/pages/inventory/components/ProductOverviewTab.tsx
+++ b/frontend/src/pages/inventory/components/ProductOverviewTab.tsx
@@ -27,7 +27,8 @@ export default function ProductOverviewTab({ product }: { product: Product }) {
   )
   const { data: regionalSettings } = useGetRegionalSettingsQuery()
   const lowStockThreshold = regionalSettings?.lowStockThreshold ?? 10
-  const stockStatus = getStockStatus(product.stockQuantity, lowStockThreshold)
+  const isService = product.type === 'Service'
+  const stockStatus = isService ? null : getStockStatus(product.stockQuantity, lowStockThreshold)
 
   return (
     <Box>
@@ -71,9 +72,15 @@ export default function ProductOverviewTab({ product }: { product: Product }) {
             <CardContent>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
                 <Typography variant="h6">Stock</Typography>
-                <StatusChip status={stockStatus} />
+                {!isService && stockStatus && <StatusChip status={stockStatus} />}
               </Box>
-              <Field label="Stock Qty" value={formatNumber(product.stockQuantity)} />
+              {isService ? (
+                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                  Stock not tracked for services
+                </Typography>
+              ) : (
+                <Field label="Stock Qty" value={formatNumber(product.stockQuantity)} />
+              )}
             </CardContent>
           </Card>
         </Grid>

--- a/frontend/src/pages/inventory/components/__tests__/ProductOverviewTab.test.tsx
+++ b/frontend/src/pages/inventory/components/__tests__/ProductOverviewTab.test.tsx
@@ -28,6 +28,13 @@ const product = {
 } as unknown as Product
 
 describe('ProductOverviewTab', () => {
+  it('shows "not tracked" for service products instead of stock status', () => {
+    render(<ProductOverviewTab product={{ ...product, type: 'Service', stockQuantity: 0 } as Product} />)
+    expect(screen.getByText('Stock not tracked for services')).toBeInTheDocument()
+    expect(screen.queryByText('Out of Stock')).not.toBeInTheDocument()
+    expect(screen.queryByText('Stock Qty')).not.toBeInTheDocument()
+  })
+
   it('renders basic info and a margin chip for the price list', () => {
     render(<ProductOverviewTab product={product} />)
     expect(screen.getByText('B1')).toBeInTheDocument()


### PR DESCRIPTION
Closes #871

Four fixes so Service-type products no longer appear in stock UI, plus a backend hard stop.

## Changes
- **Product detail** — Overview tab renders "Stock not tracked for services" instead of a stock-status card for Service products. `stockUtils.ts` left pure (no product-type logic).
- **Stock adjustment picker** — excludes services via the backend `type: 'Stocked Product'` filter (payload + UI aligned), not a client-side filter.
- **Stock adjustment form** — new **Qty After** column (current stock + qty change), red when negative. Shared `calculateQtyAfter` helper feeds both the cell and the negative-stock guard.
- **Backend hard stop** — `StockAdjustmentService` rejects service product IDs in `create()` and `update()`. `update()` now validates (existence + service-type) **before** deleting existing items, closing a delete-before-validate data-loss trap.

## Invariant
DB check found 0 stock-adjustment items referencing a Service product — no cleanup migration or legacy display fallback needed.

## Verification
- Frontend: lint + type-check clean, 22/22 tests pass.
- Backend: lint clean, 1213/1213 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)