### PR TITLE
fix(inventory): refresh draft stock adjustment live stock after later completions

### DIFF
--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -175,6 +175,28 @@ const CreateStockAdjustmentPage: React.FC = () => {
   }, [adjustment, isEditMode, reset])
 
   useEffect(() => {
+    if (!adjustment || !isEditMode || !editAppliedRef.current) return
+
+    const liveStockByProductId = new Map<string, number>(
+      ((adjustment as any).items ?? []).map((item: any) => [
+        item.productId,
+        Number(item.liveStock ?? item.oldQuantity ?? 0),
+      ]),
+    )
+
+    ;(watchedItems ?? []).forEach((item, index) => {
+      if (!item.productId) return
+      const liveStock = liveStockByProductId.get(item.productId)
+      if (liveStock === undefined || liveStock === item.liveStock) return
+
+      setValue(`items.${index}.liveStock`, liveStock, {
+        shouldDirty: false,
+        shouldValidate: false,
+      })
+    })
+  }, [adjustment, isEditMode, watchedItems, setValue])
+
+  useEffect(() => {
     if (!revertFrom || !sourceAdjustment || !products.length || revertAppliedRef.current) return
     if ((sourceAdjustment as any).status !== 'completed') {
       showError('Cannot revert an adjustment that is not completed')

--- a/frontend/src/pages/inventory/StockAdjustmentViewPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentViewPage.tsx
@@ -148,7 +148,7 @@ export default function StockAdjustmentViewPage() {
             <TableHead>
               <TableRow sx={{ '& .MuiTableCell-head': { fontWeight: 600 } }}>
                 <TableCell>Product</TableCell>
-                <TableCell align="right">Current Stock</TableCell>
+                <TableCell align="right">{isCompleted ? 'Stock Before' : 'Current Stock'}</TableCell>
                 <TableCell align="right">Qty Change</TableCell>
                 <TableCell align="right">Unit Cost</TableCell>
                 <TableCell align="right">Total</TableCell>

--- a/frontend/src/pages/inventory/StockAdjustmentViewPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentViewPage.tsx
@@ -150,9 +150,9 @@ export default function StockAdjustmentViewPage() {
                 <TableCell>Product</TableCell>
                 <TableCell align="right">{isCompleted ? 'Stock Before' : 'Current Stock'}</TableCell>
                 <TableCell align="right">Qty Change</TableCell>
+                <TableCell align="right">Stock After</TableCell>
                 <TableCell align="right">Unit Cost</TableCell>
                 <TableCell align="right">Total</TableCell>
-                <TableCell align="right">Stock After</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -165,11 +165,11 @@ export default function StockAdjustmentViewPage() {
                   <TableCell align="right" sx={{ color: item.difference > 0 ? 'success.main' : 'error.main', fontWeight: 600 }}>
                     {item.difference > 0 ? '+' : ''}{formatNumber(item.difference)}
                   </TableCell>
-                  <TableCell align="right">{formatCurrency(item.unitCost ?? 0)}</TableCell>
-                  <TableCell align="right">{formatCurrency(item.totalValue ?? 0)}</TableCell>
                   <TableCell align="right">
                     {isCompleted ? (item.stockAfter != null ? formatNumber(item.stockAfter) : '—') : '—'}
                   </TableCell>
+                  <TableCell align="right">{formatCurrency(item.unitCost ?? 0)}</TableCell>
+                  <TableCell align="right">{formatCurrency(item.totalValue ?? 0)}</TableCell>
                 </TableRow>
               ))}
             </TableBody>

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -336,6 +336,75 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
     })
   })
 
