### PR TITLE
fix(inventory): return to view page after editing stock adjustment from view

### DIFF
--- a/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
+++ b/frontend/src/pages/inventory/CreateStockAdjustmentPage.tsx
@@ -93,7 +93,9 @@ const CreateStockAdjustmentPage: React.FC = () => {
   const { id } = useParams<{ id: string }>()
   const [searchParams] = useSearchParams()
   const revertFrom = searchParams.get('revertFrom')
+  const fromView = searchParams.get('from') === 'view'
   const isEditMode = !!id
+  const editReturnPath = fromView && id ? `/inventory/stock-adjustments/${id}/view` : null
   const { showSuccess, showError } = useNotification()
 
   const { data: productsData, isLoading: productsLoading } = useGetProductsQuery({ isActive: true, type: 'Stocked Product' })
@@ -314,7 +316,7 @@ const CreateStockAdjustmentPage: React.FC = () => {
       if (isEditMode && id) {
         const updated = await updateStockAdjustment({ id, data: payload }).unwrap()
         showSuccess(`Stock adjustment ${updated.adjustmentNumber || ''} updated successfully`)
-        navigate(`/inventory/stock-adjustments?highlight=${updated.id}`)
+        navigate(editReturnPath ?? `/inventory/stock-adjustments?highlight=${updated.id}`)
       } else {
         const created = await createStockAdjustment(payload).unwrap()
         showSuccess(`Stock adjustment ${created.adjustmentNumber || ''} created successfully`)
@@ -342,12 +344,12 @@ const CreateStockAdjustmentPage: React.FC = () => {
       <TransactionFormShell
         title={isEditMode ? 'Edit Stock Adjustment' : revertFrom ? 'Revert Stock Adjustment' : 'Create Stock Adjustment'}
         subtitle={isEditMode ? 'Update adjustment details and quantities' : 'Adjust stock quantities for inventory corrections'}
-        backAction={() => navigate('/inventory/stock-adjustments')}
+        backAction={() => navigate(editReturnPath ?? '/inventory/stock-adjustments')}
         onSubmit={handleSubmit(onSubmit)}
         isSaving={isSaving}
         submitLabel={isEditMode ? 'Update Adjustment' : 'Create Adjustment'}
         submitDisabled={hasNegativeStock}
-        onCancel={() => navigate('/inventory/stock-adjustments')}
+        onCancel={() => navigate(editReturnPath ?? '/inventory/stock-adjustments')}
       >
         <Grid size={12}>
           <Card>

--- a/frontend/src/pages/inventory/StockAdjustmentViewPage.tsx
+++ b/frontend/src/pages/inventory/StockAdjustmentViewPage.tsx
@@ -76,7 +76,7 @@ export default function StockAdjustmentViewPage() {
 
   const handleEdit = () => {
     if (isDraft) {
-      navigate(`/inventory/stock-adjustments/${adj.id}/edit`)
+      navigate(`/inventory/stock-adjustments/${adj.id}/edit?from=view`)
     } else {
       setNotesDraft(adj.notes || '')
       setNotesOpen(true)

--- a/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/CreateStockAdjustmentPage.test.tsx
@@ -752,4 +752,55 @@ describe('CreateStockAdjustmentPage', { timeout: 30000 }, () => {
       expect(screen.getByRole('heading', { name: /^additional$/i })).toBeInTheDocument()
     })
   })
+
+  describe('view-origin edit returns to view page (#877)', () => {
+    const editData = (id: string) => ({
+      data: {
+        id,
+        adjustmentNumber: 'SA-001',
+        adjustmentDate: '2026-03-15T00:00:00.000Z',
+        notes: '',
+        items: [{ productId: 'p1', difference: 5, unitCost: 5, oldQuantity: 10, newQuantity: 15 }],
+      },
+      isLoading: false,
+      isError: false,
+    })
+
+    beforeEach(() => {
+      mockParams.mockReturnValue({ id: 'abc-123' })
+      mockSearchParams.mockReturnValue([new URLSearchParams('from=view'), vi.fn()])
+      mockAdjustmentQuery.mockImplementation((id: string) =>
+        id === 'abc-123' ? editData('abc-123') : stableAdjNull,
+      )
+      mockUpdateAdjustment.mockReturnValue({
+        unwrap: vi.fn().mockResolvedValue({ id: 'abc-123', adjustmentNumber: 'SA-001' }),
+      })
+    })
+
+    it('Save returns to the view page instead of the list', async () => {
+      renderPage()
+      await waitFor(() => expect(screen.getByText(/edit stock adjustment/i)).toBeInTheDocument())
+      fireEvent.click(screen.getByRole('button', { name: /update adjustment/i }))
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith('/inventory/stock-adjustments/abc-123/view'),
+      )
+    })
+
+    it('Cancel returns to the view page', async () => {
+      renderPage()
+      await waitFor(() => expect(screen.getByText(/edit stock adjustment/i)).toBeInTheDocument())
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+      expect(mockNavigate).toHaveBeenCalledWith('/inventory/stock-adjustments/abc-123/view')
+    })
+
+    it('Back returns to the view page', async () => {
+      const { container } = renderPage()
+      await waitFor(() => expect(screen.getByText(/edit stock adjustment/i)).toBeInTheDocument())
+      // Back is an icon-only IconButton (ArrowBackIcon) in PageHeader with no
+      // accessible name; it is the button holding the ArrowBackIcon svg.
+      const backIcon = container.querySelector('[data-testid="ArrowBackIcon"]')
+      fireEvent.click(backIcon!.closest('button')!)
+      expect(mockNavigate).toHaveBeenCalledWith('/inventory/stock-adjustments/abc-123/view')
+    })
+  })
 })

--- a/frontend/src/pages/inventory/__tests__/StockAdjustmentViewPage.test.tsx
+++ b/frontend/src/pages/inventory/__tests__/StockAdjustmentViewPage.test.tsx
@@ -1,7 +1,14 @@
 import '@testing-library/jest-dom/vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { describe, it, vi, expect } from 'vitest'
+
+const { mockNavigate } = vi.hoisted(() => ({ mockNavigate: vi.fn() }))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
 
 const { mockAdjustment } = vi.hoisted(() => ({
   mockAdjustment: {
@@ -53,6 +60,25 @@ describe('StockAdjustmentViewPage', () => {
     expect(screen.queryByText('Current Stock')).not.toBeInTheDocument()
     expect(screen.getByText('5')).toBeInTheDocument()
     expect(screen.getByText('7')).toBeInTheDocument()
+  })
+
+  it('navigates to edit with ?from=view when editing a draft from the view page (#877)', async () => {
+    const original = mockAdjustment.status
+    mockAdjustment.status = 'draft'
+    mockNavigate.mockClear()
+    try {
+      render(
+        <MemoryRouter initialEntries={['/inventory/stock-adjustments/a1/view']}>
+          <Routes>
+            <Route path="/inventory/stock-adjustments/:id/view" element={<StockAdjustmentViewPage />} />
+          </Routes>
+        </MemoryRouter>,
+      )
+      fireEvent.click(screen.getByRole('button', { name: /^edit$/i }))
+      expect(mockNavigate).toHaveBeenCalledWith('/inventory/stock-adjustments/a1/edit?from=view')
+    } finally {
+      mockAdjustment.status = original
+    }
   })
 
   it('labels the column "Current Stock" and shows liveStock for a draft', () => {


### PR DESCRIPTION
## Summary

Fixes #877 — editing a Stock Adjustment from the View page and clicking Save (or Cancel/Back) returned the user to the **List** page instead of the same **View** page.

## Changes

- `StockAdjustmentViewPage.tsx` — draft `Edit` link now carries a `?from=view` origin marker.
- `CreateStockAdjustmentPage.tsx` — reads `?from=view`, computes `editReturnPath`, and routes Save, Cancel, and Back to `/inventory/stock-adjustments/{id}/view` for view-origin edits.
- All other edit entry points (list, audit log, journal surfaces) omit the marker and keep the existing list-highlight behavior.

## Behavior

| Origin | Save | Cancel / Back |
|--------|------|---------------|
| View page | → `/{id}/view` | → `/{id}/view` |
| List / audit / journal (no marker) | → `?highlight={id}` (list) | → list |
| Create | → `?highlight={id}` (list) | → list |

Cancel/Back returning to View is an intentional scope expansion beyond the issue's Save-only text, confirmed during design.

## Tests

- `StockAdjustmentViewPage.test.tsx` — asserts draft Edit navigates with `?from=view` (guards the marker against regression).
- `CreateStockAdjustmentPage.test.tsx` — 3 new tests: Save, Cancel, Back all return to View for view-origin edits. Existing list/create tests unchanged (guard the default path).

Type-check clean, lint clean, touched-file tests 32/32 pass.

Closes #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)