### PR TITLE
fix(frontend): nest Accounting nav under a collapsible parent in a Finance section

### DIFF
--- a/frontend/src/config/__tests__/navigation.test.tsx
+++ b/frontend/src/config/__tests__/navigation.test.tsx
@@ -1,11 +1,116 @@
 import { describe, it, expect } from 'vitest'
-import { menuSections } from '../navigation'
+import { isValidElement, type ReactElement } from 'react'
+import {
+  menuSections,
+  getFilteredMenuSections,
+  type MenuItem,
+  type MenuSection,
+} from '../navigation'
 
-describe('navigation order', () => {
-  it('places Accounting before Administration', () => {
+const financeSection = (): MenuSection => {
+  const section = menuSections.find((s) => s.id === 'finance')
+  if (!section) throw new Error('finance section not found')
+  return section
+}
+
+const accountingParent = (): MenuItem => {
+  const parent = financeSection().items.find((i) => i.id === 'accounting')
+  if (!parent) throw new Error('accounting parent item not found')
+  return parent
+}
+
+describe('navigation structure', () => {
+  it('orders sections operations -> finance -> administration', () => {
     const ids = menuSections.map((s) => s.id)
-    expect(ids.indexOf('accounting')).toBeGreaterThan(-1)
-    expect(ids.indexOf('administration')).toBeGreaterThan(-1)
-    expect(ids.indexOf('accounting')).toBeLessThan(ids.indexOf('administration'))
+    expect(ids).toContain('operations')
+    expect(ids).toContain('finance')
+    expect(ids).toContain('administration')
+    expect(ids.indexOf('operations')).toBeLessThan(ids.indexOf('finance'))
+    expect(ids.indexOf('finance')).toBeLessThan(ids.indexOf('administration'))
+  })
+
+  it('has no flat top-level accounting section', () => {
+    expect(menuSections.map((s) => s.id)).not.toContain('accounting')
+  })
+
+  it('holds exactly one Accounting parent item in the finance section', () => {
+    const section = financeSection()
+    expect(section.title).toBe('Finance')
+    expect(section.items).toHaveLength(1)
+
+    const parent = section.items[0]
+    expect(parent.id).toBe('accounting')
+    expect(parent.title).toBe('Accounting')
+    expect(parent.path).toBeUndefined()
+    expect(parent.children).toBeDefined()
+  })
+
+  it('nests the five accounting pages as children with unchanged paths', () => {
+    const children = accountingParent().children ?? []
+    expect(
+      children.map((c) => ({ id: c.id, title: c.title, path: c.path })),
+    ).toEqual([
+      {
+        id: 'chart-of-accounts',
+        title: 'Chart of Accounts',
+        path: '/accounting/chart-of-accounts',
+      },
+      {
+        id: 'journal-entries',
+        title: 'Journal Entries',
+        path: '/accounting/journal-entries',
+      },
+      {
+        id: 'general-ledger',
+        title: 'General Ledger',
+        path: '/accounting/general-ledger',
+      },
+      {
+        id: 'trial-balance',
+        title: 'Trial Balance',
+        path: '/accounting/trial-balance',
+      },
+      {
+        id: 'accounting-settings',
+        title: 'Accounting Settings',
+        path: '/accounting/settings',
+      },
+    ])
+  })
+
+  it('gives every accounting child a distinct icon', () => {
+    const children = accountingParent().children ?? []
+    const iconTypes = children.map((child) => {
+      expect(isValidElement(child.icon)).toBe(true)
+      return (child.icon as ReactElement).type
+    })
+    expect(new Set(iconTypes).size).toBe(children.length)
+  })
+
+  it('restricts every accounting child to admin', () => {
+    const children = accountingParent().children ?? []
+    expect(children).toHaveLength(5)
+    children.forEach((child) => {
+      expect(child.roles).toEqual(['admin'])
+    })
+  })
+
+  it('keeps the finance section for an admin', () => {
+    const ids = getFilteredMenuSections(menuSections, 'admin').map((s) => s.id)
+    expect(ids).toContain('finance')
+  })
+
+  it('drops the finance section for a non-admin role', () => {
+    const nonAdminRoles = [
+      'manager',
+      'sales_staff',
+      'inventory_staff',
+      'procurement_staff',
+    ] as const
+
+    nonAdminRoles.forEach((role) => {
+      const ids = getFilteredMenuSections(menuSections, role).map((s) => s.id)
+      expect(ids).not.toContain('finance')
+    })
   })
 })

--- a/frontend/src/config/navigation.tsx
+++ b/frontend/src/config/navigation.tsx
@@ -16,6 +16,10 @@ import { default as StockAdjustmentIcon } from '@mui/icons-material/SwapVert';
 import { default as SwapHorizIcon } from '@mui/icons-material/SwapHoriz';
 import { default as PriceCostingIcon } from '@mui/icons-material/PriceChange';
 import { default as AccountBalanceWalletIcon } from '@mui/icons-material/AccountBalanceWallet';
+import { default as AccountTreeIcon } from '@mui/icons-material/AccountTree';
+import { default as ReceiptLongIcon } from '@mui/icons-material/ReceiptLong';
+import { default as MenuBookIcon } from '@mui/icons-material/MenuBook';
+import { default as BalanceIcon } from '@mui/icons-material/Balance';
 import { default as PrintIcon } from '@mui/icons-material/Print';
 import { default as DocumentNumberIcon } from '@mui/icons-material/FormatListNumbered';
 import { default as BackupIcon } from '@mui/icons-material/Backup';
@@ -194,43 +198,50 @@ export const menuSections: MenuSection[] = [
     ],
   },
   {
-    id: 'accounting',
-    title: 'Accounting',
+    id: 'finance',
+    title: 'Finance',
     items: [
       {
-        id: 'chart-of-accounts',
-        title: 'Chart of Accounts',
+        id: 'accounting',
+        title: 'Accounting',
         icon: <AccountBalanceWalletIcon />,
-        path: '/accounting/chart-of-accounts',
-        roles: ADMIN_ONLY,
-      },
-      {
-        id: 'accounting-settings',
-        title: 'Accounting Settings',
-        icon: <SettingsIcon />,
-        path: '/accounting/settings',
-        roles: ADMIN_ONLY,
-      },
-      {
-        id: 'journal-entries',
-        title: 'Journal Entries',
-        icon: <OrdersIcon />,
-        path: '/accounting/journal-entries',
-        roles: ADMIN_ONLY,
-      },
-      {
-        id: 'general-ledger',
-        title: 'General Ledger',
-        icon: <AccountBalanceWalletIcon />,
-        path: '/accounting/general-ledger',
-        roles: ADMIN_ONLY,
-      },
-      {
-        id: 'trial-balance',
-        title: 'Trial Balance',
-        icon: <AccountBalanceWalletIcon />,
-        path: '/accounting/trial-balance',
-        roles: ADMIN_ONLY,
+        children: [
+          {
+            id: 'chart-of-accounts',
+            title: 'Chart of Accounts',
+            icon: <AccountTreeIcon />,
+            path: '/accounting/chart-of-accounts',
+            roles: ADMIN_ONLY,
+          },
+          {
+            id: 'journal-entries',
+            title: 'Journal Entries',
+            icon: <ReceiptLongIcon />,
+            path: '/accounting/journal-entries',
+            roles: ADMIN_ONLY,
+          },
+          {
+            id: 'general-ledger',
+            title: 'General Ledger',
+            icon: <MenuBookIcon />,
+            path: '/accounting/general-ledger',
+            roles: ADMIN_ONLY,
+          },
+          {
+            id: 'trial-balance',
+            title: 'Trial Balance',
+            icon: <BalanceIcon />,
+            path: '/accounting/trial-balance',
+            roles: ADMIN_ONLY,
+          },
+          {
+            id: 'accounting-settings',
+            title: 'Accounting Settings',
+            icon: <SettingsIcon />,
+            path: '/accounting/settings',
+            roles: ADMIN_ONLY,
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
## Summary

Accounting was the only module rendered as a flat sidebar section with five direct items, while Sales, Purchasing, Inventory, and Settings each render as a collapsible parent with children. This nests the five accounting pages under a single `Accounting` parent inside a new `Finance` section, gives each child a distinct icon, and moves the settings entry last to match sibling modules.

Sidebar ordering was already correct (fixed in #891 / `ef13a8acc`); the live defect in #893 was the missing parent/child nesting.

```
OPERATIONS
  ▸ Sales / Purchasing / Inventory
FINANCE
  ▸ Accounting
      Chart of Accounts
      Journal Entries
      General Ledger
      Trial Balance
      Accounting Settings
ADMINISTRATION
  ▸ Settings
```

Production code change is limited to `frontend/src/config/navigation.tsx`; its test file was updated alongside. No other file changed.

All five paths are byte-identical, so routes, `BREADCRUMB_MAP` in `TopBar.tsx`, RTK Query, and the backend are untouched. Every child keeps `roles: ADMIN_ONLY`, and `getFilteredMenuSections` already drops the emptied section for non-admins — no new gating code.

New icons: `AccountTreeIcon`, `ReceiptLongIcon`, `MenuBookIcon`, `BalanceIcon` (previously `AccountBalanceWalletIcon` was reused across three children).

## Verification

- `cd frontend && npm run lint` — passed (exit 0, `--max-warnings 0`)
- `cd frontend && npm run type-check` — passed (exit 0)
- `cd frontend && npm run test` — passed (177 files, 1240 tests, 0 failures)

Nav test rewritten from 1 test to 8, covering section order, absence of the old flat section, parent/child shape, unchanged paths, distinct icons (compared by element `.type`), `ADMIN_ONLY` on every child, and `getFilteredMenuSections` dropping the `finance` section for all four non-admin roles.

**Not yet done:** the manual browser check (collapse/expand, active-route highlight, non-admin sees no Finance section) has not been run against a rebuilt frontend image.

Closes #893

🤖 Generated with [Claude Code](https://claude.com/claude-code)