+  describe('live stock refresh on refetch (issue #873)', () => {
+    it('syncs Current Stock from a same-id refetch while preserving the entered qty change', async () => {
+      mockParams.mockReturnValue({ id: 'abc-123' })
+
+      const ui = (
+        <BrowserRouter>
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <CreateStockAdjustmentPage />
+          </LocalizationProvider>
+        </BrowserRouter>
+      )
+
+      const initialEdit = {
+        data: {
+          id: 'abc-123',
+          adjustmentNumber: 'SA-001',
+          adjustmentDate: '2026-03-15T00:00:00.000Z',
+          notes: '',
+          items: [
+            { productId: 'p1', difference: 0, unitCost: 5, oldQuantity: 10, newQuantity: 10, liveStock: 10 },
+          ],
+        },
+        isLoading: false,
+        isError: false,
+      }
+      mockAdjustmentQuery.mockImplementation((id: string) =>
+        id === 'abc-123' ? initialEdit : stableAdjNull,
+      )
+
+      const { rerender } = render(ui)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('liveStock-0')).toHaveTextContent('10')
+      })
+
+      const diffInput = screen.getByTestId('items.0.difference') as HTMLInputElement
+      await userEvent.clear(diffInput)
+      await userEvent.type(diffInput, '7')
+      await waitFor(() => expect(diffInput.value).toBe('7'))
+
+      const refetchedEdit = {
+        data: {
+          ...initialEdit.data,
+          items: [
+            { productId: 'p1', difference: 0, unitCost: 5, oldQuantity: 10, newQuantity: 10, liveStock: 25 },
+          ],
+        },
+        isLoading: false,
+        isError: false,
+      }
+      mockAdjustmentQuery.mockImplementation((id: string) =>
+        id === 'abc-123' ? refetchedEdit : stableAdjNull,
+      )
+      rerender(
+        <BrowserRouter>
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <CreateStockAdjustmentPage />
+          </LocalizationProvider>
+        </BrowserRouter>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('liveStock-0')).toHaveTextContent('25')
+      })
+      expect((screen.getByTestId('items.0.difference') as HTMLInputElement).value).toBe('7')
+      expect(screen.getByTestId('qtyAfter-0')).toHaveTextContent('32')
+    })
+  })
+
   it('renders a read-only Adjustment Number field in create mode', () => {
     renderPage()
     const field = screen.getByLabelText(/adjustment number/i) as HTMLInputElement

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -403,6 +403,77 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
       expect((screen.getByTestId('items.0.difference') as HTMLInputElement).value).toBe('7')
       expect(screen.getByTestId('qtyAfter-0')).toHaveTextContent('32')
     })
