### PR TITLE
fix(inventory): show product name on stock adjustment edit form

### DIFF
--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -84,6 +84,9 @@ const calculateQtyAfter = (
   difference: number | string,
 ): number => (Number(liveStock) || 0) + (Number(difference) || 0)
 
+const getAdjustmentItemProductId = (item: any): string =>
+  item?.productId ?? item?.product?.id ?? ''
+
 const CreateStockAdjustmentPage: React.FC = () => {
   const theme = useTheme()
   const navigate = useNavigate()
@@ -121,6 +124,22 @@ const CreateStockAdjustmentPage: React.FC = () => {
   const isSaving = isCreating || isUpdating
 
   const products = (productsData?.data ?? []) as any[]
+  const fallbackProductsById = useMemo(() => {
+    const map = new Map<string, any>()
+    const sources = [adjustment, sourceAdjustment]
+    for (const src of sources) {
+      for (const item of ((src as any)?.items ?? [])) {
+        const id = getAdjustmentItemProductId(item)
+        if (!id || !item.product || map.has(id)) continue
+        map.set(id, {
+          ...item.product,
+          stockQuantity: item.liveStock ?? item.oldQuantity ?? 0,
+          baseCost: item.unitCost ?? 0,
+        })
+      }
+    }
+    return map
+  }, [adjustment, sourceAdjustment])
   const [duplicateError, setDuplicateError] = useState<string | null>(null)
   const [pageError, setPageError] = useState<string | null>(null)
 
@@ -164,7 +183,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
         : getCurrentDate(),
       notes: (adjustment as any).notes || '',
       items: ((adjustment as any).items ?? []).map((item: any) => ({
-        productId: item.productId,
+        productId: getAdjustmentItemProductId(item),
         // Prefer current live stock (backend-enriched) over the stored oldQuantity snapshot,
         // so a re-edited draft derives old/new from up-to-date stock (matches spec).
         liveStock: Number(item.liveStock ?? item.oldQuantity ?? 0),
@@ -177,11 +196,13 @@ const CreateStockAdjustmentPage: React.FC = () => {
   useEffect(() => {
     if (!adjustment || !isEditMode || !editAppliedRef.current) return
 
-    const liveStockByProductId = new Map<string, number>(
-      ((adjustment as any).items ?? []).map((item: any) => [
-        item.productId,
-        Number(item.liveStock ?? item.oldQuantity ?? 0),
-      ]),
+    const liveStockByProductId = ((adjustment as any).items ?? []).reduce(
+      (map: Map<string, number>, item: any) => {
+        const pid = getAdjustmentItemProductId(item)
+        if (pid) map.set(pid, Number(item.liveStock ?? item.oldQuantity ?? 0))
+        return map
+      },
+      new Map<string, number>(),
     )
 
     ;(watchedItems ?? []).forEach((item, index) => {
@@ -197,7 +218,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
   }, [adjustment, isEditMode, watchedItems, setValue])
 
   useEffect(() => {
-    if (!revertFrom || !sourceAdjustment || !products.length || revertAppliedRef.current) return
+    if (!revertFrom || !sourceAdjustment || revertAppliedRef.current) return
     if ((sourceAdjustment as any).status !== 'completed') {
       showError('Cannot revert an adjustment that is not completed')
       navigate(`/inventory/stock-adjustments/${revertFrom}/view`)
@@ -206,12 +227,14 @@ const CreateStockAdjustmentPage: React.FC = () => {
     revertAppliedRef.current = true
     const grouped = new Map<string, { productId: string; unitCost: number; diffSum: number }>()
     ;((sourceAdjustment as any).items ?? []).forEach((item: any) => {
-      const existing = grouped.get(item.productId)
+      const productId = getAdjustmentItemProductId(item)
+      if (!productId) return
+      const existing = grouped.get(productId)
       if (existing) {
         existing.diffSum += Number(item.difference) || 0
       } else {
-        grouped.set(item.productId, {
-          productId: item.productId,
+        grouped.set(productId, {
+          productId,
           unitCost: Number(item.unitCost) || 0,
           diffSum: Number(item.difference) || 0,
         })
@@ -219,10 +242,12 @@ const CreateStockAdjustmentPage: React.FC = () => {
     })
     const prefillItems = Array.from(grouped.values())
       .map((g) => {
-        const product = products.find((p: any) => p.id === g.productId)
+        const product =
+          products.find((p: any) => p.id === g.productId) ??
+          fallbackProductsById.get(g.productId)
         return {
           productId: g.productId,
-          liveStock: product?.stockQuantity ?? 0,
+          liveStock: Number(product?.stockQuantity ?? 0),
           difference: -g.diffSum,
           unitCost: g.unitCost,
         }
@@ -233,7 +258,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
       notes: '',
       items: prefillItems.length > 0 ? prefillItems : [{ productId: '', liveStock: 0, difference: 0, unitCost: 0 }],
     })
-  }, [revertFrom, sourceAdjustment, products, reset, navigate, showError])
+  }, [revertFrom, sourceAdjustment, products, fallbackProductsById, reset, navigate, showError])
 
   const hasNegativeStock = (watchedItems ?? []).some((item) => {
     if (!item.productId) return false
@@ -427,14 +452,24 @@ const CreateStockAdjustmentPage: React.FC = () => {
                             control={control}
                             render={({ field: pdField }) => (
                               <Autocomplete
-                                options={products.filter(
-                                  (p: any) =>
-                                    p.id === pdField.value ||
-                                    !selectedProductIds.has(p.id),
-                                )}
+                                options={(() => {
+                                  const base = products.filter(
+                                    (p: any) =>
+                                      p.id === pdField.value ||
+                                      !selectedProductIds.has(p.id),
+                                  )
+                                  const fb = fallbackProductsById.get(pdField.value)
+                                  return fb && !base.some((p: any) => p.id === fb.id)
+                                    ? [...base, fb]
+                                    : base
+                                })()}
                                 getOptionLabel={(option: any) => option?.name || ''}
                                 isOptionEqualToValue={(option: any, value: any) => option.id === value.id}
-                                value={products.find((p: any) => p.id === pdField.value) || null}
+                                value={
+                                  products.find((p: any) => p.id === pdField.value) ??
+                                  fallbackProductsById.get(pdField.value) ??
+                                  null
+                                }
                                 onChange={(_, value) => handleProductSelect(index, value)}
                                 size="small"
                                 renderInput={(params) => (

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -336,6 +336,131 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
     })
   })
 
+  describe('edit shows product name from nested DTO (#875)', () => {
+    const editWith = (item: any) => {
+      mockParams.mockReturnValue({ id: 'abc-123' })
+      mockAdjustmentQuery.mockImplementation((id: string) =>
+        id === 'abc-123'
+          ? {
+              data: {
+                id: 'abc-123',
+                adjustmentNumber: 'SA-001',
+                adjustmentDate: '2026-03-15T00:00:00.000Z',
+                notes: '',
+                items: [item],
+              },
+              isLoading: false,
+              isError: false,
+            }
+          : stableAdjNull,
+      )
+    }
+
+    it('restores the product name when the DTO item is nested-only (product.id, no flat productId)', async () => {
+      editWith({
+        product: { id: 'p1', name: 'Alpha Widget', barcode: 'A1' },
+        difference: 5, unitCost: 5, oldQuantity: 10, newQuantity: 15, liveStock: 10,
+      })
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search product...')).toHaveValue('Alpha Widget')
+      })
+    })
+
+    it('still shows the name when the restored product is absent from the products query', async () => {
+      editWith({
+        product: { id: 'gone', name: 'Retired Widget', barcode: 'Z9' },
+        difference: 2, unitCost: 7, oldQuantity: 4, newQuantity: 6, liveStock: 4,
+      })
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search product...')).toHaveValue('Retired Widget')
+      })
+    })
+
+    it('preserves liveStock/unitCost for a fallback-only product (no zeroing)', async () => {
+      editWith({
+        product: { id: 'gone', name: 'Retired Widget', barcode: 'Z9' },
+        difference: 2, unitCost: 7, oldQuantity: 4, newQuantity: 6, liveStock: 4,
+      })
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search product...')).toHaveValue('Retired Widget')
+      })
+      expect(screen.getByTestId('liveStock-0')).toHaveTextContent('4')
+      const row = (screen.getByTestId('items.0.difference') as HTMLInputElement).closest('tr') as HTMLElement
+      expect(within(row).getByText(formatCurrency(7))).toBeInTheDocument()
+    })
+
+    it('leaves the row invalid (required) when the DTO item has no product at all', async () => {
+      editWith({ difference: 2, unitCost: 7, oldQuantity: 4, newQuantity: 6, liveStock: 4 })
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search product...')).toHaveValue('')
+      })
+      await userEvent.click(screen.getByRole('button', { name: /update adjustment/i }))
+      await waitFor(() => {
+        expect(screen.getByText(/product is required/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('revert prefill from nested-only DTO (#875)', () => {
+    it('groups revert items by nested product.id and shows the product name', async () => {
+      mockSearchParams.mockReturnValue([new URLSearchParams('revertFrom=source-1'), vi.fn()])
+      mockAdjustmentQuery.mockImplementation((id: string) =>
+        id === 'source-1'
+          ? {
+              data: {
+                id: 'source-1',
+                status: 'completed',
+                items: [
+                  { product: { id: 'p1', name: 'Alpha Widget', barcode: 'A1' },
+                    difference: 10, unitCost: 5, oldQuantity: 20, newQuantity: 30, liveStock: 30 },
+                ],
+              },
+              isLoading: false,
+              isError: false,
+            }
+          : stableAdjNull,
+      )
+      renderPage()
+      await waitFor(() => {
+        const diffInput = screen.getByTestId('items.0.difference') as HTMLInputElement
+        expect(diffInput.value).toBe('-10')
+      })
+      expect(screen.getByPlaceholderText('Search product...')).toHaveValue('Alpha Widget')
+    })
+
+    it('prefills a revert product that is absent from the products query (empty products list)', async () => {
+      mockSearchParams.mockReturnValue([new URLSearchParams('revertFrom=source-1'), vi.fn()])
+      mockAdjustmentQuery.mockImplementation((id: string) =>
+        id === 'source-1'
+          ? {
+              data: {
+                id: 'source-1',
+                status: 'completed',
+                items: [
+                  { product: { id: 'gone', name: 'Retired Widget', barcode: 'Z9' },
+                    difference: 10, unitCost: 5, oldQuantity: 20, newQuantity: 30, liveStock: 30 },
+                ],
+              },
+              isLoading: false,
+              isError: false,
+            }
+          : stableAdjNull,
+      )
+      mockProductsQuery.mockReturnValue(stableProductsEmpty)
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search product...')).toHaveValue('Retired Widget')
+      })
+      const diffInput = screen.getByTestId('items.0.difference') as HTMLInputElement
+      expect(diffInput.value).toBe('-10')
+      expect(screen.getByTestId('liveStock-0')).toHaveTextContent('30')
+    })
+  })
+
   describe('live stock refresh on refetch (issue #873)', () => {
     it('syncs Current Stock from a same-id refetch while preserving the entered qty change', async () => {
       mockParams.mockReturnValue({ id: 'abc-123' })


### PR DESCRIPTION
## Problem

On the Stock Adjustment edit (and revert) form, all restored fields (qty change, notes, date, live stock) appeared correctly, but the selected product name was blank.

## Root Cause

The `findOne` response DTO (`StockAdjustmentItemResponseDto`) exposes the product id **only** nested under `item.product.id` — there is no top-level `productId` on the response. The edit-restore effect read `item.productId` (`undefined`), so the form stored an empty product id and the line-item Autocomplete `value` lookup resolved to `null` → blank name. The same nested-only shape affected the live-stock sync map and the revert grouping.

## Fix (frontend-only)

- Add `getAdjustmentItemProductId(item)` accessor (`item?.productId ?? item?.product?.id ?? ''`), used at all 3 DTO read sites: edit restore, live-stock sync (typed `reduce`), and revert grouping. Backward-compatible with the legacy flat `productId`.
- Add a memoized `fallbackProductsById` map built from the loaded adjustment's own `item.product`, **enriched** with the item's `liveStock`/`unitCost`, unioned into the Autocomplete `options`/`value` so a product no longer in the active-Stocked query still renders and stays selectable without zeroing stock/cost.
- Drop the `!products.length` early-return on the revert effect so revert prefill works from the fallback map even when the active-products query is empty.
- Empty product id resolves to `''`, so the existing `required('Product is required')` rule still fires — no placeholder invented.

No backend change: the DTO already carries `product.{id,name}`.

## Testing

6 new tests: nested-only DTO edit restore, product-absent-from-query fallback, liveStock/unitCost enrichment (no zeroing), missing-product required-validation, nested-only revert grouping, and revert with an empty active-products list.

- `npm run test` — 200 files, 1446 tests pass
- `npm run type-check` — pass
- `npm run lint` — pass

Closes #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)