+
+    it('matches refreshed live stock by productId, not server array index', async () => {
+      mockParams.mockReturnValue({ id: 'abc-123' })
+
+      const ui = (
+        <BrowserRouter>
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <CreateStockAdjustmentPage />
+          </LocalizationProvider>
+        </BrowserRouter>
+      )
+
+      // Two rows: p1 (row 0, live 10), p2 (row 1, live 5)
+      const initialEdit = {
+        data: {
+          id: 'abc-123',
+          adjustmentNumber: 'SA-001',
+          adjustmentDate: '2026-03-15T00:00:00.000Z',
+          notes: '',
+          items: [
+            { productId: 'p1', difference: 0, unitCost: 5, oldQuantity: 10, newQuantity: 10, liveStock: 10 },
+            { productId: 'p2', difference: 0, unitCost: 3, oldQuantity: 5, newQuantity: 5, liveStock: 5 },
+          ],
+        },
+        isLoading: false,
+        isError: false,
+      }
+      mockAdjustmentQuery.mockImplementation((id: string) =>
+        id === 'abc-123' ? initialEdit : stableAdjNull,
+      )
+
+      const { rerender } = render(ui)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('liveStock-0')).toHaveTextContent('10')
+        expect(screen.getByTestId('liveStock-1')).toHaveTextContent('5')
+      })
+
+      // Refetch returns the SAME products but in REVERSED array order, each with
+      // new live stock: p2 -> 8, p1 -> 25. An index-based sync would put p2's 8
+      // into row 0 (p1) and p1's 25 into row 1 (p2). productId matching keeps
+      // row 0 (p1) = 25 and row 1 (p2) = 8.
+      const refetchedEdit = {
+        data: {
+          ...initialEdit.data,
+          items: [
+            { productId: 'p2', difference: 0, unitCost: 3, oldQuantity: 5, newQuantity: 5, liveStock: 8 },
+            { productId: 'p1', difference: 0, unitCost: 5, oldQuantity: 10, newQuantity: 10, liveStock: 25 },
+          ],
+        },
+        isLoading: false,
+        isError: false,
+      }
+      mockAdjustmentQuery.mockImplementation((id: string) =>
+        id === 'abc-123' ? refetchedEdit : stableAdjNull,
+      )
+      rerender(
+        <BrowserRouter>
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <CreateStockAdjustmentPage />
+          </LocalizationProvider>
+        </BrowserRouter>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('liveStock-0')).toHaveTextContent('25')
+      })
+      // row 0 is p1 -> 25 (not p2's 8), row 1 is p2 -> 8 (not p1's 25)
+      expect(screen.getByTestId('liveStock-0')).toHaveTextContent('25')
+      expect(screen.getByTestId('liveStock-1')).toHaveTextContent('8')
+    })
   })
 
   it('renders a read-only Adjustment Number field in create mode', () => {

--- a/frontend/src/pages/inventory/__tests__/StockAdjustmentViewPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/StockAdjustmentViewPage.test.tsx
@@ -38,7 +38,7 @@ vi.mock('@/store/api/inventoryApi', () => ({
 import StockAdjustmentViewPage from '../StockAdjustmentViewPage'
 
 describe('StockAdjustmentViewPage', () => {
-  it('shows historical Current Stock and Stock After for completed items', () => {
+  it('labels the historical column "Stock Before" and shows stockBefore/stockAfter for completed items', () => {
     render(
       <MemoryRouter initialEntries={['/inventory/stock-adjustments/a1/view']}>
         <Routes>
@@ -47,7 +47,31 @@ describe('StockAdjustmentViewPage', () => {
       </MemoryRouter>,
     )
     expect(screen.getByText('Widget')).toBeInTheDocument()
+    // completed view relabels "Current Stock" -> "Stock Before" so the historical
+    // snapshot (stockBefore) is not mistaken for live stock (issue #873 follow-up)
+    expect(screen.getByText('Stock Before')).toBeInTheDocument()
+    expect(screen.queryByText('Current Stock')).not.toBeInTheDocument()
     expect(screen.getByText('5')).toBeInTheDocument()
     expect(screen.getByText('7')).toBeInTheDocument()
+  })
+
+  it('labels the column "Current Stock" and shows liveStock for a draft', () => {
+    const original = mockAdjustment.status
+    mockAdjustment.status = 'draft'
+    try {
+      render(
+        <MemoryRouter initialEntries={['/inventory/stock-adjustments/a1/view']}>
+          <Routes>
+            <Route path="/inventory/stock-adjustments/:id/view" element={<StockAdjustmentViewPage />} />
+          </Routes>
+        </MemoryRouter>,
+      )
+      // draft view keeps live-stock semantics: header "Current Stock", value = liveStock (7)
+      expect(screen.getByText('Current Stock')).toBeInTheDocument()
+      expect(screen.queryByText('Stock Before')).not.toBeInTheDocument()
+      expect(screen.getByText('7')).toBeInTheDocument()
+    } finally {
+      mockAdjustment.status = original
+    }
   })
 })


### PR DESCRIPTION
Closes #873

## Problem

Two draft stock adjustments for the same product: completing the newer one, then reopening the earlier draft, showed a stale create-time stock snapshot instead of live stock. Users comparing drafts could act on outdated numbers.

## Root cause

The edit form (`CreateStockAdjustmentPage.tsx`) seeded each row's `liveStock` once via a `reset()` gated by `editAppliedRef`. When the `getStockAdjustment(id)` query refetched with fresh live stock (after another adjustment completed), the one-shot reset never re-applied it. Backend `findOne()` already returned correct live stock; the frontend didn't rebind.

## Changes

- **Draft live-stock refresh** — new `useEffect` in `CreateStockAdjustmentPage.tsx` that, after initial hydration (`editAppliedRef.current`), re-syncs each row's `liveStock` from the refreshed `adjustment.items`, matched by **`productId`** (not array index), preserving the user's `difference` / `unitCost` / product selection (`shouldDirty: false`, `shouldValidate: false`). `Qty After` recomputes automatically.
- **View clarity** — completed adjustments displayed historical `stockBefore` under a "Current Stock" header, which read as wrong once live stock changed. Relabelled to **"Stock Before"** for completed adjustments; drafts keep live "Current Stock".
- **Column order** — moved **Stock After** to directly after **Qty Change** in the view table, so rows read before → change → after, then cost columns.

## Tests

- `CreateStockAdjustmentPage.test.tsx`: same-`id` refetch updates Current Stock while preserving entered Qty Change (10 → diff 7 → refetch 25 → 25 / 7 / 32); plus a productId-vs-index discrimination test (reversed server order must not mis-assign stock).
- `StockAdjustmentViewPage.test.tsx`: completed view shows "Stock Before" (not "Current Stock"); draft view keeps "Current Stock" with live stock.
- Full frontend suite green: **1440 tests / 200 files**. Type-check + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)